### PR TITLE
Fix two small issues with the docs

### DIFF
--- a/components/omega/doc/design/Decomp.md
+++ b/components/omega/doc/design/Decomp.md
@@ -167,7 +167,7 @@ algorithms.
 These parameters and the mesh input file will be read as part of
 the input configuration file in a decomp configuration group:
 
-```yakl
+```yaml
     decomp:
        meshInputFilename: 'omegaMeshFile.nc'
        partitionMethod: 'MetisKWay'

--- a/components/omega/doc/devGuide/CMakeBuild.md
+++ b/components/omega/doc/devGuide/CMakeBuild.md
@@ -34,7 +34,7 @@ with an underscore ("_").
 The following is a list of Omega-specific variables available in
 this version:
 
-```vbnet
+```
 OMEGA_PROJECT_NAME: Name of the project ("OmegaOceanModel")
 OMEGA_EXE_NAME: Name of the executable ("omega.exe")
 OMEGA_LIB_NAME: Name of the library ("OmegaLib")
@@ -52,7 +52,7 @@ OMEGA_BUILD_TEST: Enable building Omega tests
 
 E3SM-specific variables
 
-```vbnet
+```
 E3SM_SOURCE_DIR: E3SM component directory (${E3SM_ROOT}/components)
 E3SM_CIME_ROOT: CIME root directory
 E3SM_CIMECONFIG_ROOT: E3SM CIME config directory
@@ -62,7 +62,7 @@ E3SM_DEFAULT_BUILD_TYPE: E3SM build type (Release or Debug)
 
 CMake variables
 
-```vbnet
+```
 CMAKE_CURRENT_SOURCE_DIR
 CMAKE_CXX_STANDARD
 CMAKE_CURRENT_LIST_DIR


### PR DESCRIPTION
One code block is type `yaml`, not `yakl`.

Sphinx doesn't understand type `vbnet` and I don't think this is correct for the CMAKE variable descriptions in any case.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/omega/develop/developers_guide/building_docs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


