### PR TITLE
Clean up design docs

### DIFF
--- a/components/omega/doc/design/Broadcast.md
+++ b/components/omega/doc/design/Broadcast.md
@@ -1,7 +1,5 @@
-<!--- OMEGA Broadcast Requirements and Design --------------------------------->
-
-# OMEGA Requirements and Design:
-## *Broadcast*
+(omega-design-broadcast)=
+# Broadcast
 
 ## 1 Overview
 
@@ -52,7 +50,9 @@ function with simplified arguments.
 For non-blocking broadcasts, we will alias the MPI_request type
 to a Broadcast ID:
 
-    using BroadcastID = MPI_Request;
+```c++
+using BroadcastID = MPI_Request;
+```
 
 ### 4.2 Methods
 
@@ -66,14 +66,18 @@ interfaces cleaner.
 The first form is the simplest for a broadcast within the default 
 environment and from the master task:
 
-    int Broadcast([data type] value);
+```c++
+int Broadcast([data type] value);
+```
 
 where `[data type]` is one of the supported types (I4, I8 R4, R8, Real,
 boolean, std::string). In actual use, this would look like:
 
-    ierr = Broadcast(myIntVar);
-    ierr = Broadcast(myRealVar);
-    [etc for all data types]
+```c++
+ierr = Broadcast(myIntVar);
+ierr = Broadcast(myRealVar);
+[etc for all data types]
+```
 
 On the master task, the value would be broadcast and remain unchanged.
 The remaining tasks would receive the broadcast and store the value.
@@ -83,26 +87,32 @@ The remaining tasks would receive the broadcast and store the value.
 This is similar to the above, but adds the additional argument
 for the source rank to broadcast from.
 
-    int Broadcast([data type] value,  ///< [in] value to be broadcast
-                  const int srcRank   ///< [in] rank to broadcast from
-                  );      // 
+```c++
+int Broadcast([data type] value,  ///< [in] value to be broadcast
+              const int srcRank   ///< [in] rank to broadcast from
+              );      // 
+```
 
 #### 4.2.3 Broadcast from master rank within a different environment
 
 As in 4.2.1, but adds the machine environment as an argument:
 
-    int Broadcast([data type] value,    ///< [in] value to be broadcast
-                  const MachEnv subEnv, ///< [in] defined OMEGA environment
-                  );
+```c++
+int Broadcast([data type] value,    ///< [in] value to be broadcast
+              const MachEnv subEnv, ///< [in] defined OMEGA environment
+              );
+```
 
 #### 4.2.4 Broadcast from another rank within a different environment
 
 As in 4.2.2, but adds the machine environment as an argument:
 
-    int Broadcast([data type] value,     ///< [in] value to be broadcast
-                  const MachEnv subEnv,  ///< [in] defined OMEGA environment
-                  const int srcRank      ///< [in] rank to broadcast from
-                  );
+```c++
+int Broadcast([data type] value,     ///< [in] value to be broadcast
+              const MachEnv subEnv,  ///< [in] defined OMEGA environment
+              const int srcRank      ///< [in] rank to broadcast from
+              );
+```
 
 #### 4.2.5 Broadcast of vector variables
 
@@ -117,9 +127,11 @@ be named IBroadcast. In addition, an IBroadcastWait will be
 included to wait for the request to complete. A non-blocking
 sequence would look like:
 
-    BroadcastID myReqID = IBroadcast(myVar);
-    [ perform other tasks/computation ]
-    int err = IBroadcastWait(myReqID);
+```c++
+BroadcastID myReqID = IBroadcast(myVar);
+[ perform other tasks/computation ]
+int err = IBroadcastWait(myReqID);
+```
 
 ## 5 Verification and Testing
 
@@ -155,5 +167,3 @@ verification on the non-blocking results.
 Create a new MachEnv with a subset of ranks and repeat the above tests
 with the extra environment argument. Check also that ranks not in
 the environment are not corrupted/overwritten with the broadcast value.
-
-

--- a/components/omega/doc/design/Config.md
+++ b/components/omega/doc/design/Config.md
@@ -1,8 +1,5 @@
-<!--- Omega Config Requirements and Design ------------------------------------>
-
-# OMEGA Requirements and Design:
-
-# *Config*
+(omega-design-config)=
+# Config
 
 ## 1 Overview
 
@@ -92,7 +89,7 @@ If extra or unexpected values are encountered, they will be ignored.
 ### 2.13 Desired: Automated generation of default input and error checking
 
 While the source code defines the configuration variables, it would
-desirable to have a means to extract from the source code what the 
+be desirable to have a means to extract from the source code what the 
 code is expecting into a default input config file. This would also
 enable some external error checking for missing or extra entries.
 
@@ -142,7 +139,9 @@ There are no global parameters or shared constants.
 
 We define a Config type, which is actually an alias of YAML::node:
 
-    using Config = YAML::node;
+```c++
+using Config = YAML::node;
+```
 
 from the yaml-cpp library. A YAML node is more fully and accurately 
 defined in the YAML specification, but for the purposes of this 
@@ -157,50 +156,51 @@ but will be a similar hierarchy under the full omega config node.
 
 An example YAML input file might then look like:
 
-    omega:
-       timeManagement:
-          doRestart: false
-          restartTimestampName: restartTimestamp
-          startTime: 0001-01-01_00:00:00
-          stopTime: none
-          runDuration: 0010_00:00:00
-          calendarType: noleap
+```yaml
+omega:
+   timeManagement:
+      doRestart: false
+      restartTimestampName: restartTimestamp
+      startTime: 0001-01-01_00:00:00
+      stopTime: none
+      runDuration: 0010_00:00:00
+      calendarType: noleap
 
-       [Other config options in a similar way]
+   [Other config options in a similar way]
 
-       hmix:
-          hmixScaleWithMesh: false
-          maxMeshDensity: -1.0
-          hmixUseRefWidth: false
-          hmixRefWidth: 30.0e3
+   hmix:
+      hmixScaleWithMesh: false
+      maxMeshDensity: -1.0
+      hmixUseRefWidth: false
+      hmixRefWidth: 30.0e3
 
-       [more config options]
+   [more config options]
 
-       streams:
+   streams:
 
-          mesh:
-             type: input
-             filenameTemplate: mesh.nc
-             inputInterval: initial_only
+      mesh:
+         type: input
+         filenameTemplate: mesh.nc
+         inputInterval: initial_only
 
-          output:
-             type: output
-             filenameTemplate: output/output.$Y-$M-$D_$h.$m.$s.nc
-             filenameInterval: 01-00-00_00:00:00
-             referenceTime: 0001-01-01_00:00:00
-             clobberMode: truncate
-             precision: single
-             outputInterval: 0001_00:00:00
-             contents:
-             - tracers
-             - layerThickness
-             - ssh
-             - kineticEnergyCell
-             - relativeVorticityCell
-             - [other fields]
+      output:
+         type: output
+         filenameTemplate: output/output.$Y-$M-$D_$h.$m.$s.nc
+         filenameInterval: 01-00-00_00:00:00
+         referenceTime: 0001-01-01_00:00:00
+         clobberMode: truncate
+         precision: single
+         outputInterval: 0001_00:00:00
+         contents:
+         - tracers
+         - layerThickness
+         - ssh
+         - kineticEnergyCell
+         - relativeVorticityCell
+         - [other fields]
 
-          [other streams in similar form]
-
+      [other streams in similar form]
+```
 
 ### 4.2 Methods
 
@@ -213,7 +213,9 @@ to be associated with Config.
 The most common use case should be creating a Config by reading a
 YAML configuration file using: 
 
-    Config omegaConfig = ConfigRead(“omega.yml”);
+```c++
+Config omegaConfig = ConfigRead("omega.yml");
+```
 
 where the argument is the name for the YAML input file. In OMEGA,
 we will retain this master configuration throughout the initialization
@@ -228,11 +230,13 @@ associated with the local module/group. In the sample above, if we need
 to retrieve a variable from the hmix group, we first retrieve the hmix
 config and then the variable using:
 
-    Config hmixConfig = ConfigGet(omegaConfig,"hmix",iErr);
-    Real refWidth{0.0};
-    bool useRefWidth{false};
-    refWidth    = ConfigGet(hmixConfig, "hmixRefWidth",    iErr);
-    useRefWidth = ConfigGet(hmixConfig, "hmixUseRefWidth", iErr);
+```c++
+Config hmixConfig = ConfigGet(omegaConfig,"hmix",iErr);
+Real refWidth{0.0};
+bool useRefWidth{false};
+refWidth    = ConfigGet(hmixConfig, "hmixRefWidth",    iErr);
+useRefWidth = ConfigGet(hmixConfig, "hmixUseRefWidth", iErr);
+```
 
 where there is a retrieval function for all supported Omega data types:
 bool, I4, I8, R4, R8, Real, std::string. These retrievals are just
@@ -246,7 +250,9 @@ Another interface will allow the setting of a default value if the
 variable is missing from the input config.  This interface simply
 adds the default value as an additional argument, for example:
 
-    refWidth = ConfigGet(hmixConfig, "hmixRefWidth", defaultVal, iErr);
+```c++
+refWidth = ConfigGet(hmixConfig, "hmixRefWidth", defaultVal, iErr);
+```
 
 In this case, if the variable does not exist, it will not only
 use the default value but print a warning that the default is
@@ -260,9 +266,11 @@ file read interface above, the capability modify a value is also
 required. The syntax is essentially the inverse of the get/retrieval 
 above. Similar to that case, the sub-group will need to be retrieved first.
 
-    Config hmixConfig = ConfigGet(omegaConfig, "hmix", iErr);
-    ConfigSet(hmixConfig, "hmixRefWidth", 10.0e3, iErr);
-    ConfigSet(hmixConfig, "hmixUseRefWidth", true, iErr);
+```c++
+Config hmixConfig = ConfigGet(omegaConfig, "hmix", iErr);
+ConfigSet(hmixConfig, "hmixRefWidth", 10.0e3, iErr);
+ConfigSet(hmixConfig, "hmixUseRefWidth", true, iErr);
+```
 
 There will be overloaded interfaces for each supported type. For 
 literals (as in the example above), they will be cast to an appropriate
@@ -276,16 +284,18 @@ It may be necessary to build up a configuration that does not yet
 exist or add new entries to an existing group. We provide an Add
 interface to distinguish this case from the Set case above.
 
-    // For an existing subgroup:
-    Config hmixConfig = ConfigGet(omegaConfig, "hmix", iErr);
-    ConfigAdd(hmixConfig, "hmixRefWidth", 10.0e3, iErr);
-    ConfigAdd(hmixConfig, "hmixUseRefWidth", true, iErr);
+```c++
+// For an existing subgroup:
+Config hmixConfig = ConfigGet(omegaConfig, "hmix", iErr);
+ConfigAdd(hmixConfig, "hmixRefWidth", 10.0e3, iErr);
+ConfigAdd(hmixConfig, "hmixUseRefWidth", true, iErr);
 
-    // To add a new subgroup:
-    Config hmixConfig; // empty Config constructor
-    ConfigAdd(hmixConfig, "hmixRefWidth", 10.0e3, iErr); // build subgroup
-    ConfigAdd(hmixConfig, "hmixUseRefWidth", true, iErr);
-    ConfigAdd(omegaConfig, hmixConfig); // add new subgroup to parent
+// To add a new subgroup:
+Config hmixConfig; // empty Config constructor
+ConfigAdd(hmixConfig, "hmixRefWidth", 10.0e3, iErr); // build subgroup
+ConfigAdd(hmixConfig, "hmixUseRefWidth", true, iErr);
+ConfigAdd(omegaConfig, hmixConfig); // add new subgroup to parent
+```
 
 There will be overloaded interfaces for each supported type. For 
 literals (as in the example above), they will be cast to an appropriate
@@ -301,28 +311,36 @@ satisfy requirement 2.11, we will add a function to test the
 existence of an entry, given a config or sub-config.
 Using the hmix example again:
 
-    if (ConfigExists(hmixConfig,"hmixRefWidth") {
-       // variable exists, do stuff
-    }
+```c++
+if (ConfigExists(hmixConfig,"hmixRefWidth") {
+   // variable exists, do stuff
+}
+```
 
 Note that this can also be used to test the existence of a complete
 sub-group as well:
 
-    bool hmixExists = ConfigExists(omegaConfig, "hmix");
+```c++
+bool hmixExists = ConfigExists(omegaConfig, "hmix");
+```
 
 #### 4.2.5 File write
 
 While we may decide to save provenance a different way, a write interface
 is supplied to write a configuration to an output YAML file:
 
-    err = ConfigWrite(myConfig, “outputFileName”);
+```c++
+err = ConfigWrite(myConfig, "outputFileName");
+```
 
 #### 4.2.6 Constructor/destructor
 
 A default constructor for an empty Config and destructor will be provided:
 
-    Config myConfig;
-    delete myConfig;
+```c++
+Config myConfig;
+delete myConfig;
+```
 
 The destructor may be important to free up space since the Config is
 likely to only be used during the init phase in the current plan.
@@ -334,23 +352,25 @@ and avoid missing or extra entries, we propose inserting a block within
 each source code header (where other interfaces will be documented).
 This block would follow Doxygen-like format and look something like:
 
-    /// \ConfigInput
-    /// #
-    /// # Group description (eg. hmix: the horizontal mix configuration)
-    /// #
-    /// groupName:
-    ///    #
-    ///    # Parameter description (eg horizontal mixing coeff)
-    ///    #    more description (units, acceptable values or range)
-    ///    #
-    ///    varName1: defaultValue1
-    ///    #
-    ///    # Parameter description
-    ///    #
-    ///    varName2: defaultValue2
-    ///    [ continue for remaining vars in this block]
-    ///
-    /// \EndConfigInput (might not be necessary?)
+```c++
+/// \ConfigInput
+/// #
+/// # Group description (eg. hmix: the horizontal mix configuration)
+/// #
+/// groupName:
+///    #
+///    # Parameter description (eg horizontal mixing coeff)
+///    #    more description (units, acceptable values or range)
+///    #
+///    varName1: defaultValue1
+///    #
+///    # Parameter description
+///    #
+///    varName2: defaultValue2
+///    [ continue for remaining vars in this block]
+///
+/// \EndConfigInput (might not be necessary?)
+```
 
 The block between the ConfigInput lines could be extracted verbatim
 and written (with proper indenting) into a fully documented yaml 
@@ -406,4 +426,3 @@ read in the new file. Add an extra variable to the new file.
 Verify that the newly read Config matches the original, ignoring
 the extra variable.
    - tests 2.3, 2.12
-

--- a/components/omega/doc/design/DataTypes.md
+++ b/components/omega/doc/design/DataTypes.md
@@ -1,9 +1,5 @@
-<!--- DataTypes Requirements and Design --------------------------------------->
-
-# OMEGA Requirements and Design:
-
-# *DataTypes*
-
+(omega-design-data-types)=
+# DataTypes
 
 ## 1 Overview
 
@@ -74,35 +70,35 @@ file DataTypes.h We will use the "using" syntax rather than
 the older typedef. For YAKL arrays, we require both device arrays (default)
 and host array types and will use C-ordering.
 
+```c++
+// Standard integer and floating point types
+using I4 = std::int32_t;
+using I8 = std::int64_t;
+using R4 = float;
+using R8 = double;
+#ifdef SINGLE_PRECISION
+using Real = float;
+#else
+using Real = double;
+#endif
 
-    // Standard integer and floating point types
-    using I4 = std::int32_t;
-    using I8 = std::int64_t;
-    using R4 = float;
-    using R8 = double;
-    #ifdef SINGLE_PRECISION
-    using Real = float;
-    #else
-    using Real = double;
-    #endif
-
-    // Aliases for YAKL arrays - by default on device and in
-    // C-ordering.
-    using Array1DI4   = YAKL::Array<I4,1,memDevice,styleC>
-    using Array1DI8   = YAKL::Array<I8,1,memDevice,styleC>
-    using Array1DR4   = YAKL::Array<R4,1,memDevice,styleC>
-    using Array1DR8   = YAKL::Array<R8,1,memDevice,styleC>
-    using Array1DReal = YAKL::Array<Real,1,memDevice,styleC>
-    using Array2DI4   = YAKL::Array<I4,2,memDevice,styleC>
-    using Array2DI8   = YAKL::Array<I8,2,memDevice,styleC>
-    using Array2DR4   = YAKL::Array<R4,2,memDevice,styleC>
-    using Array2DR8   = YAKL::Array<R8,2,memDevice,styleC>
-    using Array2DReal = YAKL::Array<Real,2,memDevice,styleC>
-    // continue this pattern for higher-dimensional arrays
-    // Also need similar aliases for arrays on the host
-    using ArrayHost1DI4   = YAKL::Array<I4,1,memHost,styleC>
-    // replicated as above for each type, dimension
-
+// Aliases for YAKL arrays - by default on device and in
+// C-ordering.
+using Array1DI4   = YAKL::Array<I4,1,memDevice,styleC>
+using Array1DI8   = YAKL::Array<I8,1,memDevice,styleC>
+using Array1DR4   = YAKL::Array<R4,1,memDevice,styleC>
+using Array1DR8   = YAKL::Array<R8,1,memDevice,styleC>
+using Array1DReal = YAKL::Array<Real,1,memDevice,styleC>
+using Array2DI4   = YAKL::Array<I4,2,memDevice,styleC>
+using Array2DI8   = YAKL::Array<I8,2,memDevice,styleC>
+using Array2DR4   = YAKL::Array<R4,2,memDevice,styleC>
+using Array2DR8   = YAKL::Array<R8,2,memDevice,styleC>
+using Array2DReal = YAKL::Array<Real,2,memDevice,styleC>
+// continue this pattern for higher-dimensional arrays
+// Also need similar aliases for arrays on the host
+using ArrayHost1DI4   = YAKL::Array<I4,1,memHost,styleC>
+// replicated as above for each type, dimension
+```
 
 ### 4.2 Methods
 

--- a/components/omega/doc/design/Logging.md
+++ b/components/omega/doc/design/Logging.md
@@ -1,8 +1,5 @@
-<!--- Omega OMEGA logging system Requirements and Design ------------------------------------>
-
-# OMEGA Requirements and Design:
-
-## *OMEGA logging system*
+(omega-design-logging)=
+# Logging
 
 ## 1 Overview
 

--- a/components/omega/doc/design/MachEnv.md
+++ b/components/omega/doc/design/MachEnv.md
@@ -1,10 +1,5 @@
-<!--- OMEGA Machine Environment Requirements and Design ----------------------->
-
-# OMEGA Requirements and Design:
-
-
-# *MachineEnv*
-
+(omega-design-machine-env)=
+# MachineEnv
 
 ## 1 Overview
 
@@ -100,20 +95,22 @@ There will be a simple class MachEnv. We use a class here rather than
 a struct so that we can make members private to prevent overwriting 
 these variables.
 
-    class MachEnv {
+```c++
+class MachEnv {
 
-       private:
-          int mComm;      ///< MPI communicator for this environment
-          int mMyRank;    ///< rank ID for local MPI rank
-          int mNumRanks;  ///< total number of MPI ranks
-          int mMasterRank;///< rank ID for master rank
-          bool mIsMaster; ///< true if the local rank is the master
+   private:
+      int mComm;      ///< MPI communicator for this environment
+      int mMyRank;    ///< rank ID for local MPI rank
+      int mNumRanks;  ///< total number of MPI ranks
+      int mMasterRank;///< rank ID for master rank
+      bool mIsMaster; ///< true if the local rank is the master
 
-       public:
+   public:
 
-          // Methods
-          [define methods here - see below]
-    }
+      // Methods
+      [define methods here - see below]
+}
+```
 
 #### 4.1.3 Default environment
 
@@ -131,12 +128,14 @@ these two must be called as early as possible in OMEGA initialization
 (typically the first call). Both forms will return an integer
 error code and will define the default environment `OMEGA::defaultEnv`.
 
-    // Initialization - standalone
-    int MachEnvInit();
+```c++
+// Initialization - standalone
+int MachEnvInit();
 
-    // Initialization - coupled
-    int MachEnvInit(int inCommunicator, ///< [in] parent MPI communicator 
-                    );
+// Initialization - coupled
+int MachEnvInit(int inCommunicator, ///< [in] parent MPI communicator 
+                );
+```
 
 #### 4.2.2 Constructors
 
@@ -144,37 +143,41 @@ We provide several constructors for creating instances of the environment.
 These will be used primarily by the above initialization routine, though
 can also be used to create additional environments per requirement 2.7.
 
-    // Generic constructor that uses `MPI_COMM_WORLD`
-    MachEnv();
+```c++
+// Generic constructor that uses `MPI_COMM_WORLD`
+MachEnv();
 
-    // Constructor that uses an assigned communicator (eg from coupler)
-    MachEnv(const int inCommunicator ///< [in] parent MPI communicator
-            );
+// Constructor that uses an assigned communicator (eg from coupler)
+MachEnv(const int inCommunicator ///< [in] parent MPI communicator
+        );
 
-    // Create a new environment from a contiguous subset of an
-    // existing environment
-    MachEnv(const int inCommunicator,///< [in] parent MPI communicator
-            const int newSize        ///< [in] use first newSize ranks
-            );
+// Create a new environment from a contiguous subset of an
+// existing environment
+MachEnv(const int inCommunicator,///< [in] parent MPI communicator
+        const int newSize        ///< [in] use first newSize ranks
+        );
 
-    // Create a new environment from a strided subset of an
-    // existing environment
-    MachEnv(const int inCommunicator,///< [in] parent MPI communicator
-            const int newSize,       ///< [in] num ranks in new env
-            const int begin,         ///< [in] starting parent rank
-            const int stride         ///< [in] stride for ranks to incl
-            );
+// Create a new environment from a strided subset of an
+// existing environment
+MachEnv(const int inCommunicator,///< [in] parent MPI communicator
+        const int newSize,       ///< [in] num ranks in new env
+        const int begin,         ///< [in] starting parent rank
+        const int stride         ///< [in] stride for ranks to incl
+        );
 
-    // Create a new environment from a custome subset of an
-    // existing environment, supplying list of parent ranks to include
-    MachEnv(const int inCommunicator ///< [in] parent MPI communicator
-            const int newSize,       ///< [in] num ranks in new env
-            const int ranks[]        ///< [in] vector of parent ranks to incl
-            );
+// Create a new environment from a custome subset of an
+// existing environment, supplying list of parent ranks to include
+MachEnv(const int inCommunicator ///< [in] parent MPI communicator
+        const int newSize,       ///< [in] num ranks in new env
+        const int ranks[]        ///< [in] vector of parent ranks to incl
+        );
+```
 
 In standalone mode, the simple constructor would be used:
 
-    MachEnv omegaEnv(); // Initialize MPI and machine environment
+```c++
+MachEnv omegaEnv(); // Initialize MPI and machine environment
+```
 
 and would define `MPI_COMM_WORLD` as the communicator as well
 as initialize various other environments as needed.  In coupled mode,
@@ -193,22 +196,28 @@ a vector of specific ranks of the parent to include in the new environment.
 We provide specific retrieval functions for each class member to mimic
 using this environment as a struct:
 
-    int Comm() const;      ///< returns MPI communicator for this environment
-    int MyRank() const;    ///< returns local MPI rank
-    int NumRanks() const;  ///< total number of MPI ranks 
+```c++
+int Comm() const;      ///< returns MPI communicator for this environment
+int MyRank() const;    ///< returns local MPI rank
+int NumRanks() const;  ///< total number of MPI ranks 
+```
 
 In typical use, these would look like:
 
-    myRank = OMEGA::defaultEnv.MyRank(); // retrieve local rank id
-    if (OMEGA::defaultEnv.IsMaster()){
-       // do stuff on master rank
-    }
+```c++
+myRank = OMEGA::defaultEnv.MyRank(); // retrieve local rank id
+if (OMEGA::defaultEnv.IsMaster()){
+   // do stuff on master rank
+}
+```
 
 #### 4.2.3 Change master task
 
 While most of the members should not be modified (read only using the get above), we will need a single set function to satisfy requirement 2.6.
 
-    int SetMaster(const int newMasterRank);
+```c++
+int SetMaster(const int newMasterRank);
+```
 
 Note that this should occur as soon as possible after the environment is
 created. Resetting the master after other activities have already assumed
@@ -261,5 +270,3 @@ and build the test with `-D OMEGA_VECTOR_SIZE=16`. Verify the
 internal variable is also 16 to test that the preprocessor properly
 propagates the value internally.
   * tests requirement 2.5
-
-


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
This merge clean up the existing design docs so they integrate more cleanly into the documentation as a whole.  This includes:
* giving each design doc an anchor (like `(omega-design-logging)=`) in case we want to link to it in the docs
* removing the `OMEGA Requirements and Design:` super-title, because it shows up as the document name in the table of contents
* Explicitly formatting code as c++, yaml, etc. for improved readability

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Design document has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/omega/develop/developers_guide/building_docs.html) and changes look as expected
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


