### PR TITLE
Update pre-commit dependencies and clang-format versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 files: ^components/omega/
 repos:
   - repo: https://github.com/Takishima/cmake-pre-commit-hooks
-    rev: v1.9.0
+    rev: v1.9.5
     hooks:
       - id: clang-format
       # - id: clang-tidy
@@ -10,21 +10,21 @@ repos:
       # - id: include-what-you-use
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
 
   # Can run individually with `pre-commit run isort --all-files`
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         args: ["--settings-file=components/omega/python_lint.cfg"]
 
   # Can run individually with `flynt [file]` or `flynt [source]`
   - repo: https://github.com/ikamensh/flynt
-    rev: '0.78'
+    rev: 1.0.1
     hooks:
       - id: flynt
         args: ["--fail-on-change", "--verbose", "--line-length=79"]
@@ -34,7 +34,7 @@ repos:
   # Need to use flake8 GitHub mirror due to CentOS git issue with GitLab
   # https://github.com/pre-commit/pre-commit/issues/1206
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         args: ["--config=components/omega/python_lint.cfg"]
@@ -42,7 +42,7 @@ repos:
 
   # Can run individually with `pre-commit run mypy --all-files`
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.9.0
     hooks:
       - id: mypy
         args: ["--config=components/omega/python_lint.cfg", "--show-error-codes"]

--- a/components/omega/dev-conda.txt
+++ b/components/omega/dev-conda.txt
@@ -8,8 +8,8 @@
 pre-commit
 
 # c++ linting
-clang-format
-clang-tools
+clang-format >=18.1.0,<18.2.0
+clang-tools >=18.1.0,<18.2.0
 cppcheck
 cpplint
 lizard


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
@grnydawn ran into issues where the version of clang-format he used locally didn't match what CI is using.  It seems like the easiest way to handle this is to be pretty explicit about what CI is using.  So I have:
```
clang-format >=18.1.0,<18.2.0
```
This should allow for bug fixes but no major changes.  I can update this later with a PR that will let folks know that it's happening.

I also noticed that all the `pre-commit` dependencies are out of date so I'm piggybacking updates to those onto this PR.