### PR TITLE
Add a quick start for developers

### DIFF
--- a/components/omega/doc/devGuide/CondaEnv.md
+++ b/components/omega/doc/devGuide/CondaEnv.md
@@ -7,45 +7,53 @@ code, you will need your own
 [conda](https://conda.io/projects/conda/en/latest/index.html) environment with
 the necessary packages.
 
-(omega-dev-install-mambaforge)=
+(omega-dev-install-miniforge3)=
 
-## Installing Mambaforge
+## Installing Miniforge3
 
 If you have not already done so, you will install
-[Mambaforge](https://github.com/conda-forge/miniforge#mambaforge), preferably
-somewhere in your home directory but possibly somewhere in your scratch space.
-In what follows, we assume you have Mambaforge installed in
-`${HOME}/mambaforge`.
+[Miniforge3](https://github.com/conda-forge/miniforge#miniforge3):
+```bash
+curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+bash Miniforge3-$(uname)-$(uname -m).sh
+```
+If you have the space to do so, we recommend installing Miniforge3 somewhere in
+our home directory.  Typically, this file system will be faster than on a
+scratch space spaces.  Also, a conda environment will be rendered useless if
+its contents get purged.  However, conda environments each require several GB
+of space, which may quickly use up your disk quota so you will need to weigh
+these trade-offs for yourself.
 
-You may wish to skip the step in the Mambaforge installation where it
-wants to modify your `.bashrc`.  If you allow it to, it will add
-activation of the `mamba` and `conda` commands and the `base` conda
-environment, and this may not be something you want.
+In what follows, we assume you have Miniforge3 installed in
+`${HOME}/miniforge3`.
 
-If you opt not to allow Mambforge to update your `.bashrc`, it may be helpful
+You may wish to skip the step in the Miniforge3 installation where it
+wants to modify your `.bashrc`.  If you allow it to, it will add activation of
+the `conda` command and the `base` conda environment, and this may not be
+something you want.
+
+If you opt not to allow Miniforge3 to update your `.bashrc`, it may be helpful
 to add an alias like the following to your `.bashrc`:
 
 ```bash
-alias mamba_base='
-source ${HOME}/mambaforge/etc/profile.d/conda.sh
-source ${HOME}/mambaforge/etc/profile.d/mamba.sh
-mamba activate'
+alias conda_base='
+source ${HOME}/miniforge3/etc/profile.d/conda.sh
+conda activate'
 ```
 
-Anytime you need `conda` and `mamba` commands, you can first run `mamba_base`
-to get them.
+Anytime you need `conda` command, you can first run `conda_base`to get it.
 
 
 (omega-dev-create-conda-env)=
 
 ## Creating the Conda Environment
 
-With Mambaforge installed and the `conda` and `mamba` commands activated,
-you can create the OMEGA development environment, starting from the root
-of an OMEGA branch, with:
+With Miniforge3 installed and the `conda` command available, you can create the
+Omega development environment, starting from the root
+of an Omega branch, with:
 
 ```bash
 cd components/omega/
-mamba create -n omega_dev --file dev-conda.txt
+conda create -n omega_dev --file dev-conda.txt
 conda activate omega_dev
 ```

--- a/components/omega/doc/devGuide/QuickStart.md
+++ b/components/omega/doc/devGuide/QuickStart.md
@@ -2,7 +2,249 @@
 
 # Quick Start for Developers
 
-:::{admonition} Quick Start for Developers is coming soon
-OMEGA is still in such an early stages of development that we don't even have
-a quick start for developers yet.
-:::
+## Getting set up
+
+### Creating an E3SM fork
+
+We ask developers to make their own fork of the E3SM to use for development
+branches.  To do this, go to the page for the
+[E3SM-Project/E3SM](https://github.com/E3SM-Project/E3SM) respository and
+click on the `fork` button near the upper right corner.  Set "owner" to your
+GitHub username (this should be the default) and click "Create fork".
+
+There is no need to have a separate for for Omega, since the Omega repository
+is also a fork of E3SM.  Your E3SM fork will server for both E3SM and Omega
+development.  In fact, GitHub will not let you make an Omega fork if you
+already have an E3SM fork (or visa versa).
+
+### Check out the code
+
+Make sure you have added the SSH key for the machine you are using to your
+GitHub account, see
+[Adding a new SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
+
+Clone the develop branch of the Omega repo:
+```sh
+git clone git@github.com:E3SM-Project/Omega.git develop
+```
+
+You may wish to rename `origin` to `E3SM-Project/Omega` for clarity:
+```sh
+git remote rename origin E3SM-Project/Omega
+```
+
+Consider adding some other remotes, e.g.:
+```sh
+git remote add E3SM-Project/E3SM git@github.com:E3SM-Project/E3SM.git
+git remote add <github_username>/E3SM git@github.com:<github_username>/E3SM.git
+```
+where `<github_username>` is your username or that of a collaborator.
+
+To sync your local clone with all the remotes, run:
+```sh
+git fetch --all -p
+```
+
+### Create a conda environment
+
+If you do not have conda set up in your own space yet, follow
+{ref}`omega-dev-install-miniforge3` for instructions on how to install it.
+
+
+Activate the `base` conda environment.  Go to the base of the Omega branch you
+plan to develop and create conda environment for
+linting your code and building the documentation:
+```sh
+cd components/omega/
+conda create -n omega_dev --file dev-conda.txt
+conda activate omega_dev
+```
+(You can reuse `omega_dev` for other branches as long as `dev-conda.txt` has
+not changed between branchs.)
+
+Please activate this environment each time you commit code.  This will ensure
+that `pre-commit` and the associated linting utilities are available and that
+they check your code as it is committed (rather than requiring fix-up commits
+later on).
+
+## Building and testing Omega
+
+### Polaris CTest Utility
+
+If you are using Polaris, you may wish to use its
+[Omega CTest utility](https://github.com/E3SM-Project/polaris/tree/main/utils/omega/ctest)
+to buid and test Omega. The utility automates many of the steps below.
+
+### Building Omega
+
+In the Omega branch you would like to build, first update the submodules that
+Omega requires:
+```sh
+git submodule update --init --recursive externals/YAKL externals/ekat \
+    externals/scorpio cime
+```
+
+Since some systems require tests to be run on in a scratch space, it is a good
+idea to build the code somewhere in your scratch space.  We will simply refer
+to the build directory as `$BUILD_DIR` and leave it up to you to decide where
+it is best to put it.  If you have previously built in `$BUILD_DIR`, you
+very likely need to remove it first and start fresh:
+```sh
+rm -rf $BUILD_DIR
+mkdir $BUILD_DIR
+cd $BUILD_DIR
+```
+
+Set `$PARMETIS_ROOT` to the appropriate location for Metis and Parmetis
+libraries built for your machine and compiler (see
+{ref}`omega-dev-parmetis-libs` below for some shared locations on some
+supported machines):
+```sh
+export PARMETIS_ROOT=<parmetis_root>
+```
+
+Run CMake for the build type, machine and compiler you want:
+```sh
+cmake \
+   -DOMEGA_BUILD_TYPE=<build_type> \
+   -DOMEGA_CIME_COMPILER=<compiler> \
+   -DOMEGA_CIME_MACHINE=<machine> \
+   -DOMEGA_PARMETIS_ROOT=${PARMETIS_ROOT} \
+   -DOMEGA_BUILD_TEST=ON \
+   -Wno-dev \
+   -S <omega_branch>/components/omega \
+   -B .
+```
+where `<build_type>` is either `Debug` or `Release`, `<omega_branch>` is the
+path to the base of the Omega branch you want to build, and where `<machine>`
+and `<compiler>` are the current machine and a compiler supported by E3SM on
+that machine (see
+[config_machines.xml](https://github.com/E3SM-Project/Omega/blob/develop/cime_config/machines/config_machines.xml)).
+
+The command above will configure Omega to build CTests
+(`-DOMEGA_BUILD_TEST=ON`), which is recommended.
+
+If CMake configuration runs correctly, you should have an `omega_build.sh`
+script that you can run to build Omega:
+```sh
+./omega_build.sh
+```
+
+### Running CTests
+
+Omega includes several unit tests that run through CTest.  These need to be
+run on a compute node.  Some tests also require a valid Omega mesh file
+called `test/OmegaMesh.nc`.  An appropriate mesh file can be downloaded from
+[mesh.230220.nc](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/polaris_cache/global_convergence/icos/cosine_bell/Icos480/mesh/mesh.230220.nc).
+```sh
+wget https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/polaris_cache/global_convergence/icos/cosine_bell/Icos480/mesh/mesh.230220.nc
+mv mesh.230220.nc test/OmegaMesh.nc
+```
+
+Then, run the tests:
+```sh
+./omega_ctest.sh
+```
+
+The results should look something like:
+```
+Test project /gpfs/fs1/home/ac.xylar/e3sm_work/polaris/add-omega-ctest-util/build_omega/build_chrysalis_intel
+    Start 1: DATA_TYPES_TEST
+1/9 Test #1: DATA_TYPES_TEST ..................   Passed    0.38 sec
+    Start 2: MACHINE_ENV_TEST
+2/9 Test #2: MACHINE_ENV_TEST .................   Passed    0.98 sec
+    Start 3: BROADCAST_TEST
+3/9 Test #3: BROADCAST_TEST ...................   Passed    1.13 sec
+    Start 4: LOGGING_TEST
+4/9 Test #4: LOGGING_TEST .....................   Passed    0.03 sec
+    Start 5: DECOMP_TEST
+5/9 Test #5: DECOMP_TEST ......................   Passed    1.20 sec
+    Start 6: HALO_TEST
+6/9 Test #6: HALO_TEST ........................   Passed    1.08 sec
+    Start 7: IO_TEST
+7/9 Test #7: IO_TEST ..........................   Passed    2.94 sec
+    Start 8: CONFIG_TEST
+8/9 Test #8: CONFIG_TEST ......................   Passed    1.01 sec
+    Start 9: YAKL_TEST
+9/9 Test #9: YAKL_TEST ........................   Passed    0.03 sec
+
+100% tests passed, 0 tests failed out of 9
+
+Total Test time (real) =   8.91 sec
+```
+
+### Debugging tips
+
+If Omega CTests are failing or simulations are crashing, setting
+`OMEGA_BUILD_TYPE` to `Debug` can be helpful for debugging purposes. If you
+need to identify which test has failed, it may be useful to examin the CMake
+ctest log file located at `$BUILD_DIR/Testing/Temporary/LastTest.log`.
+
+(omega-dev-parmetis-libs)=
+
+### Metis and Parmetis libraries
+
+The following table shows locations for Metis and Parmetis libraries on
+supported E3SM machines.  The pattern is:
+```
+<polaris_base>/<machine>/spack/dev_polaris_0_3_0_<compiler>_<mpi>/var/spack/environments/dev_polaris_0_3_0_<compiler>_<mpi>/.spack-env/view
+```
+
+```{eval-rst}
++--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Machine      | Compiler     | Parmetis path                                                                                                                                                     |
++==============+==============+===================================================================================================================================================================+
+| chicoma-cpu  | gnu          | /usr/projects/e3sm/polaris/chicoma-cpu/spack/dev_polaris_0_3_0_gnu_mpich/var/spack/environments/dev_polaris_0_3_0_gnu_mpich/.spack-env/view                       |
++--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| chrysalis    | intel        | /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_0_3_0_intel_openmpi/var/spack/environments/dev_polaris_0_3_0_intel_openmpi/.spack-env/view                 |
+|              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | gnu          | /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_0_3_0_gnu_openmpi/var/spack/environments/dev_polaris_0_3_0_gnu_openmpi/.spack-env/view                     |
++--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| frontier     | gnu          | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_3_0_gnu_mpich/var/spack/environments/dev_polaris_0_3_0_gnu_mpich/.spack-env/view                   |
+|              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | gnugpu       | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_3_0_gnugpu_mpich/var/spack/environments/dev_polaris_0_3_0_gnugpu_mpich/.spack-env/view             |
+|              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | crayclang    | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_3_0_crayclang_mpich/var/spack/environments/dev_polaris_0_3_0_crayclang_mpich/.spack-env/view       |
+|              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | crayclanggpu | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_3_0_crayclanggpu_mpich/var/spack/environments/dev_polaris_0_3_0_crayclanggpu_mpich/.spack-env/view |
++--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| pm-cpu       | gnu          | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_3_0_gnu_mpich/var/spack/environments/dev_polaris_0_3_0_gnu_mpich/.spack-env/view               |
+|              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | intel        | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_3_0_intel_mpich/var/spack/environments/dev_polaris_0_3_0_intel_mpich/.spack-env/view           |
+|              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | nvidia       | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_3_0_nvidia_mpich/var/spack/environments/dev_polaris_0_3_0_nvidia_mpich/.spack-env/view         |
++--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| pm-gpu       | gnugpu       | /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_0_3_0_gnugpu_mpich/var/spack/environments/dev_polaris_0_3_0_gnugpu_mpich/.spack-env/view         |
+|              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | nvidiagpu    | /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_0_3_0_nvidiagpu_mpich/var/spack/environments/dev_polaris_0_3_0_nvidiagpu_mpich/.spack-env/view   |
++--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+```
+
+## Code development
+
+### Code style
+
+We require that the C++ code in Omega adhere to the
+[LLVM code style](https://llvm.org/docs/CodingStandards.html). These
+conventions are enforced using the linting tools described in
+{ref}`omega-dev-linting`.  This style may take new developers some time to get
+used to but the hope is that it leads to a coherent code style in Omega.
+
+### VS Code
+
+You may wish to condier using an integrated development environment (IDE) to
+develop your code.  A convenient option for developing on HPC is
+[Visual Studio Code (VS Code)](https://code.visualstudio.com/).  It has plugins
+for [c++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools),
+[CMake](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools),
+[Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python),
+and so on.  If configured correctly, it should help to enforce the
+[code formatting style](https://code.visualstudio.com/docs/cpp/cpp-ide#_code-formatting)
+by recognizing Omega's `.clang-format` file.
+
+A convenient feature is the ability to connect to edit code directly on HPC
+systems from your laptop or desktop
+[using a n SSH connection](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh).
+
+VS Code also provides a convenient way to preview the Markdown files used in
+the Omega documentation as you are writing them.


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

This includes instructions on setting up the developer's conda environment, building Omega and running CTests. It also gives locations for Parmetis for various compilers on the 4 machines we're supporting so far.

This merge also includes some clean up to the documentation on creating a conda environment.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


