### PR TITLE
Common test functionality and operators refactor

### DIFF
--- a/components/omega/src/ocn/HorzOperators.h
+++ b/components/omega/src/ocn/HorzOperators.h
@@ -10,12 +10,13 @@ class DivergenceOnCell {
  public:
    DivergenceOnCell(HorzMesh const *Mesh);
 
-   KOKKOS_FUNCTION Real operator()(int ICell,
-                                   const Array1DReal &VecEdge) const {
+   KOKKOS_FUNCTION Real operator()(int ICell, int K,
+                                   const Array2DReal &VecEdge) const {
       Real DivCell = 0;
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
          const int JEdge = EdgesOnCell(ICell, J);
-         DivCell -= DvEdge(JEdge) * EdgeSignOnCell(ICell, J) * VecEdge(JEdge);
+         DivCell -=
+             DvEdge(JEdge) * EdgeSignOnCell(ICell, J) * VecEdge(JEdge, K);
       }
       const Real InvAreaCell = 1. / AreaCell(ICell);
       DivCell *= InvAreaCell;
@@ -34,13 +35,13 @@ class GradientOnEdge {
  public:
    GradientOnEdge(HorzMesh const *Mesh);
 
-   KOKKOS_FUNCTION Real operator()(int IEdge,
-                                   const Array1DReal &ScalarCell) const {
+   KOKKOS_FUNCTION Real operator()(int IEdge, int K,
+                                   const Array2DReal &ScalarCell) const {
       const auto JCell0    = CellsOnEdge(IEdge, 0);
       const auto JCell1    = CellsOnEdge(IEdge, 1);
       const Real InvDcEdge = 1. / DcEdge(IEdge);
       const Real GradEdge =
-          InvDcEdge * (ScalarCell(JCell1) - ScalarCell(JCell0));
+          InvDcEdge * (ScalarCell(JCell1, K) - ScalarCell(JCell0, K));
       return GradEdge;
    }
 
@@ -53,13 +54,13 @@ class CurlOnVertex {
  public:
    CurlOnVertex(HorzMesh const *Mesh);
 
-   KOKKOS_FUNCTION Real operator()(int IVertex,
-                                   const Array1DReal &VecEdge) const {
+   KOKKOS_FUNCTION Real operator()(int IVertex, int K,
+                                   const Array2DReal &VecEdge) const {
       Real CurlVertex = 0;
       for (int J = 0; J < VertexDegree; ++J) {
          const int JEdge = EdgesOnVertex(IVertex, J);
          CurlVertex +=
-             DcEdge(JEdge) * EdgeSignOnVertex(IVertex, J) * VecEdge(JEdge);
+             DcEdge(JEdge) * EdgeSignOnVertex(IVertex, J) * VecEdge(JEdge, K);
       }
       const Real InvAreaTriangle = 1. / AreaTriangle(IVertex);
       CurlVertex *= InvAreaTriangle;
@@ -78,12 +79,12 @@ class TangentialReconOnEdge {
  public:
    TangentialReconOnEdge(HorzMesh const *Mesh);
 
-   KOKKOS_FUNCTION Real operator()(int IEdge,
-                                   const Array1DReal &VecEdge) const {
+   KOKKOS_FUNCTION Real operator()(int IEdge, int K,
+                                   const Array2DReal &VecEdge) const {
       Real ReconEdge = 0;
       for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
          const int JEdge = EdgesOnEdge(IEdge, J);
-         ReconEdge += WeightsOnEdge(IEdge, J) * VecEdge(JEdge);
+         ReconEdge += WeightsOnEdge(IEdge, J) * VecEdge(JEdge, K);
       }
       return ReconEdge;
    }

--- a/components/omega/src/ocn/HorzOperators.h
+++ b/components/omega/src/ocn/HorzOperators.h
@@ -16,18 +16,20 @@ class DivergenceOnCell {
       const int KStart       = KChunk * VecLength;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
-         const int K       = KStart + KVec;
-         DivCell(ICell, K) = 0;
-      }
+      Real DivCellTmp[VecLength] = {0};
 
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
          const int JEdge = EdgesOnCell(ICell, J);
          for (int KVec = 0; KVec < VecLength; ++KVec) {
             const int K = KStart + KVec;
-            DivCell(ICell, K) -= DvEdge(JEdge) * EdgeSignOnCell(ICell, J) *
-                                 VecEdge(JEdge, K) * InvAreaCell;
+            DivCellTmp[KVec] -= DvEdge(JEdge) * EdgeSignOnCell(ICell, J) *
+                                VecEdge(JEdge, K) * InvAreaCell;
          }
+      }
+
+      for (int KVec = 0; KVec < VecLength; ++KVec) {
+         const int K       = KStart + KVec;
+         DivCell(ICell, K) = DivCellTmp[KVec];
       }
    }
 
@@ -73,19 +75,21 @@ class CurlOnVertex {
       const int KStart           = KChunk * VecLength;
       const Real InvAreaTriangle = 1._Real / AreaTriangle(IVertex);
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
-         const int K            = KStart + KVec;
-         CurlVertex(IVertex, K) = 0;
-      }
+      Real CurlVertexTmp[VecLength] = {0};
 
       for (int J = 0; J < VertexDegree; ++J) {
          const int JEdge = EdgesOnVertex(IVertex, J);
          for (int KVec = 0; KVec < VecLength; ++KVec) {
             const int K = KStart + KVec;
-            CurlVertex(IVertex, K) += DcEdge(JEdge) *
-                                      EdgeSignOnVertex(IVertex, J) *
-                                      VecEdge(JEdge, K) * InvAreaTriangle;
+            CurlVertexTmp[KVec] += DcEdge(JEdge) *
+                                   EdgeSignOnVertex(IVertex, J) *
+                                   VecEdge(JEdge, K) * InvAreaTriangle;
          }
+      }
+
+      for (int KVec = 0; KVec < VecLength; ++KVec) {
+         const int K            = KStart + KVec;
+         CurlVertex(IVertex, K) = CurlVertexTmp[KVec];
       }
    }
 
@@ -106,17 +110,19 @@ class TangentialReconOnEdge {
                                    const Array2DReal &VecEdge) const {
       const int KStart = KChunk * VecLength;
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
-         const int K         = KStart + KVec;
-         ReconEdge(IEdge, K) = 0;
-      }
+      Real ReconEdgeTmp[VecLength] = {0};
 
       for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
          const int JEdge = EdgesOnEdge(IEdge, J);
          for (int KVec = 0; KVec < VecLength; ++KVec) {
             const int K = KStart + KVec;
-            ReconEdge(IEdge, K) += WeightsOnEdge(IEdge, J) * VecEdge(JEdge, K);
+            ReconEdgeTmp[KVec] += WeightsOnEdge(IEdge, J) * VecEdge(JEdge, K);
          }
+      }
+
+      for (int KVec = 0; KVec < VecLength; ++KVec) {
+         const int K         = KStart + KVec;
+         ReconEdge(IEdge, K) = ReconEdgeTmp[KVec];
       }
    }
 

--- a/components/omega/src/ocn/HorzOperators.h
+++ b/components/omega/src/ocn/HorzOperators.h
@@ -10,17 +10,25 @@ class DivergenceOnCell {
  public:
    DivergenceOnCell(HorzMesh const *Mesh);
 
-   KOKKOS_FUNCTION Real operator()(int ICell, int K,
+   KOKKOS_FUNCTION void operator()(const Array2DReal &DivCell, int ICell,
+                                   int KChunk,
                                    const Array2DReal &VecEdge) const {
-      Real DivCell = 0;
+      const int KStart       = KChunk * VecLength;
+      const Real InvAreaCell = 1._Real / AreaCell(ICell);
+
+      for (int KVec = 0; KVec < VecLength; ++KVec) {
+         const int K       = KStart + KVec;
+         DivCell(ICell, K) = 0;
+      }
+
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
          const int JEdge = EdgesOnCell(ICell, J);
-         DivCell -=
-             DvEdge(JEdge) * EdgeSignOnCell(ICell, J) * VecEdge(JEdge, K);
+         for (int KVec = 0; KVec < VecLength; ++KVec) {
+            const int K = KStart + KVec;
+            DivCell(ICell, K) -= DvEdge(JEdge) * EdgeSignOnCell(ICell, J) *
+                                 VecEdge(JEdge, K) * InvAreaCell;
+         }
       }
-      const Real InvAreaCell = 1. / AreaCell(ICell);
-      DivCell *= InvAreaCell;
-      return DivCell;
    }
 
  private:
@@ -35,14 +43,19 @@ class GradientOnEdge {
  public:
    GradientOnEdge(HorzMesh const *Mesh);
 
-   KOKKOS_FUNCTION Real operator()(int IEdge, int K,
+   KOKKOS_FUNCTION void operator()(const Array2DReal &GradEdge, int IEdge,
+                                   int KChunk,
                                    const Array2DReal &ScalarCell) const {
+      const int KStart     = KChunk * VecLength;
+      const Real InvDcEdge = 1._Real / DcEdge(IEdge);
       const auto JCell0    = CellsOnEdge(IEdge, 0);
       const auto JCell1    = CellsOnEdge(IEdge, 1);
-      const Real InvDcEdge = 1. / DcEdge(IEdge);
-      const Real GradEdge =
-          InvDcEdge * (ScalarCell(JCell1, K) - ScalarCell(JCell0, K));
-      return GradEdge;
+
+      for (int KVec = 0; KVec < VecLength; ++KVec) {
+         const int K = KStart + KVec;
+         GradEdge(IEdge, K) =
+             InvDcEdge * (ScalarCell(JCell1, K) - ScalarCell(JCell0, K));
+      }
    }
 
  private:
@@ -54,17 +67,26 @@ class CurlOnVertex {
  public:
    CurlOnVertex(HorzMesh const *Mesh);
 
-   KOKKOS_FUNCTION Real operator()(int IVertex, int K,
+   KOKKOS_FUNCTION void operator()(const Array2DReal &CurlVertex, int IVertex,
+                                   int KChunk,
                                    const Array2DReal &VecEdge) const {
-      Real CurlVertex = 0;
+      const int KStart           = KChunk * VecLength;
+      const Real InvAreaTriangle = 1._Real / AreaTriangle(IVertex);
+
+      for (int KVec = 0; KVec < VecLength; ++KVec) {
+         const int K            = KStart + KVec;
+         CurlVertex(IVertex, K) = 0;
+      }
+
       for (int J = 0; J < VertexDegree; ++J) {
          const int JEdge = EdgesOnVertex(IVertex, J);
-         CurlVertex +=
-             DcEdge(JEdge) * EdgeSignOnVertex(IVertex, J) * VecEdge(JEdge, K);
+         for (int KVec = 0; KVec < VecLength; ++KVec) {
+            const int K = KStart + KVec;
+            CurlVertex(IVertex, K) += DcEdge(JEdge) *
+                                      EdgeSignOnVertex(IVertex, J) *
+                                      VecEdge(JEdge, K) * InvAreaTriangle;
+         }
       }
-      const Real InvAreaTriangle = 1. / AreaTriangle(IVertex);
-      CurlVertex *= InvAreaTriangle;
-      return CurlVertex;
    }
 
  private:
@@ -79,14 +101,23 @@ class TangentialReconOnEdge {
  public:
    TangentialReconOnEdge(HorzMesh const *Mesh);
 
-   KOKKOS_FUNCTION Real operator()(int IEdge, int K,
+   KOKKOS_FUNCTION void operator()(const Array2DReal &ReconEdge, int IEdge,
+                                   int KChunk,
                                    const Array2DReal &VecEdge) const {
-      Real ReconEdge = 0;
+      const int KStart = KChunk * VecLength;
+
+      for (int KVec = 0; KVec < VecLength; ++KVec) {
+         const int K         = KStart + KVec;
+         ReconEdge(IEdge, K) = 0;
+      }
+
       for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
          const int JEdge = EdgesOnEdge(IEdge, J);
-         ReconEdge += WeightsOnEdge(IEdge, J) * VecEdge(JEdge, K);
+         for (int KVec = 0; KVec < VecLength; ++KVec) {
+            const int K = KStart + KVec;
+            ReconEdge(IEdge, K) += WeightsOnEdge(IEdge, J) * VecEdge(JEdge, K);
+         }
       }
-      return ReconEdge;
    }
 
  private:

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -6,6 +6,7 @@
 #include "IO.h"
 #include "Logging.h"
 #include "MachEnv.h"
+#include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
 #include "mpi.h"
 
@@ -13,182 +14,10 @@
 
 using namespace OMEGA;
 
-// check if two real numbers are equal with a given relative tolerance
-bool isApprox(Real X, Real Y, Real RTol) {
-   return std::abs(X - Y) <= RTol * std::max(std::abs(X), std::abs(Y));
-}
-
-// convert spherical components of a vector to Cartesian
-KOKKOS_INLINE_FUNCTION void sphereToCartVec(Real (&CartVec)[3],
-                                            const Real (&SphereVec)[2],
-                                            Real Lon, Real Lat) {
-   using std::cos;
-   using std::sin;
-   CartVec[0] = -sin(Lon) * SphereVec[0] - sin(Lat) * cos(Lon) * SphereVec[1];
-   CartVec[1] = cos(Lon) * SphereVec[0] - sin(Lat) * sin(Lon) * SphereVec[1];
-   CartVec[2] = cos(Lat) * SphereVec[1];
-}
-
-// returns Cartesian components of unit vector tangent to the spherical arc
-// between Cartesian points X1 and X2 parametrized with t
-KOKKOS_INLINE_FUNCTION void tangentVector(Real (&TanVec)[3],
-                                          const Real (&X1)[3],
-                                          const Real (&X2)[3], Real t = 0) {
-   const Real Radius =
-       Kokkos::sqrt(X1[0] * X1[0] + X1[1] * X1[1] + X1[2] * X1[2]);
-   Real XC[3];
-   Real DX[3];
-   for (int Dim = 0; Dim < 3; ++Dim) {
-      XC[Dim] = (1 - t) * X1[Dim] + t * X2[Dim];
-      DX[Dim] = X2[Dim] - X1[Dim];
-   }
-   const Real XCDotDX = XC[0] * DX[0] + XC[1] * DX[1] + XC[2] * DX[2];
-   const Real NormXC =
-       Kokkos::sqrt(XC[0] * XC[0] + XC[1] * XC[1] + XC[2] * XC[2]);
-
-   for (int Dim = 0; Dim < 3; ++Dim) {
-      const Real NormXC3 = NormXC * NormXC * NormXC;
-      TanVec[Dim] =
-          Radius / NormXC * DX[Dim] - (Radius * XCDotDX) / NormXC3 * XC[Dim];
-   }
-
-   const Real NormTanVec = Kokkos::sqrt(
-       TanVec[0] * TanVec[0] + TanVec[1] * TanVec[1] + TanVec[2] * TanVec[2]);
-   for (int Dim = 0; Dim < 3; ++Dim) {
-      TanVec[Dim] /= NormTanVec;
-   }
-}
-
-enum class EdgeOrientation { Normal, Tangential };
-
-template <class Functor>
-void computeVecFieldEdge(const Functor &Fun, const Array1DReal &VecFieldArr,
-                         EdgeOrientation EdgeOrient, const HorzMesh *Mesh) {
-   auto XEdge = createDeviceMirrorCopy(Mesh->XEdgeH);
-   auto YEdge = createDeviceMirrorCopy(Mesh->YEdgeH);
-   auto ZEdge = createDeviceMirrorCopy(Mesh->ZEdgeH);
-
-   auto XCell = createDeviceMirrorCopy(Mesh->XCellH);
-   auto YCell = createDeviceMirrorCopy(Mesh->YCellH);
-   auto ZCell = createDeviceMirrorCopy(Mesh->ZCellH);
-
-   auto XVertex = createDeviceMirrorCopy(Mesh->XVertexH);
-   auto YVertex = createDeviceMirrorCopy(Mesh->YVertexH);
-   auto ZVertex = createDeviceMirrorCopy(Mesh->ZVertexH);
-
-   auto LonEdge = createDeviceMirrorCopy(Mesh->LonEdgeH);
-   auto LatEdge = createDeviceMirrorCopy(Mesh->LatEdgeH);
-
-   auto &AngleEdge      = Mesh->AngleEdge;
-   auto &CellsOnEdge    = Mesh->CellsOnEdge;
-   auto &VerticesOnEdge = Mesh->VerticesOnEdge;
-
-   parallelFor(
-       {Mesh->NEdgesOwned}, KOKKOS_LAMBDA(int IEdge) {
-          Real VecFieldEdge;
-#ifdef HORZOPERATORS_TEST_PLANE
-          const Real XE = XEdge(IEdge);
-          const Real YE = YEdge(IEdge);
-
-          Real VecField[2];
-          Fun(VecField, XE, YE);
-
-          if (EdgeOrient == EdgeOrientation::Normal) {
-             const Real EdgeNormalX = std::cos(AngleEdge(IEdge));
-             const Real EdgeNormalY = std::sin(AngleEdge(IEdge));
-             VecFieldEdge =
-                 EdgeNormalX * VecField[0] + EdgeNormalY * VecField[1];
-          }
-
-          if (EdgeOrient == EdgeOrientation::Tangential) {
-             const Real EdgeTangentX = -std::sin(AngleEdge(IEdge));
-             const Real EdgeTangentY = std::cos(AngleEdge(IEdge));
-             VecFieldEdge =
-                 EdgeTangentX * VecField[0] + EdgeTangentY * VecField[1];
-          }
-#else
-          const Real LonE                = LonEdge(IEdge);
-          const Real LatE                = LatEdge(IEdge);
-
-          Real VecField[2];
-          Fun(VecField, LonE, LatE);
-
-          bool UseCartesianProjection = true;
-
-          if (UseCartesianProjection) {
-            Real VecFieldCart[3];
-            sphereToCartVec(VecFieldCart, VecField, LonE, LatE);
-
-            const Real EdgeCoords[3] = {XEdge[IEdge], YEdge[IEdge], ZEdge[IEdge]};
-
-            if (EdgeOrient == EdgeOrientation::Normal) {
-              const int JCell1 = CellsOnEdge(IEdge, 1);
-              const Real CellCoords[3] = {XCell(JCell1), YCell(JCell1), ZCell(JCell1)};
-
-              Real EdgeNormal[3];
-              tangentVector(EdgeNormal, EdgeCoords, CellCoords);
-              VecFieldEdge = EdgeNormal[0] * VecFieldCart[0] +
-                             EdgeNormal[1] * VecFieldCart[1] +
-                             EdgeNormal[2] * VecFieldCart[2];
-            }
-
-            if (EdgeOrient == EdgeOrientation::Tangential) {
-              const int JVertex1 = VerticesOnEdge(IEdge, 1);
-              const Real VertexCoords[3] = {XVertex(JVertex1), YVertex(JVertex1), ZVertex(JVertex1)};
-
-              Real EdgeTangent[3];
-              tangentVector(EdgeTangent, EdgeCoords, VertexCoords);
-              VecFieldEdge = EdgeTangent[0] * VecFieldCart[0] +
-                             EdgeTangent[1] * VecFieldCart[1] +
-                             EdgeTangent[2] * VecFieldCart[2];
-            }
-          } else {
-            if (EdgeOrient == EdgeOrientation::Normal) {
-              const Real EdgeNormalX      = std::cos(AngleEdge(IEdge));
-              const Real EdgeNormalY      = std::sin(AngleEdge(IEdge));
-              VecFieldEdge = EdgeNormalX * VecField[0] + EdgeNormalY * VecField[1];
-            }
-
-            if (EdgeOrient == EdgeOrientation::Tangential) {
-              const Real EdgeTangentX  = -std::sin(AngleEdge(IEdge));
-              const Real EdgeTangentY  = std::cos(AngleEdge(IEdge));
-              VecFieldEdge = EdgeTangentX * VecField[0] + EdgeTangentY * VecField[1];
-            }
-          }
-#endif
-          VecFieldArr[IEdge] = VecFieldEdge;
-       });
-}
-
-// temporary replacement for YAKL intrinsics
-Real maxVal(const Array1DReal &Arr) {
-   Real MaxVal;
-
-   parallelReduce(
-       {Arr.extent_int(0)},
-       KOKKOS_LAMBDA(int I, Real &Accum) {
-          Accum = Kokkos::max(Arr(I), Accum);
-       },
-       Kokkos::Max<Real>(MaxVal));
-
-   return MaxVal;
-}
-
-Real sum(const Array1DReal &Arr) {
-   Real Sum;
-
-   parallelReduce(
-       {Arr.extent_int(0)},
-       KOKKOS_LAMBDA(int I, Real &Accum) { Accum += Arr(I); }, Sum);
-
-   return Sum;
-}
-
-#ifdef HORZOPERATORS_TEST_PLANE
 // analytical expressions for scalar and vector fields used as input for
 // operator tests together with exact values of operators for computing errors
 // and expected error values
-struct TestSetup {
+struct TestSetupPlane {
    Real Pi = M_PI;
 
    // lengths of periodic planar mesh
@@ -238,13 +67,8 @@ struct TestSetup {
              std::sin(2 * Pi * Y / Ly);
    }
 };
-#endif
 
-#ifdef HORZOPERATORS_TEST_SPHERE_1
-// analytical expressions for scalar and vector fields used as input for
-// operator tests together with exact values of operators for computing errors
-// and expected error values
-struct TestSetup {
+struct TestSetupSphere1 {
    // radius of spherical mesh
    // TODO: get this from the mesh
    Real Radius = 6371220;
@@ -289,13 +113,8 @@ struct TestSetup {
              std::sin(Lat);
    }
 };
-#endif
 
-#ifdef HORZOPERATORS_TEST_SPHERE_2
-// analytical expressions for scalar and vector fields used as input for
-// operator tests together with exact values of operators for computing errors
-// and expected error values
-struct TestSetup {
+struct TestSetupSphere2 {
    // radius of spherical mesh
    // TODO: get this from the mesh
    Real Radius = 6371220;
@@ -331,409 +150,272 @@ struct TestSetup {
       return 2 * std::sin(Lat) / Radius;
    }
 };
+
+#ifdef HORZOPERATORS_TEST_PLANE
+constexpr Geometry Geom          = Geometry::Planar;
+constexpr char DefaultMeshFile[] = "OmegaPlanarMesh.nc";
+#else
+constexpr Geometry Geom          = Geometry::Spherical;
+constexpr char DefaultMeshFile[] = "OmegaSphereMesh.nc";
+#endif
+
+#if defined HORZOPERATORS_TEST_PLANE
+using TestSetup = TestSetupPlane;
+#elif defined HORZOPERATORS_TEST_SPHERE_1
+using TestSetup = TestSetupSphere1;
+#elif defined HORZOPERATORS_TEST_SPHERE_2
+using TestSetup = TestSetupSphere2;
 #endif
 
 int testDivergence(Real RTol) {
-   int Err;
+   int Err = 0;
    TestSetup Setup;
 
-   const auto &Mesh = HorzMesh::getDefault();
+   const auto &Mesh      = HorzMesh::getDefault();
+   const int NVertLevels = 1;
 
    // Prepare operator input
-   Array1DReal VecEdge("VecEdge", Mesh->NEdgesSize);
-
-   computeVecFieldEdge(
+   Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLevels);
+   Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
           VecField[0] = Setup.exactVecX(X, Y);
           VecField[1] = Setup.exactVecY(X, Y);
        },
-       VecEdge, EdgeOrientation::Normal, Mesh);
+       VecEdge, EdgeComponent::Normal, Geom, Mesh, NVertLevels);
 
-   // Perform halo exchange
-   auto MyHalo   = Halo::getDefault();
-   auto VecEdgeH = createHostMirrorCopy(VecEdge);
-   MyHalo->exchangeFullArrayHalo(VecEdgeH, OnEdge);
-   deepCopy(VecEdge, VecEdgeH);
+   // Compute exact result
+   Array2DReal ExactDivCell("ExactDivCell", Mesh->NCellsOwned, NVertLevels);
+   Err += setScalarCell(
+       KOKKOS_LAMBDA(Real X, Real Y) { return Setup.exactDivVec(X, Y); },
+       ExactDivCell, Geom, Mesh, NVertLevels, false);
 
-#ifdef HORZOPERATORS_TEST_PLANE
-   auto XCell = createDeviceMirrorCopy(Mesh->XCellH);
-   auto YCell = createDeviceMirrorCopy(Mesh->YCellH);
-#else
-   auto XCell = createDeviceMirrorCopy(Mesh->LonCellH);
-   auto YCell = createDeviceMirrorCopy(Mesh->LatCellH);
-#endif
-   auto &AreaCell = Mesh->AreaCell;
-
-   // Compute element-wise errors
-   Array1DReal LInfCell("LInfCell", Mesh->NCellsOwned);
-   Array1DReal L2Cell("L2Cell", Mesh->NCellsOwned);
-
-   Array1DReal LInfScaleCell("LInfScaleCell", Mesh->NCellsOwned);
-   Array1DReal L2ScaleCell("L2ScaleCell", Mesh->NCellsOwned);
+   // Compute numerical result
+   Array2DReal NumDivCell("NumDivCell", Mesh->NCellsOwned, NVertLevels);
    DivergenceOnCell DivergenceCell(Mesh);
    parallelFor(
-       {Mesh->NCellsOwned}, KOKKOS_LAMBDA(int ICell) {
-          // Numerical result
-          const Real DivCellNum = DivergenceCell(ICell, VecEdge);
-
-          // Exact result
-          const Real X            = XCell(ICell);
-          const Real Y            = YCell(ICell);
-          const Real DivCellExact = Setup.exactDivVec(X, Y);
-
-          // Errors
-          LInfCell(ICell)      = std::abs(DivCellNum - DivCellExact);
-          LInfScaleCell(ICell) = std::abs(DivCellExact);
-          L2Cell(ICell) = AreaCell(ICell) * LInfCell(ICell) * LInfCell(ICell);
-          L2ScaleCell(ICell) =
-              AreaCell(ICell) * LInfScaleCell(ICell) * LInfScaleCell(ICell);
+       {Mesh->NCellsOwned, NVertLevels}, KOKKOS_LAMBDA(int ICell, int K) {
+          NumDivCell(ICell, K) = DivergenceCell(ICell, K, VecEdge);
        });
 
-   // Compute global normalized error norms
-   const Real LInfErrorLoc = maxVal(LInfCell);
-   const Real L2ErrorLoc   = sum(L2Cell);
-   const Real LInfScaleLoc = maxVal(LInfScaleCell);
-   const Real L2ScaleLoc   = sum(L2ScaleCell);
-
-   MPI_Comm Comm = MachEnv::getDefaultEnv()->getComm();
-   Real LInfError, LInfScale;
-   Err =
-       MPI_Allreduce(&LInfErrorLoc, &LInfError, 1, MPI_RealKind, MPI_MAX, Comm);
-   Err =
-       MPI_Allreduce(&LInfScaleLoc, &LInfScale, 1, MPI_RealKind, MPI_MAX, Comm);
-   if (LInfScale > 0) {
-      LInfError /= LInfScale;
-   }
-
-   Real L2Error, L2Scale;
-   Err = MPI_Allreduce(&L2ErrorLoc, &L2Error, 1, MPI_RealKind, MPI_SUM, Comm);
-   Err = MPI_Allreduce(&L2ScaleLoc, &L2Scale, 1, MPI_RealKind, MPI_SUM, Comm);
-   if (L2Scale > 0) {
-      L2Error = std::sqrt(L2Error / L2Scale);
-   } else {
-      L2Error = std::sqrt(L2Error);
-   }
+   // Compute error measures
+   ErrorMeasures DivErrors;
+   Err += computeErrorsCell(DivErrors, NumDivCell, ExactDivCell, Mesh,
+                            NVertLevels);
 
    // Check error values
-   if (Err == 0 && isApprox(LInfError, Setup.ExpectedDivErrorLInf, RTol) &&
-       isApprox(L2Error, Setup.ExpectedDivErrorL2, RTol)) {
-      return 0;
-   } else {
-      return 1;
+   if (!isApprox(DivErrors.LInf, Setup.ExpectedDivErrorLInf, RTol)) {
+      Err++;
+      LOG_ERROR("OperatorsTest: Divergence LInf FAIL");
    }
+
+   if (!isApprox(DivErrors.L2, Setup.ExpectedDivErrorL2, RTol)) {
+      Err++;
+      LOG_ERROR("OperatorsTest: Divergence L2 FAIL");
+   }
+
+   if (Err == 0) {
+      LOG_INFO("OperatorsTest: Divergence PASS");
+   }
+
+   return Err;
 }
 
 int testGradient(Real RTol) {
-   int Err;
+   int Err = 0;
    TestSetup Setup;
 
-   const auto &Mesh = HorzMesh::getDefault();
-#ifdef HORZOPERATORS_TEST_PLANE
-   const auto XCell = createDeviceMirrorCopy(Mesh->XCellH);
-   const auto YCell = createDeviceMirrorCopy(Mesh->YCellH);
-#else
-   const auto XCell = createDeviceMirrorCopy(Mesh->LonCellH);
-   const auto YCell = createDeviceMirrorCopy(Mesh->LatCellH);
-#endif
+   const auto &Mesh      = HorzMesh::getDefault();
+   const int NVertLevels = 1;
 
    // Prepare operator input
-   Array1DReal ScalarCell("ScalarCell", Mesh->NCellsSize);
-   parallelFor(
-       {Mesh->NCellsOwned}, KOKKOS_LAMBDA(int ICell) {
-          const Real X      = XCell(ICell);
-          const Real Y      = YCell(ICell);
-          ScalarCell(ICell) = Setup.exactScalar(X, Y);
-       });
-
-   // Perform halo exchange
-   auto MyHalo      = Halo::getDefault();
-   auto ScalarCellH = createHostMirrorCopy(ScalarCell);
-   MyHalo->exchangeFullArrayHalo(ScalarCellH, OnCell);
-   deepCopy(ScalarCell, ScalarCellH);
+   Array2DReal ScalarCell("ScalarCell", Mesh->NCellsSize, NVertLevels);
+   Err += setScalarCell(
+       KOKKOS_LAMBDA(Real Coord1, Real Coord2) {
+          return Setup.exactScalar(Coord1, Coord2);
+       },
+       ScalarCell, Geom, Mesh, NVertLevels);
 
    // Compute exact result
-   Array1DReal ExactGradEdge("ExactGradEdge", Mesh->NEdgesOwned);
-   computeVecFieldEdge(
+   Array2DReal ExactGradEdge("ExactGradEdge", Mesh->NEdgesOwned, NVertLevels);
+   Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
           VecField[0] = Setup.exactGradScalarX(X, Y);
           VecField[1] = Setup.exactGradScalarY(X, Y);
        },
-       ExactGradEdge, EdgeOrientation::Normal, Mesh);
+       ExactGradEdge, EdgeComponent::Normal, Geom, Mesh, NVertLevels, false);
 
-   const auto &DcEdge = Mesh->DcEdge;
-   const auto &DvEdge = Mesh->DvEdge;
-   // Compute element-wise errors
-   Array1DReal LInfEdge("LInfEdge", Mesh->NEdgesOwned);
-   Array1DReal L2Edge("L2Edge", Mesh->NEdgesOwned);
-   Array1DReal LInfScaleEdge("LInfScaleEdge", Mesh->NEdgesOwned);
-   Array1DReal L2ScaleEdge("L2ScaleEdge", Mesh->NEdgesOwned);
+   // Compute numerical result
    GradientOnEdge GradientEdge(Mesh);
+   Array2DReal NumGradEdge("NumGradEdge", Mesh->NEdgesOwned, NVertLevels);
    parallelFor(
-       {Mesh->NEdgesOwned}, KOKKOS_LAMBDA(int IEdge) {
-          // Numerical result
-          const Real GradScalarNum = GradientEdge(IEdge, ScalarCell);
-
-          // Exact result
-          const Real GradScalarExact = ExactGradEdge(IEdge);
-
-          LInfEdge(IEdge)      = std::abs(GradScalarNum - GradScalarExact);
-          LInfScaleEdge(IEdge) = std::abs(GradScalarExact);
-          const Real AreaEdge  = DcEdge(IEdge) * DvEdge(IEdge) / 2;
-          L2Edge(IEdge)        = AreaEdge * LInfEdge(IEdge) * LInfEdge(IEdge);
-          L2ScaleEdge(IEdge) =
-              AreaEdge * LInfScaleEdge(IEdge) * LInfScaleEdge(IEdge);
+       {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
+          NumGradEdge(IEdge, K) = GradientEdge(IEdge, K, ScalarCell);
        });
 
-   // Compute global normalized error norms
-   const Real LInfErrorLoc = maxVal(LInfEdge);
-   const Real LInfScaleLoc = maxVal(LInfScaleEdge);
-   const Real L2ErrorLoc   = sum(L2Edge);
-   const Real L2ScaleLoc   = sum(L2ScaleEdge);
-
-   MPI_Comm Comm = MachEnv::getDefaultEnv()->getComm();
-   Real LInfError, LInfScale;
-   Err =
-       MPI_Allreduce(&LInfErrorLoc, &LInfError, 1, MPI_RealKind, MPI_MAX, Comm);
-   Err =
-       MPI_Allreduce(&LInfScaleLoc, &LInfScale, 1, MPI_RealKind, MPI_MAX, Comm);
-   if (LInfScale > 0) {
-      LInfError /= LInfScale;
-   }
-
-   Real L2Error, L2Scale;
-   Err = MPI_Allreduce(&L2ErrorLoc, &L2Error, 1, MPI_RealKind, MPI_SUM, Comm);
-   Err = MPI_Allreduce(&L2ScaleLoc, &L2Scale, 1, MPI_RealKind, MPI_SUM, Comm);
-   if (L2Scale > 0) {
-      L2Error = std::sqrt(L2Error / L2Scale);
-   } else {
-      L2Error = std::sqrt(L2Error);
-   }
+   // Compute error measures
+   ErrorMeasures GradErrors;
+   Err += computeErrorsEdge(GradErrors, NumGradEdge, ExactGradEdge, Mesh,
+                            NVertLevels);
 
    // Check error values
-   if (Err == 0 && isApprox(LInfError, Setup.ExpectedGradErrorLInf, RTol) &&
-       isApprox(L2Error, Setup.ExpectedGradErrorL2, RTol)) {
-      return 0;
-   } else {
-      return 1;
+   if (!isApprox(GradErrors.LInf, Setup.ExpectedGradErrorLInf, RTol)) {
+      Err++;
+      LOG_ERROR("OperatorsTest: Gradient LInf FAIL");
    }
+
+   if (!isApprox(GradErrors.L2, Setup.ExpectedGradErrorL2, RTol)) {
+      Err++;
+      LOG_ERROR("OperatorsTest: Gradient L2 FAIL");
+   }
+
+   if (Err == 0) {
+      LOG_INFO("OperatorsTest: Gradient PASS");
+   }
+
+   return Err;
 }
 
 int testCurl(Real RTol) {
-   int Err;
+   int Err = 0;
    TestSetup Setup;
-   const auto &Mesh = HorzMesh::getDefault();
+   const auto &Mesh      = HorzMesh::getDefault();
+   const int NVertLevels = 1;
 
    // Prepare operator input
-   Array1DReal VecEdge("VecEdge", Mesh->NEdgesSize);
-
-   computeVecFieldEdge(
+   Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLevels);
+   Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
           VecField[0] = Setup.exactVecX(X, Y);
           VecField[1] = Setup.exactVecY(X, Y);
        },
-       VecEdge, EdgeOrientation::Normal, Mesh);
+       VecEdge, EdgeComponent::Normal, Geom, Mesh, NVertLevels);
 
-   // Perform halo exchange
-   auto MyHalo   = Halo::getDefault();
-   auto VecEdgeH = createHostMirrorCopy(VecEdge);
-   MyHalo->exchangeFullArrayHalo(VecEdgeH, OnEdge);
-   deepCopy(VecEdge, VecEdgeH);
+   // Compute exact result
+   Array2DReal ExactCurlVertex("ExactCurlVertex", Mesh->NVerticesOwned,
+                               NVertLevels);
+   Err += setScalarVertex(
+       KOKKOS_LAMBDA(Real X, Real Y) { return Setup.exactCurlVec(X, Y); },
+       ExactCurlVertex, Geom, Mesh, NVertLevels, false);
 
-#ifdef HORZOPERATORS_TEST_PLANE
-   const auto XVertex = createDeviceMirrorCopy(Mesh->XVertexH);
-   const auto YVertex = createDeviceMirrorCopy(Mesh->YVertexH);
-#else
-   const auto XVertex = createDeviceMirrorCopy(Mesh->LonVertexH);
-   const auto YVertex = createDeviceMirrorCopy(Mesh->LatVertexH);
-#endif
-   const auto &AreaTriangle = Mesh->AreaTriangle;
-
-   // Compute element-wise errors
-   Array1DReal LInfVertex("LInfVertex", Mesh->NVerticesOwned);
-   Array1DReal LInfScaleVertex("LInfScaleVertex", Mesh->NVerticesOwned);
-   Array1DReal L2Vertex("L2Vertex", Mesh->NVerticesOwned);
-   Array1DReal L2ScaleVertex("L2ScaleVertex", Mesh->NVerticesOwned);
+   // Compute numerical result
+   Array2DReal NumCurlVertex("NumCurlVertex", Mesh->NVerticesOwned,
+                             NVertLevels);
    CurlOnVertex CurlVertex(Mesh);
    parallelFor(
-       {Mesh->NVerticesOwned}, KOKKOS_LAMBDA(int IVertex) {
-          // Numerical result
-          const Real CurlNum = CurlVertex(IVertex, VecEdge);
-
-          // Exact result
-          const Real X         = XVertex(IVertex);
-          const Real Y         = YVertex(IVertex);
-          const Real CurlExact = Setup.exactCurlVec(X, Y);
-
-          // Errors
-          LInfVertex(IVertex)      = std::abs(CurlNum - CurlExact);
-          LInfScaleVertex(IVertex) = std::abs(CurlExact);
-          L2Vertex(IVertex) =
-              AreaTriangle(IVertex) * LInfVertex(IVertex) * LInfVertex(IVertex);
-          L2ScaleVertex(IVertex) = AreaTriangle(IVertex) *
-                                   LInfScaleVertex(IVertex) *
-                                   LInfScaleVertex(IVertex);
+       {Mesh->NVerticesOwned, NVertLevels}, KOKKOS_LAMBDA(int IVertex, int K) {
+          NumCurlVertex(IVertex, K) = CurlVertex(IVertex, K, VecEdge);
        });
 
-   // Compute global normalized error norms
-   const Real LInfErrorLoc = maxVal(LInfVertex);
-   const Real LInfScaleLoc = maxVal(LInfScaleVertex);
-   const Real L2ErrorLoc   = sum(L2Vertex);
-   const Real L2ScaleLoc   = sum(L2ScaleVertex);
-
-   MPI_Comm Comm = MachEnv::getDefaultEnv()->getComm();
-   Real LInfError, LInfScale;
-   Err =
-       MPI_Allreduce(&LInfErrorLoc, &LInfError, 1, MPI_RealKind, MPI_MAX, Comm);
-   Err =
-       MPI_Allreduce(&LInfScaleLoc, &LInfScale, 1, MPI_RealKind, MPI_MAX, Comm);
-   if (LInfScale > 0) {
-      LInfError /= LInfScale;
-   }
-
-   Real L2Error, L2Scale;
-   Err = MPI_Allreduce(&L2ErrorLoc, &L2Error, 1, MPI_RealKind, MPI_SUM, Comm);
-   Err = MPI_Allreduce(&L2ScaleLoc, &L2Scale, 1, MPI_RealKind, MPI_SUM, Comm);
-   if (L2Scale > 0) {
-      L2Error = std::sqrt(L2Error / L2Scale);
-   } else {
-      L2Error = std::sqrt(L2Error);
-   }
+   // Compute error measures
+   ErrorMeasures CurlErrors;
+   Err += computeErrorsVertex(CurlErrors, NumCurlVertex, ExactCurlVertex, Mesh,
+                              NVertLevels);
 
    // Check error values
-   if (Err == 0 && isApprox(LInfError, Setup.ExpectedCurlErrorLInf, RTol) &&
-       isApprox(L2Error, Setup.ExpectedCurlErrorL2, RTol)) {
-      return 0;
-   } else {
-      return 1;
+   if (!isApprox(CurlErrors.LInf, Setup.ExpectedCurlErrorLInf, RTol)) {
+      Err++;
+      LOG_ERROR("OperatorsTest: Curl LInf FAIL");
    }
+
+   if (!isApprox(CurlErrors.L2, Setup.ExpectedCurlErrorL2, RTol)) {
+      Err++;
+      LOG_ERROR("OperatorsTest: Curl L2 FAIL");
+   }
+
+   if (Err == 0) {
+      LOG_INFO("OperatorsTest: Curl PASS");
+   }
+
+   return Err;
 }
 
 int testRecon(Real RTol) {
-   int Err;
+   int Err = 0;
    TestSetup Setup;
 
-   const auto &Mesh = HorzMesh::getDefault();
+   const auto &Mesh      = HorzMesh::getDefault();
+   const int NVertLevels = 1;
 
    // Prepare operator input
-   Array1DReal VecEdge("VecEdge", Mesh->NEdgesSize);
-
-   computeVecFieldEdge(
+   Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLevels);
+   Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
           VecField[0] = Setup.exactVecX(X, Y);
           VecField[1] = Setup.exactVecY(X, Y);
        },
-       VecEdge, EdgeOrientation::Normal, Mesh);
-
-   // Perform halo exchange
-   auto MyHalo   = Halo::getDefault();
-   auto VecEdgeH = createHostMirrorCopy(VecEdge);
-   MyHalo->exchangeFullArrayHalo(VecEdgeH, OnEdge);
-   deepCopy(VecEdge, VecEdgeH);
+       VecEdge, EdgeComponent::Normal, Geom, Mesh, NVertLevels);
 
    // Compute exact result
-   Array1DReal ExactReconEdge("ExactReconEdge", Mesh->NEdgesOwned);
+   Array2DReal ExactReconEdge("ExactReconEdge", Mesh->NEdgesOwned, NVertLevels);
 
-   computeVecFieldEdge(
+   Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
           VecField[0] = Setup.exactVecX(X, Y);
           VecField[1] = Setup.exactVecY(X, Y);
        },
-       ExactReconEdge, EdgeOrientation::Tangential, Mesh);
+       ExactReconEdge, EdgeComponent::Tangential, Geom, Mesh, NVertLevels,
+       false);
 
-   const auto &DcEdge = Mesh->DcEdge;
-   const auto &DvEdge = Mesh->DvEdge;
-
-   // Compute element-wise errors
-   Array1DReal LInfEdge("LInfEdge", Mesh->NEdgesOwned);
-   Array1DReal LInfScaleEdge("LInfScaleEdge", Mesh->NEdgesOwned);
-   Array1DReal L2Edge("L2Edge", Mesh->NEdgesOwned);
-   Array1DReal L2ScaleEdge("L2ScaleEdge", Mesh->NEdgesOwned);
+   // Compute numerical result
+   Array2DReal NumReconEdge("NumReconEdge", Mesh->NEdgesOwned, NVertLevels);
    TangentialReconOnEdge TanReconEdge(Mesh);
    parallelFor(
-       {Mesh->NEdgesOwned}, KOKKOS_LAMBDA(int IEdge) {
-          // Numerical result
-          const Real VecReconNum = TanReconEdge(IEdge, VecEdge);
-
-          // Exact result
-          const Real VecReconExact = ExactReconEdge(IEdge);
-
-          // Errors
-          LInfEdge(IEdge)      = std::abs(VecReconNum - VecReconExact);
-          LInfScaleEdge(IEdge) = std::abs(VecReconExact);
-          const Real AreaEdge  = DcEdge(IEdge) * DvEdge(IEdge) / 2;
-          L2Edge(IEdge)        = AreaEdge * LInfEdge(IEdge) * LInfEdge(IEdge);
-          L2ScaleEdge(IEdge) =
-              AreaEdge * LInfScaleEdge(IEdge) * LInfScaleEdge(IEdge);
+       {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
+          NumReconEdge(IEdge, K) = TanReconEdge(IEdge, K, VecEdge);
        });
 
-   // Compute global normalized error norms
-   const Real LInfErrorLoc = maxVal(LInfEdge);
-   const Real LInfScaleLoc = maxVal(LInfScaleEdge);
-   const Real L2ErrorLoc   = sum(L2Edge);
-   const Real L2ScaleLoc   = sum(L2ScaleEdge);
+   // Compute error measures
+   ErrorMeasures ReconErrors;
+   Err += computeErrorsEdge(ReconErrors, NumReconEdge, ExactReconEdge, Mesh,
+                            NVertLevels);
 
-   MPI_Comm Comm = MachEnv::getDefaultEnv()->getComm();
-   Real LInfError, LInfScale;
-   Err =
-       MPI_Allreduce(&LInfErrorLoc, &LInfError, 1, MPI_RealKind, MPI_MAX, Comm);
-   Err =
-       MPI_Allreduce(&LInfScaleLoc, &LInfScale, 1, MPI_RealKind, MPI_MAX, Comm);
-   if (LInfScale > 0) {
-      LInfError /= LInfScale;
+   if (!isApprox(ReconErrors.LInf, Setup.ExpectedReconErrorLInf, RTol)) {
+      Err++;
+      LOG_ERROR("OperatorsTest: Recon LInf FAIL");
    }
 
-   Real L2Error, L2Scale;
-   Err = MPI_Allreduce(&L2ErrorLoc, &L2Error, 1, MPI_RealKind, MPI_SUM, Comm);
-   Err = MPI_Allreduce(&L2ScaleLoc, &L2Scale, 1, MPI_RealKind, MPI_SUM, Comm);
-   if (L2Scale > 0) {
-      L2Error = std::sqrt(L2Error / L2Scale);
-   } else {
-      L2Error = std::sqrt(L2Error);
+   if (!isApprox(ReconErrors.L2, Setup.ExpectedReconErrorL2, RTol)) {
+      Err++;
+      LOG_ERROR("OperatorsTest: Recon L2 FAIL");
    }
 
-   // Check error values
-   if (Err == 0 && isApprox(LInfError, Setup.ExpectedReconErrorLInf, RTol) &&
-       isApprox(L2Error, Setup.ExpectedReconErrorL2, RTol)) {
-      return 0;
-   } else {
-      return 1;
+   if (Err == 0) {
+      LOG_INFO("OperatorsTest: Recon PASS");
    }
+
+   return Err;
 }
 
 //------------------------------------------------------------------------------
 // The initialization routine for Operators testing
-int initOperatorsTest(int argc, char *argv[]) {
-
-   MPI_Init(&argc, &argv);
-   Kokkos::initialize(argc, argv);
-
+int initOperatorsTest(const std::string &MeshFile) {
    int Err = 0;
 
    MachEnv::init(MPI_COMM_WORLD);
    MachEnv *DefEnv  = MachEnv::getDefaultEnv();
    MPI_Comm DefComm = DefEnv->getComm();
 
-   Err = IO::init(DefComm);
-   if (Err != 0) {
+   int IOErr = IO::init(DefComm);
+   if (IOErr != 0) {
+      Err++;
       LOG_ERROR("OperatorsTest: error initializing parallel IO");
    }
 
-#ifdef HORZOPERATORS_TEST_PLANE
-   Err = Decomp::init("OmegaPlanarMesh.nc");
-#else
-   Err = Decomp::init("OmegaSphereMesh.nc");
-#endif
-   if (Err != 0) {
+   int DecompErr = Decomp::init(MeshFile);
+   if (DecompErr != 0) {
+      Err++;
       LOG_ERROR("OperatorsTest: error initializing default decomposition");
    }
 
-   Err = Halo::init();
-   if (Err != 0) {
+   int HaloErr = Halo::init();
+   if (HaloErr != 0) {
+      Err++;
       LOG_ERROR("OperatorsTest: error initializing default halo");
    }
 
-   Err = HorzMesh::init();
-   if (Err != 0) {
+   int MeshErr = HorzMesh::init();
+   if (MeshErr != 0) {
+      Err++;
       LOG_ERROR("OperatorsTest: error initializing default mesh");
    }
 
@@ -745,54 +427,34 @@ void finalizeOperatorsTest() {
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();
-   Kokkos::finalize();
-   MPI_Finalize();
 }
 
-int main(int argc, char *argv[]) {
-   int Err = initOperatorsTest(argc, argv);
+void operatorsTest(const std::string &MeshFile = DefaultMeshFile) {
+   int Err = initOperatorsTest(MeshFile);
    if (Err != 0) {
       LOG_CRITICAL("OperatorsTest: Error initializing");
    }
 
    const Real RTol = sizeof(Real) == 4 ? 1e-2 : 1e-10;
 
-   int DivErr = testDivergence(RTol);
-   if (DivErr == 0) {
-      LOG_INFO("OperatorsTest: Divergence PASS");
-   } else {
-      Err = DivErr;
-      LOG_INFO("OperatorsTest: Divergence FAIL");
-   }
-
-   int GradErr = testGradient(RTol);
-   if (GradErr == 0) {
-      LOG_INFO("OperatorsTest: Gradient PASS");
-   } else {
-      Err = GradErr;
-      LOG_INFO("OperatorsTest: Gradient FAIL");
-   }
-
-   int CurlErr = testCurl(RTol);
-   if (CurlErr == 0) {
-      LOG_INFO("OperatorsTest: Curl PASS");
-   } else {
-      Err = CurlErr;
-      LOG_INFO("OperatorsTest: Curl FAIL");
-   }
-
-   int ReconErr = testRecon(RTol);
-   if (Err == 0) {
-      LOG_INFO("OperatorsTest: Recon PASS");
-   } else {
-      Err = ReconErr;
-      LOG_INFO("OperatorsTest: Recon FAIL");
-   }
+   Err += testDivergence(RTol);
+   Err += testGradient(RTol);
+   Err += testCurl(RTol);
+   Err += testRecon(RTol);
 
    if (Err == 0) {
       LOG_INFO("OperatorsTest: Successful completion");
    }
-
    finalizeOperatorsTest();
+}
+
+int main(int argc, char *argv[]) {
+   MPI_Init(&argc, &argv);
+   Kokkos::initialize(argc, argv);
+
+   operatorsTest();
+
+   Kokkos::finalize();
+   MPI_Finalize();
 } // end of main
 //===-----------------------------------------------------------------------===/

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -14,8 +14,6 @@
 
 using namespace OMEGA;
 
-static_assert(VecLength == 1, "HorzOperatorsTest needs vector length to be 1");
-
 // analytical expressions for scalar and vector fields used as input for
 // operator tests together with exact values of operators for computing errors
 // and expected error values
@@ -174,7 +172,7 @@ int testDivergence(Real RTol) {
    TestSetup Setup;
 
    const auto &Mesh      = HorzMesh::getDefault();
-   const int NVertLevels = 1;
+   const int NVertLevels = 16;
 
    // Prepare operator input
    Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLevels);
@@ -227,7 +225,7 @@ int testGradient(Real RTol) {
    TestSetup Setup;
 
    const auto &Mesh      = HorzMesh::getDefault();
-   const int NVertLevels = 1;
+   const int NVertLevels = 16;
 
    // Prepare operator input
    Array2DReal ScalarCell("ScalarCell", Mesh->NCellsSize, NVertLevels);
@@ -281,7 +279,7 @@ int testCurl(Real RTol) {
    int Err = 0;
    TestSetup Setup;
    const auto &Mesh      = HorzMesh::getDefault();
-   const int NVertLevels = 1;
+   const int NVertLevels = 16;
 
    // Prepare operator input
    Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLevels);
@@ -336,7 +334,7 @@ int testRecon(Real RTol) {
    TestSetup Setup;
 
    const auto &Mesh      = HorzMesh::getDefault();
-   const int NVertLevels = 1;
+   const int NVertLevels = 16;
 
    // Prepare operator input
    Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLevels);

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -14,6 +14,8 @@
 
 using namespace OMEGA;
 
+static_assert(VecLength == 1, "HorzOperatorsTest needs vector length to be 1");
+
 // analytical expressions for scalar and vector fields used as input for
 // operator tests together with exact values of operators for computing errors
 // and expected error values
@@ -194,7 +196,7 @@ int testDivergence(Real RTol) {
    DivergenceOnCell DivergenceCell(Mesh);
    parallelFor(
        {Mesh->NCellsOwned, NVertLevels}, KOKKOS_LAMBDA(int ICell, int K) {
-          NumDivCell(ICell, K) = DivergenceCell(ICell, K, VecEdge);
+          DivergenceCell(NumDivCell, ICell, K, VecEdge);
        });
 
    // Compute error measures
@@ -249,7 +251,7 @@ int testGradient(Real RTol) {
    Array2DReal NumGradEdge("NumGradEdge", Mesh->NEdgesOwned, NVertLevels);
    parallelFor(
        {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
-          NumGradEdge(IEdge, K) = GradientEdge(IEdge, K, ScalarCell);
+          GradientEdge(NumGradEdge, IEdge, K, ScalarCell);
        });
 
    // Compute error measures
@@ -303,7 +305,7 @@ int testCurl(Real RTol) {
    CurlOnVertex CurlVertex(Mesh);
    parallelFor(
        {Mesh->NVerticesOwned, NVertLevels}, KOKKOS_LAMBDA(int IVertex, int K) {
-          NumCurlVertex(IVertex, K) = CurlVertex(IVertex, K, VecEdge);
+          CurlVertex(NumCurlVertex, IVertex, K, VecEdge);
        });
 
    // Compute error measures
@@ -361,7 +363,7 @@ int testRecon(Real RTol) {
    TangentialReconOnEdge TanReconEdge(Mesh);
    parallelFor(
        {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
-          NumReconEdge(IEdge, K) = TanReconEdge(IEdge, K, VecEdge);
+          TanReconEdge(NumReconEdge, IEdge, K, VecEdge);
        });
 
    // Compute error measures

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -199,8 +199,8 @@ int testDivergence(Real RTol) {
 
    // Compute error measures
    ErrorMeasures DivErrors;
-   Err += computeErrorsCell(DivErrors, NumDivCell, ExactDivCell, Mesh,
-                            NVertLevels);
+   Err += computeErrors(DivErrors, NumDivCell, ExactDivCell, Mesh, OnCell,
+                        NVertLevels);
 
    // Check error values
    if (!isApprox(DivErrors.LInf, Setup.ExpectedDivErrorLInf, RTol)) {
@@ -254,8 +254,8 @@ int testGradient(Real RTol) {
 
    // Compute error measures
    ErrorMeasures GradErrors;
-   Err += computeErrorsEdge(GradErrors, NumGradEdge, ExactGradEdge, Mesh,
-                            NVertLevels);
+   Err += computeErrors(GradErrors, NumGradEdge, ExactGradEdge, Mesh, OnEdge,
+                        NVertLevels);
 
    // Check error values
    if (!isApprox(GradErrors.LInf, Setup.ExpectedGradErrorLInf, RTol)) {
@@ -308,8 +308,8 @@ int testCurl(Real RTol) {
 
    // Compute error measures
    ErrorMeasures CurlErrors;
-   Err += computeErrorsVertex(CurlErrors, NumCurlVertex, ExactCurlVertex, Mesh,
-                              NVertLevels);
+   Err += computeErrors(CurlErrors, NumCurlVertex, ExactCurlVertex, Mesh,
+                        OnVertex, NVertLevels);
 
    // Check error values
    if (!isApprox(CurlErrors.LInf, Setup.ExpectedCurlErrorLInf, RTol)) {
@@ -366,8 +366,8 @@ int testRecon(Real RTol) {
 
    // Compute error measures
    ErrorMeasures ReconErrors;
-   Err += computeErrorsEdge(ReconErrors, NumReconEdge, ExactReconEdge, Mesh,
-                            NVertLevels);
+   Err += computeErrors(ReconErrors, NumReconEdge, ExactReconEdge, Mesh, OnEdge,
+                        NVertLevels);
 
    if (!isApprox(ReconErrors.LInf, Setup.ExpectedReconErrorLInf, RTol)) {
       Err++;

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -185,9 +185,9 @@ int testDivergence(Real RTol) {
 
    // Compute exact result
    Array2DReal ExactDivCell("ExactDivCell", Mesh->NCellsOwned, NVertLevels);
-   Err += setScalarCell(
+   Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.exactDivVec(X, Y); },
-       ExactDivCell, Geom, Mesh, NVertLevels, false);
+       ExactDivCell, Geom, Mesh, OnCell, NVertLevels, false);
 
    // Compute numerical result
    Array2DReal NumDivCell("NumDivCell", Mesh->NCellsOwned, NVertLevels);
@@ -229,11 +229,11 @@ int testGradient(Real RTol) {
 
    // Prepare operator input
    Array2DReal ScalarCell("ScalarCell", Mesh->NCellsSize, NVertLevels);
-   Err += setScalarCell(
+   Err += setScalar(
        KOKKOS_LAMBDA(Real Coord1, Real Coord2) {
           return Setup.exactScalar(Coord1, Coord2);
        },
-       ScalarCell, Geom, Mesh, NVertLevels);
+       ScalarCell, Geom, Mesh, OnCell, NVertLevels);
 
    // Compute exact result
    Array2DReal ExactGradEdge("ExactGradEdge", Mesh->NEdgesOwned, NVertLevels);
@@ -293,9 +293,9 @@ int testCurl(Real RTol) {
    // Compute exact result
    Array2DReal ExactCurlVertex("ExactCurlVertex", Mesh->NVerticesOwned,
                                NVertLevels);
-   Err += setScalarVertex(
+   Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.exactCurlVec(X, Y); },
-       ExactCurlVertex, Geom, Mesh, NVertLevels, false);
+       ExactCurlVertex, Geom, Mesh, OnVertex, NVertLevels, false);
 
    // Compute numerical result
    Array2DReal NumCurlVertex("NumCurlVertex", Mesh->NVerticesOwned,

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -1,0 +1,536 @@
+#ifndef OMEGA_OCEAN_TEST_COMMON_H
+#define OMEGA_OCEAN_TEST_COMMON_H
+
+#include "DataTypes.h"
+#include "Decomp.h"
+#include "Halo.h"
+#include "HorzMesh.h"
+#include "IO.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "OmegaKokkos.h"
+
+namespace OMEGA {
+
+// check if two real numbers are equal with a given relative tolerance
+inline bool isApprox(Real X, Real Y, Real RTol) {
+   return std::abs(X - Y) <= RTol * std::max(std::abs(X), std::abs(Y));
+}
+
+// convert spherical components of a vector to Cartesian
+KOKKOS_INLINE_FUNCTION void sphereToCartVec(Real (&CartVec)[3],
+                                            const Real (&SphereVec)[2],
+                                            Real Lon, Real Lat) {
+   using std::cos;
+   using std::sin;
+   CartVec[0] = -sin(Lon) * SphereVec[0] - sin(Lat) * cos(Lon) * SphereVec[1];
+   CartVec[1] = cos(Lon) * SphereVec[0] - sin(Lat) * sin(Lon) * SphereVec[1];
+   CartVec[2] = cos(Lat) * SphereVec[1];
+}
+
+// returns Cartesian components of unit vector tangent to the spherical arc
+// between Cartesian points X1 and X2 parametrized with t
+KOKKOS_INLINE_FUNCTION void tangentVector(Real (&TanVec)[3],
+                                          const Real (&X1)[3],
+                                          const Real (&X2)[3], Real t = 0) {
+   const Real Radius =
+       Kokkos::sqrt(X1[0] * X1[0] + X1[1] * X1[1] + X1[2] * X1[2]);
+   Real XC[3];
+   Real DX[3];
+   for (int Dim = 0; Dim < 3; ++Dim) {
+      XC[Dim] = (1 - t) * X1[Dim] + t * X2[Dim];
+      DX[Dim] = X2[Dim] - X1[Dim];
+   }
+   const Real XCDotDX = XC[0] * DX[0] + XC[1] * DX[1] + XC[2] * DX[2];
+   const Real NormXC =
+       Kokkos::sqrt(XC[0] * XC[0] + XC[1] * XC[1] + XC[2] * XC[2]);
+
+   for (int Dim = 0; Dim < 3; ++Dim) {
+      const Real NormXC3 = NormXC * NormXC * NormXC;
+      TanVec[Dim] =
+          Radius / NormXC * DX[Dim] - (Radius * XCDotDX) / NormXC3 * XC[Dim];
+   }
+
+   const Real NormTanVec = Kokkos::sqrt(
+       TanVec[0] * TanVec[0] + TanVec[1] * TanVec[1] + TanVec[2] * TanVec[2]);
+   for (int Dim = 0; Dim < 3; ++Dim) {
+      TanVec[Dim] /= NormTanVec;
+   }
+}
+
+enum class EdgeComponent { Normal, Tangential };
+enum class Geometry { Planar, Spherical };
+
+// set scalar field on cells based on analytical formula and optionally
+// exchange halos
+template <class Functor>
+int setScalarCell(const Functor &Fun, const Array2DReal &ScalarCell,
+                  Geometry Geom, const HorzMesh *Mesh, int NVertLevels,
+                  bool ExchangeHalos = true) {
+   int Err = 0;
+
+   auto XCell = createDeviceMirrorCopy(Mesh->XCellH);
+   auto YCell = createDeviceMirrorCopy(Mesh->YCellH);
+
+   auto LonCell = createDeviceMirrorCopy(Mesh->LonCellH);
+   auto LatCell = createDeviceMirrorCopy(Mesh->LatCellH);
+
+   parallelFor(
+       {Mesh->NCellsOwned, NVertLevels}, KOKKOS_LAMBDA(int ICell, int K) {
+          if (Geom == Geometry::Planar) {
+             const Real X         = XCell(ICell);
+             const Real Y         = YCell(ICell);
+             ScalarCell(ICell, K) = Fun(X, Y);
+          } else {
+             const Real Lon       = LonCell(ICell);
+             const Real Lat       = LatCell(ICell);
+             ScalarCell(ICell, K) = Fun(Lon, Lat);
+          }
+       });
+
+   if (ExchangeHalos) {
+      auto MyHalo      = Halo::getDefault();
+      auto ScalarCellH = createHostMirrorCopy(ScalarCell);
+      Err              = MyHalo->exchangeFullArrayHalo(ScalarCellH, OnCell);
+      if (Err != 0)
+         LOG_ERROR("setScalarCell: error in halo exchange");
+      deepCopy(ScalarCell, ScalarCellH);
+   }
+   return Err;
+}
+
+// set scalar field on vertices based on analytical formula and optionally
+// exchange halos
+template <class Functor>
+int setScalarVertex(const Functor &Fun, const Array2DReal &ScalarVertex,
+                    Geometry Geom, const HorzMesh *Mesh, int NVertLevels,
+                    bool ExchangeHalos = true) {
+
+   int Err = 0;
+
+   auto XVertex = createDeviceMirrorCopy(Mesh->XVertexH);
+   auto YVertex = createDeviceMirrorCopy(Mesh->YVertexH);
+
+   auto LonVertex = createDeviceMirrorCopy(Mesh->LonVertexH);
+   auto LatVertex = createDeviceMirrorCopy(Mesh->LatVertexH);
+
+   parallelFor(
+       {Mesh->NVerticesOwned, NVertLevels}, KOKKOS_LAMBDA(int IVertex, int K) {
+          if (Geom == Geometry::Planar) {
+             const Real X             = XVertex(IVertex);
+             const Real Y             = YVertex(IVertex);
+             ScalarVertex(IVertex, K) = Fun(X, Y);
+          } else {
+             const Real Lon           = LonVertex(IVertex);
+             const Real Lat           = LatVertex(IVertex);
+             ScalarVertex(IVertex, K) = Fun(Lon, Lat);
+          }
+       });
+
+   if (ExchangeHalos) {
+      auto MyHalo        = Halo::getDefault();
+      auto ScalarVertexH = createHostMirrorCopy(ScalarVertex);
+      Err = MyHalo->exchangeFullArrayHalo(ScalarVertexH, OnVertex);
+      if (Err != 0)
+         LOG_ERROR("setScalarVertex: error in halo exchange");
+      deepCopy(ScalarVertex, ScalarVertexH);
+   }
+   return Err;
+}
+
+// set scalar field on edges based on analytical formula and optionally
+// exchange halos
+template <class Functor>
+int setScalarEdge(const Functor &Fun, const Array2DReal &ScalarFieldEdge,
+                  Geometry Geom, const HorzMesh *Mesh, int NVertLevels,
+                  bool ExchangeHalos = true) {
+
+   int Err = 0;
+
+   auto XEdge = createDeviceMirrorCopy(Mesh->XEdgeH);
+   auto YEdge = createDeviceMirrorCopy(Mesh->YEdgeH);
+
+   auto LonEdge = createDeviceMirrorCopy(Mesh->LonEdgeH);
+   auto LatEdge = createDeviceMirrorCopy(Mesh->LatEdgeH);
+
+   parallelFor(
+       {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
+          Real VecFieldEdge;
+          if (Geom == Geometry::Planar) {
+             const Real XE = XEdge(IEdge);
+             const Real YE = YEdge(IEdge);
+
+             ScalarFieldEdge(IEdge, K) = Fun(XE, YE);
+          } else {
+             const Real LonE = LonEdge(IEdge);
+             const Real LatE = LatEdge(IEdge);
+
+             ScalarFieldEdge(IEdge, K) = Fun(LonE, LatE);
+          }
+       });
+
+   if (ExchangeHalos) {
+      auto MyHalo           = Halo::getDefault();
+      auto ScalarFieldEdgeH = createHostMirrorCopy(ScalarFieldEdge);
+      Err = MyHalo->exchangeFullArrayHalo(ScalarFieldEdgeH, OnEdge);
+      if (Err != 0)
+         LOG_ERROR("setScalarEdge: error in halo exchange");
+      deepCopy(ScalarFieldEdge, ScalarFieldEdgeH);
+   }
+
+   return Err;
+}
+
+// set vector field on edges based on analytical formula and optionally
+// exchange halos
+template <class Functor>
+int setVectorEdge(const Functor &Fun, const Array2DReal &VectorFieldEdge,
+                  EdgeComponent EdgeComp, Geometry Geom, const HorzMesh *Mesh,
+                  int NVertLevels, bool ExchangeHalos = true) {
+
+   int Err = 0;
+
+   auto XEdge = createDeviceMirrorCopy(Mesh->XEdgeH);
+   auto YEdge = createDeviceMirrorCopy(Mesh->YEdgeH);
+   auto ZEdge = createDeviceMirrorCopy(Mesh->ZEdgeH);
+
+   auto XCell = createDeviceMirrorCopy(Mesh->XCellH);
+   auto YCell = createDeviceMirrorCopy(Mesh->YCellH);
+   auto ZCell = createDeviceMirrorCopy(Mesh->ZCellH);
+
+   auto XVertex = createDeviceMirrorCopy(Mesh->XVertexH);
+   auto YVertex = createDeviceMirrorCopy(Mesh->YVertexH);
+   auto ZVertex = createDeviceMirrorCopy(Mesh->ZVertexH);
+
+   auto LonEdge = createDeviceMirrorCopy(Mesh->LonEdgeH);
+   auto LatEdge = createDeviceMirrorCopy(Mesh->LatEdgeH);
+
+   auto &AngleEdge      = Mesh->AngleEdge;
+   auto &CellsOnEdge    = Mesh->CellsOnEdge;
+   auto &VerticesOnEdge = Mesh->VerticesOnEdge;
+
+   parallelFor(
+       {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
+          Real VecFieldEdge;
+          if (Geom == Geometry::Planar) {
+             const Real XE = XEdge(IEdge);
+             const Real YE = YEdge(IEdge);
+
+             Real VecField[2];
+             Fun(VecField, XE, YE);
+
+             if (EdgeComp == EdgeComponent::Normal) {
+                const Real EdgeNormalX = std::cos(AngleEdge(IEdge));
+                const Real EdgeNormalY = std::sin(AngleEdge(IEdge));
+                VecFieldEdge =
+                    EdgeNormalX * VecField[0] + EdgeNormalY * VecField[1];
+             }
+
+             if (EdgeComp == EdgeComponent::Tangential) {
+                const Real EdgeTangentX = -std::sin(AngleEdge(IEdge));
+                const Real EdgeTangentY = std::cos(AngleEdge(IEdge));
+                VecFieldEdge =
+                    EdgeTangentX * VecField[0] + EdgeTangentY * VecField[1];
+             }
+          } else {
+             const Real LonE = LonEdge(IEdge);
+             const Real LatE = LatEdge(IEdge);
+
+             Real VecField[2];
+             Fun(VecField, LonE, LatE);
+
+             bool UseCartesianProjection = true;
+
+             if (UseCartesianProjection) {
+                Real VecFieldCart[3];
+                sphereToCartVec(VecFieldCart, VecField, LonE, LatE);
+
+                const Real EdgeCoords[3] = {XEdge[IEdge], YEdge[IEdge],
+                                            ZEdge[IEdge]};
+
+                if (EdgeComp == EdgeComponent::Normal) {
+                   const int JCell1         = CellsOnEdge(IEdge, 1);
+                   const Real CellCoords[3] = {XCell(JCell1), YCell(JCell1),
+                                               ZCell(JCell1)};
+
+                   Real EdgeNormal[3];
+                   tangentVector(EdgeNormal, EdgeCoords, CellCoords);
+                   VecFieldEdge = EdgeNormal[0] * VecFieldCart[0] +
+                                  EdgeNormal[1] * VecFieldCart[1] +
+                                  EdgeNormal[2] * VecFieldCart[2];
+                }
+
+                if (EdgeComp == EdgeComponent::Tangential) {
+                   const int JVertex1         = VerticesOnEdge(IEdge, 1);
+                   const Real VertexCoords[3] = {
+                       XVertex(JVertex1), YVertex(JVertex1), ZVertex(JVertex1)};
+
+                   Real EdgeTangent[3];
+                   tangentVector(EdgeTangent, EdgeCoords, VertexCoords);
+                   VecFieldEdge = EdgeTangent[0] * VecFieldCart[0] +
+                                  EdgeTangent[1] * VecFieldCart[1] +
+                                  EdgeTangent[2] * VecFieldCart[2];
+                }
+             } else {
+                if (EdgeComp == EdgeComponent::Normal) {
+                   const Real EdgeNormalX = std::cos(AngleEdge(IEdge));
+                   const Real EdgeNormalY = std::sin(AngleEdge(IEdge));
+                   VecFieldEdge =
+                       EdgeNormalX * VecField[0] + EdgeNormalY * VecField[1];
+                }
+
+                if (EdgeComp == EdgeComponent::Tangential) {
+                   const Real EdgeTangentX = -std::sin(AngleEdge(IEdge));
+                   const Real EdgeTangentY = std::cos(AngleEdge(IEdge));
+                   VecFieldEdge =
+                       EdgeTangentX * VecField[0] + EdgeTangentY * VecField[1];
+                }
+             }
+          }
+          VectorFieldEdge(IEdge, K) = VecFieldEdge;
+       });
+
+   if (ExchangeHalos) {
+      auto MyHalo           = Halo::getDefault();
+      auto VectorFieldEdgeH = createHostMirrorCopy(VectorFieldEdge);
+      Err = MyHalo->exchangeFullArrayHalo(VectorFieldEdgeH, OnEdge);
+      if (Err != 0)
+         LOG_ERROR("setVectorEdge: error in halo exchange");
+      deepCopy(VectorFieldEdge, VectorFieldEdgeH);
+   }
+   return Err;
+}
+
+inline Real maxVal(const Array2DReal &Arr) {
+   Real MaxVal;
+
+   parallelReduce(
+       {Arr.extent_int(0), Arr.extent_int(1)},
+       KOKKOS_LAMBDA(int I, int J, Real &Accum) {
+          Accum = Kokkos::max(Arr(I, J), Accum);
+       },
+       Kokkos::Max<Real>(MaxVal));
+
+   return MaxVal;
+}
+
+inline Real sum(const Array2DReal &Arr) {
+   Real Sum;
+
+   parallelReduce(
+       {Arr.extent_int(0), Arr.extent_int(1)},
+       KOKKOS_LAMBDA(int I, int J, Real &Accum) { Accum += Arr(I, J); }, Sum);
+
+   return Sum;
+}
+
+struct ErrorMeasures {
+   Real LInf;
+   Real L2;
+};
+
+// compute global normalized error measures based on the difference
+// between two cell fields
+inline int computeErrorsCell(ErrorMeasures &ErrorMeasures,
+                             const Array2DReal &NumFieldCell,
+                             const Array2DReal &ExactFieldCell,
+                             const HorzMesh *Mesh, int NVertLevels) {
+
+   int Err = 0;
+
+   auto &AreaCell = Mesh->AreaCell;
+
+   // Compute element-wise errors
+   Array2DReal LInfCell("LInfCell", Mesh->NCellsOwned, NVertLevels);
+   Array2DReal L2Cell("L2Cell", Mesh->NCellsOwned, NVertLevels);
+
+   Array2DReal LInfScaleCell("LInfScaleCell", Mesh->NCellsOwned, NVertLevels);
+   Array2DReal L2ScaleCell("L2ScaleCell", Mesh->NCellsOwned, NVertLevels);
+
+   parallelFor(
+       {Mesh->NCellsOwned, NVertLevels}, KOKKOS_LAMBDA(int ICell, int K) {
+          const Real NumValCell   = NumFieldCell(ICell, K);
+          const Real ExactValCell = ExactFieldCell(ICell, K);
+
+          // Errors
+          LInfCell(ICell, K)      = std::abs(NumValCell - ExactValCell);
+          LInfScaleCell(ICell, K) = std::abs(ExactValCell);
+          L2Cell(ICell, K) =
+              AreaCell(ICell) * LInfCell(ICell, K) * LInfCell(ICell, K);
+          L2ScaleCell(ICell, K) = AreaCell(ICell) * LInfScaleCell(ICell, K) *
+                                  LInfScaleCell(ICell, K);
+       });
+
+   // Compute global normalized error norms
+   const Real LInfErrorLoc = maxVal(LInfCell);
+   const Real L2ErrorLoc   = sum(L2Cell);
+   const Real LInfScaleLoc = maxVal(LInfScaleCell);
+   const Real L2ScaleLoc   = sum(L2ScaleCell);
+
+   MPI_Comm Comm = MachEnv::getDefaultEnv()->getComm();
+   Real LInfError, LInfScale;
+   Err +=
+       MPI_Allreduce(&LInfErrorLoc, &LInfError, 1, MPI_RealKind, MPI_MAX, Comm);
+   Err +=
+       MPI_Allreduce(&LInfScaleLoc, &LInfScale, 1, MPI_RealKind, MPI_MAX, Comm);
+   if (LInfScale > 0) {
+      LInfError /= LInfScale;
+   }
+
+   Real L2Error, L2Scale;
+   Err += MPI_Allreduce(&L2ErrorLoc, &L2Error, 1, MPI_RealKind, MPI_SUM, Comm);
+   Err += MPI_Allreduce(&L2ScaleLoc, &L2Scale, 1, MPI_RealKind, MPI_SUM, Comm);
+
+   if (Err != 0)
+      LOG_ERROR("computeErrorsCell: MPI Allreduce error");
+
+   if (L2Scale > 0) {
+      L2Error = std::sqrt(L2Error / L2Scale);
+   } else {
+      L2Error = std::sqrt(L2Error);
+   }
+
+   ErrorMeasures.L2   = L2Error;
+   ErrorMeasures.LInf = LInfError;
+
+   return Err;
+}
+
+// compute global normalized error measures based on the difference
+// between two vertex fields
+inline int computeErrorsVertex(ErrorMeasures &ErrorMeasures,
+                               const Array2DReal &NumFieldVertex,
+                               const Array2DReal &ExactFieldVertex,
+                               const HorzMesh *Mesh, int NVertLevels) {
+
+   int Err = 0;
+
+   const auto &AreaTriangle = Mesh->AreaTriangle;
+
+   // Compute element-wise errors
+   Array2DReal LInfVertex("LInfVertex", Mesh->NVerticesOwned, NVertLevels);
+   Array2DReal LInfScaleVertex("LInfScaleVertex", Mesh->NVerticesOwned,
+                               NVertLevels);
+   Array2DReal L2Vertex("L2Vertex", Mesh->NVerticesOwned, NVertLevels);
+   Array2DReal L2ScaleVertex("L2ScaleVertex", Mesh->NVerticesOwned,
+                             NVertLevels);
+   parallelFor(
+       {Mesh->NVerticesOwned, NVertLevels}, KOKKOS_LAMBDA(int IVertex, int K) {
+          const Real NumValVertex   = NumFieldVertex(IVertex, K);
+          const Real ExactValVertex = ExactFieldVertex(IVertex, K);
+
+          // Errors
+          LInfVertex(IVertex, K)      = std::abs(NumValVertex - ExactValVertex);
+          LInfScaleVertex(IVertex, K) = std::abs(ExactValVertex);
+          L2Vertex(IVertex, K)        = AreaTriangle(IVertex) *
+                                 LInfVertex(IVertex, K) *
+                                 LInfVertex(IVertex, K);
+          L2ScaleVertex(IVertex, K) = AreaTriangle(IVertex) *
+                                      LInfScaleVertex(IVertex, K) *
+                                      LInfScaleVertex(IVertex, K);
+       });
+
+   // Compute global normalized error norms
+   const Real LInfErrorLoc = maxVal(LInfVertex);
+   const Real LInfScaleLoc = maxVal(LInfScaleVertex);
+   const Real L2ErrorLoc   = sum(L2Vertex);
+   const Real L2ScaleLoc   = sum(L2ScaleVertex);
+
+   MPI_Comm Comm = MachEnv::getDefaultEnv()->getComm();
+   Real LInfError, LInfScale;
+   Err +=
+       MPI_Allreduce(&LInfErrorLoc, &LInfError, 1, MPI_RealKind, MPI_MAX, Comm);
+   Err +=
+       MPI_Allreduce(&LInfScaleLoc, &LInfScale, 1, MPI_RealKind, MPI_MAX, Comm);
+   if (LInfScale > 0) {
+      LInfError /= LInfScale;
+   }
+
+   Real L2Error, L2Scale;
+   Err += MPI_Allreduce(&L2ErrorLoc, &L2Error, 1, MPI_RealKind, MPI_SUM, Comm);
+   Err += MPI_Allreduce(&L2ScaleLoc, &L2Scale, 1, MPI_RealKind, MPI_SUM, Comm);
+
+   if (Err != 0)
+      LOG_ERROR("computeErrorsCell: MPI Allreduce error");
+
+   if (L2Scale > 0) {
+      L2Error = std::sqrt(L2Error / L2Scale);
+   } else {
+      L2Error = std::sqrt(L2Error);
+   }
+
+   ErrorMeasures.LInf = LInfError;
+   ErrorMeasures.L2   = L2Error;
+
+   return Err;
+}
+
+// compute global normalized error measures based on the difference
+// between two edge fields
+inline int computeErrorsEdge(ErrorMeasures &ErrMeasures,
+                             const Array2DReal &FieldEdge,
+                             const Array2DReal &ExactFieldEdge,
+                             const HorzMesh *Mesh, int NVertLevels) {
+
+   int Err = 0;
+
+   const auto &DcEdge = Mesh->DcEdge;
+   const auto &DvEdge = Mesh->DvEdge;
+
+   // Compute element-wise errors
+   Array2DReal LInfEdge("LInfEdge", Mesh->NEdgesOwned, NVertLevels);
+   Array2DReal L2Edge("L2Edge", Mesh->NEdgesOwned, NVertLevels);
+   Array2DReal LInfScaleEdge("LInfScaleEdge", Mesh->NEdgesOwned, NVertLevels);
+   Array2DReal L2ScaleEdge("L2ScaleEdge", Mesh->NEdgesOwned, NVertLevels);
+
+   parallelFor(
+       {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
+          const Real NumValEdge   = FieldEdge(IEdge, K);
+          const Real ExactValEdge = ExactFieldEdge(IEdge, K);
+
+          LInfEdge(IEdge, K)      = std::abs(NumValEdge - ExactValEdge);
+          LInfScaleEdge(IEdge, K) = std::abs(ExactValEdge);
+          const Real AreaEdge     = DcEdge(IEdge) * DvEdge(IEdge) / 2;
+          L2Edge(IEdge, K) = AreaEdge * LInfEdge(IEdge, K) * LInfEdge(IEdge, K);
+          L2ScaleEdge(IEdge, K) =
+              AreaEdge * LInfScaleEdge(IEdge, K) * LInfScaleEdge(IEdge, K);
+       });
+
+   // Compute global normalized error norms
+   const Real LInfErrorLoc = maxVal(LInfEdge);
+   const Real LInfScaleLoc = maxVal(LInfScaleEdge);
+   const Real L2ErrorLoc   = sum(L2Edge);
+   const Real L2ScaleLoc   = sum(L2ScaleEdge);
+
+   MPI_Comm Comm = MachEnv::getDefaultEnv()->getComm();
+
+   Real LInfError, LInfScale;
+   Err +=
+       MPI_Allreduce(&LInfErrorLoc, &LInfError, 1, MPI_RealKind, MPI_MAX, Comm);
+   Err +=
+       MPI_Allreduce(&LInfScaleLoc, &LInfScale, 1, MPI_RealKind, MPI_MAX, Comm);
+
+   Real L2Error, L2Scale;
+   Err += MPI_Allreduce(&L2ErrorLoc, &L2Error, 1, MPI_RealKind, MPI_SUM, Comm);
+   Err += MPI_Allreduce(&L2ScaleLoc, &L2Scale, 1, MPI_RealKind, MPI_SUM, Comm);
+
+   if (Err != 0)
+      LOG_ERROR("computeErrorsCell: MPI Allreduce error");
+
+   if (LInfScale > 0) {
+      LInfError /= LInfScale;
+   }
+
+   if (L2Scale > 0) {
+      L2Error = std::sqrt(L2Error / L2Scale);
+   } else {
+      L2Error = std::sqrt(L2Error);
+   }
+
+   ErrMeasures.L2   = L2Error;
+   ErrMeasures.LInf = LInfError;
+   return Err;
+}
+
+} // namespace OMEGA
+#endif

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -301,6 +301,7 @@ inline int computeErrors(ErrorMeasures &ErrorMeasures,
       {
          auto &DcEdge = Mesh->DcEdge;
          auto &DvEdge = Mesh->DvEdge;
+         AreaElement  = Array1DReal("AreaEdge", Mesh->NEdgesOwned);
          parallelFor(
              {Mesh->NEdgesOwned}, KOKKOS_LAMBDA(int IEdge) {
                 AreaElement(IEdge) = DcEdge(IEdge) * DvEdge(IEdge) / 2;


### PR DESCRIPTION
This PR:
- Isolates some common functionality for tests that rely on setting up idealized inputs and computation of error norms into a header `OceanTestCommon.h`.
- Refactors the operator classes to be more similar to the proposed approach for the tendency terms in order to allow using this common code for the current and future tests.
- Uses the helpers in the existing operators tests.

* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


