### PR TITLE
Added iterator functionality to Omega Config class

### DIFF
--- a/components/omega/src/infra/Config.cpp
+++ b/components/omega/src/infra/Config.cpp
@@ -145,15 +145,16 @@ int Config::get(Config &SubConfig // [inout] sub-configuration to retrieve
 
 int Config::getName(Config::Iter ConfigIter, // [in] input iterator
                     std::string &ConfigName  // [out] name of a configuration
-){
+) {
 
    // Initialize return values
-   int Err = 0;
+   int Err    = 0;
    ConfigName = "unknown";
 
    ConfigName = ConfigIter->first.as<std::string>();
 
-   if (ConfigName == "unknown") Err = -1;
+   if (ConfigName == "unknown")
+      Err = -1;
 
    return Err;
 

--- a/components/omega/src/infra/Config.cpp
+++ b/components/omega/src/infra/Config.cpp
@@ -104,6 +104,14 @@ int Config::readAll(const std::string ConfigFile // [in] input YAML config file
 
 } // end Config::readAll
 
+// Iterator for Config
+//------------------------------------------------------------------------------
+// Returns an iterator to the first item in the contained YAML::Node
+Config::Iter Config::begin() const { return Node.begin(); }
+
+// Returns an iterator to the last item in the contained YAML::Node
+Config::Iter Config::end() const { return Node.end(); }
+
 //------------------------------------------------------------------------------
 // Retrieval (get) functions
 //------------------------------------------------------------------------------
@@ -129,6 +137,27 @@ int Config::get(Config &SubConfig // [inout] sub-configuration to retrieve
 
    return Err;
 }
+
+//------------------------------------------------------------------------------
+// Retrieves the name of a configuration or a key in a key:value pair. It is
+// used when iterating through a configuration so takes the iterator as input.
+// This assumes the Config is a name-value pair (map).
+
+int Config::getName(Config::Iter ConfigIter, // [in] input iterator
+                    std::string &ConfigName  // [out] name of a configuration
+){
+
+   // Initialize return values
+   int Err = 0;
+   ConfigName = "unknown";
+
+   ConfigName = ConfigIter->first.as<std::string>();
+
+   if (ConfigName == "unknown") Err = -1;
+
+   return Err;
+
+} // end getName
 
 //------------------------------------------------------------------------------
 // Retrieves a 4-byte integer value from the Config based on name

--- a/components/omega/src/infra/Config.h
+++ b/components/omega/src/infra/Config.h
@@ -69,6 +69,15 @@ class Config {
    /// is created before it can be properly initialized.
    Config();
 
+   /// An iterator is sometimes needed to iterate through the YAML::Node
+   using Iter = YAML::const_iterator;
+
+   /// Returns an iterator to the first item in the contained YAML::Node
+   Iter begin() const;
+
+   /// Returns an iterator to the last item in the contained YAML::Node
+   Iter end() const;
+
    /// Reads the full configuration for omega and stores in it a static
    /// YAML node for later use.  The file must be in YAML format and must be in
    /// the same directory as the executable, though Unix soft links can be used
@@ -93,6 +102,14 @@ class Config {
    int get(Config &SubConfig ///< [inout] sub-configuration to retrieve
    );
 
+   /// Retrieves the name of a configuration (or the key in the key:value
+   /// pair). This is used when iterating through configuration entries so
+   /// takes the iterator as an argument. This assumes the Config is a
+   /// name-value pair (map) and returns an error code if not.
+   static int getName(Iter ConfigIter,        ///< [in] iterator for this entry
+                      std::string &ConfigName ///< [out] name of a configuration
+   );
+   
    /// Retrieves a 4-byte integer value from the Config based on name
    /// Returns a non-zero error code if the variable does not exist
    int get(const std::string VarName, ///< [in] name of variable to get

--- a/components/omega/src/infra/Config.h
+++ b/components/omega/src/infra/Config.h
@@ -109,7 +109,7 @@ class Config {
    static int getName(Iter ConfigIter,        ///< [in] iterator for this entry
                       std::string &ConfigName ///< [out] name of a configuration
    );
-   
+
    /// Retrieves a 4-byte integer value from the Config based on name
    /// Returns a non-zero error code if the variable does not exist
    int get(const std::string VarName, ///< [in] name of variable to get

--- a/components/omega/src/infra/Config.h
+++ b/components/omega/src/infra/Config.h
@@ -42,11 +42,13 @@ class Config {
    /// The YAML node containing the configuration.
    YAML::Node Node;
 
-   /// We store the configuration on the master task and broadcast
-   /// as needed to other tasks via the get function. This flag determines
-   /// whether this is the master task and is copied from the default
-   /// MachEnv.
-   static bool IsMasterTask;
+   /// All MPI tasks must read the initial input file but there may
+   /// be a limit to the number of tasks who can simultaneously read
+   /// so only a subset of tasks reads at the same time
+   static const int ReadGroupSize;
+   static int ReadGroupID;
+   static int NumReadGroups;
+   static MPI_Comm ConfigComm;
 
    /// We do not use an initialization routine, so we include this
    /// initialization flag so that the first Config constructed will

--- a/components/omega/test/infra/ConfigTest.cpp
+++ b/components/omega/test/infra/ConfigTest.cpp
@@ -914,23 +914,32 @@ int main(int argc, char *argv[]) {
    }
 
    // Test retrieval of values using an iterator
-   Err1 = 0;
-   RefTest = true;
+   Err1      = 0;
+   RefTest   = true;
    int IList = 0;
-   for (auto It = ConfigOmega->begin();  It != ConfigOmega->end(); ++It) {
+   for (auto It = ConfigOmega->begin(); It != ConfigOmega->end(); ++It) {
       std::string NodeName;
-      Err1 = OMEGA::Config::getName(It, NodeName); 
+      Err1 = OMEGA::Config::getName(It, NodeName);
       // Note that iteration order not guaranteed but so far has
       // been consistent with location in the file.
-      if (IList == 0 and NodeName != "Hmix") RefTest = false;
-      if (IList == 1 and NodeName != "Vmix") RefTest = false;
-      if (IList == 2 and NodeName != "VectorI4") RefTest = false;
-      if (IList == 3 and NodeName != "VectorI8") RefTest = false;
-      if (IList == 4 and NodeName != "VectorR4") RefTest = false;
-      if (IList == 5 and NodeName != "VectorR8") RefTest = false;
-      if (IList == 6 and NodeName != "VectorLog") RefTest = false;
-      if (IList == 7 and NodeName != "StrList") RefTest = false;
-      if (IList > 7) RefTest = false;
+      if (IList == 0 and NodeName != "Hmix")
+         RefTest = false;
+      if (IList == 1 and NodeName != "Vmix")
+         RefTest = false;
+      if (IList == 2 and NodeName != "VectorI4")
+         RefTest = false;
+      if (IList == 3 and NodeName != "VectorI8")
+         RefTest = false;
+      if (IList == 4 and NodeName != "VectorR4")
+         RefTest = false;
+      if (IList == 5 and NodeName != "VectorR8")
+         RefTest = false;
+      if (IList == 6 and NodeName != "VectorLog")
+         RefTest = false;
+      if (IList == 7 and NodeName != "StrList")
+         RefTest = false;
+      if (IList > 7)
+         RefTest = false;
       ++IList;
    }
    if (Err1 == 0 && RefTest) {

--- a/components/omega/test/infra/ConfigTest.cpp
+++ b/components/omega/test/infra/ConfigTest.cpp
@@ -913,6 +913,32 @@ int main(int argc, char *argv[]) {
       LOG_INFO("ConfigTest {}: Get string list full config - FAIL", MyTask);
    }
 
+   // Test retrieval of values using an iterator
+   Err1 = 0;
+   RefTest = true;
+   int IList = 0;
+   for (auto It = ConfigOmega->begin();  It != ConfigOmega->end(); ++It) {
+      std::string NodeName;
+      Err1 = OMEGA::Config::getName(It, NodeName); 
+      // Note that iteration order not guaranteed but so far has
+      // been consistent with location in the file.
+      if (IList == 0 and NodeName != "Hmix") RefTest = false;
+      if (IList == 1 and NodeName != "Vmix") RefTest = false;
+      if (IList == 2 and NodeName != "VectorI4") RefTest = false;
+      if (IList == 3 and NodeName != "VectorI8") RefTest = false;
+      if (IList == 4 and NodeName != "VectorR4") RefTest = false;
+      if (IList == 5 and NodeName != "VectorR8") RefTest = false;
+      if (IList == 6 and NodeName != "VectorLog") RefTest = false;
+      if (IList == 7 and NodeName != "StrList") RefTest = false;
+      if (IList > 7) RefTest = false;
+      ++IList;
+   }
+   if (Err1 == 0 && RefTest) {
+      LOG_INFO("ConfigTest {}: Get config list using iter - PASS", MyTask);
+   } else {
+      LOG_INFO("ConfigTest {}: Get config list using iter - FAIL", MyTask);
+   }
+
    // Test removals by removing both variables and sub-configs and
    // checking the further retrievals fail
 


### PR DESCRIPTION
In the original Config implementation, most of the operations relied on knowing the name of the variable or sub-configuration in order to retrieve values. In some cases (eg IO streams) users can define the names and properties within the configuration file and the code will not know in advance what these are. Here we introduce a means for iterating over the entries of a configuration and extracting the name for further processing.

This change also required making the full configuration available on all MPI tasks (the previous version performed operations on the master task and broadcast results). So this PR also includes the reading of the full configuration by
all MPI tasks in stages to avoid too many simultaneous reads of the input config file.

The developer guide has been modified to describe the new functionality and the unit test was modified to test the new capability.

All tests pass on Chrysalis/Intel and on Frontier cpu/gpu.

Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

