### PR TITLE
Add FindParmetis.cmake to locate Parmetis libraries

### DIFF
--- a/components/omega/FindParmetis.cmake
+++ b/components/omega/FindParmetis.cmake
@@ -1,0 +1,110 @@
+FIND_PATH(Parmetis_INCLUDE_DIR
+          parmetis.h
+          PATHS ${OMEGA_PARMETIS_ROOT}
+          PATH_SUFFIXES include
+          NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+
+# If not defined, assume the METIS path isthe same as ParMETIS
+if(NOT DEFINED OMEGA_METIS_ROOT)
+   set(OMEGA_METIS_ROOT ${OMEGA_PARMETIS_ROOT})
+endif()
+
+FIND_PATH(Metis_INCLUDE_DIR
+          metis.h
+          PATHS ${OMEGA_METIS_ROOT}
+          PATH_SUFFIXES include
+          NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+
+# Assume the GKlib path is the same as METIS if it is not defined.
+# This library is not mandatory and is therefore optional.
+if(NOT DEFINED OMEGA_GKLIB_ROOT)
+   set(OMEGA_GKLIB_ROOT ${OMEGA_PARMETIS_ROOT})
+endif()
+
+FIND_PATH(GKlib_INCLUDE_DIR
+          GKlib.h
+	  PATHS ${OMEGA_GKLIB_ROOT}
+          PATH_SUFFIXES include
+          NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+
+# Currently using static libraries, but retain the following for
+# potential future use with shared libraries.
+#IF (${OMEGA_PREFER_SHARED})
+#  FIND_LIBRARY(Parmetis_LIBRARY
+#               NAMES parmetis
+#               HINTS ${Parmetis_INCLUDE_DIR}/../lib
+#               NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+#
+#  FIND_LIBRARY(Metis_LIBRARY
+#               NAMES metis
+#               HINTS ${Metis_INCLUDE_DIR}/../lib
+#               NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+#
+#  IF (${GKlib_INCLUDE_DIR})
+#    FIND_LIBRARY(GKlib_LIBRARY
+#                 NAMES GKlib
+#	         HINTS ${GKlib_INCLUDE_DIR}/../lib
+#	         NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+#  ENDIF ()
+#
+#ELSE ()
+
+  FIND_LIBRARY(Parmetis_LIBRARY
+               NAMES libparmetis.a
+               HINTS ${Parmetis_INCLUDE_DIR}/../lib
+               NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+
+  FIND_LIBRARY(Metis_LIBRARY
+               NAMES libmetis.a
+               HINTS ${Metis_INCLUDE_DIR}/../lib
+               NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+
+  # In some installations, GKlib is optional
+  IF (DEFINED GKlib_INCLUDE_DIR AND NOT GKlib_INCLUDE_DIR STREQUAL "")
+    FIND_LIBRARY(GKlib_LIBRARY
+                 NAMES libGKlib.a
+                 HINTS ${GKlib_INCLUDE_DIR}/../lib
+                 NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+  ENDIF ()
+
+#ENDIF ()
+
+SET(Parmetis_INCLUDE_DIRS)
+
+IF (Parmetis_INCLUDE_DIR AND Parmetis_LIBRARY)
+
+  SET(Parmetis_FOUND TRUE)
+  LIST(APPEND Parmetis_INCLUDE_DIRS ${Parmetis_INCLUDE_DIR})
+
+  MESSAGE(STATUS "Found Parmetis Library: ${Parmetis_LIBRARY}")
+  MESSAGE(STATUS "Found Parmetis Include: ${Parmetis_INCLUDE_DIR}")
+ELSE()
+  SET(Parmetis_FOUND FALSE)
+ENDIF()
+
+IF (Metis_INCLUDE_DIR AND Metis_LIBRARY)
+
+  LIST(APPEND Parmetis_INCLUDE_DIRS ${Metis_INCLUDE_DIR})
+  SET(Metis_FOUND TRUE)
+
+  MESSAGE(STATUS "Found Metis Library: ${Metis_LIBRARY}")
+  MESSAGE(STATUS "Found Metis Include: ${Metis_INCLUDE_DIR}")
+ELSE()
+  SET(Metis_FOUND FALSE)
+ENDIF()
+
+IF (GKlib_INCLUDE_DIR AND GKlib_LIBRARY)
+
+  LIST(APPEND Parmetis_INCLUDE_DIRS ${GKlib_INCLUDE_DIR})
+  SET(GKlib_FOUND TRUE)
+
+  MESSAGE(STATUS "Found GKlib Library: ${GKlib_LIBRARY}")
+  MESSAGE(STATUS "Found GKlib Include: ${GKlib_INCLUDE_DIR}")
+ELSE()
+  SET(GKlib_FOUND FALSE)
+ENDIF()
+
+IF(NOT Parmetis_FOUND OR NOT Metis_FOUND)
+  MESSAGE(STATUS "Did not find required library Parmetis.\n"
+          "Please set location of Parmetis with -DOMEGA_PARMETIS_ROOT")
+ENDIF()

--- a/components/omega/OmegaBuild.cmake
+++ b/components/omega/OmegaBuild.cmake
@@ -316,6 +316,10 @@ macro(update_variables)
 
   endif()
 
+  # Include the findParmetis script
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+  find_package(Parmetis REQUIRED)
+
 #  # prints generates all cmake variables
 #  get_cmake_property(_variableNames VARIABLES)
 #  list (SORT _variableNames)

--- a/components/omega/doc/devGuide/CMakeBuild.md
+++ b/components/omega/doc/devGuide/CMakeBuild.md
@@ -55,6 +55,9 @@ OMEGA_CXX_FLAGS: a list for C++ compiler flags
 OMEGA_LINK_OPTIONS: a list for linker flags
 OMEGA_BUILD_EXECUTABLE: Enable building the Omega executable
 OMEGA_BUILD_TEST: Enable building Omega tests
+OMEGA_PARMETIS_ROOT: Parmetis installtion directory
+OMEGA_METIS_ROOT: Metis installtion directory
+OMEGA_GKLIB_ROOT: GKlib installtion directory
 ```
 
 E3SM-specific variables

--- a/components/omega/doc/userGuide/OmegaBuild.md
+++ b/components/omega/doc/userGuide/OmegaBuild.md
@@ -31,16 +31,19 @@ to specify which system you intend to use. The values of `OMEGA_CIME_COMPILER`
 and `OMEGA_CIME_MACHINE` are defined in
 "${E3SM}/cime\_config/machines/config\_machines.xml".
 OMEGA requires some external libraries. Many of these are built automatically
-from the E3SM distribution. However, the METIS and ParMETIS libraries must
-be built separately and the path must be supplied during the cmake invocation
-as shown below. If a METIS_ROOT is not supplied, it is assumed that both METIS
-and ParMETIS are installed in the same PARMETIS_ROOT location.
+from the E3SM distribution. However, the METIS, ParMETIS, and, optionally,
+GKlib libraries must be built separately and the path must be supplied during
+the cmake invocation as shown below. If a `OMEGA_METIS_ROOT` is not supplied,
+it is assumed that both METIS and ParMETIS are installed in the same
+`OMEGA_PARMETIS_ROOT` location. If a `OMEGA_GKLIB_ROOT` is not supplied, it is
+assumed that both GKLIB and METIS are installed in the same `OMEGA_METIS_ROOT`
+location. All three libraries should be static libraries.
 
 ```sh
 >> cmake \
   -DOMEGA_CIME_COMPILER=nvidiagpu \
   -DOMEGA_CIME_MACHINE=pm-gpu \
-  -DPARMETIS_ROOT=/path/to/parmetis \
+  -DOMEGA_PARMETIS_ROOT=/path/to/parmetis \
   ${E3SM_HOME}/components/omega
 ```
 

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -22,16 +22,20 @@ endif()
 
 # forward env. variables to Scorpio build
 if(DEFINED ENV{NETCDF_PATH})
-  set(NetCDF_PATH "$ENV{NETCDF_PATH}")
+  set(NetCDF_PATH $ENV{NETCDF_PATH}
+		CACHE STRING "Path to NETCDF library" FORCE)
 endif()
 if(DEFINED ENV{NETCDF_C_PATH})
-  set(NetCDF_C_PATH "$ENV{NETCDF_C_PATH}")
+  set(NetCDF_C_PATH $ENV{NETCDF_C_PATH}
+		CACHE STRING "Path to NETCDF-C library" FORCE)
 endif()
 if(DEFINED ENV{NETCDF_FORTRAN_PATH})
-  set(NetCDF_Fortran_PATH "$ENV{NETCDF_FORTRAN_PATH}")
+  set(NetCDF_Fortran_PATH $ENV{NETCDF_FORTRAN_PATH}
+		CACHE STRING "Path to NETCDF-Fortran library" FORCE)
 endif()
 if(DEFINED ENV{PNETCDF_PATH})
-  set(PnetCDF_PATH "$ENV{PNETCDF_PATH}")
+  set(PnetCDF_PATH $ENV{PNETCDF_PATH}
+		CACHE STRING "Path to PNETCDF library" FORCE)
 endif()
 
 option(PIO_ENABLE_TOOLS "" OFF)
@@ -42,19 +46,22 @@ add_subdirectory(
   ${CMAKE_CURRENT_BINARY_DIR}/scorpio
 )
 
-
-
 # Add the parmetis and related libraries
 
-# If not defined, assume the METIS paths are the same as ParMETIS
-if(NOT DEFINED METIS_ROOT)
-   set(METIS_ROOT ${PARMETIS_ROOT})
+if(Parmetis_FOUND)
+  add_library(parmetis STATIC IMPORTED GLOBAL)
+  set_target_properties(parmetis PROPERTIES
+     IMPORTED_LOCATION ${Parmetis_LIBRARY})
 endif()
 
-add_library(metis STATIC IMPORTED GLOBAL)
-set_target_properties(metis PROPERTIES
-   IMPORTED_LOCATION ${METIS_ROOT}/lib/libmetis.a)
+if(Metis_FOUND)
+  add_library(metis STATIC IMPORTED GLOBAL)
+  set_target_properties(metis PROPERTIES
+     IMPORTED_LOCATION ${Metis_LIBRARY})
+endif()
 
-add_library(parmetis STATIC IMPORTED GLOBAL)
-set_target_properties(parmetis PROPERTIES
-   IMPORTED_LOCATION ${PARMETIS_ROOT}/lib/libparmetis.a)
+if(GKlib_FOUND)
+  add_library(gklib STATIC IMPORTED GLOBAL)
+  set_target_properties(gklib PROPERTIES
+     IMPORTED_LOCATION ${GKlib_LIBRARY})
+endif()

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(
     PRIVATE
     ${OMEGA_SOURCE_DIR}/src/base
     ${OMEGA_SOURCE_DIR}/src/infra
-    ${PARMETIS_ROOT}/include
+    ${Parmetis_INCLUDE_DIRS}
 )
 
 # add compiler options
@@ -29,7 +29,11 @@ target_link_options(
     ${OMEGA_LINK_OPTIONS}
 )
 
-target_link_libraries(${OMEGA_LIB_NAME} spdlog yakl pioc metis)
+target_link_libraries(${OMEGA_LIB_NAME} spdlog yakl pioc parmetis metis)
+
+if(GKlib_FOUND)
+    target_link_libraries(${OMEGA_LIB_NAME} gklib)
+endif()
 
 # build Omega executable
 if(OMEGA_BUILD_EXECUTABLE)

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -22,7 +22,11 @@ target_link_options(
   ${OMEGA_LINK_OPTIONS}
 )
 
-target_link_libraries(${_TestDataTypesName} ${OMEGA_LIB_NAME} yakl metis)
+target_link_libraries(${_TestDataTypesName} ${OMEGA_LIB_NAME} yakl parmetis metis)
+
+if(GKlib_FOUND)
+  target_link_libraries(${_TestDataTypesName} gklib)
+endif()
 
 add_test(
   NAME DATA_TYPES_TEST
@@ -131,7 +135,7 @@ target_include_directories(
   PRIVATE
   ${OMEGA_SOURCE_DIR}/src/base
   ${OMEGA_SOURCE_DIR}/src/infra
-  ${PARMETIS_ROOT}/include
+  ${Parmetis_INCLUDE_DIRS}
 )
 
 target_compile_options(
@@ -146,7 +150,11 @@ target_link_options(
   ${OMEGA_LINK_OPTIONS}
 )
 
-target_link_libraries(${_TestDecompName} ${OMEGA_LIB_NAME} yakl metis)
+target_link_libraries(${_TestDecompName} ${OMEGA_LIB_NAME} yakl parmetis metis)
+
+if(GKlib_FOUND)
+  target_link_libraries(${_TestDecompName} gklib)
+endif()
 
 add_test(
   NAME DECOMP_TEST
@@ -161,7 +169,7 @@ add_test(
 set(_TestYaklName testYakl.exe)
 
 add_executable(
-  ${_TestYaklName} ${E3SM_EXTERNALS_ROOT}/YAKL/unit/performance/performance.cpp
+  ${_TestYaklName} ${E3SM_EXTERNALS_ROOT}/YAKL/unit/ParForC/ParForC.cpp
 )
 
 include(${E3SM_EXTERNALS_ROOT}/YAKL/yakl_utils.cmake)


### PR DESCRIPTION
Add FindParmetis.cmake to locate Parmetis libraries.

* Assumes that the user provides OMEGA_PARMETIS_ROOT.
* If Metis is located elsewhere than OMEGA_PARMETIS_ROOT, the user should provide OMEGA_METIS_ROOT.
* If GKlib is located in a different location from METIS, specify its location with OMEGA_GKLIB_ROOT.


Checklist
* [X] Documentation:
  * [ ] Design document has been generated and added to the docs
  * [X] User's Guide has been updated
  * [X] Developer's Guide has been updated
  * [ ] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [X] Testing
  * [ ] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [X] CTest unit tests for new features have been added per the approved design. 
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
  * [ ] Unit tests have passed. Please provide a relevant CDash build entry for verification.
  * [ ] Polaris test suite has passed
  * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.


