### PR TITLE
Add a new MachEnv class to hold various machine and messaging parameters

### DIFF
--- a/components/omega/doc/devGuide/MachEnv.md
+++ b/components/omega/doc/devGuide/MachEnv.md
@@ -1,0 +1,69 @@
+(omega-dev-mach-env)=
+
+## Machine Environment (MachEnv)
+
+The MachEnv class maintains a number of parameters associated with
+the parallel machine environment. These include message-passing parameters
+like MPI communicators and task information, the number of threads
+if threaded, vector length for CPUs, and GPU and node information as
+needed. Multiple environments can be defined to support running portions
+of the model on subsets of tasks. 
+
+On model initiation, the initialization routine `OMEGA::MachEnv::init()`
+is called to set up the default MachEnv, which can be retrieved at
+any time using:
+```c++
+OMEGA::MachEnv DefEnv = OMEGA::MachEnv::getDefaultEnv();
+```
+that returns a pointer to the default environment.
+Once an environment has been retrieved, the individual data members
+are retrieved using various get functions:
+```c++
+  MPI_Comm Comm   = DefEnv->getComm();
+  int MyTask      = DefEnv->getMyTask();
+  int NumTasks    = DefEnv->getNumTasks();
+  int MasterTask  = DefEnv->getMasterTask();
+```
+There is also a logical function `isMasterTask` that can be used
+for work that should only be done on the master task. By default,
+the master task is defined as task 0 in the environment, but if
+the master task is overloaded, there is a `setMasterTask` that can
+redefine any other task in the group as the master.
+
+If OMEGA has been built with OpenMP threading, a `getNumThreads`
+function is available; it returns 1 if threading is not on.
+The MachEnv also has a public parameter `OMEGA::VecLength` that can
+be used to tune the vector length for CPU architectures. For
+GPU builds, this VecLength is set to 1.
+
+As noted previously, additional environments can be defined for
+subsets of a parent environment. There are three interfaces for
+creating an environment:
+```c++
+  OMEGA::MachEnv MyNewEnv = 
+      OMEGA::MachEnv::createNewEnv(Name, ParentEnv, NewSize);
+  OMEGA::MachEnv MyNewEnv = 
+      OMEGA::MachEnv::createNewEnv(Name, ParentEnv, NewSize, Begin, Stride);
+  OMEGA::MachEnv MyNewEnv = 
+      OMEGA::MachEnv::createNewEnv(Name, ParentEnv, NewSize, Tasks);
+```
+The first creates a new environment from the first `NewSize` contiguous
+tasks in the parent machine environment. The second creates a new
+environment from a strided set of tasks starting at the `Begin` Task
+(eg all odd tasks would have Begin=1 and Stride=2). The final
+interface creates a subset containing the selected tasks stored in
+a vector `Tasks`. Each new environment is given a `Name` and can be
+retrieved by name using `OMEGA::MachEnv::getEnv(Name)`. Once retrieved,
+the other get functions listed above are used to get each data member.
+Because the new environments are subsets of the default environment, one
+additional function `OMEGA::MachEnv::isMember()` is provided so that
+non-member tasks can be excluded from calculations. The retrieval functions
+call from non-member tasks will return invalid values. Finally, there is
+a `removeEnv` function that can delete any defined environment.
+
+As a class that is basically a container for the environment parameters,
+the implementation is a simple class with several scalar data members and
+the retrieval/creation functions noted above. To track all defined
+environments, a c++ map container is used to pair a name with a pointer to
+a defined environment.  
+

--- a/components/omega/doc/devGuide/MachEnv.md
+++ b/components/omega/doc/devGuide/MachEnv.md
@@ -47,7 +47,10 @@ creating an environment:
   OMEGA::MachEnv MyNewEnv = 
       OMEGA::MachEnv::createNewEnv(Name, ParentEnv, NewSize, Tasks);
 ```
-The first creates a new environment from the first `NewSize` contiguous
+An optional additional argument exists for all three that can supply an
+alternative task to use as the Master Task for message passing. If not
+provided, the master task defaults to 0. The first interface above
+creates a new environment from the first `NewSize` contiguous
 tasks in the parent machine environment. The second creates a new
 environment from a strided set of tasks starting at the `Begin` Task
 (eg all odd tasks would have Begin=1 and Stride=2). The final
@@ -64,6 +67,6 @@ a `removeEnv` function that can delete any defined environment.
 As a class that is basically a container for the environment parameters,
 the implementation is a simple class with several scalar data members and
 the retrieval/creation functions noted above. To track all defined
-environments, a c++ map container is used to pair a name with a pointer to
-a defined environment.  
+environments, a c++ map container is used to pair a name with each
+defined environment.  
 

--- a/components/omega/doc/devGuide/MachEnv.md
+++ b/components/omega/doc/devGuide/MachEnv.md
@@ -37,15 +37,12 @@ be used to tune the vector length for CPU architectures. For
 GPU builds, this VecLength is set to 1.
 
 As noted previously, additional environments can be defined for
-subsets of a parent environment. There are three interfaces for
-creating an environment:
+subsets of a parent environment. There are three constructor
+interfaces for creating an environment:
 ```c++
-  OMEGA::MachEnv MyNewEnv = 
-      OMEGA::MachEnv::createNewEnv(Name, ParentEnv, NewSize);
-  OMEGA::MachEnv MyNewEnv = 
-      OMEGA::MachEnv::createNewEnv(Name, ParentEnv, NewSize, Begin, Stride);
-  OMEGA::MachEnv MyNewEnv = 
-      OMEGA::MachEnv::createNewEnv(Name, ParentEnv, NewSize, Tasks);
+  OMEGA::MachEnv MyNewEnv(Name, ParentEnv, NewSize);
+  OMEGA::MachEnv MyNewEnv(Name, ParentEnv, NewSize, Begin, Stride);
+  OMEGA::MachEnv MyNewEnv(Name, ParentEnv, NewSize, Tasks);
 ```
 An optional additional argument exists for all three that can supply an
 alternative task to use as the Master Task for message passing. If not

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -23,6 +23,7 @@ Development is taking place at https://github.com/E3SM-Project/Omega.
 userGuide/QuickStart
 userGuide/OmegaBuild
 userGuide/DataTypes
+userGuide/MachEnv
 ```
 
 ```{toctree}
@@ -31,6 +32,7 @@ userGuide/DataTypes
 
 devGuide/QuickStart
 devGuide/DataTypes
+devGuide/MachEnv
 devGuide/CondaEnv
 devGuide/Docs
 devGuide/BuildDocs

--- a/components/omega/doc/userGuide/MachEnv.md
+++ b/components/omega/doc/userGuide/MachEnv.md
@@ -1,0 +1,24 @@
+(omega-user-mach-env)=
+
+## Machine Environment (MachEnv)
+
+Within OMEGA, many aspects of the machine environment are stored
+in a class called MachEnv. These include message-passing parameters
+like MPI communicators and task information, number of threads
+if threaded, vector length for CPUs, GPU and node information as
+needed. Multiple environments are supported in case portions of the
+code need to run on subsets of tasks or in different contexts. A
+default environment is defined early in the initialization of the
+model and can be retrieved as described in the
+[Developer's Guide](#omega-dev-mach-env).
+
+The user is not expected to set any parameters in MachEnv. All
+quantities are derived from either the job launch command
+(eg mpirun or srun) that defines the number of MPI tasks and tasks
+layouts or from machine parameters enforced during the build based
+on supported machine xml configurations.
+The latter include the pre-processing parameters 
+`-DOMEGA_VECTOR_LENGTH=xx` and `-DOMEGA_THREADED` that define an
+optimal vector length for CPU code and turn on OpenMP threading
+if desired.
+

--- a/components/omega/src/base/MachEnv.cpp
+++ b/components/omega/src/base/MachEnv.cpp
@@ -15,8 +15,8 @@
 #include "MachEnv.h"
 #include "mpi.h"
 
-#include <string>
 #include <map>
+#include <string>
 // Note that we should replace iostream and std::cerr with the logging
 // capability once that is enabled.
 #include <iostream>
@@ -24,15 +24,15 @@
 namespace OMEGA {
 
 // create the static class members
-MachEnv* MachEnv::DefaultEnv = nullptr;
-std::map<std::string, MachEnv*> MachEnv::AllEnvs;
+MachEnv *MachEnv::DefaultEnv = nullptr;
+std::map<std::string, MachEnv *> MachEnv::AllEnvs;
 
 // Constructors
 //------------------------------------------------------------------------------
 // Default constructor that fills a MachEnv with mostly invalid values.
 // Environments are instead created using the relevant create function.
 
-MachEnv::MachEnv(){
+MachEnv::MachEnv() {
 
    // Set the communicator to the MPI equivalent of a null ptr
    Comm = MPI_COMM_NULL;
@@ -51,14 +51,14 @@ MachEnv::MachEnv(){
 // Add a MachEnv to list of instances
 //
 void MachEnv::addEnv(const std::string Name, // [in] name of environment
-                     MachEnv* NewEnv         // [in] environment to add
-                     ){
+                     MachEnv *NewEnv         // [in] environment to add
+) {
 
    // Check to see if an environment of the same name already exists and
    // if so, exit with an error
-   if (AllEnvs.find(Name) != AllEnvs.end()){
-      std::cerr << "Attempted to create a MachEnv with name " << Name <<
-                   " but an Env of that name already exists ";
+   if (AllEnvs.find(Name) != AllEnvs.end()) {
+      std::cerr << "Attempted to create a MachEnv with name " << Name
+                << " but an Env of that name already exists ";
       return;
    }
 
@@ -71,7 +71,7 @@ void MachEnv::addEnv(const std::string Name, // [in] name of environment
 // Initializes the Machine Environment by creating the DefaultEnv for Omega
 
 void MachEnv::init(const MPI_Comm InComm // [in] communicator to use
-                  ){
+) {
 
    // Create the Env structure and make it persistent (static)
    static MachEnv DefEnv;
@@ -89,7 +89,7 @@ void MachEnv::init(const MPI_Comm InComm // [in] communicator to use
    DefEnv.MasterTask = 0;
 
    // determine if this task is the master task
-   if (DefEnv.MyTask == DefEnv.MasterTask){
+   if (DefEnv.MyTask == DefEnv.MasterTask) {
       DefEnv.MasterTaskFlag = true;
    } else {
       DefEnv.MasterTaskFlag = false;
@@ -119,9 +119,9 @@ void MachEnv::init(const MPI_Comm InComm // [in] communicator to use
 // existing environment starting from same root task.
 
 void MachEnv::createEnv(const std::string Name, // [in] name of environment
-                        const MachEnv* InEnv,   // [in] parent MachEnv
+                        const MachEnv *InEnv,   // [in] parent MachEnv
                         const int NewSize       // [in] num tasks in new env
-                        ){
+) {
 
    // Create the new Env structure and make it persistent (static)
    static MachEnv NewEnv;
@@ -132,10 +132,10 @@ void MachEnv::createEnv(const std::string Name, // [in] name of environment
    // Error checks on new size
    int OldSize;
    MPI_Comm_size(InComm, &OldSize);
-   if (NewSize > OldSize){
-      std::cerr << "Invalid NewSize in MachEnv constructor " <<
-                   "NewSize = " << NewSize << 
-                   " is larger than old size" << OldSize << std::endl;
+   if (NewSize > OldSize) {
+      std::cerr << "Invalid NewSize in MachEnv constructor "
+                << "NewSize = " << NewSize << " is larger than old size"
+                << OldSize << std::endl;
       return;
    }
 
@@ -144,8 +144,8 @@ void MachEnv::createEnv(const std::string Name, // [in] name of environment
    MPI_Comm_group(InComm, &InGroup);
 
    // Define the range of tasks in new group (0, NewSize-1)
-   int NRanges = 1;
-   int LastTask = NewSize - 1;
+   int NRanges     = 1;
+   int LastTask    = NewSize - 1;
    int Range[1][3] = {0, LastTask, 1};
 
    // Create a new group with the new range
@@ -156,7 +156,7 @@ void MachEnv::createEnv(const std::string Name, // [in] name of environment
    MPI_Comm_create(InComm, NewGroup, &NewEnv.Comm);
 
    // determine whether this task is a part of the new communicator
-   if (NewEnv.Comm != MPI_COMM_NULL){
+   if (NewEnv.Comm != MPI_COMM_NULL) {
 
       NewEnv.MemberFlag = true;
       // get task ID for local MPI task
@@ -175,7 +175,7 @@ void MachEnv::createEnv(const std::string Name, // [in] name of environment
    NewEnv.MasterTask = 0;
 
    // determine if this task is the master task
-   if (NewEnv.MyTask == NewEnv.MasterTask){
+   if (NewEnv.MyTask == NewEnv.MasterTask) {
       NewEnv.MasterTaskFlag = true;
    } else {
       NewEnv.MasterTaskFlag = false;
@@ -198,11 +198,11 @@ void MachEnv::createEnv(const std::string Name, // [in] name of environment
 // existing environment
 
 void MachEnv::createEnv(const std::string Name, // [in] name of environment
-                        const MachEnv* InEnv,   // [in] parent MachEnv
+                        const MachEnv *InEnv,   // [in] parent MachEnv
                         const int NewSize,      // [in] num tasks in new env
                         const int Begin,        // [in] starting parent task
                         const int Stride        // [in] stride for tasks to incl
-                        ){
+) {
 
    // Create the new Env structure and make it persistent (static)
    static MachEnv NewEnv;
@@ -214,17 +214,17 @@ void MachEnv::createEnv(const std::string Name, // [in] name of environment
 
    // Define the range of tasks in new group based on the input
    // start task and stride
-   int NRanges = 1;
-   int LastTask = Begin + (NewSize-1)*Stride;
+   int NRanges     = 1;
+   int LastTask    = Begin + (NewSize - 1) * Stride;
    int Range[1][3] = {Begin, LastTask, Stride};
 
    // Error checks for valid range
    int OldSize;
    MPI_Comm_size(InComm, &OldSize);
-   if (LastTask >= OldSize){
-      std::cerr << "Invalid range in strided MachEnv constructor " <<
-                   "LastTask = " << LastTask << 
-                   " is larger than old size" << OldSize << std::endl;
+   if (LastTask >= OldSize) {
+      std::cerr << "Invalid range in strided MachEnv constructor "
+                << "LastTask = " << LastTask << " is larger than old size"
+                << OldSize << std::endl;
       return;
    }
 
@@ -237,7 +237,7 @@ void MachEnv::createEnv(const std::string Name, // [in] name of environment
 
    // determine whether this task is a part of the new communicator
    // and set quantities accordingly
-   if (NewEnv.Comm != MPI_COMM_NULL){ // this task is part of the group
+   if (NewEnv.Comm != MPI_COMM_NULL) { // this task is part of the group
 
       NewEnv.MemberFlag = true;
       // get task ID for local MPI task
@@ -255,7 +255,7 @@ void MachEnv::createEnv(const std::string Name, // [in] name of environment
    NewEnv.MasterTask = 0;
 
    // determine if this task is the master task
-   if (NewEnv.MyTask == NewEnv.MasterTask){
+   if (NewEnv.MyTask == NewEnv.MasterTask) {
       NewEnv.MasterTaskFlag = true;
    } else {
       NewEnv.MasterTaskFlag = false;
@@ -277,12 +277,11 @@ void MachEnv::createEnv(const std::string Name, // [in] name of environment
 // Create a new environment from a custom subset of an
 // existing environment, supplying list of parent tasks to include
 
-void MachEnv::createEnv(
-                 const std::string Name, // [in] name of environment
-                 const MachEnv* InEnv,   // [in] parent MPI communicator
-                 const int NewSize,      // [in] num tasks in new env
-                 const int Tasks[]       // [in] vector of parent tasks to incl
-                 ){
+void MachEnv::createEnv(const std::string Name, // [in] name of environment
+                        const MachEnv *InEnv,   // [in] parent MPI communicator
+                        const int NewSize,      // [in] num tasks in new env
+                        const int Tasks[] // [in] vector of parent tasks to incl
+) {
 
    // Create the new Env structure and make it persistent (static)
    static MachEnv NewEnv;
@@ -292,14 +291,13 @@ void MachEnv::createEnv(
    int OldSize;
    int ThisTask;
    MPI_Comm_size(InComm, &OldSize);
-   for (int i=0; i < NewSize; ++i){
+   for (int i = 0; i < NewSize; ++i) {
       ThisTask = Tasks[i];
-      if (ThisTask < 0 || ThisTask >= OldSize){
-         std::cerr << "Invalid task in MachEnv constructor " <<
-                      "task = " << ThisTask << 
-                      " is < 0 or larger than old size" << OldSize
-                      << std::endl;
-      return;
+      if (ThisTask < 0 || ThisTask >= OldSize) {
+         std::cerr << "Invalid task in MachEnv constructor "
+                   << "task = " << ThisTask << " is < 0 or larger than old size"
+                   << OldSize << std::endl;
+         return;
       }
    }
 
@@ -316,7 +314,7 @@ void MachEnv::createEnv(
 
    // determine whether this task is a part of the new communicator
    // and set values accordingly
-   if (NewEnv.Comm != MPI_COMM_NULL){ // member of new group
+   if (NewEnv.Comm != MPI_COMM_NULL) { // member of new group
 
       NewEnv.MemberFlag = true;
       // get task ID for local MPI task
@@ -334,7 +332,7 @@ void MachEnv::createEnv(
    NewEnv.MasterTask = 0;
 
    // determine if this task is the master task
-   if (NewEnv.MyTask == NewEnv.MasterTask){
+   if (NewEnv.MyTask == NewEnv.MasterTask) {
       NewEnv.MasterTaskFlag = true;
    } else {
       NewEnv.MasterTaskFlag = false;
@@ -350,15 +348,14 @@ void MachEnv::createEnv(
    // Add to list of environments
    OMEGA::MachEnv::addEnv(Name, &NewEnv);
 
-
 } // end constructor with selected tasks
 
 // Remove/delete functions
 //------------------------------------------------------------------------------
 // Remove environment
 
-void MachEnv::removeEnv (const std::string name // [in] name of env to remove
-      ){
+void MachEnv::removeEnv(const std::string name // [in] name of env to remove
+) {
 
    AllEnvs.erase(name);
 
@@ -367,27 +364,26 @@ void MachEnv::removeEnv (const std::string name // [in] name of env to remove
 // Retrieval functions
 //------------------------------------------------------------------------------
 // Get default environment
-MachEnv* MachEnv::getDefaultEnv() { return MachEnv::DefaultEnv; }
+MachEnv *MachEnv::getDefaultEnv() { return MachEnv::DefaultEnv; }
 
 //------------------------------------------------------------------------------
 // Get environment by name
-MachEnv* MachEnv::getEnv(
-                const std::string name ///< [in] name of environment
-                ){
+MachEnv *MachEnv::getEnv(const std::string name ///< [in] name of environment
+) {
 
-    // look for an instance of this name
-    auto it = AllEnvs.find(name);
+   // look for an instance of this name
+   auto it = AllEnvs.find(name);
 
-    // if found, return the environment pointer
-    if (it != AllEnvs.end()){
-       return it->second;
+   // if found, return the environment pointer
+   if (it != AllEnvs.end()) {
+      return it->second;
 
-    // otherwise print an error and return a null pointer
-    } else {
-       std::cerr << "Attempt to retrieve a non-existent MachEnv " <<
-                    name << " has not been defined or has been removed";
-       return nullptr;
-    }
+      // otherwise print an error and return a null pointer
+   } else {
+      std::cerr << "Attempt to retrieve a non-existent MachEnv " << name
+                << " has not been defined or has been removed";
+      return nullptr;
+   }
 
 } // end getEnv
 
@@ -420,20 +416,20 @@ bool MachEnv::isMember() const { return MemberFlag; }
 //------------------------------------------------------------------------------
 // Set task ID for the master task (if not 0)
 
-int MachEnv::setMasterTask(const int TaskID){
+int MachEnv::setMasterTask(const int TaskID) {
 
-   int Err=0;
+   int Err = 0;
 
-   if (TaskID >= 0 && TaskID < NumTasks){
+   if (TaskID >= 0 && TaskID < NumTasks) {
       MasterTask = TaskID;
-      if (MyTask == MasterTask){
+      if (MyTask == MasterTask) {
          MasterTaskFlag = true;
       } else {
          MasterTaskFlag = false;
       }
    } else {
-      std::cerr << "Error: invalid TaskID sent to MachEnv.setMasterTask" <<
-                   std::endl;
+      std::cerr << "Error: invalid TaskID sent to MachEnv.setMasterTask"
+                << std::endl;
       Err = -1;
    }
    return Err;

--- a/components/omega/src/base/MachEnv.cpp
+++ b/components/omega/src/base/MachEnv.cpp
@@ -74,7 +74,7 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
 #endif
 
    // Add this environment to the list of environments
-   AllEnvs.emplace(Name,*this);
+   AllEnvs.emplace(Name, *this);
 
 } // end constructor with MPI communicator
 
@@ -151,8 +151,7 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
          MasterTaskFlag = false;
       }
 
-
-   // otherwise initialize all values to bogus values
+      // otherwise initialize all values to bogus values
    } else {
 
       MemberFlag     = false;
@@ -160,7 +159,6 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
       NumTasks       = -999;
       MasterTask     = -999;
       MasterTaskFlag = false;
-
    }
 
 #ifdef OMEGA_THREADED
@@ -249,8 +247,7 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
          MasterTaskFlag = false;
       }
 
-
-   // otherwise, set all members to bogus values
+      // otherwise, set all members to bogus values
    } else {
 
       MemberFlag     = false;
@@ -258,7 +255,6 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
       NumTasks       = -999;
       MasterTask     = -999;
       MasterTaskFlag = false;
-
    }
 
 #ifdef OMEGA_THREADED
@@ -344,7 +340,7 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
          MasterTaskFlag = false;
       }
 
-   // otherwise, set all members to bogus values
+      // otherwise, set all members to bogus values
    } else {
 
       MemberFlag     = false;
@@ -352,7 +348,6 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
       NumTasks       = -999;
       MasterTask     = -999;
       MasterTaskFlag = false;
-
    }
 
 #ifdef OMEGA_THREADED
@@ -452,7 +447,8 @@ int MachEnv::setMasterTask(const int TaskID) {
    int Err = 0;
 
    // If called from outside the group, don't do anything
-   if (!MemberFlag) return Err;
+   if (!MemberFlag)
+      return Err;
 
    // Check for valid input and reset the master if valid
    if (TaskID >= 0 && TaskID < NumTasks) {
@@ -474,16 +470,16 @@ int MachEnv::setMasterTask(const int TaskID) {
 //------------------------------------------------------------------------------
 // Print all members of a MachEnv
 
-void MachEnv::print() const { 
+void MachEnv::print() const {
 
-   std::cout << "  Comm           = " << Comm           << std::endl;
-   std::cout << "  MyTask         = " << MyTask         << std::endl;
-   std::cout << "  NumTasks       = " << NumTasks       << std::endl;
-   std::cout << "  MasterTask     = " << MasterTask     << std::endl;
+   std::cout << "  Comm           = " << Comm << std::endl;
+   std::cout << "  MyTask         = " << MyTask << std::endl;
+   std::cout << "  NumTasks       = " << NumTasks << std::endl;
+   std::cout << "  MasterTask     = " << MasterTask << std::endl;
    std::cout << "  MasterTaskFlag = " << MasterTaskFlag << std::endl;
-   std::cout << "  MemberFlag     = " << MemberFlag     << std::endl;
-   std::cout << "  NumThreads     = " << NumThreads     << std::endl;
-   std::cout << "  VecLength      = " << VecLength      << std::endl;
+   std::cout << "  MemberFlag     = " << MemberFlag << std::endl;
+   std::cout << "  NumThreads     = " << NumThreads << std::endl;
+   std::cout << "  VecLength      = " << VecLength << std::endl;
 
 } // end print
 

--- a/components/omega/src/base/MachEnv.cpp
+++ b/components/omega/src/base/MachEnv.cpp
@@ -1,0 +1,445 @@
+//===-- base/MachEnv.cpp - machine environment methods ----------*- C++ -*-===//
+//
+// The machine environment defines a number of parameters associated with
+// the message-passing and threading environments. It also can describe
+// the node-level hardware environment, including any useful accelerator
+// or processor-level constants. Multiple machine environments can be defined,
+// mostly associated with subsets of the processor decomposition, but
+// a default machine env must be created very early in model
+// initialization. All environments can be retrieved by name, though a
+// specific retrieval for the most common default environment is provided
+// for efficiency.
+//
+//===----------------------------------------------------------------------===//
+
+#include "MachEnv.h"
+#include "mpi.h"
+
+#include <string>
+#include <map>
+// Note that we should replace iostream and std::cerr with the logging
+// capability once that is enabled.
+#include <iostream>
+
+namespace OMEGA {
+
+// create the static class members
+MachEnv* MachEnv::DefaultEnv = nullptr;
+std::map<std::string, MachEnv*> MachEnv::AllEnvs;
+
+// Constructors
+//------------------------------------------------------------------------------
+// Default constructor that fills a MachEnv with mostly invalid values.
+// Environments are instead created using the relevant create function.
+
+MachEnv::MachEnv(){
+
+   // Set the communicator to the MPI equivalent of a null ptr
+   Comm = MPI_COMM_NULL;
+
+   // Set all other values to invalid numbers
+   MyTask         = -999;
+   NumTasks       = -999;
+   MasterTask     = -999;
+   MasterTaskFlag = false;
+   MemberFlag     = true;
+   NumThreads     = -999;
+
+} // end default constructor
+
+//------------------------------------------------------------------------------
+// Add a MachEnv to list of instances
+//
+void MachEnv::addEnv(const std::string Name, // [in] name of environment
+                     MachEnv* NewEnv         // [in] environment to add
+                     ){
+
+   // Check to see if an environment of the same name already exists and
+   // if so, exit with an error
+   if (AllEnvs.find(Name) != AllEnvs.end()){
+      std::cerr << "Attempted to create a MachEnv with name " << Name <<
+                   " but an Env of that name already exists ";
+      return;
+   }
+
+   // Add to list of environments
+   AllEnvs[Name] = NewEnv;
+
+} // end addEnv
+
+//------------------------------------------------------------------------------
+// Initializes the Machine Environment by creating the DefaultEnv for Omega
+
+void MachEnv::init(const MPI_Comm InComm // [in] communicator to use
+                  ){
+
+   // Create the Env structure and make it persistent (static)
+   static MachEnv DefEnv;
+
+   // Set the communicator to the input communicator by duplicating it
+   MPI_Comm_dup(InComm, &(DefEnv.Comm));
+
+   // get task ID and set local MPI task
+   MPI_Comm_rank(DefEnv.Comm, &(DefEnv.MyTask));
+
+   // get total number of MPI tasks
+   MPI_Comm_size(DefEnv.Comm, &(DefEnv.NumTasks));
+
+   // Set task 0 as master
+   DefEnv.MasterTask = 0;
+
+   // determine if this task is the master task
+   if (DefEnv.MyTask == DefEnv.MasterTask){
+      DefEnv.MasterTaskFlag = true;
+   } else {
+      DefEnv.MasterTaskFlag = false;
+   }
+
+   // All tasks are members of this communicator's group
+   DefEnv.MemberFlag = true;
+
+#ifdef OMEGA_THREADED
+   // total number of OpenMP threads
+   DefEnv.NumThreads = omp_get_num_threads();
+#else
+   DefEnv.NumThreads = 1;
+#endif
+
+   // Add to list of environments
+   OMEGA::MachEnv::addEnv("Default", &DefEnv);
+
+   // Retrieve this environment and set pointer to DefaultEnv
+   MachEnv::DefaultEnv = getEnv("Default");
+
+} // end init Mach Env
+
+// Create functions
+//------------------------------------------------------------------------------
+// Create a new environment from a contiguous subset of an
+// existing environment starting from same root task.
+
+void MachEnv::createEnv(const std::string Name, // [in] name of environment
+                        const MachEnv* InEnv,   // [in] parent MachEnv
+                        const int NewSize       // [in] num tasks in new env
+                        ){
+
+   // Create the new Env structure and make it persistent (static)
+   static MachEnv NewEnv;
+
+   // Get communicator from old environment
+   MPI_Comm InComm = InEnv->getComm();
+
+   // Error checks on new size
+   int OldSize;
+   MPI_Comm_size(InComm, &OldSize);
+   if (NewSize > OldSize){
+      std::cerr << "Invalid NewSize in MachEnv constructor " <<
+                   "NewSize = " << NewSize << 
+                   " is larger than old size" << OldSize << std::endl;
+      return;
+   }
+
+   // First retrieve the group associated with the old environment
+   MPI_Group InGroup;
+   MPI_Comm_group(InComm, &InGroup);
+
+   // Define the range of tasks in new group (0, NewSize-1)
+   int NRanges = 1;
+   int LastTask = NewSize - 1;
+   int Range[1][3] = {0, LastTask, 1};
+
+   // Create a new group with the new range
+   MPI_Group NewGroup;
+   MPI_Group_range_incl(InGroup, NRanges, Range, &NewGroup);
+
+   // Create the communicator for the new group
+   MPI_Comm_create(InComm, NewGroup, &NewEnv.Comm);
+
+   // determine whether this task is a part of the new communicator
+   if (NewEnv.Comm != MPI_COMM_NULL){
+
+      NewEnv.MemberFlag = true;
+      // get task ID for local MPI task
+      MPI_Comm_rank(NewEnv.Comm, &NewEnv.MyTask);
+      // get total number of MPI tasks
+      MPI_Comm_size(NewEnv.Comm, &NewEnv.NumTasks);
+
+   } else {
+
+      NewEnv.MemberFlag = false;
+      NewEnv.MyTask     = -999;
+      NewEnv.NumTasks   = -999;
+   }
+
+   // Set task 0 as master
+   NewEnv.MasterTask = 0;
+
+   // determine if this task is the master task
+   if (NewEnv.MyTask == NewEnv.MasterTask){
+      NewEnv.MasterTaskFlag = true;
+   } else {
+      NewEnv.MasterTaskFlag = false;
+   }
+
+#ifdef OMEGA_THREADED
+   // total number of OpenMP threads
+   NewEnv.NumThreads = omp_get_num_threads();
+#else
+   NewEnv.NumThreads = 1;
+#endif
+
+   // Add to list of environments
+   OMEGA::MachEnv::addEnv(Name, &NewEnv);
+
+} // end create with contiguous range
+
+//------------------------------------------------------------------------------
+// Create a new environment from a strided subset of an
+// existing environment
+
+void MachEnv::createEnv(const std::string Name, // [in] name of environment
+                        const MachEnv* InEnv,   // [in] parent MachEnv
+                        const int NewSize,      // [in] num tasks in new env
+                        const int Begin,        // [in] starting parent task
+                        const int Stride        // [in] stride for tasks to incl
+                        ){
+
+   // Create the new Env structure and make it persistent (static)
+   static MachEnv NewEnv;
+
+   // First retrieve the group associated with the parent environment
+   MPI_Comm InComm = InEnv->getComm();
+   MPI_Group InGroup;
+   MPI_Comm_group(InComm, &InGroup);
+
+   // Define the range of tasks in new group based on the input
+   // start task and stride
+   int NRanges = 1;
+   int LastTask = Begin + (NewSize-1)*Stride;
+   int Range[1][3] = {Begin, LastTask, Stride};
+
+   // Error checks for valid range
+   int OldSize;
+   MPI_Comm_size(InComm, &OldSize);
+   if (LastTask >= OldSize){
+      std::cerr << "Invalid range in strided MachEnv constructor " <<
+                   "LastTask = " << LastTask << 
+                   " is larger than old size" << OldSize << std::endl;
+      return;
+   }
+
+   // Create a new group with the new range
+   MPI_Group NewGroup;
+   MPI_Group_range_incl(InGroup, NRanges, Range, &NewGroup);
+
+   // Create the communicator for the new group
+   MPI_Comm_create(InComm, NewGroup, &(NewEnv.Comm));
+
+   // determine whether this task is a part of the new communicator
+   // and set quantities accordingly
+   if (NewEnv.Comm != MPI_COMM_NULL){ // this task is part of the group
+
+      NewEnv.MemberFlag = true;
+      // get task ID for local MPI task
+      MPI_Comm_rank(NewEnv.Comm, &(NewEnv.MyTask));
+      // get total number of MPI tasks
+      MPI_Comm_size(NewEnv.Comm, &(NewEnv.NumTasks));
+
+   } else {
+      NewEnv.MemberFlag = false;
+      NewEnv.MyTask     = -999;
+      NewEnv.NumTasks   = -999;
+   }
+
+   // Set task 0 as master
+   NewEnv.MasterTask = 0;
+
+   // determine if this task is the master task
+   if (NewEnv.MyTask == NewEnv.MasterTask){
+      NewEnv.MasterTaskFlag = true;
+   } else {
+      NewEnv.MasterTaskFlag = false;
+   }
+
+#ifdef OMEGA_THREADED
+   // total number of OpenMP threads
+   NewEnv.NumThreads = omp_get_num_threads();
+#else
+   NewEnv.NumThreads = 1;
+#endif
+
+   // Add to list of environments
+   OMEGA::MachEnv::addEnv(Name, &NewEnv);
+
+} // end constructor using strided range
+
+//------------------------------------------------------------------------------
+// Create a new environment from a custom subset of an
+// existing environment, supplying list of parent tasks to include
+
+void MachEnv::createEnv(
+                 const std::string Name, // [in] name of environment
+                 const MachEnv* InEnv,   // [in] parent MPI communicator
+                 const int NewSize,      // [in] num tasks in new env
+                 const int Tasks[]       // [in] vector of parent tasks to incl
+                 ){
+
+   // Create the new Env structure and make it persistent (static)
+   static MachEnv NewEnv;
+
+   // Error checks on valid tasks
+   MPI_Comm InComm = InEnv->getComm();
+   int OldSize;
+   int ThisTask;
+   MPI_Comm_size(InComm, &OldSize);
+   for (int i=0; i < NewSize; ++i){
+      ThisTask = Tasks[i];
+      if (ThisTask < 0 || ThisTask >= OldSize){
+         std::cerr << "Invalid task in MachEnv constructor " <<
+                      "task = " << ThisTask << 
+                      " is < 0 or larger than old size" << OldSize
+                      << std::endl;
+      return;
+      }
+   }
+
+   // First retrieve the group associated with the input communicator
+   MPI_Group InGroup;
+   MPI_Comm_group(InComm, &InGroup);
+
+   // Create a new group with the selected tasks
+   MPI_Group NewGroup;
+   MPI_Group_incl(InGroup, NewSize, Tasks, &NewGroup);
+
+   // Create the communicator for the new group
+   MPI_Comm_create(InComm, NewGroup, &(NewEnv.Comm));
+
+   // determine whether this task is a part of the new communicator
+   // and set values accordingly
+   if (NewEnv.Comm != MPI_COMM_NULL){ // member of new group
+
+      NewEnv.MemberFlag = true;
+      // get task ID for local MPI task
+      MPI_Comm_rank(NewEnv.Comm, &(NewEnv.MyTask));
+      // get total number of MPI tasks
+      MPI_Comm_size(NewEnv.Comm, &(NewEnv.NumTasks));
+
+   } else {
+      NewEnv.MemberFlag = false;
+      NewEnv.MyTask     = -999;
+      NewEnv.NumTasks   = -999;
+   }
+
+   // Set task 0 as master
+   NewEnv.MasterTask = 0;
+
+   // determine if this task is the master task
+   if (NewEnv.MyTask == NewEnv.MasterTask){
+      NewEnv.MasterTaskFlag = true;
+   } else {
+      NewEnv.MasterTaskFlag = false;
+   }
+
+#ifdef OMEGA_THREADED
+   // total number of OpenMP threads
+   NewEnv.NumThreads = omp_get_num_threads();
+#else
+   NewEnv.NumThreads = 1;
+#endif
+
+   // Add to list of environments
+   OMEGA::MachEnv::addEnv(Name, &NewEnv);
+
+
+} // end constructor with selected tasks
+
+// Remove/delete functions
+//------------------------------------------------------------------------------
+// Remove environment
+
+void MachEnv::removeEnv (const std::string name // [in] name of env to remove
+      ){
+
+   AllEnvs.erase(name);
+
+} // end removeEnv
+
+// Retrieval functions
+//------------------------------------------------------------------------------
+// Get default environment
+MachEnv* MachEnv::getDefaultEnv() { return MachEnv::DefaultEnv; }
+
+//------------------------------------------------------------------------------
+// Get environment by name
+MachEnv* MachEnv::getEnv(
+                const std::string name ///< [in] name of environment
+                ){
+
+    // look for an instance of this name
+    auto it = AllEnvs.find(name);
+
+    // if found, return the environment pointer
+    if (it != AllEnvs.end()){
+       return it->second;
+
+    // otherwise print an error and return a null pointer
+    } else {
+       std::cerr << "Attempt to retrieve a non-existent MachEnv " <<
+                    name << " has not been defined or has been removed";
+       return nullptr;
+    }
+
+} // end getEnv
+
+//------------------------------------------------------------------------------
+// Get communicator for an environment
+MPI_Comm MachEnv::getComm() const { return Comm; }
+
+//------------------------------------------------------------------------------
+// Get local task/rank ID
+int MachEnv::getMyTask() const { return MyTask; }
+
+//------------------------------------------------------------------------------
+// Get total number of MPI tasks/ranks
+int MachEnv::getNumTasks() const { return NumTasks; }
+
+//------------------------------------------------------------------------------
+// Get task ID for the master task (typically 0)
+int MachEnv::getMasterTask() const { return MasterTask; }
+
+//------------------------------------------------------------------------------
+// Determine whether local task is the master
+
+bool MachEnv::isMasterTask() const { return MasterTaskFlag; }
+
+//------------------------------------------------------------------------------
+// Determine whether local task is in this communicator's group
+
+bool MachEnv::isMember() const { return MemberFlag; }
+
+//------------------------------------------------------------------------------
+// Set task ID for the master task (if not 0)
+
+int MachEnv::setMasterTask(const int TaskID){
+
+   int Err=0;
+
+   if (TaskID >= 0 && TaskID < NumTasks){
+      MasterTask = TaskID;
+      if (MyTask == MasterTask){
+         MasterTaskFlag = true;
+      } else {
+         MasterTaskFlag = false;
+      }
+   } else {
+      std::cerr << "Error: invalid TaskID sent to MachEnv.setMasterTask" <<
+                   std::endl;
+      Err = -1;
+   }
+   return Err;
+
+} // end setMasterTask
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//

--- a/components/omega/src/base/MachEnv.cpp
+++ b/components/omega/src/base/MachEnv.cpp
@@ -131,7 +131,12 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
    MPI_Group_range_incl(InGroup, NRanges, Range, &NewGroup);
 
    // Create the communicator for the new group
-   MPI_Comm_create(InComm, NewGroup, &Comm);
+   int Err = MPI_Comm_create(InComm, NewGroup, &Comm);
+   if (Err != MPI_SUCCESS) {
+      std::cerr << "Error creating new communicator in MachEnv constructor"
+                << std::endl;
+      return;
+   }
 
    // if this task is part of the new group/communicator,
    // initialize all values
@@ -227,7 +232,12 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
    MPI_Group_range_incl(InGroup, NRanges, Range, &NewGroup);
 
    // Create the communicator for the new group
-   MPI_Comm_create(InComm, NewGroup, &Comm);
+   int Err = MPI_Comm_create(InComm, NewGroup, &Comm);
+   if (Err != MPI_SUCCESS) {
+      std::cerr << "Error creating new communicator in MachEnv constructor"
+                << std::endl;
+      return;
+   }
 
    // if this task is part of the new group/communicator
    // initialize all members
@@ -320,7 +330,12 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
    MPI_Group_incl(InGroup, NewSize, Tasks, &NewGroup);
 
    // Create the communicator for the new group
-   MPI_Comm_create(InComm, NewGroup, &Comm);
+   int Err = MPI_Comm_create(InComm, NewGroup, &Comm);
+   if (Err != MPI_SUCCESS) {
+      std::cerr << "Error creating new communicator in MachEnv constructor"
+                << std::endl;
+      return;
+   }
 
    // If this task is part of the new group/communicator
    // initialize all class members

--- a/components/omega/src/base/MachEnv.h
+++ b/components/omega/src/base/MachEnv.h
@@ -59,21 +59,15 @@ class MachEnv {
    /// we store the extra pointer here for easier retrieval.
    static MachEnv *DefaultEnv;
 
-   /// All environments are tracked/stored within the class and
-   /// paired with a name in this map for later retrieval.
-   static std::map<std::string, MachEnv *> AllEnvs;
+   /// All environments are tracked/stored within the class as a
+   /// map paired with a name for later retrieval.
+   static std::map<std::string, MachEnv> AllEnvs;
 
-   /// Default constructor. This constructor fills a MachEnv with
-   /// mostly invalid values. Most environments are actually defined
-   /// using either the Init routine (for the default environment) or
-   /// the createEnv routine for all other environments
-   MachEnv();
-
-   /// Adds a created MachEnv to list of all instances. It also
-   /// performs some error checking to prevent duplicate names or
-   /// environments.
-   static void addEnv(const std::string Name, ///< [in] name of environment
-                      MachEnv *newEnv         ///< [in] new environment to add
+   /// Constructor for environment based on input MPI communicator
+   /// This should only be used for the default environment so is
+   /// kept private and called from the init routine.
+   MachEnv(const std::string Name, ///< [in] name of the environment
+           const MPI_Comm inComm   ///< [in] MPI communicator to use
    );
 
  public:
@@ -87,31 +81,36 @@ class MachEnv {
    static void init(const MPI_Comm InComm ///< [in] MPI communicator to use
    );
 
-   /// Creates a new environment with a given name from a contiguous
+   /// Constructs a new environment with a given name from a contiguous
    /// subset of tasks in an existing environment starting at task 0
-   /// of the parent environment.
-   static void createEnv(const std::string Name, ///< [in] name of environment
-                         const MachEnv *InEnv, ///< [in] existing parent MachEnv
-                         const int NewSize     ///< [in] use first newSize tasks
+   /// of the parent environment. The master task can optionally be
+   /// set but will default to zero if not provided.
+   MachEnv(const std::string Name,   ///< [in] name of environment
+           const MachEnv *InEnv,     ///< [in] existing parent MachEnv
+           const int NewSize,        ///< [in] use first newSize tasks
+           const int InMasterTask=0  ///< [in] optional task to use for master
    );
 
-   /// Creates a new environment with a given name from a strided
-   /// subset of of tasks in an existing environment.
-   static void createEnv(const std::string Name, ///< [in] name of env
-                         const MachEnv *InEnv, ///< [in] existing parent MachEnv
-                         const int NewSize,    ///< [in] num tasks in new env
-                         const int Begin,      ///< [in] starting parent task
-                         const int Stride ///< [in] stride for tasks to incl
+   /// Constructs a new environment with a given name from a strided
+   /// subset of of tasks in an existing environment. The master task
+   /// can optionally be set but will default to zero if not provided.
+   MachEnv(const std::string Name,   ///< [in] name of env
+           const MachEnv *InEnv,     ///< [in] existing parent MachEnv
+           const int NewSize,        ///< [in] num tasks in new env
+           const int Begin,          ///< [in] starting parent task
+           const int Stride,         ///< [in] stride for tasks to incl
+           const int InMasterTask=0  ///< [in] optional task to use for master
    );
 
-   /// Creates a new environment with a given name from a custom subset
+   /// Constructs a new environment with a given name from a custom subset
    /// of tasks in an existing environment. The tasks are defined by a
-   /// list of parent tasks to include.
-   static void
-   createEnv(const std::string Name, ///< [in] name of environment
-             const MachEnv *InEnv,   ///< [in] existing parent MachEnv
-             const int NewSize,      ///< [in] num tasks in new env
-             const int Tasks[]       ///< [in] vector of parent tasks to incl
+   /// list of parent tasks to include. The master task can optionally be
+   /// set but will default to zero if not provided.
+   MachEnv(const std::string Name,  ///< [in] name of environment
+           const MachEnv *InEnv,    ///< [in] existing parent MachEnv
+           const int NewSize,       ///< [in] num tasks in new env
+           const int Tasks[],       ///< [in] vector of parent tasks to incl
+           const int InMasterTask=0 ///< [in] optional task to use for master
    );
 
    /// Removes a MachEnv
@@ -157,6 +156,9 @@ class MachEnv {
    /// all components are using the same master).
    int setMasterTask(const int TaskID ///< [in] new task to use as master
    );
+
+   /// Prints all members of a MachEnv (typically for debugging)
+   void print() const;
 
 }; // end class MachEnv
 

--- a/components/omega/src/base/MachEnv.h
+++ b/components/omega/src/base/MachEnv.h
@@ -85,32 +85,32 @@ class MachEnv {
    /// subset of tasks in an existing environment starting at task 0
    /// of the parent environment. The master task can optionally be
    /// set but will default to zero if not provided.
-   MachEnv(const std::string Name,   ///< [in] name of environment
-           const MachEnv *InEnv,     ///< [in] existing parent MachEnv
-           const int NewSize,        ///< [in] use first newSize tasks
-           const int InMasterTask=0  ///< [in] optional task to use for master
+   MachEnv(const std::string Name,    ///< [in] name of environment
+           const MachEnv *InEnv,      ///< [in] existing parent MachEnv
+           const int NewSize,         ///< [in] use first newSize tasks
+           const int InMasterTask = 0 ///< [in] optional task to use for master
    );
 
    /// Constructs a new environment with a given name from a strided
    /// subset of of tasks in an existing environment. The master task
    /// can optionally be set but will default to zero if not provided.
-   MachEnv(const std::string Name,   ///< [in] name of env
-           const MachEnv *InEnv,     ///< [in] existing parent MachEnv
-           const int NewSize,        ///< [in] num tasks in new env
-           const int Begin,          ///< [in] starting parent task
-           const int Stride,         ///< [in] stride for tasks to incl
-           const int InMasterTask=0  ///< [in] optional task to use for master
+   MachEnv(const std::string Name,    ///< [in] name of env
+           const MachEnv *InEnv,      ///< [in] existing parent MachEnv
+           const int NewSize,         ///< [in] num tasks in new env
+           const int Begin,           ///< [in] starting parent task
+           const int Stride,          ///< [in] stride for tasks to incl
+           const int InMasterTask = 0 ///< [in] optional task to use for master
    );
 
    /// Constructs a new environment with a given name from a custom subset
    /// of tasks in an existing environment. The tasks are defined by a
    /// list of parent tasks to include. The master task can optionally be
    /// set but will default to zero if not provided.
-   MachEnv(const std::string Name,  ///< [in] name of environment
-           const MachEnv *InEnv,    ///< [in] existing parent MachEnv
-           const int NewSize,       ///< [in] num tasks in new env
-           const int Tasks[],       ///< [in] vector of parent tasks to incl
-           const int InMasterTask=0 ///< [in] optional task to use for master
+   MachEnv(const std::string Name,    ///< [in] name of environment
+           const MachEnv *InEnv,      ///< [in] existing parent MachEnv
+           const int NewSize,         ///< [in] num tasks in new env
+           const int Tasks[],         ///< [in] vector of parent tasks to incl
+           const int InMasterTask = 0 ///< [in] optional task to use for master
    );
 
    /// Removes a MachEnv

--- a/components/omega/src/base/MachEnv.h
+++ b/components/omega/src/base/MachEnv.h
@@ -1,0 +1,172 @@
+#ifndef OMEGA_MACH_ENV_H
+#define OMEGA_MACH_ENV_H
+//===-- base/MachEnv.h - machine environment definitions --------*- C++ -*-===//
+//
+/// \file
+/// \brief Defines aspects of the parallel and node machine environment
+///
+/// The machine environment defines a number of parameters associated with
+/// the message-passing and threading environments. It also can describe
+/// the node-level hardware environment, including any useful accelerator
+/// or processor-level constants. Multiple machine environments can be defined,
+/// mostly associated with subsets of the processor decomposition, but
+/// a default machine env must be created very early in model
+/// initialization. All environments can be retrieved by name, though a
+/// specific retrieval for the most common default environment is provided
+/// for efficiency.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mpi.h"
+
+#include <string>
+#include <map>
+
+namespace OMEGA {
+
+// For CPUs, a compile-time vector length is useful for
+// blocking the inner loops. This should be set to an appropriate
+// length (typically 32, 64, 128) for CPU-only builds, but set to one for
+// GPU builds to maximize parallelism instead.
+#ifdef OMEGA_VECTOR_LENGTH
+constexpr int VecLength = OMEGA_VECTOR_LENGTH;
+#else
+constexpr int VecLength = 1;
+#endif
+
+/// The MachEnv class is a container that holds information on
+/// the message passing, threading and node environment. 
+class MachEnv {
+
+   private:
+      MPI_Comm Comm;       ///< MPI communicator for this environment
+      int MyTask;          ///< task ID for local MPI task (rank)
+      int NumTasks;        ///< total number of MPI tasks (ranks)
+      int MasterTask;      ///< task ID for master task
+      bool MasterTaskFlag; ///< true if this task is the master task
+      bool MemberFlag;     ///< true if task is in communicator group
+
+      // Add threading variables here
+      int NumThreads;    ///< number of OpenMP threads per task
+
+      // Add any other useful machine parameters here
+      // It may be useful at some point to track the number
+      // of various devices per node (CPUs, GPUs), the number
+      // of tasks allocated per node, etc.
+
+      /// The default environment describes the environment for OMEGA
+      /// defined for most of the model. Because it is used most often,
+      /// we store the extra pointer here for easier retrieval.
+      static MachEnv* DefaultEnv;
+
+      /// All environments are tracked/stored within the class and
+      /// paired with a name in this map for later retrieval.
+      static std::map<std::string, MachEnv*> AllEnvs;
+
+      /// Default constructor. This constructor fills a MachEnv with
+      /// mostly invalid values. Most environments are actually defined
+      /// using either the Init routine (for the default environment) or
+      /// the createEnv routine for all other environments
+      MachEnv();
+
+      /// Adds a created MachEnv to list of all instances. It also
+      /// performs some error checking to prevent duplicate names or
+      /// environments.
+      static void addEnv(
+               const std::string Name, ///< [in] name of environment
+               MachEnv* newEnv         ///< [in] new environment to add
+               );
+
+   public:
+
+      // Methods
+
+      /// Initializes the Machine Environment and creates the default
+      /// machine environment based on an input MPI communicator. In
+      /// standalone mode, this will typically be MPI_COMM_WORLD, but
+      /// in coupled mode, this is the communicator assigned to the
+      /// Omega component.
+      static void init(
+              const MPI_Comm InComm ///< [in] MPI communicator to use
+              );
+
+      /// Creates a new environment with a given name from a contiguous
+      /// subset of tasks in an existing environment starting at task 0
+      /// of the parent environment.
+      static void createEnv(
+              const std::string Name, ///< [in] name of environment
+              const MachEnv* InEnv,   ///< [in] existing parent MachEnv
+              const int NewSize       ///< [in] use first newSize tasks
+              );
+
+      /// Creates a new environment with a given name from a strided
+      /// subset of of tasks in an existing environment.
+      static void createEnv(
+              const std::string Name, ///< [in] name of env
+              const MachEnv* InEnv,   ///< [in] existing parent MachEnv
+              const int NewSize,      ///< [in] num tasks in new env
+              const int Begin,        ///< [in] starting parent task
+              const int Stride        ///< [in] stride for tasks to incl
+              );
+
+      /// Creates a new environment with a given name from a custom subset
+      /// of tasks in an existing environment. The tasks are defined by a
+      /// list of parent tasks to include.
+      static void createEnv(
+              const std::string Name, ///< [in] name of environment
+              const MachEnv* InEnv,   ///< [in] existing parent MachEnv
+              const int NewSize,      ///< [in] num tasks in new env
+              const int Tasks[]       ///< [in] vector of parent tasks to incl
+              );
+
+      /// Removes a MachEnv
+      static void removeEnv(
+              const std::string Name  ///< [in] name of environment to remove
+              );
+
+      // Retrieval functions
+
+      /// Retrieve the default environment
+      static MachEnv* getDefaultEnv();
+
+      /// Retrieve any other environment by name
+      static MachEnv* getEnv(
+                const std::string Name ///< [in] name of environment
+                );
+
+      /// Get communicator for an environment
+      MPI_Comm getComm() const; ///< returns MPI communicator for this env
+
+      /// Get local task/rank ID
+      int getMyTask() const;
+
+      /// Get total number of MPI tasks/ranks
+      int getNumTasks() const;
+
+      /// Get task ID for the master task (typically 0)
+      int getMasterTask() const;
+
+      /// Determine whether local task is the master
+      bool isMasterTask() const;
+
+      /// Determine whether local task is a member of this environment.
+      /// This is primarily to prevent retrievals of non-existent
+      /// values when a given environment uses only a subset of the
+      /// tasks.
+      bool isMember() const;
+
+      // Only one variable can be set
+
+      /// Set master task ID. By default, the master task is task 0 but
+      /// can be set here to a different task if the master task has
+      /// become over-burdened by work or memory (eg in coupled mode when
+      /// all components are using the same master).
+      int setMasterTask(const int TaskID ///< [in] new task to use as master
+                       );
+
+}; // end class MachEnv
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif // defined OMEGA_MACH_ENV_H

--- a/components/omega/test/base/MachEnvTest.cpp
+++ b/components/omega/test/base/MachEnvTest.cpp
@@ -1,0 +1,384 @@
+//===-- Test driver for OMEGA MachEnv ----------------------------*- C++ -*-===/
+//
+/// \file
+/// \brief Test driver for OMEGA MachEnv
+///
+/// This driver tests the OMEGA model MachEnv module that sets up various
+/// machine parameters, including message passing (MPI) variables, threading
+/// and other potential variables related to the underlying machine
+/// architecture. This unit test driver primarily tests that the quantities
+/// and retrieval functions are working correctly.
+///
+//
+//===-----------------------------------------------------------------------===/
+
+#include "MachEnv.h"
+#include "mpi.h"
+
+#include <iostream>
+
+//------------------------------------------------------------------------------
+//
+/// \brief Initialization for OMEGA MachEnv tests
+///
+/// This initialization routine initializes several environments in a setting
+/// other than the test driver to make sure the environments are persistent
+/// across subroutine calls.
+
+void InitMachEnvs() {
+
+   // Initialize three environments in reverse order that they
+   // are tested.  Use default as parent env
+   OMEGA::MachEnv* tmpEnv=OMEGA::MachEnv::getDefaultEnv();
+
+   // Initialize general subset environment
+   int InclSize = 4;
+   int InclTasks[4] = {1, 2, 5, 7};
+   OMEGA::MachEnv::createEnv("Subset", tmpEnv, InclSize, InclTasks); 
+
+   // Initialize strided environment
+   OMEGA::MachEnv::createEnv("Stride", tmpEnv, 4, 1, 2); 
+
+   // Initialize contiguous subset environment
+   OMEGA::MachEnv::createEnv("Contig", tmpEnv, 4); 
+
+} // end of InitMachEnvs
+
+
+//------------------------------------------------------------------------------
+// The test driver for MachEnv. This tests the values stored in the Default
+// Environment and three other based on the three subsetting options.  All
+// current values and get routines are tested.
+//
+int main(int argc, char *argv[]) {
+
+   // initialize environments
+   MPI_Init(&argc, &argv);
+
+   // Create reference values based on MPI_COMM_WORLD
+   int WorldTask;
+   int WorldSize;
+   MPI_Comm_rank(MPI_COMM_WORLD, &WorldTask);
+   MPI_Comm_size(MPI_COMM_WORLD, &WorldSize);
+   int WorldMaster = 0;
+   bool IsWorldMaster;
+   if (WorldTask == WorldMaster){
+      IsWorldMaster = true;
+   } else {
+      IsWorldMaster = false;
+   }
+
+   // The subset environments create 4-task sub-environments so
+   // make sure the unit test is run with at least 8 to adequately
+   // test all subsets.
+   std::cout << "MachEnv unit tests " << std::endl;
+   if (WorldSize < 8) {
+      std::cerr << "Please run unit test with at least 8 tasks" << std::endl;
+      std::cout << "MachEnv unit test: FAIL" << std::endl;
+      return -1;
+   }
+
+   // Initialize the Machine Environment and the subset environments
+   // Not that the initialization also creates the default env.
+   OMEGA::MachEnv::init(MPI_COMM_WORLD);
+   InitMachEnvs();
+
+   // Verify retrieved values match expected reference values for the
+   // DefaultEnv
+   OMEGA::MachEnv* tmpEnv = OMEGA::MachEnv::getDefaultEnv();
+   int MyTask = tmpEnv->getMyTask();
+   if (MyTask == WorldTask)
+      std::cout << "DefaultEnv task test: PASS" << std::endl;
+   else {
+      std::cout << "DefaultEnv task test: FAIL " <<
+                   "MyTask, WorldTask = " << MyTask << WorldTask << std::endl;
+   }
+
+   int MySize = tmpEnv->getNumTasks();
+   if (MySize == WorldSize)
+      std::cout << "DefaultEnv NumTasks test: PASS" << std::endl;
+   else {
+      std::cout << "DefaultEnv NumTasks test: FAIL " <<
+                   "MySize, WorldSize = " <<
+                    MySize << " " << WorldSize << std::endl;
+   }
+
+   int MyMaster = tmpEnv->getMasterTask();
+   if (MyMaster == WorldMaster)
+      std::cout << "DefaultEnv master task test: PASS" << std::endl;
+   else {
+      std::cout << "DefaultEnv master task test: FAIL " <<
+                   "MyMaster, WorldMaster = " <<
+                    MyMaster << " " << WorldMaster << std::endl;
+   }
+
+   bool IsMyMaster = tmpEnv->isMasterTask();
+   if (MyTask == MyMaster){
+      if (IsMyMaster)
+         std::cout << "DefaultEnv is master task test: PASS" << std::endl;
+      else
+         std::cout << "DefaultEnv is master task test: FAIL" << std::endl;
+   } else {
+      if (IsMyMaster)
+         std::cout << "DefaultEnv is master task test: FAIL" << std::endl;
+      else
+         std::cout << "DefaultEnv is master task test: PASS" << std::endl;
+   }
+
+   // Test setting a new master task
+
+   tmpEnv->setMasterTask(2);
+
+   MyMaster = tmpEnv->getMasterTask();
+   if (MyMaster == 2)
+      std::cout << "DefaultEnv set master task test: PASS" << std::endl;
+   else {
+      std::cout << "DefaultEnv set master task test: FAIL " <<
+                   "MyMaster = " << MyMaster << std::endl;
+   }
+
+   IsMyMaster = tmpEnv->isMasterTask();
+   if (MyTask == 2){
+      if (IsMyMaster)
+         std::cout << "DefaultEnv isMaster after setMaster: PASS" << std::endl;
+      else
+         std::cout << "DefaultEnv isMaster after setMaster: FAIL" << std::endl;
+   } else {
+      if (IsMyMaster)
+         std::cout << "DefaultEnv isMaster after setMaster: FAIL" << std::endl;
+      else
+         std::cout << "DefaultEnv isMaster after setMaster: PASS" << std::endl;
+   }
+
+   //---------------------------------------------------------------------------
+   // Test contiguous subset environment (first four tasks of default)
+
+   // Test retrieval of environment
+   OMEGA::MachEnv* ContigEnv = OMEGA::MachEnv::getEnv("Contig");
+
+   // Check membership in the new communicator
+   if (MyTask < 4) {
+      if (ContigEnv->isMember())
+         std::cout << "contiguous member test: PASS" << std::endl;
+      else
+         std::cout << "contiguous member test: FAIL " << 
+                      "MyTask " << MyTask << std::endl;
+
+   } else {
+      if (ContigEnv->isMember())
+         std::cout << "contiguous member test: FAIL " <<
+                      "MyTask " << MyTask << std::endl;
+      else
+         std::cout << "contiguous member test: PASS" << std::endl;
+   }
+
+   // Perform standard checks on new communicator
+   if (ContigEnv->isMember()){
+      int ContigTask = ContigEnv->getMyTask();
+      if (ContigTask == WorldTask)
+         std::cout << "contiguous task test: PASS" << std::endl;
+      else {
+         std::cout << "contiguous task test: FAIL " <<
+                      "ContigTask, WorldTask = " <<
+                       ContigTask << " " << WorldTask << std::endl;
+      }
+
+      int ContigSize = ContigEnv->getNumTasks();
+      if (ContigSize == 4)
+         std::cout << "contiguous NumTasks test: PASS " << std::endl;
+      else {
+         std::cout << "contiguous NumTasks test: FAIL " <<
+                      "ContigSize (should be 4)  = " << ContigSize << std::endl;
+      }
+
+      int ContigMaster = ContigEnv->getMasterTask();
+      if (ContigMaster == WorldMaster)
+         std::cout << "contiguous master task test: PASS" << std::endl;
+      else {
+         std::cout << "contiguous master task test: FAIL " <<
+                      "MyMaster, WorldMaster = " <<
+                       MyMaster << " " << WorldMaster << std::endl;
+      }
+
+      bool IsContigMaster = ContigEnv->isMasterTask();
+      if (ContigTask == ContigMaster){
+         if (IsContigMaster)
+            std::cout << "contiguous is master task test: PASS" << std::endl;
+         else
+            std::cout << "contiguous is master task test: FAIL" << std::endl;
+      } else {
+         if (IsContigMaster)
+            std::cout << "contiguous is master task test: FAIL" << std::endl;
+         else
+            std::cout << "contiguous is master task test: PASS" << std::endl;
+      }
+
+   } // end if member of Contiguous subset
+
+   //---------------------------------------------------------------------------
+   // Test the strided constructor with only odd-numbered tasks
+
+   // Test retrieval
+   OMEGA::MachEnv* StrideEnv = OMEGA::MachEnv::getEnv("Stride");
+
+   // Check membership in the new communicator
+   if (MyTask%2 == 1) {
+      if (StrideEnv->isMember())
+         std::cout << "strided member test: PASS" << std::endl;
+      else
+         std::cout << "strided member test: FAIL " <<
+                      "MyTask " << MyTask << std::endl;
+
+   } else {
+      if (StrideEnv->isMember())
+         std::cout << "strided member test: FAIL " <<
+                      "MyTask " << MyTask << std::endl;
+      else
+         std::cout << "strided member test: PASS" << std::endl;
+   }
+
+   // Perform standard checks on new communicator
+   if (StrideEnv->isMember()){
+      int StrideTask = StrideEnv->getMyTask();
+      if (StrideTask == WorldTask/2)
+         std::cout << "strided task test: PASS" << std::endl;
+      else {
+         std::cout << "strided task test: FAIL " <<
+                      "StrideTask, WorldTask = " <<
+                       StrideTask <<  " " << WorldTask << std::endl;
+      }
+
+      int StrideSize = StrideEnv->getNumTasks();
+      if (StrideSize == 4)
+         std::cout << "strided NumTasks test: PASS" << std::endl;
+      else {
+         std::cout << "strided NumTasks test: FAIL " <<
+                      "StrideSize (should be 4)  = " << StrideSize << std::endl;
+      }
+
+      int StrideMaster = StrideEnv->getMasterTask();
+      if (StrideMaster == 0)
+         std::cout << "strided master task test: PASS" << std::endl;
+      else {
+         std::cout << "strided master task test: FAIL " <<
+                      "master = " << StrideMaster << std::endl;
+      }
+
+      bool IsStrideMaster = StrideEnv->isMasterTask();
+      if (StrideTask == StrideMaster){
+         if (IsStrideMaster)
+            std::cout << "strided is master task test: PASS" << std::endl;
+         else
+            std::cout << "strided is master task test: FAIL" << std::endl;
+      } else {
+         if (IsStrideMaster)
+            std::cout << "strided is master task test: FAIL" << std::endl;
+         else
+            std::cout << "strided is master task test: PASS" << std::endl;
+      }
+
+   } // end if member of strided subset
+
+   //---------------------------------------------------------------------------
+   // Test general subset constructor using tasks 1,2,5,7
+
+   int InclSize = 4;
+   int InclTasks[4] = {1, 2, 5, 7};
+
+   // Test retrieval
+   OMEGA::MachEnv* SubsetEnv = OMEGA::MachEnv::getEnv("Subset");
+
+   // Check membership in the new communicator
+   MyTask = SubsetEnv->getMyTask();
+   bool TaskInList = false;
+   int NewTask = -1;
+   for (int i=0; i < InclSize; ++i){
+      ++NewTask;
+      if (WorldTask == InclTasks[i]){
+         TaskInList = true;
+         break;
+      }
+   }
+
+   if (TaskInList) {
+      if (SubsetEnv->isMember())
+         std::cout << "subset member test: PASS" << std::endl;
+      else {
+         std::cout << "subset member test: FAIL" << std::endl;
+      }
+
+   } else {
+      if (SubsetEnv->isMember()){
+         std::cout << "subset non-member test: FAIL" <<
+                      " MyTask " << MyTask << " InclTasks ";
+         for (int i=0; i < InclSize; ++i){
+            std::cout << InclTasks[i];
+         }
+         std::cout << std::endl;
+      } else {
+         std::cout << "subset non-member test: PASS " << std::endl;
+      }
+   }
+
+   // Perform standard checks on new communicator
+   if (SubsetEnv->isMember()){
+      int SubsetTask = SubsetEnv->getMyTask();
+      if (SubsetTask == NewTask)
+         std::cout << "subset task test: PASS " << std::endl;
+      else {
+         std::cout << "subset task test: FAIL " <<
+                      "SubsetTask, NewTask = " <<
+                       SubsetTask << " " << NewTask << std::endl;
+      }
+
+      int SubsetSize = SubsetEnv->getNumTasks();
+      if (SubsetSize == InclSize)
+         std::cout << "subset size test: PASS " << std::endl;
+      else {
+         std::cout << "subset size test: FAIL " <<
+                      "SubsetSize, InclSize  = " <<
+                       SubsetSize << " " << InclSize << std::endl;
+      }
+
+      int SubsetMaster = SubsetEnv->getMasterTask();
+      if (SubsetMaster == 0)
+         std::cout << "subset master task test: PASS" << std::endl;
+      else {
+         std::cout << "subset master task test: FAIL" << std::endl;
+         std::cout << "master = " << SubsetMaster << std::endl;
+      }
+
+      bool IsSubsetMaster = SubsetEnv->isMasterTask();
+      if (SubsetTask == SubsetMaster){
+         if (IsSubsetMaster)
+            std::cout << "subset is master task test: PASS" << std::endl;
+         else
+            std::cout << "subset is master task test: FAIL" << std::endl;
+      } else {
+         if (IsSubsetMaster)
+            std::cout << "subset is master task test: FAIL" << std::endl;
+         else
+            std::cout << "subset is master task test: PASS" << std::endl;
+      }
+
+   } // end if member of general subset env
+
+   //---------------------------------------------------------------------------
+   // Test setting of compile-time vector length
+
+#ifdef OMEGA_VECTOR_LENGTH
+   if (OMEGA::VecLength == 16)
+      std::cout << "MPI vector length test: PASS" << std::endl;
+   else {
+      std::cout << "MPI vector length test: FAIL" << std::endl;
+      std::cout << "Was test driver built with -D OMEGA_VECTOR_LENGTH=16 ?"
+                << std::endl;
+   }
+#endif
+
+   // finalize environments
+   // MPI_Status status;
+   MPI_Finalize();
+
+} // end of main
+//===-----------------------------------------------------------------------===/

--- a/components/omega/test/base/MachEnvTest.cpp
+++ b/components/omega/test/base/MachEnvTest.cpp
@@ -29,21 +29,20 @@ void InitMachEnvs() {
 
    // Initialize three environments in reverse order that they
    // are tested.  Use default as parent env
-   OMEGA::MachEnv* tmpEnv=OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *tmpEnv = OMEGA::MachEnv::getDefaultEnv();
 
    // Initialize general subset environment
-   int InclSize = 4;
+   int InclSize     = 4;
    int InclTasks[4] = {1, 2, 5, 7};
-   OMEGA::MachEnv::createEnv("Subset", tmpEnv, InclSize, InclTasks); 
+   OMEGA::MachEnv::createEnv("Subset", tmpEnv, InclSize, InclTasks);
 
    // Initialize strided environment
-   OMEGA::MachEnv::createEnv("Stride", tmpEnv, 4, 1, 2); 
+   OMEGA::MachEnv::createEnv("Stride", tmpEnv, 4, 1, 2);
 
    // Initialize contiguous subset environment
-   OMEGA::MachEnv::createEnv("Contig", tmpEnv, 4); 
+   OMEGA::MachEnv::createEnv("Contig", tmpEnv, 4);
 
 } // end of InitMachEnvs
-
 
 //------------------------------------------------------------------------------
 // The test driver for MachEnv. This tests the values stored in the Default
@@ -62,7 +61,7 @@ int main(int argc, char *argv[]) {
    MPI_Comm_size(MPI_COMM_WORLD, &WorldSize);
    int WorldMaster = 0;
    bool IsWorldMaster;
-   if (WorldTask == WorldMaster){
+   if (WorldTask == WorldMaster) {
       IsWorldMaster = true;
    } else {
       IsWorldMaster = false;
@@ -85,35 +84,35 @@ int main(int argc, char *argv[]) {
 
    // Verify retrieved values match expected reference values for the
    // DefaultEnv
-   OMEGA::MachEnv* tmpEnv = OMEGA::MachEnv::getDefaultEnv();
-   int MyTask = tmpEnv->getMyTask();
+   OMEGA::MachEnv *tmpEnv = OMEGA::MachEnv::getDefaultEnv();
+   int MyTask             = tmpEnv->getMyTask();
    if (MyTask == WorldTask)
       std::cout << "DefaultEnv task test: PASS" << std::endl;
    else {
-      std::cout << "DefaultEnv task test: FAIL " <<
-                   "MyTask, WorldTask = " << MyTask << WorldTask << std::endl;
+      std::cout << "DefaultEnv task test: FAIL "
+                << "MyTask, WorldTask = " << MyTask << WorldTask << std::endl;
    }
 
    int MySize = tmpEnv->getNumTasks();
    if (MySize == WorldSize)
       std::cout << "DefaultEnv NumTasks test: PASS" << std::endl;
    else {
-      std::cout << "DefaultEnv NumTasks test: FAIL " <<
-                   "MySize, WorldSize = " <<
-                    MySize << " " << WorldSize << std::endl;
+      std::cout << "DefaultEnv NumTasks test: FAIL "
+                << "MySize, WorldSize = " << MySize << " " << WorldSize
+                << std::endl;
    }
 
    int MyMaster = tmpEnv->getMasterTask();
    if (MyMaster == WorldMaster)
       std::cout << "DefaultEnv master task test: PASS" << std::endl;
    else {
-      std::cout << "DefaultEnv master task test: FAIL " <<
-                   "MyMaster, WorldMaster = " <<
-                    MyMaster << " " << WorldMaster << std::endl;
+      std::cout << "DefaultEnv master task test: FAIL "
+                << "MyMaster, WorldMaster = " << MyMaster << " " << WorldMaster
+                << std::endl;
    }
 
    bool IsMyMaster = tmpEnv->isMasterTask();
-   if (MyTask == MyMaster){
+   if (MyTask == MyMaster) {
       if (IsMyMaster)
          std::cout << "DefaultEnv is master task test: PASS" << std::endl;
       else
@@ -133,12 +132,12 @@ int main(int argc, char *argv[]) {
    if (MyMaster == 2)
       std::cout << "DefaultEnv set master task test: PASS" << std::endl;
    else {
-      std::cout << "DefaultEnv set master task test: FAIL " <<
-                   "MyMaster = " << MyMaster << std::endl;
+      std::cout << "DefaultEnv set master task test: FAIL "
+                << "MyMaster = " << MyMaster << std::endl;
    }
 
    IsMyMaster = tmpEnv->isMasterTask();
-   if (MyTask == 2){
+   if (MyTask == 2) {
       if (IsMyMaster)
          std::cout << "DefaultEnv isMaster after setMaster: PASS" << std::endl;
       else
@@ -154,54 +153,54 @@ int main(int argc, char *argv[]) {
    // Test contiguous subset environment (first four tasks of default)
 
    // Test retrieval of environment
-   OMEGA::MachEnv* ContigEnv = OMEGA::MachEnv::getEnv("Contig");
+   OMEGA::MachEnv *ContigEnv = OMEGA::MachEnv::getEnv("Contig");
 
    // Check membership in the new communicator
    if (MyTask < 4) {
       if (ContigEnv->isMember())
          std::cout << "contiguous member test: PASS" << std::endl;
       else
-         std::cout << "contiguous member test: FAIL " << 
-                      "MyTask " << MyTask << std::endl;
+         std::cout << "contiguous member test: FAIL "
+                   << "MyTask " << MyTask << std::endl;
 
    } else {
       if (ContigEnv->isMember())
-         std::cout << "contiguous member test: FAIL " <<
-                      "MyTask " << MyTask << std::endl;
+         std::cout << "contiguous member test: FAIL "
+                   << "MyTask " << MyTask << std::endl;
       else
          std::cout << "contiguous member test: PASS" << std::endl;
    }
 
    // Perform standard checks on new communicator
-   if (ContigEnv->isMember()){
+   if (ContigEnv->isMember()) {
       int ContigTask = ContigEnv->getMyTask();
       if (ContigTask == WorldTask)
          std::cout << "contiguous task test: PASS" << std::endl;
       else {
-         std::cout << "contiguous task test: FAIL " <<
-                      "ContigTask, WorldTask = " <<
-                       ContigTask << " " << WorldTask << std::endl;
+         std::cout << "contiguous task test: FAIL "
+                   << "ContigTask, WorldTask = " << ContigTask << " "
+                   << WorldTask << std::endl;
       }
 
       int ContigSize = ContigEnv->getNumTasks();
       if (ContigSize == 4)
          std::cout << "contiguous NumTasks test: PASS " << std::endl;
       else {
-         std::cout << "contiguous NumTasks test: FAIL " <<
-                      "ContigSize (should be 4)  = " << ContigSize << std::endl;
+         std::cout << "contiguous NumTasks test: FAIL "
+                   << "ContigSize (should be 4)  = " << ContigSize << std::endl;
       }
 
       int ContigMaster = ContigEnv->getMasterTask();
       if (ContigMaster == WorldMaster)
          std::cout << "contiguous master task test: PASS" << std::endl;
       else {
-         std::cout << "contiguous master task test: FAIL " <<
-                      "MyMaster, WorldMaster = " <<
-                       MyMaster << " " << WorldMaster << std::endl;
+         std::cout << "contiguous master task test: FAIL "
+                   << "MyMaster, WorldMaster = " << MyMaster << " "
+                   << WorldMaster << std::endl;
       }
 
       bool IsContigMaster = ContigEnv->isMasterTask();
-      if (ContigTask == ContigMaster){
+      if (ContigTask == ContigMaster) {
          if (IsContigMaster)
             std::cout << "contiguous is master task test: PASS" << std::endl;
          else
@@ -219,53 +218,53 @@ int main(int argc, char *argv[]) {
    // Test the strided constructor with only odd-numbered tasks
 
    // Test retrieval
-   OMEGA::MachEnv* StrideEnv = OMEGA::MachEnv::getEnv("Stride");
+   OMEGA::MachEnv *StrideEnv = OMEGA::MachEnv::getEnv("Stride");
 
    // Check membership in the new communicator
-   if (MyTask%2 == 1) {
+   if (MyTask % 2 == 1) {
       if (StrideEnv->isMember())
          std::cout << "strided member test: PASS" << std::endl;
       else
-         std::cout << "strided member test: FAIL " <<
-                      "MyTask " << MyTask << std::endl;
+         std::cout << "strided member test: FAIL "
+                   << "MyTask " << MyTask << std::endl;
 
    } else {
       if (StrideEnv->isMember())
-         std::cout << "strided member test: FAIL " <<
-                      "MyTask " << MyTask << std::endl;
+         std::cout << "strided member test: FAIL "
+                   << "MyTask " << MyTask << std::endl;
       else
          std::cout << "strided member test: PASS" << std::endl;
    }
 
    // Perform standard checks on new communicator
-   if (StrideEnv->isMember()){
+   if (StrideEnv->isMember()) {
       int StrideTask = StrideEnv->getMyTask();
-      if (StrideTask == WorldTask/2)
+      if (StrideTask == WorldTask / 2)
          std::cout << "strided task test: PASS" << std::endl;
       else {
-         std::cout << "strided task test: FAIL " <<
-                      "StrideTask, WorldTask = " <<
-                       StrideTask <<  " " << WorldTask << std::endl;
+         std::cout << "strided task test: FAIL "
+                   << "StrideTask, WorldTask = " << StrideTask << " "
+                   << WorldTask << std::endl;
       }
 
       int StrideSize = StrideEnv->getNumTasks();
       if (StrideSize == 4)
          std::cout << "strided NumTasks test: PASS" << std::endl;
       else {
-         std::cout << "strided NumTasks test: FAIL " <<
-                      "StrideSize (should be 4)  = " << StrideSize << std::endl;
+         std::cout << "strided NumTasks test: FAIL "
+                   << "StrideSize (should be 4)  = " << StrideSize << std::endl;
       }
 
       int StrideMaster = StrideEnv->getMasterTask();
       if (StrideMaster == 0)
          std::cout << "strided master task test: PASS" << std::endl;
       else {
-         std::cout << "strided master task test: FAIL " <<
-                      "master = " << StrideMaster << std::endl;
+         std::cout << "strided master task test: FAIL "
+                   << "master = " << StrideMaster << std::endl;
       }
 
       bool IsStrideMaster = StrideEnv->isMasterTask();
-      if (StrideTask == StrideMaster){
+      if (StrideTask == StrideMaster) {
          if (IsStrideMaster)
             std::cout << "strided is master task test: PASS" << std::endl;
          else
@@ -282,19 +281,19 @@ int main(int argc, char *argv[]) {
    //---------------------------------------------------------------------------
    // Test general subset constructor using tasks 1,2,5,7
 
-   int InclSize = 4;
+   int InclSize     = 4;
    int InclTasks[4] = {1, 2, 5, 7};
 
    // Test retrieval
-   OMEGA::MachEnv* SubsetEnv = OMEGA::MachEnv::getEnv("Subset");
+   OMEGA::MachEnv *SubsetEnv = OMEGA::MachEnv::getEnv("Subset");
 
    // Check membership in the new communicator
-   MyTask = SubsetEnv->getMyTask();
+   MyTask          = SubsetEnv->getMyTask();
    bool TaskInList = false;
-   int NewTask = -1;
-   for (int i=0; i < InclSize; ++i){
+   int NewTask     = -1;
+   for (int i = 0; i < InclSize; ++i) {
       ++NewTask;
-      if (WorldTask == InclTasks[i]){
+      if (WorldTask == InclTasks[i]) {
          TaskInList = true;
          break;
       }
@@ -308,10 +307,10 @@ int main(int argc, char *argv[]) {
       }
 
    } else {
-      if (SubsetEnv->isMember()){
-         std::cout << "subset non-member test: FAIL" <<
-                      " MyTask " << MyTask << " InclTasks ";
-         for (int i=0; i < InclSize; ++i){
+      if (SubsetEnv->isMember()) {
+         std::cout << "subset non-member test: FAIL"
+                   << " MyTask " << MyTask << " InclTasks ";
+         for (int i = 0; i < InclSize; ++i) {
             std::cout << InclTasks[i];
          }
          std::cout << std::endl;
@@ -321,23 +320,23 @@ int main(int argc, char *argv[]) {
    }
 
    // Perform standard checks on new communicator
-   if (SubsetEnv->isMember()){
+   if (SubsetEnv->isMember()) {
       int SubsetTask = SubsetEnv->getMyTask();
       if (SubsetTask == NewTask)
          std::cout << "subset task test: PASS " << std::endl;
       else {
-         std::cout << "subset task test: FAIL " <<
-                      "SubsetTask, NewTask = " <<
-                       SubsetTask << " " << NewTask << std::endl;
+         std::cout << "subset task test: FAIL "
+                   << "SubsetTask, NewTask = " << SubsetTask << " " << NewTask
+                   << std::endl;
       }
 
       int SubsetSize = SubsetEnv->getNumTasks();
       if (SubsetSize == InclSize)
          std::cout << "subset size test: PASS " << std::endl;
       else {
-         std::cout << "subset size test: FAIL " <<
-                      "SubsetSize, InclSize  = " <<
-                       SubsetSize << " " << InclSize << std::endl;
+         std::cout << "subset size test: FAIL "
+                   << "SubsetSize, InclSize  = " << SubsetSize << " "
+                   << InclSize << std::endl;
       }
 
       int SubsetMaster = SubsetEnv->getMasterTask();
@@ -349,7 +348,7 @@ int main(int argc, char *argv[]) {
       }
 
       bool IsSubsetMaster = SubsetEnv->isMasterTask();
-      if (SubsetTask == SubsetMaster){
+      if (SubsetTask == SubsetMaster) {
          if (IsSubsetMaster)
             std::cout << "subset is master task test: PASS" << std::endl;
          else

--- a/components/omega/test/base/MachEnvTest.cpp
+++ b/components/omega/test/base/MachEnvTest.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[]) {
    // expected reference values
    OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
 
-   int MyTask             = DefEnv->getMyTask();
+   int MyTask = DefEnv->getMyTask();
    if (MyTask == WorldTask)
       std::cout << "DefaultEnv task test: PASS" << std::endl;
    else {


### PR DESCRIPTION
This adds a new class MachEnv to hold a number of parameters that describe the machine environment, including MPI communicators and task info, number of threads if threaded, vector length for CPUs and potentially other GPU and node-level configuration info.  This is described in the included documentation for User's and Developer's Guides.

This has been tested on Chrysalis using a provided unit test. This unit test has not yet been integrated into Cmake, but will be soon in an upcoming PR. In the meantime, you can build the unit test in the test/base directory using
  mpicc (or other MPI-wrapped compiler) -I../../src/base  -DOMEGA_VECTOR_LENGTH=16 ../../src/base/MachEnv.cpp MachEnvTest.cpp -lstdc++ 
and run using:
  srun (or other mpi launcher) -n 8 ./a.out
Note that the unit test requires at least 8 MPI tasks.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Design document has been generated and added to the docs
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/omega/develop/developers_guide/building_docs.html) and changes look as expected
* [ ] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


