### PR TITLE
simplify clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,9 +5,6 @@ IndentWidth: 3
 Language: Cpp
 AlignConsecutiveAssignments: true
 AlignConsecutiveBitFields: true
-AlignConsecutiveMacros:
-  Enabled: true
-  AcrossEmptyLines: true
-  AcrossComments: false
+AlignConsecutiveMacros: true
 AlignEscapedNewlines: true
 AlignTrailingComments: true


### PR DESCRIPTION
This seems to be needed for CI, even though things work in local testing.