### PR TITLE
Add pre-commit for code linting

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -1,0 +1,80 @@
+name: CI/CD Build Workflow
+
+on:
+  push:
+    branches: [develop]
+
+  pull_request:
+    branches: [develop]
+
+  workflow_dispatch:
+
+env:
+  CANCEL_OTHERS: true
+  PATHS_IGNORE: '["**/README.md", "**/docs/**"]'
+
+jobs:
+  pre-commit-hooks:
+    name: lint with pre-commit - python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    strategy:
+      matrix:
+        python-version: ["3.10",]
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: ${{ env.CANCEL_OTHERS }}
+          paths_ignore: ${{ env.PATHS_IGNORE }}
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Checkout Code Repository
+        uses: actions/checkout@v3
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Cache Conda
+        uses: actions/cache@v3
+        env:
+          # Increase this value to reset cache if conda-dev-spec.template has not changed in the workflow
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('components/omega/dev-conda.txt') }}
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Set up Conda Environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: "omega_ci"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          mamba-version: "*"
+          channels: conda-forge,e3sm/label/compass,defaults
+          channel-priority: strict
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Install dependencies
+        run: |
+          mamba list
+          mamba install -y --file components/omega/dev-conda.txt
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        id: file_changes
+        uses: trilom/file-changes-action@v1.2.3
+        with:
+          output: ' '
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        # Run all pre-commit hooks on all the files.
+        # Getting only staged files can be tricky in case a new PR is opened
+        # since the action is run on a branch in detached head state
+        name: Install and Run Pre-commit
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --files ${{ steps.file_changes.outputs.files}}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+files: ^components/omega/
+repos:
+  - repo: https://github.com/Takishima/cmake-pre-commit-hooks
+    rev: v1.8.0
+    hooks:
+      - id: clang-format
+      - id: clang-tidy
+        args: [--checks=readability-magic-numbers,--warnings-as-errors=*]
+      - id: cppcheck
+      - id: include-what-you-use

--- a/components/omega/dev-conda.txt
+++ b/components/omega/dev-conda.txt
@@ -1,0 +1,25 @@
+# This file may be used to create an environment for linting Omega with
+# pre-commit using:
+# $ mamba create -n omega_dev --file <this file>
+# $ mamba activate omega_dev
+# $ pre-commit install
+
+# linting
+pre-commit
+clang-format
+clang-tools
+cppcheck
+cpplint
+lizard
+include-what-you-use
+
+# documentation
+sphinx
+sphinx_rtd_theme
+myst-parser
+sphinx-multiversion
+rst-to-myst
+
+# CF-compliance
+cfchecker
+udunits2


### PR DESCRIPTION
This merge adds support for installing and running the `pre-commit` tool, which in turn runs:
* [clang-format](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)
* [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
* [cppcheck](https://cppcheck.sourceforge.io/)
* [include-what-you-use](https://include-what-you-use.org/)
and which could also run (if we choose):
* [cpplint](https://github.com/cpplint/cpplint)
* [lizard](http://www.lizard.ws/)

The instructions to use `pre-commit` are to install [mambaforge](https://github.com/conda-forge/miniforge#mambaforge) if you hadn't already, then activate the base environment and install the dependencies as follows:
```
# update as appropriate
export MAMBA_DIR=$HOME/mambaforge
source $MAMBA_DIR/etc/profile.d/conda.sh
source $MAMBA_DIR/etc/profile.d/mamba.sh
mamba activate
mamba create -y -n omega_dev --file components/omega/lint-omega.txt
mamba activate omega_dev
pre-commit install
```
Then, commit code and linting should occur automatically before your commit goes through. In future sessions, you need to run this for `pre-commit` to work:
```
# update as appropriate
export MAMBA_DIR=$HOME/mambaforge
source $MAMBA_DIR/etc/profile.d/conda.sh
source $MAMBA_DIR/etc/profile.d/mamba.sh
mamba activate omega_dev
```
You may wish to create a bash alias for this.