### PR TITLE
Adds a time constructor from string to Omega TimeMgr

### DIFF
--- a/components/omega/doc/devGuide/TimeMgr.md
+++ b/components/omega/doc/devGuide/TimeMgr.md
@@ -46,8 +46,8 @@ for a given calendar.
 
 The TimeInstant class represents a moment in time for a particular calendar. It
 consists of a TimeFrac and a pointer to the Calendar in which the time is based.
-There are two constructors for initializing a TimeInstant. One method is with a
-pointer to an initialized Calendar object, five 8-byte integers, and an 8-byte
+There are three constructors for initializing a TimeInstant. One method is with
+a pointer to an initialized Calendar object, five 8-byte integers, and an 8-byte
 real value:
 ```c++
 OMEGA::TimeInstant TI1(&CalGreg, Year, Month, Day, Hour, Minute, RealSecond);
@@ -58,6 +58,15 @@ integers:
 ```c++
 OMEGA::TimeInstant TI2(&CalGreg, Y, M, D, H, M, Whole, Numer, Denom);
 ```
+A final constructor creates a time instant based on a time string that
+conforms roughly to the ISO standard `"YYYYYY-MM-DD_HH:MM:SS.SSSS"` though
+the constructor allows for any single-character non-numeric separator between
+each of the numeric fields and the width of the YY and SS fields can be up
+to the 8-byte standards for integer and floats, respectively.
+```c++
+OMEGA::TimeInstant TI3(&CalGreg, TimeString);
+```
+
 Among the methods defined in the TimeInstant class is `getString` which will
 produce a `std::string` representation of the time conforming to ISO standards,
  e.g. `"YYYYYY-MM-DD HH:MM:SS.SSSSS"`. The `getString` method takes two 4-byte
@@ -68,6 +77,8 @@ string formatted as above is returned with the following call:
 ```c++
 TI1.getString(6, 5, " ");
 ```
+A range of accessor functions can also get/set the TimeInstant in various
+forms.
 
 ### 4. TimeInterval
 

--- a/components/omega/src/infra/TimeMgr.cpp
+++ b/components/omega/src/infra/TimeMgr.cpp
@@ -3574,6 +3574,40 @@ TimeInstant::TimeInstant(Calendar *Cal,   //< [in] Calendar to use
 } // end TimeInstant::TimeInstant constructor from yy/mm/dd-hh:mm:ss(real ss)
 
 //------------------------------------------------------------------------------
+// TimeInstant::TimeInstant
+// Constructs a time instant from a string of the general form
+// YYYYY-MM-DD_HH:MM:SS.SSS where the width of the YY and SS fields can
+// be of arbitrary width and the separators can be any non-numeric character
+
+TimeInstant::TimeInstant(Calendar *Cal,          //< [in] Calendar to use
+                         std::string &TimeString //< [in] string with date/time
+) {
+
+   // Set the calendar
+   CalPtr = Cal;
+
+   // Extract variables from string
+   I8 Year;
+   I8 Month;
+   I8 Day;
+   I8 Hour;
+   I8 Minute;
+   R8 RSecond;
+
+   std::istringstream ss(TimeString);
+   char discard;
+   ss >> Year >> discard >> Month >> discard >> Day >> discard >> Hour >>
+       discard >> Minute >> discard >> RSecond;
+
+   // Use the set function to define the Time Instant
+   I4 Err = this->set(Year, Month, Day, Hour, Minute, RSecond);
+   if (Err != 0)
+      LOG_ERROR("TimeMgr: TimeInstant constructor from string "
+                "error using set function to construct TimeInstant.");
+
+} // end TimeInstant::TimeInstant constructor from string
+
+//------------------------------------------------------------------------------
 // TimeInstant::~TimeInstant - destructor for time instant
 // Destructor for a time instant. No allocated space so does nothing.
 

--- a/components/omega/src/infra/TimeMgr.h
+++ b/components/omega/src/infra/TimeMgr.h
@@ -614,6 +614,14 @@ class TimeInstant {
                const I8 Denom   ///< [in] second (fraction denominator)
    );
 
+   /// Construct time instant from a standard date-time string in the
+   /// form YYYY-MM-DD_HH:MM:SS.SSSS where the width of the YY and SS
+   /// strings can be of arbitrary width (within reason) and the
+   /// separators can be any single non-numeric character
+   TimeInstant(Calendar *Cal,          ///< [in] Calendar to use
+               std::string &TimeString ///< [in] string containing date/time
+   );
+
    /// Destructor for time interval
    ~TimeInstant(void);
 

--- a/components/omega/test/infra/TimeMgrTest.cpp
+++ b/components/omega/test/infra/TimeMgrTest.cpp
@@ -3290,7 +3290,7 @@ int testTimeInstant(void) {
       LOG_ERROR("TimeMgrTest/TimeInstant: decrement by second interval: FAIL");
    }
 
-   // Test time string generator
+   // Test time string generator and constructor from string
 
    std::string StrDateRef = "2019-07-04_15:16:23.2500";
    std::string StrDateChk = TiGreg.getString(4, 4, "_");
@@ -3300,6 +3300,14 @@ int testTimeInstant(void) {
    } else {
       ++ErrAll;
       LOG_ERROR("TimeMgrTest/TimeInstant: getString: FAIL");
+   }
+
+   OMEGA::TimeInstant TiFromString(&CalGreg, StrDateChk);
+   if (TiFromString == TiGreg) {
+      LOG_INFO("TimeMgrTest/TimeInstant from string: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant from string: FAIL");
    }
 
    // Finally, for each calendar, test a 5-year integration in several


### PR DESCRIPTION
A function to convert a time string of a form  YYYY-MM-DD HH:MM:SS.SSS to an Omega TimeInstant is needed to convert time strings from the configuration file into a useful form to set alarms, etc. This adds such a function. The string format can have any single-character separator between numeric fields and the width of the year and second fields can accommodate anything up to the I8 and R8 limits, respectively.
  - adds a TimeInstant constructor from a time string
  - documents change in developer guide
  - adds a test to TimeMgr unit test driver

All unit tests, including the newly added test, pass on Chrysalis/Intel and Frontier cpu and gpu.

Checklist
* [x] Documentation:
  * [x] Design document has been generated and added to the docs
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.


