### PR TITLE
adds an IOField capability

### DIFF
--- a/components/omega/doc/devGuide/IOField.md
+++ b/components/omega/doc/devGuide/IOField.md
@@ -1,0 +1,56 @@
+(omega-dev-iofield)=
+
+## IO Fields (IOField)
+
+To determine which fields are available for input or output (I/O), OMEGA
+includes an IOField class. An IOField is simply a class that includes a
+pointer to field metadata and a pointer to a data array containing the data.
+A module registers an IO field by first defining the MetaData
+(see [MetaData](#omega-dev-metadata) then calling:
+```c++
+int Err = OMEGA::IOField::define("FieldName");
+```
+where the FieldName must match the field name for the previously defined
+MetaData. Once the IOField is registered, users can select these fields
+and include them in IOStreams (see [IOStreams](#omega-dev-iostreams)).
+The actual field data must be in one of the supported array data types
+(see [DataTypes](#omega-dev-data-types)) and can be attached to the IOField
+using:
+```c++
+int Err = OMEGA::IOField::attachData<ArrayType>("FieldName", DataArray);
+```
+where ArrayType is the data type of the DataArray (eg. Array2DI4). The
+DataArray must not be a local temporary because IOStreams will need to
+retrieve this array when it comes time to write/read the stream. The
+"attach" function is separate from field definition because some data arrays
+may not have been initialized at the time of field definition and also
+because some array locations my change in time (eg different time index or
+array for different time levels for prognostic variables).
+
+When it is time to write an IOStream, the IOStream module can extract
+the metadata and data for all selected IOFields in the contents using:
+```c++
+std::shared_ptr<OMEGA::MetaData> MyFieldMeta =
+    OMEGA::IOField::getMetaData("MyField");
+
+Array2DI4 MyFieldData = OMEGA::IOField::getData<Array2DI4>("MyField");
+```
+where Array2DI4 is just an example of a supported array type. Note that
+all the array type copies are just shallow copies that copy pointers
+and adjust the reference counts for the field.
+As is probably clear from the calls above, the data attach/getData functions
+are implemented as templates for each of the supported Array data types.
+Similarly, the MetaData are represented by shared pointers that also
+enable reference counting.
+
+Additional utility functions can erase (remove) an IOField or clear all
+IOFields (this must be done before the program exits):
+```c++
+OMEGA::IOField::erase("MyFieldName");
+OMEGA::IOField::clear();
+```
+Finally, the class includes a query function to determine whether a
+field has been defined:
+```c++
+OMEGA::IOField::isDefined("MyField");
+```

--- a/components/omega/doc/devGuide/IOField.md
+++ b/components/omega/doc/devGuide/IOField.md
@@ -24,7 +24,7 @@ DataArray must not be a local temporary because IOStreams will need to
 retrieve this array when it comes time to write/read the stream. The
 "attach" function is separate from field definition because some data arrays
 may not have been initialized at the time of field definition and also
-because some array locations my change in time (eg different time index or
+because some array locations may change in time (e.g. different time index or
 array for different time levels for prognostic variables).
 
 When it is time to write an IOStream, the IOStream module can extract

--- a/components/omega/doc/devGuide/IOField.md
+++ b/components/omega/doc/devGuide/IOField.md
@@ -20,6 +20,8 @@ using:
 int Err = OMEGA::IOField::attachData<ArrayType>("FieldName", DataArray);
 ```
 where ArrayType is the data type of the DataArray (eg. Array2DI4). The
+array can be either a host or device array and the IO system will determine
+whether any data transfer is required based on the type. The
 DataArray must not be a local temporary because IOStreams will need to
 retrieve this array when it comes time to write/read the stream. The
 "attach" function is separate from field definition because some data arrays

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -30,6 +30,7 @@ userGuide/Logging
 userGuide/Decomp
 userGuide/MetaData
 userGuide/IO
+userGuide/IOField
 userGuide/Halo
 userGuide/HorzMesh
 ```
@@ -52,6 +53,7 @@ devGuide/Logging
 devGuide/Decomp
 devGuide/MetaData
 devGuide/IO
+devGuide/IOField
 devGuide/Halo
 devGuide/HorzMesh
 ```

--- a/components/omega/doc/userGuide/IOField.md
+++ b/components/omega/doc/userGuide/IOField.md
@@ -1,0 +1,12 @@
+(omega-user-iofield)=
+
+## IO Fields (IOField)
+
+Within OMEGA, each module registers which fields are available for
+input and output.  The user then selects which fields they wish to
+include via the streams section of the input configuration. This is
+described further in the [IOStreams](#omega-user-iostreams) section.
+An IOField contains pointers to both the metadata and the data arrays
+associated with the field. There are no user-configurable options
+but further details on the methods and implementation can be found
+in the [Developer's Guide](#omega-dev-iofield).

--- a/components/omega/src/infra/IOField.cpp
+++ b/components/omega/src/infra/IOField.cpp
@@ -1,0 +1,113 @@
+//===-- infra/IOField.cpp - IO field class implementation -------*- C++ -*-===//
+//
+// \file
+// \brief Implements the IO Field class and methods
+//
+// This file implements the IOField class for OMEGA. IOFields are the
+// data and metadata for all fields participating in IO at any point. Each
+// module defines which fields are available with the field metadata. Modules
+// are also responsible for assigning a correct data pointer for fields that
+// they own and for updating that pointer if the location changes (eg if a
+// time index changes).
+//
+//===----------------------------------------------------------------------===//
+
+#include "IOField.h"
+#include "DataTypes.h"
+#include "Logging.h"
+#include "MetaData.h"
+#include <map>
+#include <memory>
+
+namespace OMEGA {
+
+// Initialize static variables
+std::map<std::string, std::shared_ptr<IOField>> IOField::AvailableFields;
+
+//------------------------------------------------------------------------------
+// Defines a field so it is available for IO. The caller must
+// provide a name that matches a previously defined MetaData field.
+// This specific interface defines only the metadata and the actual data
+// array must be explicitly attached later.
+
+int IOField::define(
+    const std::string &FieldName ///< [in] Name of field to be defined
+) {
+
+   int Err = 0; // initialize return code
+
+   // Perform some error checks.
+   // If MetaData not defined, exit with an error
+   if (!MetaData::has(FieldName)) {
+      Err = -1;
+      LOG_ERROR("IOField: error defining {} - MetaData does not exist",
+                FieldName);
+      return Err;
+   }
+
+   // If a field of the same name already exists, exit with an error
+   if (IOField::isDefined(FieldName)) { // entry found
+      Err = -2;
+      LOG_ERROR("IOField: error defining {}. Field already exists", FieldName);
+      return Err;
+   }
+
+   // Create an empty IOField
+   auto ThisField = std::make_shared<IOField>();
+
+   // Retrieve and attach the MetaData
+   ThisField->MetadataPtr = MetaData::get(FieldName);
+
+   // Add entry to available fields
+   IOField::AvailableFields[FieldName] = ThisField;
+
+   return Err;
+}
+
+//------------------------------------------------------------------------------
+// Checks to see if a field exists with a given name
+bool IOField::isDefined(const std::string &FieldName // [in] Name of field
+) {
+   auto it = IOField::AvailableFields.find(FieldName);
+   if (it != IOField::AvailableFields.end()) { // entry found
+      return true;
+   } else {
+      return false;
+   }
+}
+
+//------------------------------------------------------------------------------
+// Retrieves IOField MetaData by name. Returns a pointer to attached metadata.
+
+std::shared_ptr<MetaData>
+IOField::getMetaData(const std::string &FieldName ///< [in] name of IOField
+) {
+
+   if (IOField::isDefined(FieldName)) { // entry found
+
+      auto ThisField = IOField::AvailableFields[FieldName];
+      return ThisField->MetadataPtr;
+
+   } else { // field not found
+
+      LOG_ERROR("IOField: Attempted to get metadata failed, {} does not exist",
+                FieldName);
+      return nullptr;
+   }
+}
+
+//------------------------------------------------------------------------------
+// Removes a single IOField from the list of available fields
+
+void IOField::erase(const std::string &Name /// Name of IOField to remove
+) {
+   IOField::AvailableFields.erase(Name);
+}
+
+//------------------------------------------------------------------------------
+// Removes all IOFields. This must be called before exiting environments
+
+void IOField::clear() { IOField::AvailableFields.clear(); }
+
+} // end namespace OMEGA
+//===----------------------------------------------------------------------===//

--- a/components/omega/src/infra/IOField.h
+++ b/components/omega/src/infra/IOField.h
@@ -1,0 +1,149 @@
+#ifndef OMEGA_IOFIELD_H
+#define OMEGA_IOFIELD_H
+//===-- infra/IOField.h - IO field class ------------------------*- C++ -*-===//
+//
+/// \file
+/// \brief Defines IO Field class and methods
+///
+/// This header defines classes and methods for IO Fields. IOFields are the
+/// data and metadata for all fields participating in IO at any point. Each
+/// module defines which fields are available with the field metadata. Modules
+/// are also responsible for assigning a correct data pointer for fields that
+/// they own and for updating that pointer if the location changes (eg if a
+/// time index changes).
+///
+//===----------------------------------------------------------------------===//
+
+#include "DataTypes.h"
+#include "Logging.h"
+#include "MetaData.h"
+#include <map>
+#include <memory>
+
+namespace OMEGA {
+
+class IOField {
+
+ private:
+   /// Store and maintain all defined fields
+   static std::map<std::string, std::shared_ptr<IOField>> AvailableFields;
+
+   /// Metadata associated with this field
+   std::shared_ptr<MetaData> MetadataPtr;
+
+   /// Data assigned to this field. We use a void pointer to manage the
+   /// many different Array types. These are cast to the appropriate type
+   /// on retrieval.
+   std::shared_ptr<void> Data;
+
+ public:
+   //---------------------------------------------------------------------------
+   /// Checks to see if a field is defined
+   static bool isDefined(const std::string &FieldName ///< [in] name of field
+   );
+
+   //---------------------------------------------------------------------------
+   /// Defines a field so it is available for IO. The name of the
+   /// field must match a previously defined MetaData field.
+   /// This routine simply attaches the previously defined metadata
+   /// and add the field to the list of available fields. The actual data
+   /// array is attached in a separate call.
+   static int define(const std::string &FieldName ///< [in] Name of field
+   );
+
+   //---------------------------------------------------------------------------
+   /// Retrieves IOField MetaData by name. Returns a shared pointer to
+   /// the attached metadata.
+   static std::shared_ptr<MetaData>
+   getMetaData(const std::string &FieldName ///< [in] name of IOField
+   );
+
+   // Template functions must have implementation in header files
+   //---------------------------------------------------------------------------
+   /// Attaches an array of data to an existing IOField. If a data array
+   /// needs to be updated, calling the attach routine with new data
+   /// will replaced the previously attached data array. This function is
+   /// templated based on the array data type so a template argument with
+   /// the proper array data type (eg <Array2DR4>) must be supplied.
+   template <typename T>
+   static int attachData(const std::string &FieldName, ///< [in] Name of IOField
+                         const T &DataArray ///< [in] Array with data to attach
+   ) {
+
+      int Err = 0; // initialize return code
+
+      // Check to make sure field exists
+      if (isDefined(FieldName)) { // entry found
+         // Retrieve the IO field
+         auto ThisField = AvailableFields[FieldName];
+         // Attach the data array
+         ThisField->Data = std::make_shared<T>(DataArray);
+
+      } else { // field has not yet been defined
+         Err = -1;
+         LOG_ERROR("IOField: error attaching data to {}. Field not defined",
+                   FieldName);
+      }
+      return Err;
+   };
+
+   //---------------------------------------------------------------------------
+   /// Retrieves IOField data array given the field name. Because all data
+   /// arrays in OMEGA are Kokkos/YAKL arrays, this is a shallow copy of the
+   /// attached data array. This is a templated function on the supported
+   /// OMEGA array types so a template argument with the proper type must
+   /// also be supplied.
+   template <typename T>
+   static T getData(const std::string &FieldName ///< [in] name of IOField
+   ) {
+
+      // Check to see if field is defined
+      if (!isDefined(FieldName)) { // no entry found return error
+         LOG_ERROR("IOField: Attempted to get data failed, {} does not exist",
+                   FieldName);
+         // return an empty data object
+         T Data;
+         return Data;
+      }
+
+      // Retrieve the field by name
+      auto ThisField = AvailableFields[FieldName];
+
+      // Check to make sure data is attached
+      if (ThisField->Data != nullptr) { // data is attached
+
+         // Convert the data pointer to the appropriate type and
+         // return data array dereferenced from the pointer
+         return *(std::static_pointer_cast<T>(ThisField->Data));
+
+      } else { // data has not yet been attached
+
+         LOG_ERROR("IOField: Attempted to get data failed from field {}. "
+                   "Data array has not been attached",
+                   FieldName);
+         // return an empty data object
+         T Data;
+         return Data;
+      }
+   };
+
+   //---------------------------------------------------------------------------
+   /// Removes a single IOField from the list of available fields
+   /// That process also decrements the reference counters for the
+   /// shared pointers and removes them if those counters reach 0.
+   static void erase(const std::string &FieldName /// Name of IOField to remove
+   );
+
+   //---------------------------------------------------------------------------
+   /// Removes all IOFields. This must be called before exiting environments
+   /// This removes all fields from the map structure and also
+   /// decrements the reference counter for the shared pointers,
+   /// removing them if the count has reached 0.
+   static void clear();
+
+}; // end class IOField
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif // OMEGA_IOFIELD_H

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -322,6 +322,33 @@ target_link_libraries(${_TestMetadataName} ${OMEGA_LIB_NAME} yakl)
 add_test(NAME METADATA_TEST COMMAND ./${_TestMetadataName})
 
 ##################
+# IOField test
+##################
+
+set(_TestIOFieldName testIOField.exe)
+
+add_executable(${_TestIOFieldName} infra/IOFieldTest.cpp)
+
+target_compile_options(
+   ${_TestIOFieldName}
+  PRIVATE
+  "-I${OMEGA_SOURCE_DIR}/src/base"
+  "-I${OMEGA_SOURCE_DIR}/src/infra"
+  ${OMEGA_CXX_FLAGS}
+)
+
+target_link_options(
+   ${_TestIOFieldName}
+  PRIVATE
+  ${OMEGA_LINK_OPTIONS}
+)
+
+target_link_libraries(${_TestIOFieldName} ${OMEGA_LIB_NAME} yakl)
+
+add_test(NAME IOFIELD_TEST
+         COMMAND ${MPI_EXEC} -n 8 -- ./${_TestIOFieldName})
+
+##################
 # YAKL test
 ##################
 
@@ -359,6 +386,7 @@ set_tests_properties(
   HORZMESH_TEST
   IO_TEST
   METADATA_TEST
+  IOFIELD_TEST
   PROPERTIES FAIL_REGULAR_EXPRESSION "FAIL" PASS_REGULAR_EXPRESSION "PASS"
 )
 

--- a/components/omega/test/infra/IOFieldTest.cpp
+++ b/components/omega/test/infra/IOFieldTest.cpp
@@ -81,8 +81,8 @@ int initIOFieldTest() {
    // Create host data arrays
    OMEGA::ArrayHost2DI4 DataI4H("FieldI4H", NCellsSize, NVertLevels);
    OMEGA::ArrayHost2DR8 DataR8H("FieldR8H", NCellsSize, NVertLevels);
-   for (int Cell; Cell < NCellsSize; ++Cell) {
-      for (int k; k < NVertLevels; ++k) {
+   for (int Cell = 0; Cell < NCellsSize; ++Cell) {
+      for (int k = 0; k < NVertLevels; ++k) {
          DataI4H(Cell, k) = Cell + k;
          DataR8H(Cell, k) = Cell + k + 1.2345678;
       }
@@ -172,8 +172,8 @@ int main(int argc, char **argv) {
    int NVertLevels       = 64;
    OMEGA::ArrayHost2DI4 RefI4H("RefI4H", NCellsSize, NVertLevels);
    OMEGA::ArrayHost2DR8 RefR8H("RefR8H", NCellsSize, NVertLevels);
-   for (int Cell; Cell < NCellsSize; ++Cell) {
-      for (int k; k < NVertLevels; ++k) {
+   for (int Cell = 0; Cell < NCellsSize; ++Cell) {
+      for (int k = 0; k < NVertLevels; ++k) {
          RefI4H(Cell, k) = Cell + k;
          RefR8H(Cell, k) = Cell + k + 1.2345678;
       }

--- a/components/omega/test/infra/IOFieldTest.cpp
+++ b/components/omega/test/infra/IOFieldTest.cpp
@@ -1,0 +1,342 @@
+//===-- Test driver for OMEGA IO Fields --------------------------*- C++ -*-===/
+//
+/// \file
+/// \brief Test driver for OMEGA IO Fields
+///
+/// This driver tests the capabilities for OMEGA to manage the registration
+/// and use of fields for IO. This test driver will not actually include IO
+/// but only tests the registration and retrieval of fields.
+//
+//===-----------------------------------------------------------------------===/
+
+#include "IOField.h"
+#include "DataTypes.h"
+#include "Logging.h"
+#include "MetaData.h"
+#include <cstdlib>
+#include <vector>
+
+//------------------------------------------------------------------------------
+// Initialization routine to create reference IO Fields
+int initIOFieldTest() {
+
+   int Err = 0;
+
+   // Define dimensions
+   OMEGA::I4 NCellsSize  = 100;
+   OMEGA::I4 NVertLevels = 64;
+   auto CellDim          = OMEGA::MetaDim::create("NCells", NCellsSize);
+   auto VertDim          = OMEGA::MetaDim::create("NVertLevels", NVertLevels);
+   std::vector<std::shared_ptr<OMEGA::MetaDim>> Dimensions{CellDim, VertDim};
+
+   // Define field metadata for all fields
+   auto FieldMetaI4H = OMEGA::ArrayMetaData::create(
+       "FieldI4H",
+       "Test IO Field for I4 Host", /// long Name or description
+       "unitless",                  /// units
+       "I4StdName",                 /// CF standard Name
+       0,                           /// min valid value
+       100000,                      /// max valid value
+       -999,                        /// scalar used for undefined entries
+       2,                           /// number of dimensions
+       Dimensions                   /// dim pointers
+   );
+
+   auto FieldMetaI4D = OMEGA::ArrayMetaData::create(
+       "FieldI4D",
+       "Test IO Field for I4 Device", /// long Name or description
+       "unitless",                    /// units
+       "I4StdName",                   /// CF standard Name
+       0,                             /// min valid value
+       100000,                        /// max valid value
+       -999,                          /// scalar used for undefined entries
+       2,                             /// number of dimensions
+       Dimensions                     /// dim pointers
+   );
+
+   auto FieldMetaR8H = OMEGA::ArrayMetaData::create(
+       "FieldR8H",
+       "Test IO Field for R8 Host", /// long Name or description
+       "m",                         /// units
+       "R8StdName",                 /// CF standard Name
+       -12345.0,                    /// min valid value
+       12345.0,                     /// max valid value
+       -9.99E+30,                   /// scalar used for undefined entries
+       2,                           /// number of dimensions
+       Dimensions                   /// dim pointers
+   );
+
+   auto FieldMetaR8D = OMEGA::ArrayMetaData::create(
+       "FieldR8D",
+       "Test IO Field for R8 Device", /// long Name or description
+       "m",                           /// units
+       "R8StdName",                   /// CF standard Name
+       -12345.0,                      /// min valid value
+       12345.0,                       /// max valid value
+       -9.99E+30,                     /// scalar used for undefined entries
+       2,                             /// number of dimensions
+       Dimensions                     /// dim pointers
+   );
+
+   // Create host data arrays
+   OMEGA::ArrayHost2DI4 DataI4H("FieldI4H", NCellsSize, NVertLevels);
+   OMEGA::ArrayHost2DR8 DataR8H("FieldR8H", NCellsSize, NVertLevels);
+   for (int Cell; Cell < NCellsSize; ++Cell) {
+      for (int k; k < NVertLevels; ++k) {
+         DataI4H(Cell, k) = Cell + k;
+         DataR8H(Cell, k) = Cell + k + 1.2345678;
+      }
+   }
+
+   // Create device data arrays
+   OMEGA::Array2DI4 DataI4D("FieldI4D", NCellsSize, NVertLevels);
+   OMEGA::Array2DR8 DataR8D("FieldR8D", NCellsSize, NVertLevels);
+   yakl::c::parallel_for(
+       yakl::c::Bounds<2>(NCellsSize, NVertLevels),
+       YAKL_LAMBDA(int Cell, int k) {
+          DataI4D(Cell, k) = Cell + k + 1;
+          DataR8D(Cell, k) = Cell + k + 2.2345678;
+       });
+
+   // Define IO Fields
+   int Err1 = OMEGA::IOField::define("FieldI4H");
+   int Err2 = OMEGA::IOField::define("FieldI4D");
+   if (Err1 == 0 && Err2 == 0) {
+      LOG_INFO("IOField: initializing I4 field: PASS");
+   } else {
+      LOG_ERROR("IOField: initializing I4 field: FAIL");
+      Err += std::abs(Err1) + std::abs(Err2);
+   }
+
+   Err1 = OMEGA::IOField::attachData<OMEGA::ArrayHost2DI4>("FieldI4H", DataI4H);
+   Err2 = OMEGA::IOField::attachData<OMEGA::Array2DI4>("FieldI4D", DataI4D);
+   if (Err1 == 0 && Err2 == 0) {
+      LOG_INFO("IOField: attaching I4 data: PASS");
+   } else {
+      LOG_ERROR("IOField: attaching I4 data: FAIL");
+      Err += std::abs(Err1) + std::abs(Err2);
+   }
+
+   Err1 = OMEGA::IOField::define("FieldR8H");
+   Err2 = OMEGA::IOField::define("FieldR8D");
+   if (Err1 == 0 && Err2 == 0) {
+      LOG_INFO("IOField: initializing R8 field: PASS");
+   } else {
+      LOG_ERROR("IOField: initializing R8 field: FAIL");
+      Err += std::abs(Err1) + std::abs(Err2);
+   }
+
+   Err1 = OMEGA::IOField::attachData<OMEGA::ArrayHost2DR8>("FieldR8H", DataR8H);
+   Err2 = OMEGA::IOField::attachData<OMEGA::Array2DR8>("FieldR8D", DataR8D);
+   if (Err1 == 0 && Err2 == 0) {
+      LOG_INFO("IOField: attaching R8 data: PASS");
+   } else {
+      LOG_ERROR("IOField: attaching R8 data: FAIL");
+      Err += std::abs(Err1) + std::abs(Err2);
+   }
+
+   return Err;
+
+} // End initialization of IO Fields
+
+//------------------------------------------------------------------------------
+// We will test the IO Field interfaces by defining an IO Field during init
+// and then retrieving the field and comparing results. Because IO Field makes
+// use of the Metadata class and mostly points to other arrays/classes, we
+// do not test all possible combinations - just two data types and host/device
+// arrays to make sure generic pointers work fine.
+
+int main(int argc, char **argv) {
+
+   int Err  = 0;
+   int Err1 = 0;
+   int Err2 = 0;
+   int Err3 = 0;
+   int Err4 = 0;
+
+   // Initialize the global MPI environment
+   // We do not actually use message passing but need to test the
+   // array types and behavior within the distributed environment
+   MPI_Init(&argc, &argv);
+   yakl::init();
+
+   // Call initialization to create reference IO field
+   Err = initIOFieldTest();
+   if (Err != 0)
+      LOG_ERROR("IOFieldTest: Error in initialization routine");
+
+   // Set reference data - must match the values in the init routine
+   std::string RefIUnits = "unitless";
+   std::string RefRUnits = "m";
+   int NCellsSize        = 100;
+   int NVertLevels       = 64;
+   OMEGA::ArrayHost2DI4 RefI4H("RefI4H", NCellsSize, NVertLevels);
+   OMEGA::ArrayHost2DR8 RefR8H("RefR8H", NCellsSize, NVertLevels);
+   for (int Cell; Cell < NCellsSize; ++Cell) {
+      for (int k; k < NVertLevels; ++k) {
+         RefI4H(Cell, k) = Cell + k;
+         RefR8H(Cell, k) = Cell + k + 1.2345678;
+      }
+   }
+   OMEGA::Array2DI4 RefI4D("RefI4D", NCellsSize, NVertLevels);
+   OMEGA::Array2DR8 RefR8D("RefR8D", NCellsSize, NVertLevels);
+   yakl::c::parallel_for(
+       yakl::c::Bounds<2>(NCellsSize, NVertLevels),
+       YAKL_LAMBDA(int Cell, int k) {
+          RefI4D(Cell, k) = Cell + k + 1;
+          RefR8D(Cell, k) = Cell + k + 2.2345678;
+       });
+
+   // Check existence of fields
+   bool FieldExistsI4H = OMEGA::IOField::isDefined("FieldI4H");
+   bool FieldExistsI4D = OMEGA::IOField::isDefined("FieldI4D");
+   bool FieldExistsR8H = OMEGA::IOField::isDefined("FieldR8H");
+   bool FieldExistsR8D = OMEGA::IOField::isDefined("FieldR8D");
+   if (FieldExistsI4H && FieldExistsI4D && FieldExistsR8H && FieldExistsR8D) {
+      LOG_INFO("IOFieldTest: existence test PASS");
+   } else {
+      LOG_ERROR("IOFieldTest: existence test FAIL");
+   }
+
+   bool FieldExistsJunk = OMEGA::IOField::isDefined("FieldJunk");
+   if (!FieldExistsJunk) {
+      LOG_INFO("IOFieldTest: non-existence test PASS");
+   } else {
+      LOG_ERROR("IOFieldTest: non-existence test FAIL");
+   }
+
+   // Test retrieval of data and metadata
+   // Retrieve metadata first
+   std::shared_ptr<OMEGA::MetaData> MetaI4D =
+       OMEGA::IOField::getMetaData("FieldI4D");
+   std::shared_ptr<OMEGA::MetaData> MetaR8D =
+       OMEGA::IOField::getMetaData("FieldR8D");
+   std::shared_ptr<OMEGA::MetaData> MetaI4H =
+       OMEGA::IOField::getMetaData("FieldI4H");
+   std::shared_ptr<OMEGA::MetaData> MetaR8H =
+       OMEGA::IOField::getMetaData("FieldR8H");
+
+   std::string NewIUnits;
+   std::string NewRUnits;
+
+   Err1 = MetaI4H->getEntry("Units", NewIUnits);
+   if (Err1 == 0 && NewIUnits == RefIUnits) {
+      LOG_INFO("IOField: Retrieve I4H metadata by name: PASS");
+   } else {
+      LOG_ERROR("IOField: Retrieve I4H metadata by name: FAIL");
+   }
+
+   Err2 = MetaR8H->getEntry("Units", NewRUnits);
+   if (Err2 == 0 && NewRUnits == RefRUnits) {
+      LOG_INFO("IOField: Retrieve R8H metadata by name: PASS");
+   } else {
+      LOG_ERROR("IOField: Retrieve R8H metadata by name: FAIL");
+   }
+
+   Err3 = MetaI4D->getEntry("Units", NewIUnits);
+   if (Err3 == 0 && NewIUnits == RefIUnits) {
+      LOG_INFO("IOField: Retrieve I4D metadata by name: PASS");
+   } else {
+      LOG_ERROR("IOField: Retrieve I4D metadata by name: FAIL");
+   }
+
+   Err4 = MetaR8D->getEntry("Units", NewRUnits);
+   if (Err4 == 0 && NewRUnits == RefRUnits) {
+      LOG_INFO("IOField: Retrieve R8D metadata by name: PASS");
+   } else {
+      LOG_ERROR("IOField: Retrieve R8D metadata by name: FAIL");
+   }
+   Err += std::abs(Err1) + std::abs(Err2) + std::abs(Err3) + std::abs(Err4);
+
+   // Now retrieve full data
+   OMEGA::ArrayHost2DI4 NewI4H =
+       OMEGA::IOField::getData<OMEGA::ArrayHost2DI4>("FieldI4H");
+   OMEGA::ArrayHost2DR8 NewR8H =
+       OMEGA::IOField::getData<OMEGA::ArrayHost2DR8>("FieldR8H");
+   OMEGA::Array2DI4 NewI4D =
+       OMEGA::IOField::getData<OMEGA::Array2DI4>("FieldI4D");
+   OMEGA::Array2DR8 NewR8D =
+       OMEGA::IOField::getData<OMEGA::Array2DR8>("FieldR8D");
+
+   Err1 = 0;
+   Err2 = 0;
+
+   for (int Cell = 0; Cell < NCellsSize; ++Cell) {
+      for (int k = 0; k < NVertLevels; ++k) {
+         if (NewI4H(Cell, k) != RefI4H(Cell, k))
+            ++Err1;
+         if (NewR8H(Cell, k) != RefR8H(Cell, k))
+            ++Err2;
+      }
+   }
+   if (Err1 == 0) {
+      LOG_INFO("IOField: Retrieve I4 host data by name: PASS");
+   } else {
+      LOG_ERROR("IOField: Retrieve I4 host data by name: FAIL");
+   }
+   if (Err2 == 0) {
+      LOG_INFO("IOField: Retrieve R8 host data by name: PASS");
+   } else {
+      LOG_ERROR("IOField: Retrieve R8 host data by name: FAIL");
+   }
+
+   OMEGA::Array2DI4 ErrArray("ErrorArray", NCellsSize, NVertLevels);
+
+   yakl::c::parallel_for(
+       yakl::c::Bounds<2>(NCellsSize, NVertLevels),
+       YAKL_LAMBDA(int Cell, int k) {
+          if ((NewI4D(Cell, k) != RefI4D(Cell, k)) or
+              (NewR8D(Cell, k) != RefR8D(Cell, k)))
+             ErrArray(Cell, k) += 1;
+       });
+   Err3 = yakl::intrinsics::sum(ErrArray);
+
+   if (Err3 == 0) {
+      LOG_INFO("IOField: Retrieve device data by name: PASS");
+   } else {
+      LOG_ERROR("IOField: Retrieve device data by name: FAIL");
+   }
+
+   Err += std::abs(Err1) + std::abs(Err2) + std::abs(Err3);
+
+   // Erase a field and check for non-existence
+   OMEGA::IOField::erase("FieldI4D");
+   FieldExistsI4D = OMEGA::IOField::isDefined("FieldI4D");
+   if (!FieldExistsI4D) {
+      LOG_INFO("IOFieldTest: erase field PASS");
+   } else {
+      LOG_ERROR("IOFieldTest: erase field FAIL");
+      ++Err;
+   }
+
+   // Clear all fields
+   OMEGA::IOField::clear();
+   FieldExistsI4H = OMEGA::IOField::isDefined("FieldI4H");
+   FieldExistsI4D = OMEGA::IOField::isDefined("FieldI4D");
+   FieldExistsR8H = OMEGA::IOField::isDefined("FieldR8H");
+   FieldExistsR8D = OMEGA::IOField::isDefined("FieldR8D");
+   if (FieldExistsI4H or FieldExistsI4D or FieldExistsR8H or FieldExistsR8D) {
+      LOG_ERROR("IOFieldTest: clear all data FAIL");
+      ++Err;
+   } else {
+      LOG_INFO("IOFieldTest: clear all data PASS");
+   }
+
+   // Clean up
+   RefI4H.deallocate();
+   RefI4D.deallocate();
+   RefR8H.deallocate();
+   RefR8D.deallocate();
+   NewI4H.deallocate();
+   NewI4D.deallocate();
+   NewR8H.deallocate();
+   NewR8D.deallocate();
+   ErrArray.deallocate();
+
+   yakl::finalize();
+   MPI_Finalize();
+
+   // End of testing
+   return Err;
+}
+//===--- End test driver for IO Field --------------------------------------===/


### PR DESCRIPTION
An IOField capability was part of the IO design and necessary to make fields available for IOStreams. This PR
  - adds a capability to register available fields for IO, including attaching and retrieving metadata and data arrays
  - adds a unit test for this capability
  - adds user and developer documentation

Tested on Chrysalis/Intel. Results of testing across other architectures will be added as they are completed.

Checklist
* [x] Documentation:
  * [x] Design document has been generated and added to the docs
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.


