### PR TITLE
Add user-defined literal for Real

### DIFF
--- a/components/omega/doc/devGuide/DataTypes.md
+++ b/components/omega/doc/devGuide/DataTypes.md
@@ -16,7 +16,13 @@ specific R4 or R8 forms unless the specific form is required
 (eg converting to single precision before output or if a particular
 algorithm is known to require double precision). This allows us to
 easily convert all reals to single precision to explore performance or
-accuracy in single precision mode.
+accuracy in single precision mode. In some cases creating literal values
+of type Real is necessary to avoid unwanted promotions. For that purpose
+a user-defined literal `_Real` is provided. As an example, we can compute
+the inverse area of a cell using only the Real type as follows:
+```c++
+    Real InvAreaCell = 1._Real / AreaCell(ICell);
+```
 
 ## Arrays and YAKL
 

--- a/components/omega/src/base/DataTypes.h
+++ b/components/omega/src/base/DataTypes.h
@@ -34,6 +34,9 @@ using Real = float;
 using Real = double;
 #endif
 
+// user-defined literal for generic reals
+YAKL_INLINE constexpr Real operator""_Real(long double x) { return x; }
+
 // Aliases for YAKL arrays - by default, all arrays are on the device and
 // use C-ordering.
 /// Aliases for YAKL device arrays of various dimensions and types

--- a/components/omega/test/base/DataTypesTest.cpp
+++ b/components/omega/test/base/DataTypesTest.cpp
@@ -29,6 +29,8 @@ int main(int argc, char *argv[]) {
    OMEGA::R4 MyR4     = 3.0;
    OMEGA::R8 MyR8     = 4.0000000000001;
    OMEGA::Real MyReal = 5.000001;
+   using OMEGA::operator""_Real;
+   auto MyRealLiteral = 1._Real;
    int SizeTmp        = 0;
 
    // Check expected size (in bytes) for data types
@@ -68,6 +70,12 @@ int main(int argc, char *argv[]) {
    else
       std::cout << "Size of Real is 8: FAIL " << SizeTmp << std::endl;
 #endif
+
+   SizeTmp = sizeof(MyRealLiteral);
+   if (SizeTmp == sizeof(OMEGA::Real))
+      std::cout << "Size of Real literal: PASS" << std::endl;
+   else
+      std::cout << "Size of Real literal: FAIL " << SizeTmp << std::endl;
 
    // Test creation of device arrays and copying to/from host
    // by initializing on the device, copying to host and comparing with


### PR DESCRIPTION
This PR adds a user-defined literal for the type `Real` with suffix `_Real`.
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.


