### PR TITLE
Add domain decomposition

### DIFF
--- a/components/omega/doc/devGuide/Decomp.md
+++ b/components/omega/doc/devGuide/Decomp.md
@@ -1,0 +1,32 @@
+(omega-dev-decomp)=
+
+## Domain Decomposition (Decomp)
+
+In order to run across nodes in a parallel computer, OMEGA subdivides the
+horizontal domain into subdomains that are distributed across the machine
+and communicate using message passing via the Message Passing Interface (MPI).
+To decompose the domain, we utilize the
+[METIS](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) library.
+Mesh information is first read using parallel IO into a equal-spaced
+linear decomposition, the partitioned by METIS into a more optimal
+decomposition. The parallel METIS implementation (ParMETIS) will eventually
+be used to reduce memory footpring for high-resolution configurations, but
+currently we use the serial METIS library for the partitioning.
+
+METIS requires information about the connectivity in the mesh. In particular,
+it needs the total number of cells and edges in the mesh and the connectivity
+given by the CellsOnCell array (described below). Once the cells have been
+partitioned, we determine multiple layers of halo cells that will be needed
+to avoid excessive communcation with neighbors. The CellsOnCell, EdgesOnCell
+and VerticesOnCell arrays are then distributed according to this cell
+partitioning. Edges and Vertices are then partitioned. Ownership of each
+edge/vertex is determined by the first (valid) cell index in the CellsOnEdge
+or CellsOnVertex for that edge/vertex. The remaining connectivity arrays
+(CellsOnEdge, EdgesOnEdge, VerticesOnEdge, CellsOnVertex, EdgesOnVertex)
+are the redistributed to match the edge and vertex distributions. Halos
+are filled to ensure all necessary edge and vertex information for the
+cell decomposition (and cell halos) are present in the subdomain.
+
+The mesh is fully described by the
+[MPAS Mesh Specification](https://mpas-dev.github.io/files/documents/MPAS-MeshSpec.pdf)
+which we will reproduce here eventually.

--- a/components/omega/doc/devGuide/Decomp.md
+++ b/components/omega/doc/devGuide/Decomp.md
@@ -7,17 +7,32 @@ horizontal domain into subdomains that are distributed across the machine
 and communicate using message passing via the Message Passing Interface (MPI).
 To decompose the domain, we utilize the
 [METIS](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) library.
-Mesh information is first read using parallel IO into a equal-spaced
-linear decomposition, the partitioned by METIS into a more optimal
-decomposition. The parallel METIS implementation (ParMETIS) will eventually
-be used to reduce memory footpring for high-resolution configurations, but
-currently we use the serial METIS library for the partitioning.
+An OMEGA mesh is fully described by the
+[MPAS Mesh Specification](https://mpas-dev.github.io/files/documents/MPAS-MeshSpec.pdf)
+which we will reproduce here eventually. The Decomp class decomposes
+the domain based on the index space and number of MPI tasks (currently
+one subdomain per task). Once decomposed, the Decomp class holds all
+of the index space information as described below.
+
+Within OMEGA, a default decomposition of the mesh is first created
+with the call:
+```c++
+ Decomp::init();
+```
+This must be called very early in the init process, just after initializing
+the MachEnv, Config and IO.  Mesh information is first read using parallel
+IO into an equally-spaced linear decomposition, then partitioned by METIS
+into a more optimal decomposition. The parallel METIS implementation
+(ParMETIS) will eventually be used to reduce the memory footprint for
+high-resolution configurations, but currently we use the serial METIS library
+for the partitioning.
 
 METIS requires information about the connectivity in the mesh. In particular,
 it needs the total number of cells and edges in the mesh and the connectivity
-given by the CellsOnCell array (described below). Once the cells have been
-partitioned, we determine multiple layers of halo cells that will be needed
-to avoid excessive communcation with neighbors. The CellsOnCell, EdgesOnCell
+given by the CellsOnCell array that stores the indices of neighboring cells
+for each cell. Once the cells have been partitioned, we determine multiple
+layers of halo cells that will be needed to avoid excessive communcation with
+remote neighboring subdomains. The CellsOnCell, EdgesOnCell
 and VerticesOnCell arrays are then distributed according to this cell
 partitioning. Edges and Vertices are then partitioned. Ownership of each
 edge/vertex is determined by the first (valid) cell index in the CellsOnEdge
@@ -27,6 +42,65 @@ are the redistributed to match the edge and vertex distributions. Halos
 are filled to ensure all necessary edge and vertex information for the
 cell decomposition (and cell halos) are present in the subdomain.
 
-The mesh is fully described by the
-[MPAS Mesh Specification](https://mpas-dev.github.io/files/documents/MPAS-MeshSpec.pdf)
-which we will reproduce here eventually.
+After the call to the Decomp initialization routine, a Decomp named
+Default has been created and can be retrieved with
+```c++
+OMEGA::Decomp *DefDecomp = OMEGA::Decomp::getDefault();
+```
+Once retrieved all Decomp members are public and can be accessed using
+```c++
+OMEGA::I4 NCells = DefDecomp->NCells;
+OMEGA::ArrayHost1DI4 CellIDH = DefDecomp->CellIDH;
+```
+Decomp is a container for all mesh index and connectivity arrays as
+described in the mesh specification above. In particular, it contains
+  - NCellsGlobal: the total number of cells
+  - NCellsAll: the total number of cells in the local partition
+  - NCellsSize: the length of the Cell array axis (typicall NCellsAll+1)
+  - NCellsOwned: the number of cells owned by this task
+  - NCellsHalo(i): the number of owned+halo cells for each halo layer
+  - Analogous size variables for Edges and Vertices
+  - MaxEdges: the max number of edges on a cell (and array size)
+  - VertexDegree: the number of cells/edges at each vertex
+  - CellID(NCellsSize): the global index for each local cell
+  - CellLoc(NCellsSize,2): the task and local index for every local cell
+    (redundant for owned cells but gives the remote location for halo cells)
+  - Analogous arrays for Edges, Vertices
+  - CellsOnCell(NCellsSize,MaxEdges): the local index for neighbor cells
+    across each cell edge
+  - EdgesOnCell(NCellsSize,MaxEdges): the local edge index for each cell edge
+  - VerticesOnCell(NCellsSize,MaxEdges): the local index for each cell vertex
+  - CellsOnEdge(NEdgesSize,2): the index of the 2 cells sharing an edge
+  - VerticesOnEdge(NEdgesSize,2): the vertex index at each edge endpoint
+  - EdgesOnEdge(NEdgesSize,MaxEdges x 2): the index for all edges contributing
+    to an edge (all edges of the 2 cells sharing an edge)
+  - CellsOnVertex(NVerticesSize,VertexDegree): indices for all cells meeting
+    at a vertex
+  - EdgesOnVertex(NVerticesSize,VertexDegree): indices for all edges meeting
+    at a vertex
+  - NEdgesOnCell(NCellsSize): the number of actual edges on each cell
+  - NEdgesOnEdge(NEdgesSize): the number of actual edges on each edge
+
+For each of the arrays above, there is a copy of the array on the host and
+device (GPU) with the host array named with an extra H on the end
+(eg CellsOnCellH). All are YAKL arrays so are accessed with (index) rather
+than [index] and for some of the arrays noted above are multi-dimensional.
+A typical host loop might then look something like:
+```c++
+for (int Cell = 0; Cell < NCellsOwned; ++Cell) {
+   for (int Edge = 0; Edge < NEdgesOnCell(Cell); ++Edge) {
+      VarH(Cell) = VarH(Cell) + FluxH(Cell,Edge);
+   }
+}
+```
+And on the device, we use the YAKL form (note that we will likely create
+aliases for extended yakl expressions, like parallel_for to replace
+yakl::c::parallel_for);
+```c++
+yakl::c::parallel_for( yakl::c::Bounds<2>(NCellsOwned,MaxEdges),
+                       YAKL_LAMBDA (int Cell, int Edge) {
+  if (Edge < NEdgesOnCell(Cell)) {
+      Var(Cell) = Var(Cell) + Flux(Cell,Edge);
+  }
+});
+```

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -26,6 +26,7 @@ userGuide/DataTypes
 userGuide/MachEnv
 userGuide/Broadcast
 userGuide/Logging
+userGuide/Decomp
 ```
 
 ```{toctree}
@@ -42,6 +43,7 @@ devGuide/Docs
 devGuide/BuildDocs
 devGuide/CMakeBuild
 devGuide/Logging
+devGuide/Decomp
 ```
 
 ```{toctree}

--- a/components/omega/doc/userGuide/Decomp.md
+++ b/components/omega/doc/userGuide/Decomp.md
@@ -43,3 +43,9 @@ final METIS parallel decomposition.
 METIS and ParMETIS support a number of partitioning schemes, but MetisKWay
 is currently the only supported decomposition method for Omega and is
 generally the better option.
+
+Once the mesh is decomposed, all of the mesh index arrays are stored in
+a Decomp named Default which can be retrieved as described in the
+Developer guide. In the future, additional decompositions associated
+with processor subsets (as described in MachEnv) but this capability is
+not yet supported.

--- a/components/omega/doc/userGuide/Decomp.md
+++ b/components/omega/doc/userGuide/Decomp.md
@@ -1,0 +1,45 @@
+(omega-user-decomp)=
+
+## Domain Decomposition (Decomp)
+
+OMEGA is designed to be run in parallel across multiple nodes and cores
+in a clustered architecture. As in many Earth System Models, we decompose
+the horizontal domain into subdomains that are distributed across the
+system. Communication between the domains is accomplished using the
+Message Passing Interface standard. To reduce the communication between
+subdomains, a halo of points is filled with information from remote neighbor
+cells, edges and vertices so that a time step can largely be completed
+without the need to communicate.
+
+The partitioning itself is performed using the
+[METIS](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) library that
+can partition unstructured domains in a way that also optimizes communication.
+More details on the mesh, connectivity and partitioning can be found in
+the [Developer's Guide](#omega-dev-decomp).
+
+There are three parameters that are set by the user in the input configuration
+file. These are:
+```yaml
+Decomp:
+   HaloWidth: 3
+   MeshFileName: OmegaMesh.nc
+   DecompMethod: MetisKWay
+```
+(until the config module is complete, these are currently hardwired to
+the defaults above). The HaloWidth is set to be able to compute all of the
+baroclinic terms in a timestep without communication and for higher-order
+tracer advection terms, this currently must be at least 3. The MeshFileName
+should include the complete path and filename to a standard Omega mesh file
+that contains at a minimum
+  - the total number of cells, edges and vertices (NCells, NEdges, NVertices)
+  - the mesh connectivity contained in the arrays CellsOnCell, EdgesOnCell
+    VerticesOnCell, CellsOnEdge, EdgesOnEdge, CellsOnVertex, EdgesOnVertex.
+Again, a full description of the mesh is given in the
+[Developer's Guide](#omega-dev-decomp).
+The mesh information is read via parallel IO into an initial linear domain
+decomposition and then is partitioned by METIS and rearranged into the
+final METIS parallel decomposition.
+
+METIS and ParMETIS support a number of partitioning schemes, but MetisKWay
+is currently the only supported decomposition method for Omega and is
+generally the better option.

--- a/components/omega/doc/userGuide/OmegaBuild.md
+++ b/components/omega/doc/userGuide/OmegaBuild.md
@@ -30,11 +30,17 @@ as illustrated below. In some cases, you may also want to add `OMEGA_CIME_MACHIN
 to specify which system you intend to use. The values of `OMEGA_CIME_COMPILER`
 and `OMEGA_CIME_MACHINE` are defined in
 "${E3SM}/cime\_config/machines/config\_machines.xml".
+OMEGA requires some external libraries. Many of these are built automatically
+from the E3SM distribution. However, the METIS and ParMETIS libraries must
+be built separately and the path must be supplied during the cmake invocation
+as shown below. If a METIS_ROOT is not supplied, it is assumed that both METIS
+and ParMETIS are installed in the same PARMETIS_ROOT location.
 
 ```sh
 >> cmake \
   -DOMEGA_CIME_COMPILER=nvidiagpu \
   -DOMEGA_CIME_MACHINE=pm-gpu \
+  -DPARMETIS_ROOT=/path/to/parmetis \
   ${E3SM_HOME}/components/omega
 ```
 
@@ -121,8 +127,11 @@ specified by `DOMEGA_INSTALL_PREFIX`.
 The `./omega_ctest.sh` command runs Omega unit tests. To run the tests, MPI
 parallel job launcher such as SLURM srun should be available. You may first
 get allocation of an interactive computing node or use batch system.
+In addition, you must either copy (or soft link) a mesh file into the same
+directory as the unit test executables or specify in a configuration file
+(not implemented yet) the path to that mesh input file.
 
-For example, if you are on an interactive computingnode, you can run
+For example, if you are on an interactive computing node, you can run
 Omega unit test by running `omega_ctest.sh` as shown below.
 
 ```sh

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -58,5 +58,3 @@ set_target_properties(metis PROPERTIES
 add_library(parmetis STATIC IMPORTED GLOBAL)
 set_target_properties(parmetis PROPERTIES
    IMPORTED_LOCATION ${PARMETIS_ROOT}/lib/libparmetis.a)
-
-

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -41,3 +41,22 @@ add_subdirectory(
   ${E3SM_EXTERNALS_ROOT}/scorpio
   ${CMAKE_CURRENT_BINARY_DIR}/scorpio
 )
+
+
+
+# Add the parmetis and related libraries
+
+# If not defined, assume the METIS paths are the same as ParMETIS
+if(NOT DEFINED METIS_ROOT)
+   set(METIS_ROOT ${PARMETIS_ROOT})
+endif()
+
+add_library(metis STATIC IMPORTED GLOBAL)
+set_target_properties(metis PROPERTIES
+   IMPORTED_LOCATION ${METIS_ROOT}/lib/libmetis.a)
+
+add_library(parmetis STATIC IMPORTED GLOBAL)
+set_target_properties(parmetis PROPERTIES
+   IMPORTED_LOCATION ${PARMETIS_ROOT}/lib/libparmetis.a)
+
+

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -6,12 +6,19 @@ file(GLOB _LIBSRC_FILES infra/*.cpp base/*.cpp ocn/*.cpp)
 # Create the library target
 add_library(${OMEGA_LIB_NAME} ${_LIBSRC_FILES})
 
+# add include directories
+target_include_directories(
+    ${OMEGA_LIB_NAME}
+    PRIVATE
+    ${OMEGA_SOURCE_DIR}/src/base
+    ${OMEGA_SOURCE_DIR}/src/infra
+    ${PARMETIS_ROOT}/include
+)
+
 # add compiler options
 target_compile_options(
     ${OMEGA_LIB_NAME}
     PRIVATE
-    "-I${OMEGA_SOURCE_DIR}/src/base"
-    "-I${OMEGA_SOURCE_DIR}/src/infra"
      ${OMEGA_CXX_FLAGS}
 )
 
@@ -22,7 +29,7 @@ target_link_options(
     ${OMEGA_LINK_OPTIONS}
 )
 
-target_link_libraries(${OMEGA_LIB_NAME} spdlog yakl pioc)
+target_link_libraries(${OMEGA_LIB_NAME} spdlog yakl pioc metis)
 
 # build Omega executable
 if(OMEGA_BUILD_EXECUTABLE)

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -1,0 +1,1807 @@
+//===-- base/Decomp.cpp - domain decomposition methods ----------*- C++ -*-===//
+//
+// The decomposition (Decomp) class partitions an OMEGA horizontal domain into
+// a number of sub-domains that can be distributed across a parallel
+// environment. Currently, this relies on the (Par)Metis partitioning package
+// to partition a set of nodes (cells) based on the adjacency graph created
+// during the OMEGA mesh generators. A default decomposition is created
+// from the default Machine Env that specifies the MPI details and number
+// of MPI tasks. Other decompositions can be created with the same mesh
+// on any of the subset environments that are possible in MachEnv.
+// The Decomp class stores a number of index-space arrays that describe
+// the partition, neighbor information, global IDs for cell, edge and
+// vertex points in an Omega mesh.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Decomp.h"
+#include "DataTypes.h"
+#include "IO.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "mpi.h"
+#include "parmetis.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
+// temporary for debugging
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+namespace OMEGA {
+
+// create the static class members
+Decomp *Decomp::DefaultDecomp = nullptr;
+std::map<std::string, Decomp> Decomp::AllDecomps;
+
+// Some useful local utility routines
+//------------------------------------------------------------------------------
+// checks a global cell/edge/vertex ID value to see if it is within range.
+// The readMesh function must have been called to define global sizes before
+// calling any of these.
+
+bool Decomp::validCellID(I4 InCellID) {
+   return (InCellID > 0 && InCellID <= NCellsGlobal);
+}
+bool Decomp::validEdgeID(I4 InEdgeID) {
+   return (InEdgeID > 0 && InEdgeID <= NEdgesGlobal);
+}
+bool Decomp::validVertexID(I4 InVertexID) {
+   return (InVertexID > 0 && InVertexID <= NVerticesGlobal);
+}
+
+//------------------------------------------------------------------------------
+// Local routine that searches a std::vector<I4> for a particular entry and
+// returns the index of that entry. If not found, the size is returned
+// (corresponding to the last index + 1)
+
+I4 srchVector(const std::vector<I4> &InVector, // vector to search
+              I4 Value                         // value to search for
+) {
+
+   // first use the std::find routine to determine the iterator location
+   auto it = std::find(InVector.begin(), InVector.end(), Value);
+   // now translate the iterator into an actual vector index
+   I4 LocIndx = std::distance(InVector.begin(), it);
+
+   return LocIndx;
+
+} // end function srchVector (std::vector)
+
+//------------------------------------------------------------------------------
+// A search routine for vectors in which the vector is a YAKL array rather
+// than a std::vector. It searches for a value and returns the first index of
+// that // entry. If not found, the size is returned (corresponding to the
+// last index + 1)
+
+I4 srchVector(ArrayHost1DI4 InVector, // vector to search
+              I4 Value                // value to search for
+) {
+
+   // extract the vector length
+   I4 VecSize  = InVector.totElems();
+   I4 LocIndex = VecSize; // set default to size (return value if not found)
+
+   // Loop over elements, searching for Value
+   for (int n = 0; n < VecSize; ++n) {
+      if (InVector(n) == Value) { // found value
+         LocIndex = n;
+         break;
+      }
+   }
+
+   return LocIndex;
+
+} // end function srchVector (YAKL)
+
+// Routines needed for creating the decomposition
+//------------------------------------------------------------------------------
+// Reads mesh adjacency, index and size information from a file. This includes
+// all neighbor information and connections between cells, edges, vertices.
+// These are initially read into a uniform linear distribution across MPI tasks
+// and redistributed later after the decomposition is complete.
+
+int readMesh(const int MeshFileID, // file ID for open mesh file
+             const MachEnv *InEnv, // input machine environment for MPI layout
+             I4 &NCellsGlobal,     // total number of cells
+             I4 &NEdgesGlobal,     // total number of edges
+             I4 &NVerticesGlobal,  // total number of vertices
+             I4 &MaxEdges,         // max number of edges on a cell
+             I4 &MaxCellsOnEdge,   // max number of cells sharing edge
+             I4 &VertexDegree,     // number of cells/edges sharing vrtx
+             std::vector<I4> &CellsOnCellInit, // cell neighbors for each cell
+             std::vector<I4> &EdgesOnCellInit, // edge IDs for each cell edge
+             std::vector<I4> &VerticesOnCellInit, // vertices around each cell
+             std::vector<I4> &CellsOnEdgeInit,    // cell IDs sharing edge
+             std::vector<I4> &EdgesOnEdgeInit,    // all edges neighboring edge
+             std::vector<I4> &VerticesOnEdgeInit, // vertices on ends of edge
+             std::vector<I4> &CellsOnVertexInit,  // cells meeting at each vrtx
+             std::vector<I4> &EdgesOnVertexInit   // edges meeting at each vrtx
+) {
+
+   int Err = 0;
+
+   // Retrieve some info on the MPI layout
+   MPI_Comm Comm = InEnv->getComm();
+   I4 NumTasks   = InEnv->getNumTasks();
+   I4 MyTask     = InEnv->getMyTask();
+   I4 MasterTask = InEnv->getMasterTask();
+   bool IsMaster = InEnv->isMasterTask();
+
+   // Read in mesh size information - these are dimension lengths in
+   // the input mesh file
+   NCellsGlobal = OMEGA::IOGetDimLength(MeshFileID, "nCells");
+   if (NCellsGlobal <= 0)
+      LOG_CRITICAL("Decomp: error reading nCells");
+   NEdgesGlobal = OMEGA::IOGetDimLength(MeshFileID, "nEdges");
+   if (NEdgesGlobal <= 0)
+      LOG_CRITICAL("Decomp: error reading NEdges");
+   NVerticesGlobal = OMEGA::IOGetDimLength(MeshFileID, "nVertices");
+   if (NVerticesGlobal <= 0)
+      LOG_CRITICAL("Decomp: error reading NVertices");
+   MaxEdges = OMEGA::IOGetDimLength(MeshFileID, "maxEdges");
+   if (MaxEdges <= 0)
+      LOG_CRITICAL("Decomp: error reading MaxEdges");
+   VertexDegree = OMEGA::IOGetDimLength(MeshFileID, "vertexDegree");
+   if (VertexDegree <= 0)
+      LOG_CRITICAL("Decomp: error reading VertexDegree");
+   MaxCellsOnEdge    = 2;            // currently always 2
+   I4 MaxEdgesOnEdge = 2 * MaxEdges; // 2*MaxCellsOnEdge
+
+   // Create the linear decompositions for parallel IO
+   // Determine the size of each block, divided as evenly as possible
+   I4 NCellsChunk    = (NCellsGlobal - 1) / NumTasks + 1;
+   I4 NEdgesChunk    = (NEdgesGlobal - 1) / NumTasks + 1;
+   I4 NVerticesChunk = (NVerticesGlobal - 1) / NumTasks + 1;
+
+   // If global size did not divide evenly over processors, the last processor
+   // only has the remaining indices and not a full block (chunk)
+   I4 NCellsLocal;
+   I4 NEdgesLocal;
+   I4 NVerticesLocal;
+   if (MyTask < NumTasks - 1) {
+      NCellsLocal    = NCellsChunk;
+      NEdgesLocal    = NEdgesChunk;
+      NVerticesLocal = NVerticesChunk;
+   } else { // last MPI task
+      I4 StartAdd    = NCellsChunk * (NumTasks - 1);
+      NCellsLocal    = NCellsGlobal - StartAdd;
+      StartAdd       = NEdgesChunk * (NumTasks - 1);
+      NEdgesLocal    = NEdgesGlobal - StartAdd;
+      StartAdd       = NVerticesChunk * (NumTasks - 1);
+      NVerticesLocal = NVerticesGlobal - StartAdd;
+   }
+
+   // Define offset index for each array (essentially the global index)
+   // for the parallel IO decomposition. The XxOnCell arrays are all the
+   // same size and decomposition
+
+   I4 OnCellSize = NCellsChunk * MaxEdges;
+   I4 NDims      = 2;
+   std::vector<I4> OnCellDims{NCellsGlobal, MaxEdges};
+   std::vector<I4> OnCellOffset(OnCellSize, 0);
+   for (int Cell = 0; Cell < NCellsLocal; ++Cell) {
+      I4 CellGlob = MyTask * NCellsChunk + Cell;
+      for (int Edge = 0; Edge < MaxEdges; ++Edge) {
+         OnCellOffset[Cell * MaxEdges + Edge] = CellGlob * MaxEdges + Edge;
+      }
+   }
+
+   // Now we do the same for XXOnEdge and XXOnVertex arrays
+   // The EdgesOnEdge is a different size so needs its own
+   I4 OnEdgeSize   = NEdgesChunk * MaxCellsOnEdge;
+   I4 OnEdgeSize2  = NEdgesChunk * MaxEdgesOnEdge;
+   I4 OnVertexSize = NVerticesChunk * VertexDegree;
+   std::vector<I4> OnEdgeDims{NEdgesGlobal, MaxCellsOnEdge};
+   std::vector<I4> OnEdgeDims2{NEdgesGlobal, MaxEdgesOnEdge};
+   std::vector<I4> OnVertexDims{NVerticesGlobal, VertexDegree};
+   std::vector<I4> OnEdgeOffset(OnEdgeSize, 0);
+   std::vector<I4> OnEdgeOffset2(OnEdgeSize2, 0);
+   std::vector<I4> OnVertexOffset(OnVertexSize, 0);
+   for (int Edge = 0; Edge < NEdgesLocal; ++Edge) {
+      I4 EdgeGlob = MyTask * NEdgesChunk + Edge;
+      for (int Cell = 0; Cell < MaxCellsOnEdge; ++Cell) {
+         OnEdgeOffset[Edge * MaxCellsOnEdge + Cell] =
+             EdgeGlob * MaxCellsOnEdge + Cell;
+      }
+      for (int Cell = 0; Cell < MaxEdgesOnEdge; ++Cell) {
+         OnEdgeOffset2[Edge * MaxEdgesOnEdge + Cell] =
+             EdgeGlob * MaxEdgesOnEdge + Cell;
+      }
+   }
+   for (int Vrtx = 0; Vrtx < NVerticesLocal; ++Vrtx) {
+      I4 VertexGlob = MyTask * NVerticesChunk + Vrtx;
+      for (int Cell = 0; Cell < VertexDegree; ++Cell) {
+         OnVertexOffset[Vrtx * VertexDegree + Cell] =
+             VertexGlob * VertexDegree + Cell;
+      } // end loop VertexDegree
+   }    // end loop NVerticesLocal
+
+   // Create the parallel IO decompositions
+   IORearranger Rearr = IORearrBox;
+   I4 OnCellDecomp;
+   I4 OnEdgeDecomp;
+   I4 OnEdgeDecomp2;
+   I4 OnVertexDecomp;
+   Err = OMEGA::IOCreateDecomp(OnCellDecomp, OMEGA::IOTypeI4, NDims, OnCellDims,
+                               OnCellSize, OnCellOffset, Rearr);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error creating OnCell IO decomposition");
+   Err = OMEGA::IOCreateDecomp(OnEdgeDecomp, OMEGA::IOTypeI4, NDims, OnEdgeDims,
+                               OnEdgeSize, OnEdgeOffset, Rearr);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error creating OnEdge IO decomposition");
+   Err = OMEGA::IOCreateDecomp(OnEdgeDecomp2, OMEGA::IOTypeI4, NDims,
+                               OnEdgeDims2, OnEdgeSize2, OnEdgeOffset2, Rearr);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error creating OnEdg2 IO decomposition");
+   Err =
+       OMEGA::IOCreateDecomp(OnVertexDecomp, OMEGA::IOTypeI4, NDims,
+                             OnVertexDims, OnVertexSize, OnVertexOffset, Rearr);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error creating Vertex IO decomposition");
+
+   // Now read the connectivity arrays
+   CellsOnCellInit.resize(OnCellSize);
+   EdgesOnCellInit.resize(OnCellSize);
+   VerticesOnCellInit.resize(OnCellSize);
+   CellsOnEdgeInit.resize(OnEdgeSize);
+   EdgesOnEdgeInit.resize(OnEdgeSize2);
+   VerticesOnEdgeInit.resize(OnEdgeSize);
+   CellsOnVertexInit.resize(OnVertexSize);
+   EdgesOnVertexInit.resize(OnVertexSize);
+
+   Err = OMEGA::IOReadArray(&CellsOnCellInit[0], OnCellSize, "cellsOnCell",
+                            MeshFileID, OnCellDecomp);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error reading CellsOnCell");
+   Err = OMEGA::IOReadArray(&EdgesOnCellInit[0], OnCellSize, "edgesOnCell",
+                            MeshFileID, OnCellDecomp);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error reading EdgesOnCell");
+   Err = OMEGA::IOReadArray(&VerticesOnCellInit[0], OnCellSize,
+                            "verticesOnCell", MeshFileID, OnCellDecomp);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error reading VerticesOnCell");
+   Err = OMEGA::IOReadArray(&CellsOnEdgeInit[0], OnEdgeSize, "cellsOnEdge",
+                            MeshFileID, OnEdgeDecomp);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error reading CellsOnEdge");
+   Err = OMEGA::IOReadArray(&EdgesOnEdgeInit[0], OnEdgeSize2, "edgesOnEdge",
+                            MeshFileID, OnEdgeDecomp2);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error reading EdgesOnEdge");
+   Err = OMEGA::IOReadArray(&VerticesOnEdgeInit[0], OnEdgeSize,
+                            "verticesOnEdge", MeshFileID, OnEdgeDecomp);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error reading VerticesOnEdge");
+   Err = OMEGA::IOReadArray(&CellsOnVertexInit[0], OnVertexSize,
+                            "cellsOnVertex", MeshFileID, OnVertexDecomp);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error reading CellsOnVertex");
+   Err = OMEGA::IOReadArray(&EdgesOnVertexInit[0], OnVertexSize,
+                            "edgesOnVertex", MeshFileID, OnVertexDecomp);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error reading EdgesOnVertex");
+
+   // Initial decompositions are no longer needed so remove them now
+   Err = OMEGA::IODestroyDecomp(OnCellDecomp);
+   if (Err != 0)
+      LOG_ERROR("Decomp: error destroying OnCell decomposition");
+   Err = OMEGA::IODestroyDecomp(OnEdgeDecomp);
+   if (Err != 0)
+      LOG_ERROR("Decomp: error destroying OnEdge decomposition");
+   Err = OMEGA::IODestroyDecomp(OnEdgeDecomp2);
+   if (Err != 0)
+      LOG_ERROR("Decomp: error destroying OnEdge2 decomposition");
+   Err = OMEGA::IODestroyDecomp(OnVertexDecomp);
+   if (Err != 0)
+      LOG_ERROR("Decomp: error destroying OnVertex decomposition");
+
+   return Err;
+
+} // end readMesh
+
+//------------------------------------------------------------------------------
+// Initialize the decomposition and create the default decomposition with
+// (currently) one partition per MPI task using a ParMetis KWay method.
+
+int Decomp::init() {
+
+   int Err = 0; // default successful return code
+
+   // TODO: retrieve from Config when available - currently hardwired
+   // Initialize decomposition options
+   I4 InHaloWidth           = 3;
+   std::string MeshFileName = "OmegaMesh.nc";
+   std::string DecompMethod = "MetisKWay";
+   PartMethod Method        = getPartMethodFromStr(DecompMethod);
+
+   // Retrieve the default machine environment
+   MachEnv *DefEnv = MachEnv::getDefaultEnv();
+
+   // Use one partition per MPI task as the default
+   I4 NParts = DefEnv->getNumTasks();
+
+   // Create the default decomposition
+   Decomp DefDecomp("Default", DefEnv, NParts, Method, InHaloWidth,
+                    MeshFileName);
+
+   // Retrieve this environment and set pointer to DefaultDecomp
+   Decomp::DefaultDecomp = Decomp::get("Default");
+
+   return Err;
+
+} // End init decomposition
+
+//------------------------------------------------------------------------------
+// Construct a new decomposition across an input MachEnv using
+// NPart partitions of the mesh.
+
+Decomp::Decomp(
+    const std::string &Name,        //< [in] Name for new decomposition
+    const MachEnv *InEnv,           //< [in] MachEnv for the new partition
+    I4 NParts,                      //< [in] num of partitions for new decomp
+    PartMethod Method,              //< [in] method for partitioning
+    I4 InHaloWidth,                 //< [in] width of halo in new decomp
+    const std::string &MeshFileName //< [in] name of file with mesh info
+) {
+
+   int Err = 0; // internal error code
+
+   // Retrieve some info on the MPI layout
+   MPI_Comm Comm = InEnv->getComm();
+   I4 NumTasks   = InEnv->getNumTasks();
+   I4 MyTask     = InEnv->getMyTask();
+   I4 MasterTask = InEnv->getMasterTask();
+   bool IsMaster = InEnv->isMasterTask();
+
+   // Open the mesh file for reading (assume IO has already been initialized)
+   int FileID;
+   Err = OMEGA::IOFileOpen(FileID, MeshFileName, IOModeRead);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: error opening mesh file");
+
+   // Read mesh size and connectivity information
+   std::vector<I4> CellsOnCellInit;
+   std::vector<I4> EdgesOnCellInit;
+   std::vector<I4> VerticesOnCellInit;
+   std::vector<I4> CellsOnEdgeInit;
+   std::vector<I4> EdgesOnEdgeInit;
+   std::vector<I4> VerticesOnEdgeInit;
+   std::vector<I4> CellsOnVertexInit;
+   std::vector<I4> EdgesOnVertexInit;
+   HaloWidth = InHaloWidth;
+
+   Err = readMesh(FileID, InEnv, NCellsGlobal, NEdgesGlobal, NVerticesGlobal,
+                  MaxEdges, MaxCellsOnEdge, VertexDegree, CellsOnCellInit,
+                  EdgesOnCellInit, VerticesOnCellInit, CellsOnEdgeInit,
+                  EdgesOnEdgeInit, VerticesOnEdgeInit, CellsOnVertexInit,
+                  EdgesOnVertexInit);
+   if (Err != 0)
+      LOG_CRITICAL("Decomp: Error reading mesh connectivity");
+
+   // Close file
+   Err = IOFileClose(FileID);
+
+   // Use the mesh adjacency information to create a partition of cells
+   switch (Method) { // branch depending on method chosen
+
+   //---------------------------------------------------------------------------
+   // ParMetis KWay method
+   case PartMethodMetisKWay: {
+
+      Err = partCellsKWay(InEnv, CellsOnCellInit);
+      if (Err != 0) {
+         LOG_CRITICAL("Decomp: Error partitioning cells KWay");
+         return;
+      }
+      break;
+   } // end case MethodKWay
+
+      //---------------------------------------------------------------------------
+      // Unknown partitioning method
+
+   default:
+      LOG_CRITICAL("Decomp: Unknown or unsupported decomposition method");
+      return;
+
+   } // End switch on Method
+
+   //---------------------------------------------------------------------------
+
+   // Cell partitioning complete. Redistribute the initial XXOnCell arrays
+   // to their final locations.
+   Err = rearrangeCellArrays(InEnv, CellsOnCellInit, EdgesOnCellInit,
+                             VerticesOnCellInit);
+   if (Err != 0) {
+      LOG_CRITICAL("Decomp: Error rearranging XxOnCell arrays");
+      return;
+   }
+
+   // Partition the edges
+   Err = partEdges(InEnv, CellsOnEdgeInit);
+   if (Err != 0) {
+      LOG_CRITICAL("Decomp: Error partitioning edges");
+      return;
+   }
+
+   // Edge partitioning complete. Redistribute the initial XXOnEdge arrays
+   // to their final locations.
+   Err = rearrangeEdgeArrays(InEnv, CellsOnEdgeInit, EdgesOnEdgeInit,
+                             VerticesOnEdgeInit);
+   if (Err != 0) {
+      LOG_CRITICAL("Decomp: Error rearranging XxOnEdge arrays");
+      return;
+   }
+
+   // Partition the vertices
+   Err = partVertices(InEnv, CellsOnVertexInit);
+   if (Err != 0) {
+      LOG_CRITICAL("Decomp: Error partitioning vertices");
+      return;
+   }
+
+   // Vertex partitioning complete. Redistribute the initial XXOnVertex arrays
+   // to their final locations.
+   Err = rearrangeVertexArrays(InEnv, CellsOnVertexInit, EdgesOnVertexInit);
+   if (Err != 0) {
+      LOG_CRITICAL("Decomp: Error rearranging XxOnVertex arrays");
+      return;
+   }
+
+   // Convert global addresses to local addresses. Create the global to
+   // local address ordered maps to simplify and optimize searches.
+   // Invalid/non-existent edges have been assigned NXxGlobal+1 and we want
+   // to map that to the local NXxAll+1 (NXxSize). We insert that value
+   // first in the map so that later attempts to change will be ignored.
+
+   std::map<I4, I4> GlobToLocCell;
+   GlobToLocCell[NCellsGlobal + 1] = NCellsAll;
+   for (int Cell = 0; Cell < NCellsAll; ++Cell) {
+      GlobToLocCell[CellIDH(Cell)] = Cell;
+   }
+
+   std::map<I4, I4> GlobToLocEdge;
+   GlobToLocEdge[NEdgesGlobal + 1] = NEdgesAll;
+   for (int Edge = 0; Edge < NEdgesAll; ++Edge) {
+      GlobToLocEdge[EdgeIDH(Edge)] = Edge;
+   }
+
+   std::map<I4, I4> GlobToLocVrtx;
+   GlobToLocVrtx[NVerticesGlobal + 1] = NVerticesAll;
+   for (int Vrtx = 0; Vrtx < NVerticesAll; ++Vrtx) {
+      GlobToLocVrtx[VertexIDH(Vrtx)] = Vrtx;
+   }
+
+   // CellsOnCell
+   for (int Cell = 0; Cell < NCellsSize; ++Cell) {
+      for (int NbrCell = 0; NbrCell < MaxEdges; ++NbrCell) {
+         I4 GlobID = CellsOnCellH(Cell, NbrCell);
+         // In some cases (eg in halo regions) there are still
+         // some remaining CellIDs that are not in the local owned
+         // or halo domain and are on another task.  Catch that case here
+         auto it = GlobToLocCell.find(GlobID);
+         I4 LocalAdd;
+         if (it != GlobToLocCell.end()) {
+            LocalAdd = it->second; // retrieve map entry if exists
+         } else {
+            LocalAdd = NCellsAll; // otherwise set to bndy/unknown address
+            GlobToLocCell[GlobID] = NCellsAll; // add an entry to map
+         }
+         CellsOnCellH(Cell, NbrCell) = LocalAdd;
+      }
+   }
+
+   // EdgesOnCell
+   for (int Cell = 0; Cell < NCellsSize; ++Cell) {
+      for (int Edge = 0; Edge < MaxEdges; ++Edge) {
+         I4 GlobID = EdgesOnCellH(Cell, Edge);
+         // In some cases (eg in halo regions) there are still
+         // some remaining EdgeIDs that are not in the local owned
+         // or halo domain and are on another task.  Catch that case here
+         auto it = GlobToLocEdge.find(GlobID);
+         I4 LocalAdd;
+         if (it != GlobToLocEdge.end()) {
+            LocalAdd = it->second; // retrieve map entry if exists
+         } else {
+            LocalAdd = NEdgesAll; // otherwise set to bndy/unknown address
+            GlobToLocEdge[GlobID] = NEdgesAll; // add an entry to map
+         }
+         EdgesOnCellH(Cell, Edge) = LocalAdd;
+      }
+   }
+
+   // VerticesOnCell
+   for (int Cell = 0; Cell < NCellsSize; ++Cell) {
+      for (int Vrtx = 0; Vrtx < MaxEdges; ++Vrtx) {
+         I4 GlobID = VerticesOnCellH(Cell, Vrtx);
+         // In some cases (eg in halo regions) there are still
+         // some remaining EdgeIDs that are not in the local owned
+         // or halo domain and are on another task.  Catch that case here
+         auto it = GlobToLocVrtx.find(GlobID);
+         I4 LocalAdd;
+         if (it != GlobToLocVrtx.end()) {
+            LocalAdd = it->second; // retrieve map entry if exists
+         } else {
+            LocalAdd = NVerticesAll; // otherwise set to bndy/unknown address
+            GlobToLocVrtx[GlobID] = NVerticesAll; // add an entry to map
+         }
+         VerticesOnCellH(Cell, Vrtx) = LocalAdd;
+      }
+   }
+
+   // CellsOnEdge
+   for (int Edge = 0; Edge < NEdgesSize; ++Edge) {
+      for (int Cell = 0; Cell < MaxCellsOnEdge; ++Cell) {
+         I4 GlobID = CellsOnEdgeH(Edge, Cell);
+         auto it   = GlobToLocCell.find(GlobID);
+         I4 LocalAdd;
+         if (it != GlobToLocCell.end()) {
+            LocalAdd = it->second; // retrieve map entry if exists
+         } else {
+            LocalAdd = NCellsAll; // otherwise set to bndy/unknown address
+            GlobToLocCell[GlobID] = NCellsAll; // add an entry to map
+         }
+         CellsOnEdgeH(Edge, Cell) = LocalAdd;
+      }
+   }
+
+   // EdgesOnEdge
+   for (int Edge = 0; Edge < NEdgesSize; ++Edge) {
+      for (int NbrEdge = 0; NbrEdge < 2 * MaxEdges; ++NbrEdge) {
+         I4 GlobID = EdgesOnEdgeH(Edge, NbrEdge);
+         auto it   = GlobToLocEdge.find(GlobID);
+         I4 LocalAdd;
+         if (it != GlobToLocEdge.end()) {
+            LocalAdd = it->second; // retrieve map entry if exists
+         } else {
+            LocalAdd = NEdgesAll; // otherwise set to bndy/unknown address
+            GlobToLocEdge[GlobID] = NEdgesAll; // add an entry to map
+         }
+         EdgesOnEdgeH(Edge, NbrEdge) = LocalAdd;
+      }
+   }
+
+   // VerticesOnEdge
+   for (int Edge = 0; Edge < NEdgesSize; ++Edge) {
+      for (int Vrtx = 0; Vrtx < 2; ++Vrtx) {
+         I4 GlobID = VerticesOnEdgeH(Edge, Vrtx);
+         auto it   = GlobToLocVrtx.find(GlobID);
+         I4 LocalAdd;
+         if (it != GlobToLocVrtx.end()) {
+            LocalAdd = it->second; // retrieve map entry if exists
+         } else {
+            LocalAdd = NVerticesAll; // otherwise set to bndy/unknown address
+            GlobToLocVrtx[GlobID] = NVerticesAll; // add an entry to map
+         }
+         VerticesOnEdgeH(Edge, Vrtx) = LocalAdd;
+      }
+   }
+
+   // CellsOnVertex
+   for (int Vrtx = 0; Vrtx < NVerticesSize; ++Vrtx) {
+      for (int Cell = 0; Cell < VertexDegree; ++Cell) {
+         I4 GlobID = CellsOnVertexH(Vrtx, Cell);
+         auto it   = GlobToLocCell.find(GlobID);
+         I4 LocalAdd;
+         if (it != GlobToLocCell.end()) {
+            LocalAdd = it->second; // retrieve map entry if exists
+         } else {
+            LocalAdd = NCellsAll; // otherwise set to bndy/unknown address
+            GlobToLocCell[GlobID] = NCellsAll; // add an entry to map
+         }
+         CellsOnVertexH(Vrtx, Cell) = LocalAdd;
+      }
+   }
+
+   // EdgesOnVertex
+   for (int Vrtx = 0; Vrtx < NVerticesSize; ++Vrtx) {
+      for (int Edge = 0; Edge < VertexDegree; ++Edge) {
+         I4 GlobID = EdgesOnVertexH(Vrtx, Edge);
+         auto it   = GlobToLocEdge.find(GlobID);
+         I4 LocalAdd;
+         if (it != GlobToLocEdge.end()) {
+            LocalAdd = it->second; // retrieve map entry if exists
+         } else {
+            LocalAdd = NEdgesAll; // otherwise set to bndy/unknown address
+            GlobToLocEdge[GlobID] = NEdgesAll; // add an entry to map
+         }
+         EdgesOnVertexH(Vrtx, Edge) = LocalAdd;
+      }
+   }
+
+   // Create device copies of all arrays
+
+   //NCellsHalo = NCellsHaloH.createDeviceCopy();
+   //CellID     = CellIDH.createDeviceCopy();
+   //CellLoc    = CellLocH.createDeviceCopy();
+
+   // NEdgesHalo = NEdgesHaloH.createDeviceCopy();
+   // EdgeID     = EdgeIDH.createDeviceCopy();
+   // EdgeLoc    = EdgeLocH.createDeviceCopy();
+
+   // NVerticesHalo = NVerticesHaloH.createDeviceCopy();
+   // VertexID      = VertexIDH.createDeviceCopy();
+   // VertexLoc     = VertexLocH.createDeviceCopy();
+
+   // CellsOnCell    = CellsOnCellH.createDeviceCopy();
+   // EdgesOnCell    = EdgesOnCellH.createDeviceCopy();
+   // VerticesOnCell = VerticesOnCellH.createDeviceCopy();
+   // NEdgesOnCell    = NEdgesOnCellH.createDeviceCopy();
+
+   // CellsOnEdge     = CellsOnEdgeH.createDeviceCopy();
+   // EdgesOnEdge     = EdgesOnEdgeH.createDeviceCopy();
+   // VerticesOnEdge  = VerticesOnEdgeH.createDeviceCopy();
+   // NEdgesOnEdge    = NEdgesOnEdgeH.createDeviceCopy();
+
+   // CellsOnVertex = CellsOnVertexH.createDeviceCopy();
+   // EdgesOnVertex = EdgesOnVertexH.createDeviceCopy();
+
+   // Assign this as the default decomposition
+   AllDecomps.emplace(Name, *this);
+
+} // end decomposition constructor
+
+// Destructor
+//------------------------------------------------------------------------------
+// Destroys a decomposition and deallocates all arrays
+
+Decomp::~Decomp() {
+
+   // TODO: add deletes for all arrays and remove from AllDecomps map
+
+} // end removeEnv
+
+// Retrieval functions
+//------------------------------------------------------------------------------
+// Get default decomposition
+Decomp *Decomp::getDefault() { return Decomp::DefaultDecomp; }
+
+//------------------------------------------------------------------------------
+// Get decomposition by name
+Decomp *Decomp::get(const std::string Name ///< [in] Name of environment
+) {
+
+   // look for an instance of this name
+   auto it = AllDecomps.find(Name);
+
+   // if found, return the decomposition pointer
+   if (it != AllDecomps.end()) {
+      return &(it->second);
+
+      // otherwise print an error and return a null pointer
+   } else {
+      LOG_ERROR("Decomp::get: Attempt to retrieve non-existent Decomposition:");
+      LOG_ERROR(" {} has not been defined or has been removed", Name);
+      return nullptr;
+   }
+
+} // end get Decomposition
+
+//------------------------------------------------------------------------------
+// Partition the cells using the Metis/ParMetis KWay method
+// After this partitioning, the decomposition class member CellID and
+// CellLocator arrays have been set as well as the class NCells size variables
+// (owned, halo, all).
+
+int Decomp::partCellsKWay(
+    const MachEnv *InEnv, // [in] input machine environment with MPI info
+    const std::vector<I4> &CellsOnCellInit // [in] cell nbrs in linear distrb
+) {
+
+   int Err = 0; // initialize return code
+
+   // Retrieve some info on the MPI layout
+   MPI_Comm Comm = InEnv->getComm();
+   I4 NumTasks   = InEnv->getNumTasks();
+   I4 MyTask     = InEnv->getMyTask();
+   I4 MasterTask = InEnv->getMasterTask();
+   bool IsMaster = InEnv->isMasterTask();
+
+   // TEMPORARY:
+   // Due to difficulties with ParMetis, we use serial Metis for now with
+   // each task calling the serial form with the global adjacency data.
+   // This requires us to communicate the CellsOnCell data and pack it
+   // into the Metis structure.
+
+   // Allocate adjacency arrays and a buffer for portions of the CellsOnCell
+   // array.
+   std::vector<idx_t> AdjAdd(NCellsGlobal + 1, 0);
+   std::vector<idx_t> Adjacency(2 * NEdgesGlobal, 0);
+   I4 NCellsChunk     = (NCellsGlobal - 1) / NumTasks + 1;
+   I4 CellsOnCellSize = NCellsChunk * MaxEdges;
+   std::vector<I4> CellsOnCellBuf(CellsOnCellSize, 0);
+
+   // This is an address counter needed to keep track of the starting
+   // address for each cell in the packed adjacency array.
+   I4 Add = 0;
+
+   // One at a time, each task broadcasts its portion of the CellsOnCell data
+   // and then unpacks it into the adjacency array in the packed form needed
+   // by METIS/ParMETIS
+   for (int Task = 0; Task < NumTasks; ++Task) {
+
+      // If it is this task's turn, pack up the CellsOnCell data and broadcast
+      // to other tasks.
+      if (MyTask == Task) {
+         for (int n = 0; n < CellsOnCellSize; ++n) {
+            CellsOnCellBuf[n] = CellsOnCellInit[n];
+         } // end loop CellsOnCell
+      }    // end if this is MyTask
+      Err = MPI_Bcast(&CellsOnCellBuf[0], CellsOnCellSize, MPI_INT32_T, Task,
+                      Comm);
+      if (Err != 0) {
+         LOG_CRITICAL("Decomp: Error communicating CellsOnCell info");
+         return Err;
+      }
+
+      // Create the adjacency graph by aggregating the individual
+      // chunks. Prune edges that don't have neighbors.
+      for (int Cell = 0; Cell < NCellsChunk; ++Cell) {
+
+         I4 CellGlob = Task * NCellsChunk + Cell; // global cell ID
+
+         // when chunks do not divide evenly this happens and we break out
+         if (CellGlob >= NCellsGlobal)
+            break;
+
+         AdjAdd[CellGlob] = Add; // start add for cell in Adjacency array
+         for (int Edge = 0; Edge < MaxEdges; ++Edge) {
+            I4 BufAdd  = Cell * MaxEdges + Edge;
+            I4 NbrCell = CellsOnCellBuf[BufAdd];
+            // Skip edges with no neighbors
+            if (NbrCell > 0 && NbrCell <= NCellsGlobal) {
+               // switch to 0-based indx
+               Adjacency[Add] = NbrCell - 1;
+               ++Add; // increment address counter
+            }
+         }
+      }                        // end cell loop for buffer
+   }                           // end task loop
+   AdjAdd[NCellsGlobal] = Add; // Add the ending address
+
+   // Set up remaining partitioning variables
+
+   // NConstraints is the number of balancing constraints, mostly for
+   // use when multiple vertex weights are assigned. Must be at least 1.
+   // We do not yet support weighted partitions
+   idx_t NConstraints = 1;
+
+   // Arrays needed for weighted decompositions. If no weighting used
+   // set pointers to null.
+   idx_t *VrtxWgtPtr{nullptr};
+   idx_t *EdgeWgtPtr{nullptr};
+   idx_t *VrtxSize{nullptr};
+
+   // Use default metis options
+   idx_t *Options{nullptr};
+
+   // These are for multi-constraint partitions where the vertex weight
+   // has to be distributed among the multiple constraints.
+   // We do not use them so set them to null
+   real_t *TpWgts{nullptr};
+   real_t *Ubvec{nullptr};
+
+   // Results are stored in a new partition array which returns
+   // the processor (partition) assigned to the cell (vrtx)
+   // The routine also returns the number of edge cuts in the partition
+   std::vector<idx_t> CellTask(NCellsGlobal);
+   idx_t Edgecut = 0;
+
+   // Call METIS routine to partition the mesh
+   // METIS routines are C code that expect pointers, so we use the
+   // idiom &Var[0] to extract the pointer to the data in std::vector
+   int MetisErr = METIS_PartGraphKway(&NCellsGlobal, &NConstraints, &AdjAdd[0],
+                                      &Adjacency[0], VrtxWgtPtr, VrtxSize,
+                                      EdgeWgtPtr, &NumTasks, TpWgts, Ubvec,
+                                      Options, &Edgecut, &CellTask[0]);
+
+   if (MetisErr != METIS_OK) {
+      LOG_CRITICAL("Decomp: Error in ParMETIS");
+      Err = -1;
+      return Err;
+   }
+
+   // Determine the initial sizes needed by address arrays
+
+   std::vector<I4> TaskCount(NumTasks, 0);
+   for (int Cell = 0; Cell < NCellsGlobal; ++Cell) {
+      I4 TaskLoc  = CellTask[Cell];
+      I4 LocalAdd = TaskCount[TaskLoc];
+      ++TaskCount[TaskLoc]; // increment number of cells assigned to task
+   }
+   NCellsOwned = TaskCount[MyTask];
+
+   // Assign the full address (TaskID, local index) for each cell. These
+   // are implicity sorted in CellID order.
+   // During this process we also create an ordered list of all local
+   // (owned+halo) cells using std::set for later use in halo setup
+
+   std::vector<I4> CellLocAll(2 * NCellsGlobal);
+   std::vector<I4> CellIDTmp(NCellsOwned,
+                             NCellsGlobal + 1);    // initial size only
+   std::vector<I4> CellLocTmp(2 * NCellsOwned, 0); // will grow when halo added
+   std::set<I4> CellsInList; // list of unique cells in local owned, halo
+
+   // reset local address counter
+   for (int Task = 0; Task < NumTasks; ++Task)
+      TaskCount[Task] = 0;
+
+   for (int Cell = 0; Cell < NCellsGlobal; ++Cell) {
+      I4 TaskLoc  = CellTask[Cell];
+      I4 LocalAdd = TaskCount[TaskLoc];
+      ++TaskCount[TaskLoc]; // increment number of cells assigned to task
+      CellLocAll[2 * Cell]     = TaskLoc;  // Task location
+      CellLocAll[2 * Cell + 1] = LocalAdd; // local address within task
+      // If this cell is on the local task, store as a local cell
+      if (TaskLoc == MyTask) {
+         CellIDTmp[LocalAdd] = Cell + 1; // IDs are 1-based
+         CellsInList.insert(Cell + 1);
+         CellLocTmp[2 * LocalAdd]     = TaskLoc;
+         CellLocTmp[2 * LocalAdd + 1] = LocalAdd;
+      } // end if my task
+   }    // end loop over all cells
+
+   // Find and add the halo cells to the cell list. Here we use the
+   // adjacency array to find the active neighbor cells and store if they
+   // are not already owned by the task. We use the std::set container
+   // to automatically sort each halo layer by cellID.
+   I4 CellLocStart = 0;
+   I4 CellLocEnd   = NCellsOwned - 1;
+   I4 CurSize      = NCellsOwned;
+   ArrayHost1DI4 NCellsHaloTmp("NCellsHalo", HaloWidth);
+   std::set<I4> HaloList;
+   // Loop over each halo layer
+   for (int Halo = 0; Halo < HaloWidth; ++Halo) {
+      // For each of the local cells in the previous level, retrieve
+      // the GlobalID
+      HaloList.clear(); // reset list for this halo layer
+      I4 NbrGlob;       // use for global address of each neighbor
+      I4 NbrID;         // global cell ID of each neighbor
+      for (int CellLoc = CellLocStart; CellLoc <= CellLocEnd; ++CellLoc) {
+         I4 CellGlob = CellIDTmp[CellLoc] - 1;
+         // Loop through the neighbor cells (stored in the adjacency arrays)
+         // to see if they are remote or local
+         I4 NbrStart = AdjAdd[CellGlob];     // start add in adjacency array
+         I4 NbrEnd   = AdjAdd[CellGlob + 1]; // end+1 add in adjacency array
+         for (int NbrCell = NbrStart; NbrCell < NbrEnd; ++NbrCell) {
+            // Get global ID for each neighbor cell
+            NbrGlob = Adjacency[NbrCell];
+            NbrID   = NbrGlob + 1; // Cell IDs are 1-based
+
+            // Check to see if this cell is on a remote task and has not
+            // already been added
+            I4 NbrTask = CellLocAll[2 * NbrGlob];
+            if (NbrTask != MyTask) {
+               // only add to the list if the cell is not already listed
+               // (the find function will return the end iterator if not found)
+               if (CellsInList.find(NbrID) == CellsInList.end()) {
+                  HaloList.insert(NbrID);
+                  CellsInList.insert(NbrID);
+               } // end search for existing entry
+            }    // end if not on task
+
+         } // end loop over neighbors
+
+      } // end loop over previous layer
+
+      // Extract the values from the Halo list into the ID and location
+      // vectors. Extend size of ID, Loc arrays.
+      I4 HaloAdd = CellLocEnd;
+      CurSize += HaloList.size();
+      NCellsHaloTmp(Halo) = CurSize;
+      CellIDTmp.resize(CurSize);
+      CellLocTmp.resize(2 * CurSize);
+
+      for (auto IHalo = HaloList.begin(); IHalo != HaloList.end(); IHalo++) {
+         ++HaloAdd;
+         NbrID              = *IHalo; // the neighbor cell id from the HaloList
+         NbrGlob            = NbrID - 1; // global address of this neighbor
+         CellIDTmp[HaloAdd] = NbrID;
+         CellLocTmp[2 * HaloAdd]     = CellLocAll[2 * NbrGlob];
+         CellLocTmp[2 * HaloAdd + 1] = CellLocAll[2 * NbrGlob + 1];
+      }
+
+      // Reset for next halo layer
+      CellLocStart = CellLocEnd + 1;
+      CellLocEnd   = NCellsHaloTmp(Halo) - 1;
+   }
+   NCellsAll  = NCellsHaloTmp(HaloWidth - 1);
+   NCellsSize = NCellsAll + 1; // extra entry to store boundary/undefined value
+
+   // The cell decomposition is now complete, copy the information
+   // into the final locations as class members on host (copy to device later)
+
+   NCellsHaloH = NCellsHaloTmp;
+
+   // Copy global ID for each cell, both owned and halo.
+   // Copy cell location (task, local add) for each cell, both owned and halo
+
+   ArrayHost1DI4 CellIDHTmp("CellID", NCellsSize);
+   ArrayHost2DI4 CellLocHTmp("CellLoc", NCellsSize, 2);
+   for (int Cell = 0; Cell < NCellsAll; ++Cell) {
+      CellIDHTmp(Cell)     = CellIDTmp[Cell];
+      CellLocHTmp(Cell, 0) = CellLocTmp[2 * Cell];     // task owning this cell
+      CellLocHTmp(Cell, 1) = CellLocTmp[2 * Cell + 1]; // local address on task
+   }
+   CellIDH  = CellIDHTmp;
+   CellLocH = CellLocHTmp;
+
+   // All done
+   return Err;
+
+} // end function partCellsKWay
+
+//------------------------------------------------------------------------------
+// Partition the edges based on the cell decomposition. The first cell ID in
+// the CellsOnEdge array for a given edge is assigned ownership of the edge.
+
+int Decomp::partEdges(
+    const MachEnv *InEnv, ///< [in] input machine environment with MPI info
+    const std::vector<I4> &CellsOnEdgeInit // [in] cell nbrs for each edge
+) {
+
+   I4 Err = 0; // default error code
+
+   // Retrieve some info on the MPI layout
+   MPI_Comm Comm = InEnv->getComm();
+   I4 NumTasks   = InEnv->getNumTasks();
+   I4 MyTask     = InEnv->getMyTask();
+   I4 MasterTask = InEnv->getMasterTask();
+   bool IsMaster = InEnv->isMasterTask();
+
+   // Calculate some quantities associated with the initial linear
+   // distribution
+   I4 NCellsChunk = (NCellsGlobal - 1) / NumTasks + 1;
+   I4 NEdgesChunk = (NEdgesGlobal - 1) / NumTasks + 1;
+   I4 NCellsLocal = NCellsChunk;
+   I4 NEdgesLocal = NEdgesChunk;
+
+   // If cells/edges do not divide evenly over processors, the last processor
+   // only has the remaining cells and not a full block (chunk)
+   if (MyTask == NumTasks - 1) {
+      I4 StartAdd = NCellsChunk * (NumTasks - 1);
+      NCellsLocal = NCellsGlobal - StartAdd;
+      StartAdd    = NEdgesChunk * (NumTasks - 1);
+      NEdgesLocal = NEdgesGlobal - StartAdd;
+   }
+
+   // For the tasks below, it is useful to keep a sorted list of various cells
+   // and edges using the std::set container and related search/sort functions.
+   // We create sets for local owned cells, all local edges,
+   // local owned edges and local halo edges.
+   std::set<I4> CellsOwned;
+   std::set<I4> CellsAll;
+   std::set<I4> EdgesAll;
+   std::set<I4> EdgesOwned;
+   std::set<I4> EdgesOwnedHalo1;
+
+   for (int Cell = 0; Cell < NCellsAll; ++Cell) {
+      CellsAll.insert(CellIDH(Cell));
+      if (Cell < NCellsOwned)
+         CellsOwned.insert(CellIDH(Cell));
+   }
+
+   // From the EdgesOnCell array, we count and create a sorted list of
+   // all edges that are needed locally. Edges that surround owned
+   // cells will either be owned edges or in the first halo so we track
+   // those as well for later sorting.
+
+   for (int Cell = 0; Cell < NCellsAll; ++Cell) {
+      for (int Edge = 0; Edge < MaxEdges; ++Edge) {
+         I4 EdgeGlob = EdgesOnCellH(Cell, Edge);
+         if (validEdgeID(EdgeGlob)) {
+            EdgesAll.insert(EdgeGlob);
+            if (Cell < NCellsOwned)
+               EdgesOwnedHalo1.insert(EdgeGlob);
+         }
+      }
+   }
+   NEdgesAll  = EdgesAll.size();
+   NEdgesSize = NEdgesAll + 1;
+
+   // To determine whether the edge is owned by this task, we first
+   // determine ownership as the first valid cell in the CellsOnEdge
+   // array. CellsOnEdge is only in the initial linear decomposition so
+   // we compute it there and broadcast the data to other MPI tasks.
+
+   std::vector<I4> EdgeOwnerInit(NEdgesChunk, NCellsGlobal + 1);
+   for (int Edge = 0; Edge < NEdgesLocal; ++Edge) {
+      I4 EdgeGlob = MyTask * NEdgesChunk + Edge + 1;
+      for (int Cell = 0; Cell < MaxCellsOnEdge; ++Cell) {
+         I4 CellGlob = CellsOnEdgeInit[Edge * MaxCellsOnEdge + Cell];
+         if (validCellID(CellGlob)) {
+            EdgeOwnerInit[Edge] = CellGlob;
+            break;
+         }
+      }
+   }
+
+   // Broadcast the edge ownership to all tasks, one chunk at a time
+   // and create a sorted list of all owned edges.
+
+   std::vector<I4> EdgeBuf(NEdgesChunk);
+   for (int Task = 0; Task < NumTasks; ++Task) {
+
+      // if it is this task's turn, fill the buffer with the owner info
+      if (Task == MyTask) {
+         for (int Edge = 0; Edge < NEdgesChunk; ++Edge) {
+            EdgeBuf[Edge] = EdgeOwnerInit[Edge];
+         }
+      }
+      // Broadcast this buffer
+      Err = MPI_Bcast(&EdgeBuf[0], NEdgesChunk, MPI_INT32_T, Task, Comm);
+
+      // For each edge in the buffer, check to see if the task owns
+      // the cell. If so, add the edge ID to the owned edges list.
+      for (int Edge = 0; Edge < NEdgesChunk; ++Edge) {
+
+         I4 EdgeGlob =
+             Task * NEdgesChunk + Edge + 1; // Global ID in initial distrb
+         // when number of edges doesn't divide evenly, the last
+         // task has some invalid edges at the end so break out of loop
+         if (EdgeGlob > NEdgesGlobal)
+            break;
+
+         I4 CellOwner = EdgeBuf[Edge];
+         if (CellsOwned.find(CellOwner) != CellsOwned.end()) {
+            // this task owns cell and therefore the edge
+            EdgesOwned.insert(EdgeGlob);
+         }
+      }
+
+   } // end task loop
+
+   // For compatibility with the previous MPAS model, we sort the
+   // edges based on the order encounted in EdgesOnCell. The first halo
+   // level is actually stored in reverse order from the end inward. We sort
+   // edge IDs, locations and CellsOnEdge with this ordering.
+
+   NEdgesOwned = EdgesOwned.size();
+   ArrayHost1DI4 NEdgesHaloTmp("NEdgesHalo", HaloWidth);
+   I4 HaloCount     = EdgesOwnedHalo1.size();
+   NEdgesHaloTmp(0) = HaloCount;
+
+   ArrayHost1DI4 EdgeIDTmp("EdgeID", NEdgesSize);
+   yakl::memset(EdgeIDTmp, NEdgesGlobal + 1);
+
+   // The owned and first halo of edges comes from the edges around
+   // the owned cells, so start with these.
+   I4 EdgeCount = 0;
+   HaloCount--; // initialize for first halo entry in reverse order
+   for (int Cell = 0; Cell < NCellsOwned; ++Cell) {
+      for (int CellEdge = 0; CellEdge < MaxEdges; ++CellEdge) {
+         I4 EdgeGlob = EdgesOnCellH(Cell, CellEdge);
+         // if this is a valid edge and the edge has not already been
+         // processed, add the edge to the edge list and remove from
+         // the relevant search arrays
+         if (validEdgeID(EdgeGlob) &&
+             EdgesAll.find(EdgeGlob) != EdgesAll.end()) { // edge in list
+            // determine whether location is in owned or halo list
+            if (EdgesOwned.find(EdgeGlob) != EdgesOwned.end()) {
+               EdgeIDTmp(EdgeCount) = EdgeGlob;
+               ++EdgeCount;
+               EdgesAll.erase(EdgeGlob); // remove from search list
+            } else {
+               EdgeIDTmp(HaloCount) = EdgeGlob;
+               --HaloCount;
+               EdgesAll.erase(EdgeGlob); // remove from search list
+            }
+         }
+      }
+   }
+
+   // Fill in the remaining halo regions
+   I4 CellStart = NCellsOwned;
+   HaloCount    = NEdgesHaloTmp(0); // reset to end of halo 1
+
+   // The edge halos contain edges needed for the n-1 cell halo layer
+   for (int Halo = 0; Halo < HaloWidth; ++Halo) {
+      I4 CellEnd = NCellsHaloH(Halo);
+      for (int Cell = CellStart; Cell < CellEnd; ++Cell) {
+         for (int CellEdge = 0; CellEdge < MaxEdges; ++CellEdge) {
+            I4 EdgeGlob = EdgesOnCellH(Cell, CellEdge);
+            // if this is a valid edge and the edge has not already been
+            // processed, add the edge to the halo and remove from
+            // the relevant search arrays
+            if (validEdgeID(EdgeGlob) &&
+                EdgesAll.find(EdgeGlob) != EdgesAll.end()) { // edge in list
+               EdgeIDTmp(HaloCount) = EdgeGlob;
+               ++HaloCount;
+               EdgesAll.erase(EdgeGlob);
+            } // end if valid edge
+         }    // end loop over cell edges
+      }       // end cell loop
+      // reset address range for next halo and set NEdgesHalo
+      CellStart = CellEnd;
+      if ((Halo + 1) < HaloWidth)
+         NEdgesHaloTmp(Halo + 1) = HaloCount;
+   } // end halo loop
+
+   // Now that we have the local lists, update the final location
+   // (task, local edge address) of each of the local edges. This
+   // requires one more round of communication.
+   // Resize the buffer to make sure we have enough room - the distribution
+   // may be less even than the original chunk size.
+
+   ArrayHost2DI4 EdgeLocTmp("EdgeLoc", NEdgesSize, 2);
+   EdgeBuf.resize(2 * NEdgesChunk);
+
+   for (int Edge = 0; Edge < NEdgesSize; ++Edge) {
+      EdgeLocTmp(Edge, 0) = MyTask;
+      EdgeLocTmp(Edge, 1) = NEdgesAll;
+   }
+
+   for (int Task = 0; Task < NumTasks; ++Task) {
+
+      // fill broadcast buffer with the list of owned edges. The
+      // first entry in the vector is the number of edges owned by
+      // this task.
+      if (Task == MyTask) {
+         EdgeBuf[0] = NEdgesOwned;
+         for (int BufEdge = 0; BufEdge < NEdgesOwned; ++BufEdge) {
+            EdgeBuf[BufEdge + 1] = EdgeIDTmp(BufEdge);
+         }
+      }
+      // Broadcast the list of edges owned by this task
+      Err = MPI_Bcast(&EdgeBuf[0], 2 * NEdgesChunk, MPI_INT32_T, Task, Comm);
+
+      // For each edge in the buffer, search the full list of edges on
+      // this task and store the location
+      I4 BufOwned = EdgeBuf[0];
+      for (int BufEdge = 0; BufEdge < BufOwned; ++BufEdge) {
+         I4 GlobID = EdgeBuf[BufEdge + 1];
+         I4 Edge   = srchVector(EdgeIDTmp, GlobID);
+         if (Edge < NEdgesAll) {
+            EdgeLocTmp(Edge, 0) = Task;    // Task that owns edge
+            EdgeLocTmp(Edge, 1) = BufEdge; // Local address on task
+         }
+      }
+   }
+
+   // Copy ID and location arrays into permanent storage
+   EdgeIDH     = EdgeIDTmp;
+   EdgeLocH    = EdgeLocTmp;
+   NEdgesHaloH = NEdgesHaloTmp;
+
+   return Err;
+
+} // end function partEdges
+
+//------------------------------------------------------------------------------
+// Partition the vertices based on the cell decomposition. The first cell ID
+// in the CellsOnVertex array for a given vertex is assigned ownership of the
+// vertex.
+
+int Decomp::partVertices(
+    const MachEnv *InEnv, ///< [in] input machine environment with MPI info
+    const std::vector<I4> &CellsOnVertexInit // [in] cell nbrs for each vrtx
+) {
+
+   I4 Err = 0; // default error code
+
+   // Retrieve some info on the MPI layout
+   MPI_Comm Comm = InEnv->getComm();
+   I4 NumTasks   = InEnv->getNumTasks();
+   I4 MyTask     = InEnv->getMyTask();
+   I4 MasterTask = InEnv->getMasterTask();
+   bool IsMaster = InEnv->isMasterTask();
+
+   // Calculate some quantities associated with the initial linear
+   // distribution
+   I4 NCellsChunk    = (NCellsGlobal - 1) / NumTasks + 1;
+   I4 NCellsLocal    = NCellsChunk;
+   I4 NVerticesChunk = (NVerticesGlobal - 1) / NumTasks + 1;
+   I4 NVerticesLocal = NVerticesChunk;
+
+   // If cells/edges do not divide evenly over processors, the last processor
+   // only has the remaining cells and not a full block (chunk)
+   if (MyTask == NumTasks - 1) {
+      I4 StartAdd    = NCellsChunk * (NumTasks - 1);
+      NCellsLocal    = NCellsGlobal - StartAdd;
+      StartAdd       = NVerticesChunk * (NumTasks - 1);
+      NVerticesLocal = NVerticesGlobal - StartAdd;
+   }
+
+   // For the tasks below, it is useful to keep a sorted list of various cells
+   // and vertices using the std::set container and related search/sort
+   // functions. We create sets for local owned cells, all local vertices,
+   // local owned vertices and local halo vertices.
+   std::set<I4> CellsOwned;
+   std::set<I4> CellsAll;
+   std::set<I4> VerticesAll;
+   std::set<I4> VerticesOwned;
+   std::set<I4> VerticesOwnedHalo1;
+
+   for (int Cell = 0; Cell < NCellsAll; ++Cell) {
+      CellsAll.insert(CellIDH(Cell));
+      if (Cell < NCellsOwned)
+         CellsOwned.insert(CellIDH(Cell));
+   }
+
+   // From the VerticesOnCell array, we count and create a sorted list of
+   // all vertices that are needed locally. Vertices that surround owned
+   // cells will either be owned edges or in the first halo so we track
+   // those as well for later sorting.
+
+   for (int Cell = 0; Cell < NCellsAll; ++Cell) {
+      for (int Vrtx = 0; Vrtx < MaxEdges; ++Vrtx) {
+         I4 VrtxGlob = VerticesOnCellH(Cell, Vrtx);
+         if (validVertexID(VrtxGlob)) {
+            VerticesAll.insert(VrtxGlob);
+            if (Cell < NCellsOwned)
+               VerticesOwnedHalo1.insert(VrtxGlob);
+         }
+      }
+   }
+   NVerticesAll  = VerticesAll.size();
+   NVerticesSize = NVerticesAll + 1;
+
+   // To determine whether the vertex is owned by this task, we first
+   // determine ownership as the first valid cell in the CellsOnVertex
+   // array. CellsOnVertex is only in the initial linear decomposition so
+   // we compute it there and broadcast the data to other MPI tasks.
+
+   std::vector<I4> VrtxOwnerInit(NVerticesChunk, NCellsGlobal + 1);
+   for (int Vrtx = 0; Vrtx < NVerticesLocal; ++Vrtx) {
+      I4 VrtxGlob = MyTask * NVerticesChunk + Vrtx + 1;
+      for (int Cell = 0; Cell < VertexDegree; ++Cell) {
+         I4 CellGlob = CellsOnVertexInit[Vrtx * VertexDegree + Cell];
+         if (validCellID(CellGlob)) {
+            VrtxOwnerInit[Vrtx] = CellGlob;
+            break;
+         }
+      }
+   }
+
+   // Broadcast the vertex ownership to all tasks, one chunk at a time
+   // and create a sorted list of all owned vertices.
+
+   std::vector<I4> VrtxBuf(NVerticesChunk);
+   for (int Task = 0; Task < NumTasks; ++Task) {
+
+      // if it is this task's turn, fill the buffer with the owner info
+      if (Task == MyTask) {
+         for (int Vrtx = 0; Vrtx < NVerticesChunk; ++Vrtx) {
+            VrtxBuf[Vrtx] = VrtxOwnerInit[Vrtx];
+         }
+      }
+      // Broadcast this buffer
+      Err = MPI_Bcast(&VrtxBuf[0], NVerticesChunk, MPI_INT32_T, Task, Comm);
+
+      // For each vertex in the buffer, check to see if the task owns
+      // the cell. If so, add the vertex ID to the owned vertices list.
+      for (int Vrtx = 0; Vrtx < NVerticesChunk; ++Vrtx) {
+
+         I4 VrtxGlob =
+             Task * NVerticesChunk + Vrtx + 1; // Global ID init distrb
+         // when number of vertices doesn't divide evenly, the last
+         // task has some invalid vertices at the end so break out of loop
+         if (VrtxGlob > NVerticesGlobal)
+            break;
+
+         I4 CellOwner = VrtxBuf[Vrtx];
+         if (CellsOwned.find(CellOwner) != CellsOwned.end()) {
+            // this task owns cell and therefore the edge
+            VerticesOwned.insert(VrtxGlob);
+         }
+      }
+
+   } // end task loop
+
+   // For compatibility with the previous MPAS model, we sort the
+   // vertices based on the order encounted in VerticesOnCell. The first halo
+   // level is actually stored in reverse order from the end inward. We sort
+   // vertex IDs, locations and CellsOnVertex with this ordering.
+
+   NVerticesOwned = VerticesOwned.size();
+   ArrayHost1DI4 NVerticesHaloTmp("NVerticesHalo", HaloWidth);
+   I4 HaloCount        = VerticesOwnedHalo1.size();
+   NVerticesHaloTmp(0) = HaloCount;
+
+   ArrayHost1DI4 VertexIDTmp("VertexID", NVerticesSize);
+   yakl::memset(VertexIDTmp, NVerticesGlobal + 1);
+
+   // The owned and first halo of vertices comes from the vertices around
+   // the owned cells, so start with these.
+   I4 VrtxCount = 0;
+   HaloCount--; // initialize for first halo entry in reverse order
+   for (int Cell = 0; Cell < NCellsOwned; ++Cell) {
+      for (int CellVrtx = 0; CellVrtx < MaxEdges; ++CellVrtx) {
+         I4 VrtxGlob = VerticesOnCellH(Cell, CellVrtx);
+         // if this is a valid vertex and the vertex has not already been
+         // processed, add the vertex to the vertex list and remove from
+         // the relevant search arrays
+         if (validVertexID(VrtxGlob) &&
+             VerticesAll.find(VrtxGlob) !=
+                 VerticesAll.end()) { // vertex in list
+            // determine whether location is in owned or halo list
+            if (VerticesOwned.find(VrtxGlob) != VerticesOwned.end()) {
+               VertexIDTmp(VrtxCount) = VrtxGlob;
+               ++VrtxCount;
+               VerticesAll.erase(VrtxGlob); // remove from search list
+            } else {
+               VertexIDTmp(HaloCount) = VrtxGlob;
+               --HaloCount;
+               VerticesAll.erase(VrtxGlob); // remove from search list
+            }
+         }
+      }
+   }
+
+   // Fill in the remaining halo regions
+   I4 CellStart = NCellsOwned;
+   HaloCount    = NVerticesHaloTmp(0); // reset to end of halo 1
+
+   // The vertex halos contain vertices needed for the n-1 cell halo layer
+   for (int Halo = 0; Halo < HaloWidth; ++Halo) {
+      I4 CellEnd = NCellsHaloH(Halo);
+      for (int Cell = CellStart; Cell < CellEnd; ++Cell) {
+         for (int CellVrtx = 0; CellVrtx < MaxEdges; ++CellVrtx) {
+            I4 VrtxGlob = VerticesOnCellH(Cell, CellVrtx);
+            // if this is a valid vertex and the vertex has not already been
+            // processed, add the vertex to the halo and remove from
+            // the relevant search arrays
+            if (validVertexID(VrtxGlob) &&
+                VerticesAll.find(VrtxGlob) != VerticesAll.end()) { // in list
+               VertexIDTmp(HaloCount) = VrtxGlob;
+               ++HaloCount;
+               VerticesAll.erase(VrtxGlob);
+            }
+         }
+      }
+      // reset address range for next halo and set NVerticesHalo
+      CellStart = CellEnd;
+      if ((Halo + 1) < HaloWidth)
+         NVerticesHaloTmp(Halo + 1) = HaloCount;
+   } // end halo loop
+
+   // Now that we have the local lists, update the final location
+   // (task, local edge address) of each of the local vertices. This
+   // requires one more round of communication.
+   // Resize the buffer to make sure we have enough room - the distribution
+   // may be less even than the original chunk size.
+
+   ArrayHost2DI4 VertexLocTmp("VertexLoc", NVerticesSize, 2);
+   VrtxBuf.resize(2 * NVerticesChunk);
+
+   for (int Vrtx = 0; Vrtx < NVerticesSize; ++Vrtx) {
+      VertexLocTmp(Vrtx, 0) = MyTask;
+      VertexLocTmp(Vrtx, 1) = NVerticesAll;
+   }
+
+   for (int Task = 0; Task < NumTasks; ++Task) {
+
+      // fill broadcast buffer with the list of owned vertices. The
+      // first entry in the vector is the number of vertices owned by
+      // this task.
+      if (Task == MyTask) {
+         VrtxBuf[0] = NVerticesOwned;
+         for (int BufVrtx = 0; BufVrtx < NVerticesOwned; ++BufVrtx) {
+            VrtxBuf[BufVrtx + 1] = VertexIDTmp(BufVrtx);
+         }
+      }
+      // Broadcast the list of edges owned by this task
+      Err = MPI_Bcast(&VrtxBuf[0], 2 * NVerticesChunk, MPI_INT32_T, Task, Comm);
+
+      // For each vertex in the buffer, search the full list of vertices on
+      // this task and store the location
+      I4 BufOwned = VrtxBuf[0];
+      for (int BufVrtx = 0; BufVrtx < BufOwned; ++BufVrtx) {
+         I4 GlobID = VrtxBuf[BufVrtx + 1];
+         I4 Vrtx   = srchVector(VertexIDTmp, GlobID);
+         if (Vrtx < NVerticesAll) {
+            VertexLocTmp(Vrtx, 0) = Task;    // Task that owns vertex
+            VertexLocTmp(Vrtx, 1) = BufVrtx; // Local address on task
+         }
+      }
+   }
+
+   // Copy ID and location arrays into permanent storage
+   VertexIDH      = VertexIDTmp;
+   VertexLocH     = VertexLocTmp;
+   NVerticesHaloH = NVerticesHaloTmp;
+
+   return Err;
+
+} // end function partVertices
+
+//------------------------------------------------------------------------------
+// Redistribute the various XxOnCell index arrays to the final cell
+// decomposition. The inputs are the various XxOnCell arrays in the
+// initial linear distribution. On exit, all the XxOnCell arrays are
+// in the correct final domain decomposition.
+
+int Decomp::rearrangeCellArrays(
+    const MachEnv *InEnv, // input machine environment for MPI layout
+    const std::vector<I4> &CellsOnCellInit,   //< [in] cell nbrs on each edge
+    const std::vector<I4> &EdgesOnCellInit,   //< [in] edges around each cell
+    const std::vector<I4> &VerticesOnCellInit //< [in] vertices around cell
+) {
+
+   int Err = 0; // default return code
+
+   // Extract some MPI information
+   MPI_Comm Comm = InEnv->getComm();
+   I4 NumTasks   = InEnv->getNumTasks();
+   I4 MyTask     = InEnv->getMyTask();
+   I4 MasterTask = InEnv->getMasterTask();
+   bool IsMaster = InEnv->isMasterTask();
+
+   // Define the chunk sizes for the initial linear distribution
+   I4 NCellsChunk = (NCellsGlobal - 1) / NumTasks + 1;
+
+   // Create a buffer for sending all the cell information
+   // Each of the 3 arrays are (NCellsChunk,MaxEdges)
+   I4 SizePerCell = MaxEdges * 3;
+   I4 BufSize     = NCellsChunk * SizePerCell;
+   std::vector<I4> CellBuf(BufSize);
+
+   // Create temporary arrays for holding the XxOnCell results
+   // and initialize to NXxGlobal+1 to denote a non-existent entry
+   ArrayHost2DI4 CellsOnCellTmp("CellsOnCell", NCellsSize, MaxEdges);
+   ArrayHost2DI4 EdgesOnCellTmp("EdgesOnCell", NCellsSize, MaxEdges);
+   ArrayHost2DI4 VerticesOnCellTmp("VerticesOnCell", NCellsSize, MaxEdges);
+   ArrayHost1DI4 NEdgesOnCellTmp("NEdgesOnCell", NCellsSize);
+   yakl::memset(CellsOnCellTmp, NCellsGlobal + 1);
+   yakl::memset(EdgesOnCellTmp, NEdgesGlobal + 1);
+   yakl::memset(VerticesOnCellTmp, NVerticesGlobal + 1);
+   yakl::memset(NEdgesOnCellTmp, 0);
+
+   // Each task will broadcast the cells it owns in the initial linear
+   // distribution and all tasks will search that list and extract the
+   // entries it owns.
+   for (int Task = 0; Task < NumTasks; ++Task) {
+
+      // If it is this task's turn to send, fill the buffer with the local
+      // chunk of all three arrays.
+      if (MyTask == Task) { // Fill buffer with local chunk
+         for (int Cell = 0; Cell < NCellsChunk; ++Cell) {
+            for (int Edge = 0; Edge < MaxEdges; ++Edge) {
+               I4 BufAdd           = Cell * SizePerCell + Edge * 3;
+               I4 ArrayAdd         = Cell * MaxEdges + Edge;
+               CellBuf[BufAdd]     = CellsOnCellInit[ArrayAdd];
+               CellBuf[BufAdd + 1] = VerticesOnCellInit[ArrayAdd];
+               CellBuf[BufAdd + 2] = EdgesOnCellInit[ArrayAdd];
+            }
+         }
+      }
+      Err = MPI_Bcast(&CellBuf[0], BufSize, MPI_INT32_T, Task, Comm);
+      if (Err != 0) {
+         LOG_CRITICAL("rearrangeCellArrays: Error broadcasting cell buffer");
+         return Err;
+      }
+
+      // For each cell in the message buffer, look through the local
+      // cell IDs and if this task has the cell in either the owned or
+      // halo entries, fill the cell arrays. For edges, we prune the
+      // non-active edges and track the number of edges.
+      for (int Cell = 0; Cell < NCellsChunk; ++Cell) {
+
+         I4 GlobalID = Task * NCellsChunk + Cell + 1; // IDs are 1-based
+         // if NCellsGlobal did not divide evenly, the last task will
+         // have global IDs out of range so break out of loop in that case
+         if (GlobalID > NCellsGlobal)
+            break;
+
+         // Search through local cell list to determine if a match with
+         // the global ID
+         I4 LocCell = srchVector(CellIDH, GlobalID);
+         if (LocCell < NCellsAll) {
+
+            // Local cell needs the info so extract from the buffer
+            // into the local address. For edges, we only store the
+            // active edges and maintain a count of the edges.
+            I4 EdgeCount = 0;
+            for (int Edge = 0; Edge < MaxEdges; ++Edge) {
+               I4 BufAdd  = Cell * SizePerCell + Edge * 3;
+               I4 NbrCell = CellBuf[BufAdd];
+               I4 NbrVrtx = CellBuf[BufAdd + 1];
+               I4 NbrEdge = CellBuf[BufAdd + 2];
+               if (validCellID(NbrCell)) {
+                  CellsOnCellTmp(LocCell, Edge) = NbrCell;
+               } else {
+                  CellsOnCellTmp(LocCell, Edge) = NCellsGlobal + 1;
+               }
+               if (validVertexID(NbrVrtx)) {
+                  VerticesOnCellTmp(LocCell, Edge) = NbrVrtx;
+               } else {
+                  VerticesOnCellTmp(LocCell, Edge) = NVerticesGlobal + 1;
+               }
+               if (validEdgeID(NbrEdge)) {
+                  EdgesOnCellTmp(LocCell, EdgeCount) = NbrEdge;
+                  EdgeCount++;
+               }
+            }
+            NEdgesOnCellTmp(LocCell) = EdgeCount;
+         } // end if local cell
+      }    // end loop over chunk of global cells
+   }       // end loop over MPI tasks
+
+   // Copy to final location on host - wait to create device copies until
+   // the entries are translated to local addresses rather than global IDs
+   CellsOnCellH    = CellsOnCellTmp;
+   EdgesOnCellH    = EdgesOnCellTmp;
+   VerticesOnCellH = VerticesOnCellTmp;
+   NEdgesOnCellH   = NEdgesOnCellTmp;
+
+   // All done
+   return Err;
+
+} // end function rearrangeCellArrays
+
+//------------------------------------------------------------------------------
+// Redistribute the various XxOnEdge index arrays to the final edge
+// decomposition. The inputs are the various XxOnEdge arrays in the
+// initial linear distribution. On exit, all the XxOnEdge arrays are
+// in the correct final domain decomposition.
+
+int Decomp::rearrangeEdgeArrays(
+    const MachEnv *InEnv, // input machine environment for MPI layout
+    const std::vector<I4> &CellsOnEdgeInit,   //< [in] cell nbrs on each edge
+    const std::vector<I4> &EdgesOnEdgeInit,   //< [in] edges around nbr cells
+    const std::vector<I4> &VerticesOnEdgeInit //< [in] vertices at edge end
+) {
+
+   int Err = 0; // default return code
+
+   // Extract some MPI information
+   MPI_Comm Comm = InEnv->getComm();
+   I4 NumTasks   = InEnv->getNumTasks();
+   I4 MyTask     = InEnv->getMyTask();
+   I4 MasterTask = InEnv->getMasterTask();
+   bool IsMaster = InEnv->isMasterTask();
+
+   // Define the chunk sizes for the initial linear distribution
+   I4 NEdgesChunk = (NEdgesGlobal - 1) / NumTasks + 1;
+
+   // Create a buffer for sending all the edge array information
+   // Each of the arrays are either NEdgesChunk*2 (cell, vertex)
+   // or NEdgesChunk*MaxEdges*2 (edge)
+   I4 SizePerEdge = 2 * MaxEdges + MaxCellsOnEdge + 2;
+   I4 BufSize     = NEdgesChunk * SizePerEdge;
+   std::vector<I4> EdgeBuf(BufSize);
+
+   // Create temporary arrays for holding the XxOnEdge results
+   // and initialize to NXxGlobal+1 to denote a non-existent entry
+   ArrayHost2DI4 CellsOnEdgeTmp("CellsOnEdge", NEdgesSize, MaxCellsOnEdge);
+   ArrayHost2DI4 EdgesOnEdgeTmp("EdgesOnEdge", NEdgesSize, 2 * MaxEdges);
+   ArrayHost2DI4 VerticesOnEdgeTmp("VerticesOnEdge", NEdgesSize, 2);
+   ArrayHost1DI4 NEdgesOnEdgeTmp("NEdgesOnEdge", NEdgesSize);
+   yakl::memset(CellsOnEdgeTmp, NCellsGlobal + 1);
+   yakl::memset(EdgesOnEdgeTmp, NEdgesGlobal + 1);
+   yakl::memset(VerticesOnEdgeTmp, NVerticesGlobal + 1);
+   yakl::memset(NEdgesOnEdgeTmp, 0);
+
+   // Each task will broadcast the array chunks it owns in the initial linear
+   // distribution and all tasks will search that list and extract the
+   // entries it owns.
+   for (int Task = 0; Task < NumTasks; ++Task) {
+
+      // If it is this task's turn to send, fill the buffer with the local
+      // chunk of all three arrays.
+      if (MyTask == Task) { // Fill buffer with local chunk
+         for (int Edge = 0; Edge < NEdgesChunk; ++Edge) {
+            I4 BufAdd = Edge * SizePerEdge;
+            for (int Cell = 0; Cell < MaxCellsOnEdge; ++Cell) {
+               I4 ArrayAdd     = Edge * MaxCellsOnEdge + Cell;
+               EdgeBuf[BufAdd] = CellsOnEdgeInit[ArrayAdd];
+               ++BufAdd;
+            }
+            for (int Vrtx = 0; Vrtx < 2; ++Vrtx) {
+               I4 ArrayAdd     = Edge * 2 + Vrtx;
+               EdgeBuf[BufAdd] = VerticesOnEdgeInit[ArrayAdd];
+               ++BufAdd;
+            }
+            for (int NbrEdge = 0; NbrEdge < 2 * MaxEdges; ++NbrEdge) {
+               I4 ArrayAdd     = Edge * 2 * MaxEdges + NbrEdge;
+               EdgeBuf[BufAdd] = EdgesOnEdgeInit[ArrayAdd];
+               ++BufAdd;
+            }
+         }
+      }
+      Err = MPI_Bcast(&EdgeBuf[0], BufSize, MPI_INT32_T, Task, Comm);
+      if (Err != 0) {
+         LOG_CRITICAL("rearrangeEdgeArrays: Error broadcasting edge buffer");
+         return Err;
+      }
+
+      // For each edge in the message buffer, look through the local
+      // edge IDs and if this task has the edge in either the owned or
+      // halo entries, fill the edge arrays. For EdgesOnEdge, we prune the
+      // non-active edges and track the number of active entries.
+      for (int Edge = 0; Edge < NEdgesChunk; ++Edge) {
+
+         I4 GlobalID = Task * NEdgesChunk + Edge + 1; // IDs are 1-based
+         // if NEdgesGlobal did not divide evenly, the last task will
+         // have global IDs out of range so break out of loop in that case
+         if (GlobalID > NEdgesGlobal)
+            break;
+
+         // Search through local edge list to determine if a match with
+         // the global ID
+         I4 LocEdge = srchVector(EdgeIDH, GlobalID);
+         if (LocEdge < NEdgesAll) {
+
+            // Local task owns this edge so extract the array info
+            // into the local address. For edges, we only store the
+            // active edges and maintain a count of the edges.
+            I4 BufAdd = Edge * SizePerEdge;
+            for (int Cell = 0; Cell < MaxCellsOnEdge; ++Cell) {
+               CellsOnEdgeTmp(LocEdge, Cell) = EdgeBuf[BufAdd];
+               ++BufAdd;
+            }
+            for (int Vrtx = 0; Vrtx < 2; ++Vrtx) {
+               VerticesOnEdgeTmp(LocEdge, Vrtx) = EdgeBuf[BufAdd];
+               ++BufAdd;
+            }
+            // In the EdgeOnEdge array, a zero entry must be kept in
+            // place but assigned the boundary value NEdgesGlobal+1
+            I4 EdgeCount = 0;
+            for (int NbrEdge = 0; NbrEdge < 2 * MaxEdges; ++NbrEdge) {
+               I4 EdgeID = EdgeBuf[BufAdd];
+               ++BufAdd;
+               if (EdgeID == 0) {
+                  EdgesOnEdgeTmp(LocEdge, EdgeCount) = NEdgesGlobal + 1;
+                  EdgeCount++;
+               } else if (validEdgeID(EdgeID)) {
+                  EdgesOnEdgeTmp(LocEdge, EdgeCount) = EdgeID;
+                  EdgeCount++;
+               }
+            }
+            NEdgesOnEdgeTmp(LocEdge) = EdgeCount;
+         } // end if local cell
+      }    // end loop over chunk of global cells
+   }       // end loop over MPI tasks
+
+   // Copy to final location on host - wait to create device copies until
+   // the entries are translated to local addresses rather than global IDs
+   CellsOnEdgeH    = CellsOnEdgeTmp;
+   EdgesOnEdgeH    = EdgesOnEdgeTmp;
+   VerticesOnEdgeH = VerticesOnEdgeTmp;
+   NEdgesOnEdgeH   = NEdgesOnEdgeTmp;
+
+   // All done
+   return Err;
+
+} // end function rearrangeEdgeArrays
+
+//------------------------------------------------------------------------------
+// Redistribute the various XxOnVertex index arrays to the final vertex
+// decomposition. The inputs are the various XxOnVertex arrays in the
+// initial linear distribution. On exit, all the XxOnVertex arrays are
+// in the correct final domain decomposition.
+
+int Decomp::rearrangeVertexArrays(
+    const MachEnv *InEnv, // input machine environment for MPI layout
+    const std::vector<I4> &CellsOnVertexInit, //< [in] cells at each vrtx
+    const std::vector<I4> &EdgesOnVertexInit  //< [in] edges joined at vrtx
+) {
+
+   int Err = 0; // default return code
+
+   // Extract some MPI information
+   MPI_Comm Comm = InEnv->getComm();
+   I4 NumTasks   = InEnv->getNumTasks();
+   I4 MyTask     = InEnv->getMyTask();
+   I4 MasterTask = InEnv->getMasterTask();
+   bool IsMaster = InEnv->isMasterTask();
+
+   // Define the chunk sizes for the initial linear distribution
+   I4 NVerticesChunk = (NVerticesGlobal - 1) / NumTasks + 1;
+
+   // Create a buffer for sending all the vertex array information
+   // Both of the arrays should be of size NVerticesChunk*VertexDegree
+   // so the full buffer is twice that.
+   I4 SizePerVrtx = 2 * VertexDegree;
+   I4 BufSize     = NVerticesChunk * SizePerVrtx;
+   std::vector<I4> VrtxBuf(BufSize);
+
+   // Create temporary arrays for holding the XxOnVertex results
+   // and initialize to NXxGlobal+1 to denote a non-existent entry
+   ArrayHost2DI4 CellsOnVertexTmp("CellsOnVertex", NVerticesSize, VertexDegree);
+   ArrayHost2DI4 EdgesOnVertexTmp("EdgesOnVertex", NVerticesSize, VertexDegree);
+   yakl::memset(CellsOnVertexTmp, NCellsGlobal + 1);
+   yakl::memset(EdgesOnVertexTmp, NEdgesGlobal + 1);
+
+   // Each task will broadcast the array chunks it owns in the initial linear
+   // distribution and all tasks will search that list and extract the
+   // entries it owns.
+   for (int Task = 0; Task < NumTasks; ++Task) {
+
+      // If it is this task's turn to send, fill the buffer with the local
+      // chunk of both arrays.
+      if (MyTask == Task) { // Fill buffer with local chunk
+         for (int Vrtx = 0; Vrtx < NVerticesChunk; ++Vrtx) {
+            I4 BufAdd = Vrtx * SizePerVrtx;
+            for (int Cell = 0; Cell < VertexDegree; ++Cell) {
+               I4 ArrayAdd     = Vrtx * VertexDegree + Cell;
+               VrtxBuf[BufAdd] = CellsOnVertexInit[ArrayAdd];
+               ++BufAdd;
+            }
+            for (int Edge = 0; Edge < VertexDegree; ++Edge) {
+               I4 ArrayAdd     = Vrtx * VertexDegree + Edge;
+               VrtxBuf[BufAdd] = EdgesOnVertexInit[ArrayAdd];
+               ++BufAdd;
+            }
+         }
+      }
+      Err = MPI_Bcast(&VrtxBuf[0], BufSize, MPI_INT32_T, Task, Comm);
+      if (Err != 0) {
+         LOG_CRITICAL("rearrangeVertexArrays: Error broadcasting buffer");
+         return Err;
+      }
+
+      // For each vertex in the message buffer, look through the local
+      // vertex IDs and if this task has the vertex in either the owned or
+      // halo entries, fill the vertex arrays.
+      for (int Vrtx = 0; Vrtx < NVerticesChunk; ++Vrtx) {
+
+         I4 GlobalID = Task * NVerticesChunk + Vrtx + 1; // IDs are 1-based
+         // if NVerticesGlobal did not divide evenly, the last task will
+         // have global IDs out of range so break out of loop in that case
+         if (GlobalID > NVerticesGlobal)
+            break;
+
+         // Search through local vertex list to determine if a match with
+         // the global ID
+         I4 LocVrtx = srchVector(VertexIDH, GlobalID);
+         if (LocVrtx < NVerticesAll) {
+
+            // Local task owns this vertex so extract the array info
+            // into the local address.
+            I4 BufAdd = Vrtx * SizePerVrtx;
+            for (int Cell = 0; Cell < VertexDegree; ++Cell) {
+               CellsOnVertexTmp(LocVrtx, Cell) = VrtxBuf[BufAdd];
+               ++BufAdd;
+            }
+            for (int Edge = 0; Edge < VertexDegree; ++Edge) {
+               EdgesOnVertexTmp(LocVrtx, Edge) = VrtxBuf[BufAdd];
+               ++BufAdd;
+            }
+         } // end if local cell
+      }    // end loop over chunk of global cells
+   }       // end loop over MPI tasks
+
+   // Copy to final location on host - wait to create device copies until
+   // the entries are translated to local addresses rather than global IDs
+   CellsOnVertexH = CellsOnVertexTmp;
+   EdgesOnVertexH = EdgesOnVertexTmp;
+
+   // All done
+   return Err;
+
+} // end function rearrangeVertexArrays
+
+//------------------------------------------------------------------------------
+// Utility routine to convert a partition method string into PartMethod enum
+
+PartMethod getPartMethodFromStr(const std::string &InMethod) {
+
+   // convert string to lower case for easier equivalence checking
+   std::string MethodComp = InMethod;
+   std::transform(MethodComp.begin(), MethodComp.end(), MethodComp.begin(),
+                  [](unsigned char c) { return std::tolower(c); });
+
+   // Check supported methods and return appropriate enum
+   // Currently, only the METIS/ParMETIS KWay option is supported
+   if (MethodComp == "metiskway") {
+      return PartMethodMetisKWay;
+
+   } else {
+      return PartMethodUnknown;
+
+   } // end branch on method string
+
+} // End getPartMethodFromStr
+
+//------------------------------------------------------------------------------
+// end Decomp methods
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -616,9 +616,9 @@ Decomp::Decomp(
 
    // Create device copies of all arrays
 
-   //NCellsHalo = NCellsHaloH.createDeviceCopy();
-   //CellID     = CellIDH.createDeviceCopy();
-   //CellLoc    = CellLocH.createDeviceCopy();
+   // NCellsHalo = NCellsHaloH.createDeviceCopy();
+   // CellID     = CellIDH.createDeviceCopy();
+   // CellLoc    = CellLocH.createDeviceCopy();
 
    // NEdgesHalo = NEdgesHaloH.createDeviceCopy();
    // EdgeID     = EdgeIDH.createDeviceCopy();

--- a/components/omega/src/base/Decomp.h
+++ b/components/omega/src/base/Decomp.h
@@ -1,0 +1,264 @@
+#ifndef OMEGA_DECOMP_H
+#define OMEGA_DECOMP_H
+//===-- base/Decomp.h - domain decomposition --------------------*- C++ -*-===//
+//
+/// \file
+/// \brief Decomposes/partitions an OMEGA horizontal domain
+///
+/// The decomposition (Decomp) class partitions an OMEGA horizontal domain into
+/// a number of sub-domains that can be distributed across a parallel
+/// environment. Currently, this relies on the (Par)Metis partitioning package
+/// to partition a set of nodes (cells) based on the adjacency graph created
+/// during the OMEGA mesh generators. A default decomposition is created
+/// from the default Machine Env that specifies the MPI details and number
+/// of MPI tasks. Other decompositions can be created with the same mesh
+/// on any of the subset environments that are possible in MachEnv.
+/// The Decomp class stores a number of index-space arrays that describe
+/// the partition, neighbor information, global IDs for cell, edge and
+/// vertex points in an Omega mesh.
+//
+//===----------------------------------------------------------------------===//
+
+#include "DataTypes.h"
+#include "MachEnv.h"
+#include "mpi.h"
+#include "parmetis.h"
+
+#include <string>
+
+namespace OMEGA {
+
+/// A class for the input adjacency graph file contains information
+/// related to the file itself as well as the contents and size of
+/// the adjacency graph.
+
+/// Supported partitioning methods
+enum PartMethod {
+   PartMethodUnknown,   ///< Unknown or undefined method
+   PartMethodMetisKWay, ///< Metis K-way partitioning (default)
+   PartMethodMetisRB    ///< Metis recursive bisection (not yet supported)
+};
+
+/// Translates an input string for partition method option to the
+/// enum for later use
+PartMethod getPartMethodFromStr(
+    const std::string &InMethod ///< [in] choice of partition method
+);
+
+/// The Decomp class creates and maintains most of the information related
+/// to the mesh index space and its distribution across partitions or processors
+/// in a parallel domain decomposition. This information includes the location
+/// of every cell/edge/vertex point and the adjacency or neighbor information
+/// for all mesh locations. It relies on the ParMetis package for performing
+/// the actual partitions.
+class Decomp {
+
+ private:
+   /// The default decomposition describes the index space decomposition
+   /// used for most of the model. Because it is used most often,
+   /// we store the extra pointer here for easier retrieval.
+   static Decomp *DefaultDecomp;
+
+   /// All decompositions are tracked/stored within the class as a
+   /// map paired with a name for later retrieval.
+   static std::map<std::string, Decomp> AllDecomps;
+
+   /// Partition cells by calling the METIS/ParMETIS KWay routine
+   /// It starts with the CellsOnCell array from the input mesh file
+   /// distributed across tasks in linear contiguous chunks
+   /// On output, it has defined all the NCells sizes (NCellsOwned,
+   /// NCellsHalo array, NCellsAll and NCellsSize) and the final CellID
+   /// and CellLoc arrays
+   int partCellsKWay(
+       const MachEnv *InEnv,                  ///< [in] MachEnv with MPI info
+       const std::vector<I4> &CellsOnCellInit ///< [in] cell nbrs in init dstrb
+   );
+
+   /// Partition the edges given the cell partition and edge connectivity
+   /// The first cell ID associated with an edge in the CellsOnEdge array
+   /// is assumed to own the edge. The inputs are the edge-cell connectivity
+   /// arrays that have been initially partitioned across MPI tasks in a
+   /// linear distribution. On return, this function populates all of the
+   /// NEdge sizes, edge halo indices, and final edge-related connectivity
+   /// arrays.
+   int partEdges(
+       const MachEnv *InEnv,                  ///< [in] MachEnv with MPI info
+       const std::vector<I4> &CellsOnEdgeInit ///< [in] cell nbrs on each edge
+   );
+
+   /// Partition the vertices given the cell partition and vertex connectivity
+   /// The first cell ID associated with an vertex in the CellsOnVertex array
+   /// is assumed to own the vertex. The inputs are the vertex-cell connectivity
+   /// arrays that have been initially partitioned across MPI tasks in a
+   /// linear distribution. On return, this function populates all of the
+   /// NVertex sizes, vertex halo indices, and final vertex-related connectivity
+   /// arrays.
+   int partVertices(
+       const MachEnv *InEnv,                    ///< [in] MachEnv with MPI info
+       const std::vector<I4> &CellsOnVertexInit ///< [in] cells at each vertex
+   );
+
+   /// Redistribute the various XxOnCell index arrays to the final cell
+   /// decomposition. The inputs are the various XxOnCell arrays in the
+   /// initial linear distribution. On exit, all the XxOnCell arrays are
+   /// in the correct final domain decomposition.
+   int rearrangeCellArrays(
+       const MachEnv *InEnv, ///< [in] MachEnv for the new partition
+       const std::vector<I4> &CellsOnCellInit, ///< [in] cell nbrs on each edge
+       const std::vector<I4> &EdgesOnCellInit, ///< [in] edges around each cell
+       const std::vector<I4> &VerticesOnCellInit ///< [in] vertices around cell
+   );
+
+   /// Redistribute the various XxOnEdge index arrays to the final edge
+   /// decomposition. The inputs are the various XxOnEdge arrays in the
+   /// initial linear distribution. On exit, all the XxOnEdge arrays are
+   /// in the correct final domain decomposition.
+   int rearrangeEdgeArrays(
+       const MachEnv *InEnv, ///< [in] MachEnv for the new partition
+       const std::vector<I4> &CellsOnEdgeInit, ///< [in] cell nbrs on each edge
+       const std::vector<I4> &EdgesOnEdgeInit, ///< [in] edges around each cell
+       const std::vector<I4> &VerticesOnEdgeInit ///< [in] vertices around cell
+   );
+
+   /// Redistribute the various XxOnVertex index arrays to the final vertex
+   /// decomposition. The inputs are the various XxOnVertex arrays in the
+   /// initial linear distribution. On exit, all the XxOnVertex arrays are
+   /// in the correct final domain decomposition.
+   int rearrangeVertexArrays(
+       const MachEnv *InEnv, ///< [in] MachEnv for the new partition
+       const std::vector<I4> &CellsOnVertexInit, ///< [in] cells at each vertex
+       const std::vector<I4> &EdgesOnVertexInit  ///< [in] edges at each vertex
+   );
+
+ public:
+   // Variables
+   // Since these are used frequently, we make them public to reduce the
+   // number of retrievals required.
+
+   // Sizes and global IDs
+   // Note that all sizes are actual counts (1-based) so that loop extents
+   // should always use the 0:NCellsXX-1 form.
+
+   I4 HaloWidth; ///< Number of halo layers for cell-based variables
+
+   I4 NCellsGlobal; ///< Number of cells in the full global mesh
+   I4 NCellsOwned;  ///< Number of cells owned by this task
+   I4 NCellsAll;    ///< Total number of local cells (owned + all halo)
+   I4 NCellsSize;   ///< Array size (incl padding, bndy cell) for cell arrays
+   I4 MaxEdges;     ///< Max number of edges around a cell
+
+   Array1DI4 NCellsHalo;      ///< num cells owned+halo for halo layer
+   ArrayHost1DI4 NCellsHaloH; ///< num cells owned+halo for halo layer
+   Array1DI4 CellID;          ///< global cell ID for each local cell
+   ArrayHost1DI4 CellIDH;     ///< global cell ID for each local cell
+   Array2DI4 CellLoc;      ///< location (task, local add) for local cells,halo
+   ArrayHost2DI4 CellLocH; ///< location (task, local add) for local cells,halo
+
+   I4 NEdgesGlobal;   ///< Number of edges in the full global mesh
+   I4 NEdgesOwned;    ///< Number of edges owned by this task
+   I4 NEdgesAll;      ///< Total number (owned+halo) of local edges
+   I4 NEdgesSize;     ///< Array length (incl padding, bndy) for edge dim
+   I4 MaxCellsOnEdge; ///< Max number of cells sharing an edge
+
+   Array1DI4 NEdgesHalo;      ///< num cells owned+halo for halo layer
+   ArrayHost1DI4 NEdgesHaloH; ///< num cells owned+halo for halo layer
+   Array1DI4 EdgeID;          ///< global cell ID for each local cell
+   ArrayHost1DI4 EdgeIDH;     ///< global cell ID for each local cell
+   Array2DI4 EdgeLoc;      ///< location (task, local add) for local edges,halo
+   ArrayHost2DI4 EdgeLocH; ///< location (task, local add) for local edges,halo
+
+   I4 NVerticesGlobal; ///< Number of vertices in the full global mesh
+   I4 NVerticesOwned;  ///< Number of vertices owned by this task
+   I4 NVerticesAll;    ///< Total number (owned+halo) of local vertices
+   I4 NVerticesSize;   ///< Array length (incl padding, bndy) for vrtx dim
+   I4 VertexDegree;    ///< Number of cells that meet at each vertex
+
+   Array1DI4 NVerticesHalo;      ///< num cells owned+halo for halo layer
+   ArrayHost1DI4 NVerticesHaloH; ///< num cells owned+halo for halo layer
+   Array1DI4 VertexID;           ///< global vertex ID for each local cell
+   ArrayHost1DI4 VertexIDH;      ///< global vertex ID for each local cell
+   Array2DI4 VertexLoc;      ///< location (task, local add) for local vrtx halo
+   ArrayHost2DI4 VertexLocH; ///< location (task, local add) for local vrtx halo
+
+   // Mesh connectivity
+
+   Array2DI4 CellsOnCell;      ///< Indx of cells that neighbor each cell
+   ArrayHost2DI4 CellsOnCellH; ///< Indx of cells that neighbor each cell
+
+   Array2DI4 EdgesOnCell;      ///< Indx of edges that border each cell
+   ArrayHost2DI4 EdgesOnCellH; ///< Indx of edges that border each cell
+
+   Array1DI4 NEdgesOnCell;      ///< Num of active edges around each cell
+   ArrayHost1DI4 NEdgesOnCellH; ///< Num of active edges around each cell
+
+   Array2DI4 VerticesOnCell;      ///< Indx of vertices bordering each cell
+   ArrayHost2DI4 VerticesOnCellH; ///< Indx of vertices bordering each cell
+
+   Array2DI4 CellsOnEdge;      ///< Indx of cells straddling each edge
+   ArrayHost2DI4 CellsOnEdgeH; ///< Indx of cells straddling each edge
+
+   Array2DI4 EdgesOnEdge;      ///< Indx of edges around cells across each edge
+   ArrayHost2DI4 EdgesOnEdgeH; ///< Indx of edges around cells across each edge
+
+   Array1DI4 NEdgesOnEdge;      ///< Num of edges around the cells across edge
+   ArrayHost1DI4 NEdgesOnEdgeH; ///< Num of edges around the cells across edge
+
+   Array2DI4 VerticesOnEdge;      ///< Indx of vertices straddling each edge
+   ArrayHost2DI4 VerticesOnEdgeH; ///< Indx of vertices straddling each edge
+
+   Array2DI4 CellsOnVertex;      ///< Indx of cells that share a vertex
+   ArrayHost2DI4 CellsOnVertexH; ///< Indx of cells that share a vertex
+
+   Array2DI4 EdgesOnVertex;      ///< Indx of edges sharing vertex as endpoint
+   ArrayHost2DI4 EdgesOnVertexH; ///< Indx of edges sharing vertex as endpoint
+
+   // Methods
+
+   /// Initializes Omega decomposition info and creates the default
+   /// decomposition based on the default MachEnv and configuration
+   /// options.
+   static int init();
+
+   /// Construct a new decomposition across an input MachEnv with
+   /// NPart partitions of a mesh that is read from a mesh file.
+   Decomp(const std::string &Name, ///< [in] Name for new decomposition
+          const MachEnv *InEnv,    ///< [in] MachEnv for the new partition
+          I4 NParts,               ///< [in] num of partitions for new decomp
+          PartMethod Method,       ///< [in] method for partitioning
+          I4 InHaloWidth,          ///< [in] width of halo in new decomp
+          const std::string &MeshFileName ///< [in] name of file with mesh info
+   );
+
+   /// Destructor - deallocates all memory and deletes a Decomp.
+   ~Decomp();
+
+   // Retrieval functions
+
+   /// Retrieves a pointer the default decomposition. The preference is
+   /// to pass the decomp as an argument, but a retrieval is necessary
+   /// for sharing the info between initialization and multiple run phases
+   static Decomp *getDefault();
+
+   /// Retrieve a decomposition by name.
+   static Decomp *get(std::string name);
+
+   /// Query functions
+
+   /// Checks a global cell ID to make sure it is in the valid range
+   bool validCellID(I4 InCellID ///< [in] a cell ID to check
+   );
+
+   /// Checks a global edge ID to make sure it is in the valid range
+   bool validEdgeID(I4 InEdgeID ///< [in] a edge ID to check
+   );
+
+   /// Checks a global vertex ID to make sure it is in the valid range
+   bool validVertexID(I4 InVertexID ///< [in] a vertex ID to check
+   );
+
+}; // end class Decomp
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif // defined OMEGA_DECOMP_H

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -1,0 +1,503 @@
+//===-- base/IO.cpp - basic IO utilities implementation ---------*- C++ -*-===//
+//
+// The routines here provide the interfaces to the parallel IO environment,
+// currently the SCORPIO parallel IO library.
+// These functions should generally be accessed through the IOStreams
+// interfaces and not used directly.
+//
+//===----------------------------------------------------------------------===//
+
+#include "IO.h"
+#include "DataTypes.h"
+#include "Logging.h"
+#include "mpi.h"
+#include "pio.h"
+
+#include <map>
+#include <string>
+
+namespace OMEGA {
+
+// Define global variables
+//------------------------------------------------------------------------------
+int IOSysID                = 0;
+IOFileFmt IODefaultFileFmt = IOFmtDefault;
+
+// Utilities
+//------------------------------------------------------------------------------
+// Converts string choice for PIO rearranger to an enum
+IORearranger
+IORearrFromString(const std::string &Rearr // [in] choice of IO rearranger
+) {
+   // Set default return value
+   IORearranger ReturnRearr = IORearrUnknown;
+
+   // Convert input string to lowercase for easier comparison
+   std::string RearrComp = Rearr;
+   std::transform(RearrComp.begin(), RearrComp.end(), RearrComp.begin(),
+                  [](unsigned char c) { return std::tolower(c); });
+
+   // Determine the appropriate enum to use based on the name
+   // Check most likely options first
+
+   // Box rearranger
+   if (RearrComp == "box") {
+      ReturnRearr = IORearrBox;
+
+      // Subset rearranger
+   } else if (RearrComp == "subset") {
+      ReturnRearr = IORearrSubset;
+
+      // Default
+   } else if (RearrComp == "default") {
+      ReturnRearr = IORearrDefault;
+
+   } else {
+      ReturnRearr = IORearrUnknown;
+   }
+
+   return ReturnRearr;
+
+} // End IORearrFromString
+
+//------------------------------------------------------------------------------
+// Converts string choice for File Format to an enum
+IOFileFmt
+IOFileFmtFromString(const std::string &Format // [in] choice of IO file format
+) {
+   // Set default return value
+   IOFileFmt ReturnFileFmt = IOFmtUnknown;
+
+   // Convert input string to lowercase for easier comparison
+   std::string FmtCompare = Format;
+   std::transform(FmtCompare.begin(), FmtCompare.end(), FmtCompare.begin(),
+                  [](unsigned char c) { return std::tolower(c); });
+
+   // Determine the appropriate enum to use based on the input string
+   // Check most likely options first
+
+   // NetCDF4 variants should be default so check first
+   // we assume netcdf4 refers to netcdf4p
+   if (FmtCompare == "netcdf4") {
+      ReturnFileFmt = IOFmtNetCDF4;
+
+      // Check for ADIOS
+   } else if (FmtCompare == "adios") {
+      ReturnFileFmt = IOFmtADIOS;
+
+      // Check specific netcdf4 variants - compressed
+   } else if (FmtCompare == "netcdf4c") {
+      ReturnFileFmt = IOFmtNetCDF4c;
+
+      // Check specific netcdf4 variants - parallel
+   } else if (FmtCompare == "netcdf4p") {
+      ReturnFileFmt = IOFmtNetCDF4p;
+
+      // Check for older netcdf
+   } else if (FmtCompare == "netcdf3") {
+      ReturnFileFmt = IOFmtNetCDF3;
+
+      // Check for older pnetcdf
+   } else if (FmtCompare == "pnetcdf") {
+      ReturnFileFmt = IOFmtPnetCDF;
+
+      // Check for native HDF5
+   } else if (FmtCompare == "hdf5") {
+      ReturnFileFmt = IOFmtHDF5;
+
+   } else if (FmtCompare == "default") {
+      ReturnFileFmt = IOFmtDefault;
+
+   } else {
+      ReturnFileFmt = IOFmtUnknown;
+   }
+
+   return ReturnFileFmt;
+
+} // end of IOFileFmtFromString
+
+//------------------------------------------------------------------------------
+// Converts string choice for IO read/write mode to an enum
+IOMode
+IOModeFromString(const std::string &Mode // [in] choice of IO mode (read/write)
+) {
+   // Set default return value
+   IOMode ReturnMode = IOModeUnknown;
+
+   // Convert input string to lowercase for easier comparison
+   std::string ModeComp = Mode;
+   std::transform(ModeComp.begin(), ModeComp.end(), ModeComp.begin(),
+                  [](unsigned char c) { return std::tolower(c); });
+
+   // Determine the appropriate enum to use based on the input string
+
+   // Read only
+   if (ModeComp == "read") {
+      ReturnMode = IOModeRead;
+
+      // Write only
+   } else if (ModeComp == "write") {
+      ReturnMode = IOModeWrite;
+
+   } else {
+      ReturnMode = IOModeUnknown;
+   }
+
+   return ReturnMode;
+
+} // End IOModeFromString
+
+//------------------------------------------------------------------------------
+// Converts string choice for existence behavior to an enum
+IOIfExists IOIfExistsFromString(
+    const std::string &IfExists // [in] choice of behavior on file existence
+) {
+   // Set default return value
+   IOIfExists ReturnIfExists = IOIfExists::Fail;
+
+   // Convert input string to lowercase for easier comparison
+   std::string IECompare = IfExists;
+   std::transform(IECompare.begin(), IECompare.end(), IECompare.begin(),
+                  [](unsigned char c) { return std::tolower(c); });
+
+   // Determine the appropriate enum to use based on the input string
+
+   // Fail with error
+   if (IECompare == "fail") {
+      ReturnIfExists = IOIfExists::Fail;
+
+      // Replace existing file
+   } else if (IECompare == "replace") {
+      ReturnIfExists = IOIfExists::Replace;
+
+      // Append or insert into existing file
+   } else if (IECompare == "append") {
+      ReturnIfExists = IOIfExists::Append;
+
+   } else {
+      ReturnIfExists = IOIfExists::Fail;
+   }
+
+   return ReturnIfExists;
+
+} // End IOIfExistsFromString
+
+//------------------------------------------------------------------------------
+// Converts string choice for floating point precision to an enum
+IOPrecision IOPrecisionFromString(
+    const std::string &Precision // [in] choice of floating point precision
+) {
+   // Set default return value
+   IOPrecision ReturnPrec = IOPrecision::Double;
+
+   // Convert input string to lowercase for easier comparison
+   std::string PrecComp = Precision;
+   std::transform(PrecComp.begin(), PrecComp.end(), PrecComp.begin(),
+                  [](unsigned char c) { return std::tolower(c); });
+
+   // Determine the appropriate enum to use based on the string name
+
+   // Maintain full double precision
+   if (PrecComp == "double") {
+      ReturnPrec = IOPrecision::Double;
+
+      // Write reduced (single) precision
+   } else if (PrecComp == "single") {
+      ReturnPrec = IOPrecision::Single;
+
+   } else {
+      ReturnPrec = IOPrecision::Double;
+   }
+
+   return ReturnPrec;
+
+} // End IOPrecisionFromString
+
+// Methods
+//------------------------------------------------------------------------------
+// Initializes the IO system based on configuration inputs and
+// default MPI communicator
+int IOInit(const MPI_Comm &InComm // [in] MPI communicator to use
+) {
+
+   int Err = 0; // success error code
+   // Retrieve parallel IO parameters from the Omega configuration
+   // TODO: replace with actual config, for now hardwired
+   // extern int IOSysID;
+
+   IOFileFmt IODefaultFileFmt = IOFileFmtFromString("netcdf4c");
+   int NumIOTasks             = 1;
+   int IOStride               = 1;
+   int IOBaseTask             = 0;
+   IORearranger Rearrange     = IORearrDefault;
+
+   // Call PIO routine to initialize
+   Err = PIOc_Init_Intracomm(InComm, NumIOTasks, IOStride, IOBaseTask,
+                             Rearrange, &IOSysID);
+   if (Err != 0)
+      LOG_ERROR("IOInit: Error initializing SCORPIO");
+
+   return Err;
+
+} // end IOInit
+
+//------------------------------------------------------------------------------
+// This routine opens a file for reading or writing, depending on the
+// Mode argument. The filename with full path must be supplied and
+// a FileID is returned to be used by other IO functions.
+// The format of the file is assumed to be the default defined on init
+// but can be optionally changed through this open function.
+// For files to be written, optional arguments govern the behavior to be
+// used if the file already exists, and the precision of any floating point
+// variables. Returns an error code.
+int IOFileOpen(
+    int &FileID,                 // [out] returned fileID for this file
+    const std::string &Filename, // [in] name (incl path) of file to open
+    IOMode Mode,                 // [in] mode (read or write)
+    IOFileFmt InFormat,          // [in] (optional) file format
+    IOIfExists IfExists,         // [in] (for writes) behavior if file exists
+    IOPrecision Precision        // [in] (for writes) precision of floats
+) {
+
+   int Err    = 0;        // default success return code
+   int Format = InFormat; // coerce to integer for PIO calls
+
+   switch (Mode) {
+
+   // If reading, open the file for read-only
+   case IOModeRead:
+      Err = PIOc_openfile(IOSysID, &FileID, &Format, Filename.c_str(), Mode);
+      if (Err != PIO_NOERR)
+         LOG_ERROR("IOFileOpen: PIO error opening file {} for read", Filename);
+      break;
+
+   // If writing, the open will depend on what to do if the file
+   // exists.
+   case IOModeWrite:
+
+      switch (IfExists) {
+      // If the write should be a new file and fail if the
+      // file exists, we use create and fail with an error
+      case IOIfExists::Fail:
+         Err = PIOc_createfile(IOSysID, &FileID, &Format, Filename.c_str(),
+                               NC_NOCLOBBER | Mode);
+         if (Err != PIO_NOERR)
+            LOG_ERROR("IOFileOpen: PIO error opening file {} for writing",
+                      Filename);
+         break;
+
+      // If the write should replace any existing file
+      // we use create with the CLOBBER option
+      case IOIfExists::Replace:
+         Err = PIOc_createfile(IOSysID, &FileID, &Format, Filename.c_str(),
+                               NC_CLOBBER | Mode);
+         if (Err != PIO_NOERR)
+            LOG_ERROR("IOFileOpen: PIO error opening file {} for writing",
+                      Filename);
+         break;
+
+      // If the write should append or add to an existing file
+      // we open the file for writing
+      case IOIfExists::Append:
+         Err = PIOc_openfile(IOSysID, &FileID, &Format, Filename.c_str(), Mode);
+         if (Err != PIO_NOERR)
+            LOG_ERROR("IOFileOpen: PIO error opening file {} for writing",
+                      Filename);
+         break;
+
+      default:
+         LOG_ERROR("IOFileOpen: unknown IfExists option for writing");
+
+      } // end switch IfExists
+      break;
+
+   // Unknown mode
+   default:
+      LOG_ERROR("IOFileOpen: Unknown Mode for file");
+
+   } // End switch on Mode
+
+   return Err;
+
+} // End IOFileOpen
+//------------------------------------------------------------------------------
+// Closes an open file using the fileID, returns an error code
+int IOFileClose(int &FileID /// [in] ID of the file to be closed
+) {
+   // Just calls the PIO close routine
+   int Err = PIOc_closefile(FileID);
+   return Err;
+
+} // End IOFileClose
+
+//------------------------------------------------------------------------------
+// Retrieves a dimension length from an input file, given the name
+// of the dimension. Returns the length if exists, but returns a negative
+// value if a dimension of that length is not found in the file.
+int IOGetDimLength(int FileID, // [in] ID of the file containing dim
+                   const std::string &DimName // [in] existing parent MachEnv
+) {
+
+   int Err = 0; // Local error code
+
+   // First get the dimension ID
+   int DimID = 0;
+   Err       = PIOc_inq_dimid(FileID, DimName.c_str(), &DimID);
+   if (Err != PIO_NOERR) {
+      LOG_ERROR("IOGetDimLength: PIO error while retrieving dimensionID");
+      return -1;
+   }
+
+   // Now retrieve the length and return
+   PIO_Offset Length = -1;
+   Err               = PIOc_inq_dimlen(FileID, DimID, &Length);
+   if (Err != PIO_NOERR) {
+      LOG_ERROR("IOGetDimLength: PIO error while retrieving dimension length");
+      return -1;
+   }
+   return Length;
+
+} // End IOGetDimLength
+
+//------------------------------------------------------------------------------
+// Creates a PIO decomposition description to describe the layout of
+// a distributed array of given type.
+int IOCreateDecomp(
+    int &DecompID,      // [out] ID assigned to the new decomposition
+    IODataType VarType, // [in] data type of array
+    int NDims,          // [in] number of array dimensions
+    const std::vector<int> &DimLengths, // [in] global dimension lengths
+    int Size,                           // [in] local size of array
+    const std::vector<int> &GlobalIndx, // [in] global indx for each local indx
+    IORearranger Rearr                  // [in] rearranger method to use
+) {
+
+   int Err = 0; // default return code
+
+   // Convert global index array into an offset array expected by PIO
+   std::vector<PIO_Offset> CompMap;
+   CompMap.resize(Size);
+   for (int i = 0; i < Size; ++i) {
+      CompMap[i] = GlobalIndx[i];
+   } // end global index loop
+
+   // Call the PIO routine to define the decomposition
+   // int TmpRearr = Rearr; // needed for type compliance across interface
+   // Err = PIOc_InitDecomp(IOSysID, VarType, NDims, DimLengths, Size, CompMap,
+   //                      &DecompID, &TmpRearr, nullptr, nullptr);
+   Err = PIOc_init_decomp(IOSysID, VarType, NDims, &DimLengths[0], Size,
+                          &CompMap[0], &DecompID, Rearr, nullptr, nullptr);
+   if (Err != PIO_NOERR)
+      LOG_ERROR("IOCreateDecomp: PIO error defining decomposition");
+
+   return Err;
+
+} // End IOCreateDecomp
+
+//------------------------------------------------------------------------------
+// Removes a defined PIO decomposition description to free memory
+int IODestroyDecomp(int &DecompID // [inout] ID for decomposition to be removed
+) {
+
+   int Err = PIOc_freedecomp(IOSysID, DecompID);
+   if (Err != PIO_NOERR)
+      LOG_ERROR("IODestroyDecomp: PIO error freeing decomposition");
+
+   return Err;
+
+} // End IODestroyDecomp
+
+//------------------------------------------------------------------------------
+// Reads a distributed array. This overloaded interface is for integer
+// arrays. Also, all arrays are assumed to be in contiguous storage so
+// the arrays of any dimension are treated as a 1-d array with the full
+// local size.
+int IOReadArray(int *Array,                 ///< [out] array to be read
+                int Size,                   ///< [in] local size of array
+                const std::string &VarName, ///< [in] name of variable to read
+                int FileID,  ///< [in] ID of open file to read from
+                int DecompID ///< [in] decomposition ID for this var
+) {
+
+   int Err   = 0; // default return code
+   int VarID = 0;
+
+   // Find variable ID from file
+   Err = PIOc_inq_varid(FileID, VarName.c_str(), &VarID);
+   if (Err != PIO_NOERR)
+      LOG_ERROR("IOReadArray(int): Error finding varid");
+
+   // PIO Read array call to read the distributed array
+   void *ArrayPtr   = Array;
+   PIO_Offset ASize = Size;
+   Err = PIOc_read_darray(FileID, VarID, DecompID, ASize, ArrayPtr);
+   if (Err != PIO_NOERR)
+      LOG_ERROR("IOReadArray(int): Error in SCORPIO read array");
+
+   return Err;
+
+} // End IOReadArray (int)
+
+//------------------------------------------------------------------------------
+// Reads a distributed array. This overloaded interface is for 32-bit real
+// arrays. Also, all arrays are assumed to be in contiguous storage so
+// the arrays of any dimension are treated as a 1-d array with the full
+// local size.
+int IOReadArray(float *Array,               ///< [out] array to be read
+                int Size,                   ///< [in] local size of array
+                const std::string &VarName, ///< [in] name of variable to read
+                int FileID,  ///< [in] ID of open file to read from
+                int DecompID ///< [in] decomposition ID for this var
+) {
+
+   int Err   = 0; // default return code
+   int VarID = 0;
+
+   // Find variable ID from file
+   Err = PIOc_inq_varid(FileID, VarName.c_str(), &VarID);
+   if (Err != PIO_NOERR)
+      LOG_ERROR("IOReadArray(real): Error finding varid");
+
+   // PIO Read array call to read the distributed array
+   Err = PIOc_read_darray(FileID, VarID, DecompID, Size, Array);
+   if (Err != PIO_NOERR)
+      LOG_ERROR("IOReadArray(real): Error in SCORPIO read array");
+
+   return Err;
+
+} // End IOReadArray (real)
+
+//------------------------------------------------------------------------------
+// Reads a distributed array. This overloaded interface is for 64-bit real
+// arrays. Also, all arrays are assumed to be in contiguous storage so
+// the arrays of any dimension are treated as a 1-d array with the full
+// local size.
+int IOReadArray(double *Array,              ///< [out] array to be read
+                int Size,                   ///< [in] local size of array
+                const std::string &VarName, ///< [in] name of variable to read
+                int FileID,  ///< [in] ID of open file to read from
+                int DecompID ///< [in] decomposition ID for this var
+) {
+
+   int Err   = 0; // default return code
+   int VarID = 0;
+
+   // Find variable ID from file
+   Err = PIOc_inq_varid(FileID, VarName.c_str(), &VarID);
+   if (Err != PIO_NOERR)
+      LOG_ERROR("IOReadArray(double): Error finding varid");
+
+   // PIO Read array call to read the distributed array
+   Err = PIOc_read_darray(FileID, VarID, DecompID, Size, Array);
+   if (Err != PIO_NOERR)
+      LOG_ERROR("IOReadArray(double): Error in SCORPIO read array");
+
+   return Err;
+
+} // End IOReadArray (double)
+
+//------------------------------------------------------------------------------
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//

--- a/components/omega/src/base/IO.h
+++ b/components/omega/src/base/IO.h
@@ -1,0 +1,218 @@
+#ifndef OMEGA_IO_H
+#define OMEGA_IO_H
+//===-- base/IO.h - basic IO utilities --------------------------*- C++ -*-===//
+//
+/// \file
+/// \brief Defines basic IO functions for use by IO streams
+///
+/// The routines here provide the interfaces to the parallel IO environment,
+/// currently the SCORPIO parallel IO library.
+/// These functions should generally be accessed through the IOStreams
+/// interfaces and not used directly. A few parameters are defined via
+/// the Omega input configuration:
+/// \ConfigInput
+/// # Basic parallel IO configuration
+/// IO:
+///    # Number of MPI tasks to use for IO
+///    # Default is 1 for safety but should be set to a subset of the
+///    #  total MPI tasks for efficiency, eg to map efficiently to the
+///    #  underlying hardware (network interfaces, NVM, etc)
+///    IOTasks:  1
+///    # The stride in MPI tasks when the number of IO tasks is less
+///    #  than the total number of MPI tasks
+///    IOStride: 1
+///    # When using parallel IO, the data must be rearranged to match
+///    #  the IO task decomposition. Choices are box and subset. Box is
+///    #  the default and generally preferred (ensures each IO task has
+///    #  a contiguous chunk of data). Subset is available for exploring
+///    #  the most efficient approach. See SCORPIO documentation for details.
+///    IORearranger: box
+///    # The IO supports a number of file formats. We specify a default
+///    #  here, but this value can be overridden on a file-by-file basis
+///    #  through the streams interface. Choices include all the various
+///    #  netCDF file formats as well as the ADIOS format.
+///    IODefaultFormat: NetCDF4
+/// \EndConfigInput
+//
+//===----------------------------------------------------------------------===//
+
+#include "DataTypes.h"
+#include "mpi.h"
+#include "pio.h"
+
+#include <map>
+#include <string>
+
+namespace OMEGA {
+
+// Define a number of enum classes to enumerate various options
+/// Choice of parallel IO rearranger algorithm
+enum IORearranger {
+   IORearrBox     = PIO_REARR_BOX,    ///< box rearranger (default)
+   IORearrSubset  = PIO_REARR_SUBSET, ///< subset rearranger
+   IORearrDefault = PIO_REARR_BOX,    ///< default value (Box)
+   IORearrUnknown = -1                ///< unknown or undefined
+};
+
+/// Supported file formats
+enum IOFileFmt {
+   IOFmtNetCDF3  = PIO_IOTYPE_NETCDF,   ///< NetCDF3 classic format
+   IOFmtPnetCDF  = PIO_IOTYPE_PNETCDF,  ///< Parallel NetCDF3
+   IOFmtNetCDF4c = PIO_IOTYPE_NETCDF4C, ///< NetCDF4 (HDF5-compatible) cmpressed
+   IOFmtNetCDF4p = PIO_IOTYPE_NETCDF4P, ///< NetCDF4 (HDF5-compatible) parallel
+   IOFmtNetCDF4  = PIO_IOTYPE_NETCDF4P, ///< NetCDF4 (HDF5-compatible) parallel
+   IOFmtHDF5     = PIO_IOTYPE_HDF5,     ///< native HDF5 format
+   IOFmtADIOS    = PIO_IOTYPE_ADIOS,    ///< ADIOS format
+   IOFmtUnknown  = -1,                  ///< Unknown or undefined
+   IOFmtDefault  = PIO_IOTYPE_NETCDF4C, ///< NetCDF4 is default
+};
+
+/// File operations
+enum IOMode {
+   IOModeUnknown, /// Unknown or undefined
+   IOModeRead,    /// Read  (input)
+   IOModeWrite,   /// Write (output)
+};
+
+/// Behavior (for output files) when a file already exists
+enum class IOIfExists {
+   Fail,    /// Fail with an error
+   Replace, /// Replace the file
+   Append,  /// Append to the existing file
+};
+
+/// Floating point precision to allow reduced precision to save space
+enum class IOPrecision {
+   Double, /// Maintain full double precision (64-bit) for reals
+   Single, /// Reduce all floating point variables to 32-bit reals
+};
+
+/// Data types for PIO corresponding to Omega types
+enum IODataType {
+   IOTypeI4      = PIO_INT,    /// 32-bit integer
+   IOTypeI8      = PIO_INT64,  /// 64-bit integer
+   IOTypeR4      = PIO_REAL,   /// 32-bit real
+   IOTypeR8      = PIO_DOUBLE, /// 64-bit real
+   IOTypeChar    = PIO_CHAR,   /// Character/string
+   IOTypeLogical = PIO_INT     /// Logicals are converted to ints for IO
+};
+
+/// The IO system id, defined on IO initialization and used by all
+/// IO functions
+extern int IOSysID;
+
+/// The default file format set on initialization. This value will
+/// be assumed if not overridden during file open.
+extern IOFileFmt IODefaultFileFmt;
+
+// Utilities
+
+/// Converts string choice for PIO rearranger to an enum
+IORearranger
+IORearrFromString(const std::string &Rearr ///< [in] choice of IO rearranger
+);
+/// Converts string choice for File Format to an enum
+IOFileFmt
+IOFileFmtFromString(const std::string &Format ///< [in] choice of IO file format
+);
+/// Converts string choice for IO read/write mode to an enum
+IOMode IOModeFromString(
+    const std::string &Mode ///< [in] choice of IO mode (read/write)
+);
+/// Converts string choice for existence behavior to an enum
+IOIfExists IOIfExistsFromString(
+    const std::string &IfExists ///< [in] choice of behavior on file existence
+);
+/// Converts string choice for floating point precision to an enum
+IOPrecision IOPrecisionFromString(
+    const std::string &Precision ///< [in] choice of floating point precision
+);
+
+// Methods
+
+/// Initializes the IO system based on configuration inputs and
+/// default MPI communicator
+int IOInit(const MPI_Comm &InComm ///< [in] MPI communicator to use
+);
+
+/// This routine opens a file for reading or writing, depending on the
+/// Mode argument. The filename with full path must be supplied and
+/// a FileID is returned to be used by other IO functions.
+/// The format of the file is assumed to be the default defined on init
+/// but can be optionally changed through this open function.
+/// For files to be written, optional arguments govern the behavior to be
+/// used if the file already exists, and the precision of any floating point
+/// variables. Returns an error code.
+int IOFileOpen(
+    int &FileID,                 ///< [out] returned fileID for this file
+    const std::string &Filename, ///< [in] name (incl path) of file to open
+    IOMode Mode,                 ///< [in] mode (read or write)
+    IOFileFmt Format      = IOFmtDefault,     ///< [in] (optional) file format
+    IOIfExists IfExists   = IOIfExists::Fail, ///< [in] behavior if file exists
+    IOPrecision Precision = IOPrecision::Double ///< [in] precision of floats
+);
+
+/// Closes an open file using the fileID, returns an error code
+int IOFileClose(int &FileID /// [in] ID of the file to be closed
+);
+
+/// Retrieves a dimension length from an input file, given the name
+/// of the dimension. Returns the length if exists, but returns a negative
+/// value if a dimension of that length is not found in the file.
+int IOGetDimLength(int FileID, ///< [in] ID of the file containing dim
+                   const std::string &DimName ///< [in] name of dimension
+);
+
+/// Creates a PIO decomposition description to describe the layout of
+/// a distributed array of given type.
+int IOCreateDecomp(
+    int &DecompID,                      ///< [out] ID for the new decomposition
+    IODataType VarType,                 ///< [in] data type of array
+    int NDims,                          ///< [in] number of array dimensions
+    const std::vector<int> &DimLengths, ///< [in] global dimension lengths
+    int Size,                           ///< [in] local size of array
+    const std::vector<int> &GlobalIndx, ///< [in] global indx for each loc indx
+    IORearranger Rearr                  ///< [in] rearranger method to use
+);
+
+/// Removes a PIO decomposition to free memory.
+int IODestroyDecomp(int &DecompID ///< [inout] ID for decomp to remove
+);
+
+/// Reads a distributed array. This overloaded interface is for integer
+/// arrays. Also, all arrays are assumed to be in contiguous storage so
+/// the arrays of any dimension are treated as a 1-d array with the full
+/// local size.
+int IOReadArray(int *Array,                 ///< [out] array to be read
+                int Size,                   ///< [in] local size of array
+                const std::string &VarName, ///< [in] name of variable to read
+                int FileID,  ///< [in] ID of open file to read from
+                int DecompID ///< [in] decomposition ID for this var
+);
+
+/// Reads a distributed array. This overloaded interface is for 32-bit real
+/// arrays. Also, all arrays are assumed to be in contiguous storage so
+/// the arrays of any dimension are treated as a 1-d array with the full
+/// local size.
+int IOReadArray(float *Array,               ///< [out] array to be read
+                int Size,                   ///< [in] local size of array
+                const std::string &VarName, ///< [in] name of variable to read
+                int FileID,  ///< [in] ID of open file to read from
+                int DecompID ///< [in] decomposition ID for this var
+);
+
+/// Reads a distributed array. This overloaded interface is for 64-bit real
+/// arrays. Also, all arrays are assumed to be in contiguous storage so
+/// the arrays of any dimension are treated as a 1-d array with the full
+/// local size.
+int IOReadArray(double *Array,              ///< [out] array to be read
+                int Size,                   ///< [in] local size of array
+                const std::string &VarName, ///< [in] name of variable to read
+                int FileID,  ///< [in] ID of open file to read from
+                int DecompID ///< [in] decomposition ID for this var
+);
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif // defined OMEGA_IO_H

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_options(
   ${OMEGA_LINK_OPTIONS}
 )
 
-target_link_libraries(${_TestDataTypesName} ${OMEGA_LIB_NAME} yakl)
+target_link_libraries(${_TestDataTypesName} ${OMEGA_LIB_NAME} yakl metis)
 
 add_test(
   NAME DATA_TYPES_TEST
@@ -116,6 +116,42 @@ target_link_options(
 target_link_libraries(${_TestLoggingName} ${OMEGA_LIB_NAME} yakl)
 
 add_test(NAME LOGGING_TEST COMMAND ./${_TestLoggingName})
+
+#############
+# Decomp test
+#############
+
+set(_TestDecompName testDecomp.exe)
+
+# Add broadcast test
+add_executable(${_TestDecompName} base/DecompTest.cpp)
+
+target_include_directories(
+  ${_TestDecompName}
+  PRIVATE
+  ${OMEGA_SOURCE_DIR}/src/base
+  ${OMEGA_SOURCE_DIR}/src/infra
+  ${PARMETIS_ROOT}/include
+)
+
+target_compile_options(
+  ${_TestDecompName}
+  PRIVATE
+  ${OMEGA_CXX_FLAGS}
+)
+
+target_link_options(
+  ${_TestDecompName}
+  PRIVATE
+  ${OMEGA_LINK_OPTIONS}
+)
+
+target_link_libraries(${_TestDecompName} ${OMEGA_LIB_NAME} yakl metis)
+
+add_test(
+  NAME DECOMP_TEST
+  COMMAND ${MPI_EXEC} -n 8 -- ./${_TestDecompName}
+)
 
 
 ##################

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -1,0 +1,142 @@
+//===-- Test driver for OMEGA Decomp -----------------------------*- C++ -*-===/
+//
+/// \file
+/// \brief Test driver for OMEGA domain decomposition (Decomp)
+///
+/// This driver tests the OMEGA domain decomposition, decomposing the
+/// horizontal domain and creating a number of index-space arrays for
+/// locating and describing mesh locations within a parallel distributed
+/// memory.
+///
+//
+//===-----------------------------------------------------------------------===/
+
+#include "Decomp.h"
+#include "DataTypes.h"
+#include "IO.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "mpi.h"
+
+#include <iostream>
+
+//------------------------------------------------------------------------------
+// The initialization routine for Decomp testing. It calls various
+// init routines, including the creation of the default decomposition.
+
+int initDecompTest() {
+
+   int Err = 0;
+
+   // Initialize the Machine Environment class - this also creates
+   // the default MachEnv. Then retrieve the default environment and
+   // some needed data members.
+   OMEGA::MachEnv::init(MPI_COMM_WORLD);
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   MPI_Comm DefComm       = DefEnv->getComm();
+
+   // Initialize the IO system
+   Err = OMEGA::IOInit(DefComm);
+   if (Err != 0)
+      LOG_ERROR("DecompTest: error initializing parallel IO");
+
+   // Create the default decomposition (initializes the decomposition)
+   Err = OMEGA::Decomp::init();
+   if (Err != 0)
+      LOG_ERROR("DecompTest: error initializing default decomposition");
+
+   return Err;
+}
+
+//------------------------------------------------------------------------------
+// The test driver for Decomp. This tests the decomposition of a sample
+// horizontal domain and verifies the mesh is decomposed correctly.
+//
+int main(int argc, char *argv[]) {
+
+   // Initialize the global MPI environment
+   MPI_Init(&argc, &argv);
+   yakl::init();
+
+   // Call initialization routine to create the default decomposition
+   int Err = initDecompTest();
+   if (Err != 0)
+      LOG_CRITICAL("DecompTest: Error initializing");
+
+   // Get MPI vars if needed
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   MPI_Comm Comm          = DefEnv->getComm();
+   OMEGA::I4 MyTask       = DefEnv->getMyTask();
+   OMEGA::I4 NumTasks     = DefEnv->getNumTasks();
+   bool IsMaster          = DefEnv->isMasterTask();
+
+   // Test retrieval of the default decomposition
+   OMEGA::Decomp *DefDecomp = OMEGA::Decomp::getDefault();
+   if (DefDecomp) { // true if non-null ptr
+      LOG_INFO("DecompTest: Default decomp retrieval PASS");
+   } else {
+      LOG_INFO("DecompTest: Default decomp retrieval FAIL");
+      return -1;
+   }
+
+   // Test that all Cells, Edges, Vertices are accounted for by
+   // summing the list of owned values by all tasks. The result should
+   // be the sum of the integers from 1 to NCellsGlobal (or edges, vertices).
+   OMEGA::I4 RefSumCells    = 0;
+   OMEGA::I4 RefSumEdges    = 0;
+   OMEGA::I4 RefSumVertices = 0;
+   for (int n = 0; n < DefDecomp->NCellsGlobal; ++n)
+      RefSumCells += n + 1;
+   for (int n = 0; n < DefDecomp->NEdgesGlobal; ++n)
+      RefSumEdges += n + 1;
+   for (int n = 0; n < DefDecomp->NVerticesGlobal; ++n)
+      RefSumVertices += n + 1;
+   OMEGA::I4 LocSumCells          = 0;
+   OMEGA::I4 LocSumEdges          = 0;
+   OMEGA::I4 LocSumVertices       = 0;
+   OMEGA::ArrayHost1DI4 CellIDH   = DefDecomp->CellIDH;
+   OMEGA::ArrayHost1DI4 EdgeIDH   = DefDecomp->EdgeIDH;
+   OMEGA::ArrayHost1DI4 VertexIDH = DefDecomp->VertexIDH;
+   for (int n = 0; n < DefDecomp->NCellsOwned; ++n)
+      LocSumCells += CellIDH(n);
+   for (int n = 0; n < DefDecomp->NEdgesOwned; ++n)
+      LocSumEdges += EdgeIDH(n);
+   for (int n = 0; n < DefDecomp->NVerticesOwned; ++n)
+      LocSumVertices += VertexIDH(n);
+   OMEGA::I4 SumCells    = 0;
+   OMEGA::I4 SumEdges    = 0;
+   OMEGA::I4 SumVertices = 0;
+   Err = MPI_Allreduce(&LocSumCells, &SumCells, 1, MPI_INT32_T, MPI_SUM, Comm);
+   Err = MPI_Allreduce(&LocSumEdges, &SumEdges, 1, MPI_INT32_T, MPI_SUM, Comm);
+   Err = MPI_Allreduce(&LocSumVertices, &SumVertices, 1, MPI_INT32_T, MPI_SUM,
+                       Comm);
+
+   if (SumCells == RefSumCells) {
+      LOG_INFO("DecompTest: Sum cell ID test PASS");
+   } else {
+      LOG_INFO("DecompTest: Sum cell ID test FAIL {} {}", SumCells,
+               RefSumCells);
+   }
+   if (SumEdges == RefSumEdges) {
+      LOG_INFO("DecompTest: Sum edge ID test PASS");
+   } else {
+      LOG_INFO("DecompTest: Sum edge ID test FAIL {} {}", SumEdges,
+               RefSumEdges);
+   }
+   if (SumVertices == RefSumVertices) {
+      LOG_INFO("DecompTest: Sum vertex ID test PASS");
+   } else {
+      LOG_INFO("DecompTest: Sum vertex ID test FAIL {} {}", SumVertices,
+               RefSumVertices);
+   }
+
+   // Test that device arrays are identical
+
+   // MPI_Status status;
+   if (Err == 0)
+      LOG_INFO("DecompTest: Successful completion");
+   yakl::finalize();
+   MPI_Finalize();
+
+} // end of main
+//===-----------------------------------------------------------------------===/


### PR DESCRIPTION
Adds the on-line domain decomposition for Omega meshes. It includes

  - the decomposition module
  - some initial parallel IO routines needed to read the mesh information
  -  changes to the build system to include the scorpio and metis libraries
  -  documentation of the decomposition and changes to build
  -  a unit test that performs a relatively simple test to ensure all mesh locations have been distributed

This has been tested on Frontier and on Chrysalis, both with the unit test and also with a detailed comparison
of all arrays with the previous MPAS model. It reproduces both the partition and index ordering from the MPAS
domain decomposition.

Checklist
* [x] Documentation:
  * [x] Design document has been generated and added to the docs
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.


