### PR TITLE
Update version of file-changes-action to 1.2.4

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -71,7 +71,7 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         id: file_changes
-        uses: trilom/file-changes-action@v1.2.3
+        uses: trilom/file-changes-action@v1.2.4
         with:
           output: ' '
 


### PR DESCRIPTION
This should fix "There was an issue sorting changed files from Github", see https://github.com/E3SM-Project/Omega/pull/27#issuecomment-1685024514

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


