### PR TITLE
Fix `.clang-format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 files: ^components/omega/
 repos:
   - repo: https://github.com/Takishima/cmake-pre-commit-hooks
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: clang-format
       # - id: clang-tidy


### PR DESCRIPTION
It seems that we want a simpler syntax for `AlignConsecutiveMacros`.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


