### PR TITLE
Use custom pre-commit steps instead of external action on CI

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -76,13 +76,20 @@ jobs:
           output: ' '
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit/
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         # Run all pre-commit hooks on all the files.
         # Getting only staged files can be tricky in case a new PR is opened
         # since the action is run on a branch in detached head state
-        name: Install and Run Pre-commit
-        uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --files ${{ steps.file_changes.outputs.files}}
+        name: Run pre-commit
+        run: |
+          conda activate omega_dev
+          pre-commit run --show-diff-on-failure --files ${{ steps.file_changes.outputs.files}}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Build Sphinx Docs


### PR DESCRIPTION
While working on #62 I ran into an issue with our CI. Despite using `pre-commit` locally, the formatting check failed on CI. I tracked this down to the wrong version of `clang-format` being used by the `pre-commit/action@v3.0.0` action. This is because this action doesn't run in the `omega_dev` environment.

I couldn't find a way to make this action use the correct environment. Hence, I copied the relevant steps from this action (caching and running `pre-commit`) into our CI and made sure that `omega_dev` is active before running `pre-commit`.