### PR TITLE
Halo fixes and updates

### DIFF
--- a/components/omega/doc/devGuide/Halo.md
+++ b/components/omega/doc/devGuide/Halo.md
@@ -18,20 +18,32 @@ methods to conduct the exchanges. The halo exchanges are carried out using
 non-blocking MPI (Message Passing Interface) communication.
 
 An instance of the Halo class is dependent on a parallel domain decomposition
-and the associated parallel machine environment, so the Halo constructor takes
-as input a MachEnv object and a Decomp object:
+and the associated parallel machine environment, so those objects need to be
+constructed first. The default Halo is created with the call:
 ```c++
-OMEGA::Halo NewHalo(NewEnv, NewDecomp);
+OMEGA::Halo::init();
 ```
-Therefore, these objects need to be constructed first. The Halo constructor
-will save the MPI communicator handle and the MPI task ID of the local task
-from the MachEnv object, and will extract and save from the Decomp object
-indices defining the local and neighboring halo elements for the cell, edge,
-and vertex index spaces. This information is organized into objects of two
-nested classes of the Halo class: the ExchList class and the Neighbor class.
-The ExchList class contains the indices of Halo elements to either send to or
-receive from a single neighboring task for a particular index space, and the
-Neighbor class contains all the ExchList objects needed to carry out a halo
+This must be done after the default MachEnv and Decomp have been initialized.
+Once initialized, a pointer to the default Halo can be retrieved with:
+```c++
+OMEGA::Halo *DefHalo = OMEGA::Halo::getDefault();
+```
+Additional Halo objects can be constructed for defined MachEnv and Decomp
+objects by calling the Halo constructor with a supplied `std::string` Name:
+```c++
+OMEGA::Halo NewHalo(Name, NewEnv, NewDecomp);
+```
+A pointer to each constructed Halo is stored in a `std::map` container, which
+can be retrieved by supplying the Name to `OMEGA::Halo::get(Name)`.
+
+The Halo constructor will save the MPI communicator handle and the MPI task ID
+of the local task from the MachEnv object, and will extract and save from the
+Decomp object indices defining the local and neighboring halo elements for the
+cell, edge, and vertex index spaces. This information is organized into objects
+of two nested classes of the Halo class: the ExchList class and the Neighbor
+class. The ExchList class contains the indices of Halo elements to either send
+to or receive from a single neighboring task for a particular index space, and
+the Neighbor class contains all the ExchList objects needed to carry out a halo
 exchange with a single neighboring task in any index space, as well as the
 buffer memory space to communicate with that neighbor. All member variables
 and objects and most member methods of the Halo class are declared private
@@ -46,9 +58,8 @@ The main private methods of the Halo class which execute an exchange are
 The packBuffer and unpackBuffer functions are overloaded to support different
 array types.
 
-The only public methods are the Halo class constructor, and the
-exchangeFullArrayHalo function, which is the interface for the user to conduct
-a halo exchange for any supported array defined in the DataTypes module. The
+The exchangeFullArrayHalo function is the main interface to conduct a halo
+exchange for any supported array defined in the DataTypes module. The
 exchangeFullArrayHalo function is a template which passes the array to the
 proper private Halo methods which perform the exchange, depending on the type
 and dimensionality of the array. The user must also pass the index space on

--- a/components/omega/src/base/Halo.cpp
+++ b/components/omega/src/base/Halo.cpp
@@ -399,6 +399,7 @@ int Halo::setNeighborFlags(std::vector<I4> ListOfTasks,
       }
    }
 
+   MPI_Waitall(NNghbr, SendReqs.data(), MPI_STATUS_IGNORE);
    MPI_Waitall(NNghbr, RecvReqs.data(), MPI_STATUS_IGNORE);
 
    return Err;
@@ -607,6 +608,7 @@ int Halo::exchangeVectorInt(
       }
    }
 
+   MPI_Waitall(NNghbr, SendReqs.data(), MPI_STATUS_IGNORE);
    MPI_Waitall(NNghbr, RecvReqs.data(), MPI_STATUS_IGNORE);
 
    return Err;

--- a/components/omega/src/base/Halo.h
+++ b/components/omega/src/base/Halo.h
@@ -46,6 +46,15 @@ enum MeshElement { OnCell, OnEdge, OnVertex };
 /// here for easy accesibility by the Halo methods.
 class Halo {
  private:
+   /// The default Halo handles halo exchanges for arrays defined on the mesh
+   /// with the default decomposition. A pointer is stored here for easy
+   /// retrieval.
+   static Halo *DefaultHalo;
+
+   /// All halos are tracked/stored within the class as a map paired with a
+   /// name for later retrieval.
+   static std::map<std::string, Halo> AllHalos;
+
    const Decomp *MyDecomp{nullptr}; /// Pointer to decomposition object
 
    I4 NNghbr;          /// number of neighboring tasks
@@ -222,8 +231,27 @@ class Halo {
  public:
    // Methods
 
-   // Construct a new halo for the input MachEnv and Decomp
-   Halo(const MachEnv *InEnv, const Decomp *InDecomp);
+   /// initialize default Halo
+   static int init();
+
+   /// Construct a new halo labeled Name for the input MachEnv and Decomp
+   Halo(const std::string &Name, const MachEnv *InEnv, const Decomp *InDecomp);
+
+   /// Destructor
+   ~Halo();
+
+   /// Erase - removes Halo by name
+   static void erase(std::string InName ///< [in] name of Halo to remove
+   );
+
+   /// Clear - removes all defined Halo instances
+   static void clear();
+
+   /// Retrieves a pointer to the default Halo object.
+   static Halo *getDefault();
+
+   /// Retrieves a pointer to a Halo object by Name
+   static Halo *get(std::string Name);
 
    //---------------------------------------------------------------------------
    // Function template to perform a full halo exchange on the input Kokkos

--- a/components/omega/src/base/Halo.h
+++ b/components/omega/src/base/Halo.h
@@ -317,9 +317,6 @@ class Halo {
          TotSize *= Array.extent(NDims - 1);
       }
 
-      // Synchronize all tasks before starting communication
-      MPI_Barrier(MyComm);
-
       // Allocate the receive buffers and Call MPI_Irecv for each Neighbor
       // so the local task is ready to accept messages from each
       // neighboring task

--- a/components/omega/src/base/Halo.h
+++ b/components/omega/src/base/Halo.h
@@ -23,6 +23,7 @@
 #include "Logging.h"
 #include "MachEnv.h"
 #include "mpi.h"
+#include <numeric>
 
 namespace OMEGA {
 
@@ -73,9 +74,15 @@ class Halo {
    /// exchange in any index space.
    std::vector<Neighbor> Neighbors;
 
-   /// List of Task IDs of all neighboring tasks in the order they appear
-   /// in the Neighbors vector above
+   /// Sorted list of Task IDs of all neighboring tasks in ascending order.
+   /// Another task is considered a neighbor if a mesh element owned by that
+   /// task is in the halo of the local task in at least one index space, or if
+   /// an owned element is in the halo of that task in at least one index space.
    std::vector<I4> NeighborList;
+
+   /// Flags to control which tasks in NeighborList that the local task needs to
+   /// send elements to and receive elements from for each index space.
+   std::vector<I4> SendFlags[3], RecvFlags[3];
 
    /// Pointer to current neighbor, utilized in the various member functions
    /// to make code more concise.
@@ -152,6 +159,23 @@ class Halo {
    }; // end class Neighbor
 
    // Private methods
+
+   /// Uses info from Decomp to generate a sorted list of tasks that own
+   /// elements in the the Halo of the local task for a particular index space.
+   /// Utilized only during halo construction
+   int generateListOfTasksInHalo(const I4 NOwned, const I4 NAll,
+                                 HostArray2DI4 Locs,
+                                 std::vector<I4> &ListOfTasks);
+
+   /// Set SendFlags and RecvFlags for the input index space. Utilized only
+   /// during halo construction
+   int setNeighborFlags(std::vector<I4> NeighborElem,
+                        const MeshElement IdxSpace);
+
+   /// Uses info from Decomp to determine all tasks which own elements in the
+   /// halo of the local task or need locally owned elements for their halo.
+   /// Utilized only during halo construction
+   int determineNeighbors(const I4 NumTasks);
 
    /// Send a vector of integers to each neighboring task and receive a vector
    /// of integers from each neighboring task. The first dimension of each
@@ -293,18 +317,23 @@ class Halo {
          TotSize *= Array.extent(NDims - 1);
       }
 
+      // Synchronize all tasks before starting communication
+      MPI_Barrier(MyComm);
+
       // Allocate the receive buffers and Call MPI_Irecv for each Neighbor
       // so the local task is ready to accept messages from each
       // neighboring task
       startReceives();
 
-      // Loop through each Neighbor and pack the buffers to be sent
-      // to each neighboring task
+      // Loop through each Neighbor, resetting communication flags and packing
+      // buffers if there are elements to be sent to the neighboring task
       for (int INghbr = 0; INghbr < NNghbr; ++INghbr) {
-         MyNeighbor = &Neighbors[INghbr];
-         packBuffer(Array);
+         MyNeighbor           = &Neighbors[INghbr];
          MyNeighbor->Received = false;
          MyNeighbor->Unpacked = false;
+         if (SendFlags[MyElem][INghbr]) {
+            packBuffer(Array);
+         }
       }
 
       // Call MPI_Isend for each Neighbor to send the packed buffers
@@ -312,33 +341,42 @@ class Halo {
 
       // Wait for all sends to complete before proceeding
       for (int INghbr = 0; INghbr < NNghbr; ++INghbr) {
-         MyNeighbor = &Neighbors[INghbr];
-         MPI_Wait(&MyNeighbor->SReq, MPI_STATUS_IGNORE);
+         if (SendFlags[MyElem][INghbr]) {
+            MyNeighbor = &Neighbors[INghbr];
+            MPI_Wait(&MyNeighbor->SReq, MPI_STATUS_IGNORE);
+         }
       }
 
-      I4 MaxIter = 100000000; // Large integer to prevent infinite loop
-      I4 IPass   = 0;         // Number of passes through while loop
-      I4 NRcvd   = 0;         // Number of messages received
+      I4 MaxIter = 1000000000; // Large integer to prevent infinite loop
+      I4 IPass   = 0;          // Number of passes through while loop
+      I4 NRcvd   = 0;          // Integer to track number of messages received
+
+      // Total number of messages the local task will receive
+      I4 NMessages = std::accumulate(RecvFlags[MyElem].begin(),
+                                     RecvFlags[MyElem].end(), 0);
 
       // Until all messages from neighboring tasks are received, loop
       // through Neighbor objects and use MPI_Test to check if the message
-      // has been received
+      // has been received. Unpack buffers upon receipt of each message
       while (not AllReceived) {
          for (int INghbr = 0; INghbr < NNghbr; ++INghbr) {
-            MyNeighbor = &Neighbors[INghbr];
-            if (not MyNeighbor->Received) {
-               MPI_Test(&MyNeighbor->RReq, &MyNeighbor->Received,
-                        MPI_STATUS_IGNORE);
-               if (MyNeighbor->Received) {
-                  NRcvd++;
+            if (RecvFlags[MyElem][INghbr]) {
+               MyNeighbor = &Neighbors[INghbr];
+               if (not MyNeighbor->Received) {
+                  MPI_Test(&MyNeighbor->RReq, &MyNeighbor->Received,
+                           MPI_STATUS_IGNORE);
+                  if (MyNeighbor->Received) {
+                     ++NRcvd;
+                  }
+               }
+               if (MyNeighbor->Received and not MyNeighbor->Unpacked) {
+                  unpackBuffer(Array);
+                  MyNeighbor->Unpacked = true;
                }
             }
-            if (MyNeighbor->Received and not MyNeighbor->Unpacked) {
-               unpackBuffer(Array);
-               MyNeighbor->Unpacked = true;
-            }
          }
-         if (NRcvd == NNghbr) {
+
+         if (NRcvd == NMessages) {
             AllReceived = true;
          }
          ++IPass;

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -45,6 +45,11 @@ int initHorzMeshTest() {
    if (Err != 0)
       LOG_ERROR("HorzMeshTest: error initializing default decomposition");
 
+   // Initialize the default halo
+   Err = OMEGA::Halo::init();
+   if (Err != 0)
+      LOG_ERROR("HorzMeshTest: error initializing default halo");
+
    // Initialize the default mesh
    Err = OMEGA::HorzMesh::init();
    if (Err != 0)
@@ -648,7 +653,7 @@ int main(int argc, char *argv[]) {
       // Perform halo exhange on owned cell only array and compare
       // read values
       // Tests that halo values are read in correctly
-      OMEGA::Halo MyHalo(DefEnv, DefDecomp);
+      OMEGA::Halo *DefHalo = OMEGA::Halo::getDefault();
       OMEGA::HostArray1DR8 XCellTest("XCellTest", Mesh->NCellsSize);
       // Mesh->XCellH.deep_copy_to(XCellTest);
       OMEGA::deepCopy(XCellTest, Mesh->XCellH);
@@ -656,7 +661,7 @@ int main(int argc, char *argv[]) {
       for (int Cell = Mesh->NCellsOwned; Cell < Mesh->NCellsAll; Cell++) {
          XCellTest(Cell) = 0.0;
       }
-      MyHalo.exchangeFullArrayHalo(XCellTest, OMEGA::OnCell);
+      DefHalo->exchangeFullArrayHalo(XCellTest, OMEGA::OnCell);
 
       count = 0;
       for (int Cell = 0; Cell < Mesh->NCellsAll; Cell++) {
@@ -683,7 +688,7 @@ int main(int argc, char *argv[]) {
       for (int Edge = Mesh->NEdgesOwned; Edge < Mesh->NEdgesAll; Edge++) {
          XEdgeTest(Edge) = 0.0;
       }
-      MyHalo.exchangeFullArrayHalo(XEdgeTest, OMEGA::OnEdge);
+      DefHalo->exchangeFullArrayHalo(XEdgeTest, OMEGA::OnEdge);
 
       count = 0;
       for (int Edge = 0; Edge < Mesh->NEdgesAll; Edge++) {
@@ -711,7 +716,7 @@ int main(int argc, char *argv[]) {
            Vertex++) {
          XVertexTest(Vertex) = 0.0;
       }
-      MyHalo.exchangeFullArrayHalo(XVertexTest, OMEGA::OnVertex);
+      DefHalo->exchangeFullArrayHalo(XVertexTest, OMEGA::OnVertex);
 
       count = 0;
       for (int Vertex = 0; Vertex < Mesh->NVerticesAll; Vertex++) {


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
Some updates and bug fixes for the Halo class:

- Creates static pointer DefaultHalo and static map AllHalos, along with init, accessor, and cleanup methods, for easy access to default Halo and any other defined Halo objects, and consistency with design of other Omega classes
- Fixes determination of neighboring tasks during Halo construction for decompositions where tasks need to exchange halo elements in just the edge or vertex index spaces and not the cell index space or when only a one-sided exchange is needed
- Replaces MPI blocking routines that were causing deadlock in some cases with non-blocking routines

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
 
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

Fixes #51 
~~NOTE: There are still segmentation faults that can occur running testHalo.exe with higher task counts on the QU240 and QU120 meshes (e.g. running on Chrysalis with QU240 mesh and 470 tasks). This crash occurs during buffer packs and is a separate failure point from #51. I'll keep looking into resolving these crashes.~~
Resolved this error, have run testHalo.exe on QU240 mesh with up to 2048 tasks on Chrysalis without failure.
