### PR TITLE
Separates dimension metadata within omega metadata classes

### DIFF
--- a/components/omega/doc/userGuide/MetaData.md
+++ b/components/omega/doc/userGuide/MetaData.md
@@ -1,111 +1,25 @@
 (omega-user-metadata)=
 
-# Metadata
+## Metadata
 
-### Introduction to Metadata in Omega
-- **Purpose**: Enhances Omega and E3SM data file management for streamlined analysis, archiving, and provenance.
+Metadata are additional data that are included in Omega input or output files
+to create a self-describing file. Each field in a file will have attached
+metadata that conforms to the netCDF
+[Climate and Forecast metadata standards](https://cfconventions.org),
+including fields like units, standard names, longer descriptions, min/max
+range, fill values, etc. In addition, Omega allows global metadata that
+describe either the code (eg version number) or the current experiment
+being run (eg case or experiment name, simulation time). The MetaData
+and MetaDim classes in Omega manage this information. There are no
+user-configurable parameters for the classes themselves. Internally,
+modules will define the metadata for all fields that they own and users
+will specify those field names in the yaml configuration file when listing
+contents of an [IOStream](#omega-user-iostreams). Other sections of the yaml
+configuration will define code and simulation parameters that may be part of
+global metadata. Finally, it is possible to define a metadata group (MetaGroup)
+with a list of previously-defined fields as group members. This provides a
+shortcut name for fields that are commonly grouped together and allows shorter
+lists of contents when specifying contents of IOStreams.
 
-### Working with Metadata
-- **Inclusion of Metadata**: Utilize by including `MetaData.h` in the source
-  code.
-  ```
-  #include "MetaData.h"
-  ```
-
-### Creating and Destroying MetaData Instances
-- **Creation Methods**:
-  1. Using `create` with a name string.
-     ```
-     auto Data1 = MetaData::create("MyVar1");
-     ```
-  2. Creating with name-value pairs using `std::make_pair`.
-     ```
-     auto Data2 = MetaData::create(
-                    "MyVar2",
-                    {
-                        std::make_pair("Meta1", 1),
-                        std::make_pair("Meta2", true),
-                        std::make_pair("Meta3", "MyValue3"),
-                    });
-     ```
-  3. For array-type variables, specific key-value pairs are mandatory.
-     ```
-     auto Data3 = ArrayMetaData::create(
-                    "MyVar3",
-                    "Description", /// long Name or description
-                    "Units",       /// units
-                    "StdName",     /// CF standard Name
-                    std::numeric_limits<int>::min(), /// min valid value
-                    std::numeric_limits<int>::max(), /// max valid value
-                    FILL_VALUE,    /// scalar used for undefined entries
-                    1,             /// number of dimensions
-                    Dimensions     /// dim pointers
-                    );
-     ```
-- **Destruction**: Utilize `destroy` function with the metadata name.
-  ```
-  int ret = MetaData::destroy("MyVar3");
-  ```
-
-### Managing Metadata in Instances
-- **Adding Metadata**: Use `addEntry` function.
-  ```
-  const R8 AValue = 2.0;
-  int ret = Data1->addEntry("NewMeta", AValue);
-  ```
-  The following data types are allowed as metadata values: I4, I8, R4, R8, std::string, and bool.
-- **Removing Metadata**: Employ `removeEntry` function.
-  ```
-  int ret = Data1->removeEntry("NewMeta");
-  ```
-- **Retrieving Metadata**: Use `getEntry` function.
-  ```
-  R8 R8Value;
-  int ret = Data1->getEntry("NewMeta", R8Value);
-  ```
-
-### Handling MetaData Instances
-- **Retrieval**: Use `get` static function.
-  ```
-  auto Data4 = MetaData::get("MyVar2");
-  ```
-
-### Working with MetaDim Instances
-- **Creating and Destroying**: Similar to MetaData instances.
-  ```
-  const I4 DimLength = 3;
-  auto Dim1 = MetaDim::create("MyDim1", DimLength);
-  int ret   = MetaDim::destroy("MyDim1");
-  ```
-- **Retrieving Dimensions**: Use `getLength` function.
-  ```
-  I4 DimLength;
-  Dim1->getLength(DimLength);
-  ```
-
-### Managing MetaGroup Instances
-- **Purpose**: For managing lengthy model configuration lists.
-- **Creation**: Similar to MetaData and MetaDim classes.
-  ```
-  auto Group1 = MetaGroup::create("MyGroup1");
-  int ret     = MetaGroup::destroy("MyGroup1");
-  ```
-- **Field Management**: Add, retrieve, or remove fields using `addField`,
-`getField`, and `removeField`.
-  ```
-  int ret       = Group1->addField(FieldName);
-  auto Data1    = Group1->getField(FieldName):
-  int ret       = Group1->removeField(FieldName):
-  ```
-
-### Utility Functions
-- **`has` Static Method**: Checks existence of an instance.
-  ```
-  bool exists = MetaData::has("MyVar");
-  ```
-- **`get` Static Method**: Retrieves an instance.
-  ```
-  auto Instance = MetaData::get("MyVar");
-  ```
-
-Refer to the Metadata Design and Developer Document for comprehensive details.
+The [Developer's Guide](#omega-dev-metadata) has more detail on the
+class implementation and interfaces for creating and manipulating metadata.

--- a/components/omega/src/infra/MetaData.cpp
+++ b/components/omega/src/infra/MetaData.cpp
@@ -1,10 +1,13 @@
-//===-- infra/MetaData.cpp - Implements Omega MetaData functions --*- C++
-//-*-===//
+//===-- infra/MetaData.cpp - Omega MetaData implementation ------*- C++ -*-===//
 //
-/// \file
-/// \brief implements Omega metadata functions
-///
-/// This implements Omega metadata initialization.
+// \file
+// \brief Implements Omega metadata functions
+//
+// This implements Omega metadata classes that define and store metadata
+// associated with Omega fields. These are then used to output metadata for
+// self-describing files. Fields can also be grouped together to provide a
+// more compact way of referring to a set of fields that are commonly used
+// together.
 //
 //===----------------------------------------------------------------------===//
 
@@ -13,120 +16,165 @@
 
 namespace OMEGA {
 
+// Create static class members that store instantiations of metadata
 std::map<std::string, std::shared_ptr<MetaData>> MetaData::AllFields;
 std::map<std::string, std::shared_ptr<MetaDim>> MetaDim::AllDims;
 std::map<std::string, std::shared_ptr<MetaGroup>> MetaGroup::AllGroups;
 
-bool MetaData::has(const std::string Name /// Name of field
+//----------------------------------------------------------------------------//
+// Checks for the existence of a field with the given name
+bool MetaData::has(const std::string Name // [in] Name of field
 ) {
    return (AllFields.find(Name) != AllFields.end());
 }
 
-/// Create an empty instance by FieldName, primarily for global
-/// metadata not assigned to a variable/field. An exception
-/// is occured if metadata of the same FieldName already exists
-std::shared_ptr<MetaData> MetaData::create(const std::string Name) {
+//----------------------------------------------------------------------------//
+// Creates an empty metadata container for a field with input name
+// Generates an error message if field already exists.
+std::shared_ptr<MetaData>
+MetaData::create(const std::string Name // [in] Name of field
+) {
 
    if (has(Name)) {
-      throw std::runtime_error("Failed to create a field instance because '" +
-                               Name + "' already exists.");
+      LOG_ERROR("Failed to create a field instance because {} already exists.",
+                Name);
+      return nullptr;
    }
 
    auto Data = std::make_shared<MetaData>();
 
+   Data->FieldName = Name;
    AllFields[Name] = Data;
 
    return Data;
-}
 
+} // end create for empty metadata
+
+//----------------------------------------------------------------------------//
+// Creates the metadata for an array field. This is the preferred create
+// interface for most fields in Omega. It enforces a list of required
+// metadata. Note that if input parameters don't exist
+// (eg stdName) or don't make sense (eg min/max or fill) for a
+// given field, empty or 0 entries can be provided. Similarly
+// for scalars, NumDims can be 0 and an empty Dimensions vector can be
+// supplied.
 std::shared_ptr<MetaData> MetaData::create(
-    const std::string Name,
-    const std::initializer_list<std::pair<std::string, std::any>> &MetaPairs) {
+    const std::string Name,        // [in] Name of variable/field
+    const std::string Description, // [in] long Name or description
+    const std::string Units,       // [in] units
+    const std::string StdName,     // [in] CF standard Name
+    const std::any ValidMin,       // [in] min valid field value
+    const std::any ValidMax,       // [in] max valid field value
+    const std::any FillValue,      // [in] scalar for undefined entries
+    const int NumDims,             // [in] number of dimensions
+    const std::vector<std::string> Dimensions // [in] dim names for each dim
+) {
 
-   auto Data = create(Name);
+   auto Data = MetaData::create(Name); // create and names an empty instance
 
-   for (const auto &MetaPair : MetaPairs) {
-      Data->addEntry(MetaPair.first, MetaPair.second);
+   // Fill metadata if creation was successful
+   if (Data) { // creation successful
+
+      Data->NDims    = NumDims;
+      Data->DimNames = Dimensions;
+
+      Data->addEntry("Description", Description);
+      Data->addEntry("Units", Units);
+      Data->addEntry("StdName", StdName);
+      Data->addEntry("ValidMin", ValidMin);
+      Data->addEntry("ValidMax", ValidMax);
+      Data->addEntry("FillValue", FillValue);
+
+   } else { // creation not successful, return with error
+      LOG_ERROR("Metadata create failed for field {} ", Name);
    }
 
    return Data;
 }
 
-/// Create metadata for a variable/field using all
-/// required metadata. Note that if input parameters don't exist
-/// (eg stdName) or don't make sense (eg min/max or fill) for a
-/// given field, empty or 0 entries can be provided. Similarly
-/// for scalars, nDims can be 0 and an emtpy MetaDim vector can be
-/// supplied.
+//----------------------------------------------------------------------------//
+// Creates metadata for field with given name and list of (name,value)
+// pairs
+std::shared_ptr<MetaData> MetaData::create(
+    const std::string Name, // [in] name of field to create
+    const std::initializer_list<std::pair<std::string, std::any>> &MetaPairs) {
 
-std::shared_ptr<MetaData> ArrayMetaData::create(
-    const std::string Name,        /// Name of var
-    const std::string Description, /// Long Name or description
-    const std::string Units,       /// Units
-    const std::string StdName,     /// CF standard Name
-    const std::any ValidMin,       /// Min valid field Value
-    const std::any ValidMax,       /// Max valid field Value
-    const std::any FillValue,      /// Scalar used for undefined entries
-    const int NDims,               /// Number of dimensions
-    const std::vector<std::shared_ptr<MetaDim>> Dimensions // MetaDim pointers
-) {
+   auto Data = create(Name); // creates and names an empty class instance
 
-   auto Data = MetaData::create(Name);
+   // Fill metadata if creation was successful
+   if (Data) { // creation successful
 
-   Data->addEntry("Description", Description);
-   Data->addEntry("Units", Units);
-   Data->addEntry("StdName", StdName);
-   Data->addEntry("ValidMin", ValidMin);
-   Data->addEntry("ValidMax", ValidMax);
-   Data->addEntry("FillValue", FillValue);
-   Data->addEntry("NDims", NDims);
-   Data->addEntry("Dimensions", Dimensions);
+      Data->NDims = 0; // assume this is not an array field
+      for (const auto &MetaPair : MetaPairs) {
+         Data->addEntry(MetaPair.first, MetaPair.second);
+      }
+
+   } else { // creation not successful, return with error
+      LOG_ERROR("Metadata create failed for field {} ", Name);
+   }
 
    return Data;
 }
 
-int MetaData::destroy(const std::string Name /// Name of field to remove
+//----------------------------------------------------------------------------//
+// Removes the metadata associated with a field of a given name
+int MetaData::destroy(const std::string Name // [in] Name of field to remove
 ) {
    int RetVal = 0;
 
    if (!has(Name)) {
-      LOG_ERROR("Failed to destroy the field '" + Name + "' because " +
-                "the field name does not exist.");
+      LOG_ERROR("Failed to destroy metadata for the field {}: "
+                "field does not exist.",
+                Name);
       RetVal = -1;
 
    } else {
       if (AllFields.erase(Name) != 1) {
-         LOG_ERROR("Field, '" + Name + "', is not correctly removed.");
+         LOG_ERROR("Unknown error erasing metadata for field {} ", Name);
          RetVal = -2;
       }
    }
 
    return RetVal;
-}
+} // end destroy for MetaData
 
-std::shared_ptr<MetaData> MetaData::get(const std::string Name /// Name of field
+//----------------------------------------------------------------------------//
+// Removes all defined MetaData
+void MetaData::clear() { AllFields.clear(); }
+
+//----------------------------------------------------------------------------//
+// Retrieves all metadata for a field with a given name
+std::shared_ptr<MetaData>
+MetaData::get(const std::string Name // [in] Name of field
 ) {
    if (!has(Name)) {
-      throw std::runtime_error("Failed to retrieve a field instance because '" +
-                               Name + "' does not exist.");
+      LOG_ERROR("Failed to retrieve metadata for field {}: "
+                "Field with that name does not exist",
+                Name);
+      return nullptr;
    }
 
    return AllFields[Name];
 }
 
-bool MetaData::hasEntry(const std::string Name // Name of metadata
+//----------------------------------------------------------------------------//
+// Checks for the existence of a metadata entry with the given name
+bool MetaData::hasEntry(const std::string Name // [in] Name of metadata
 ) {
    return (MetaMap.find(Name) != MetaMap.end());
 }
 
-int MetaData::addEntry(const std::string Name, /// Name of new metadata to add
-                       const std::any Value    /// Value of new metadata to add
+//----------------------------------------------------------------------------//
+// Adds a metadata entry with the (name,value) pair
+int MetaData::addEntry(const std::string Name, // [in] Name of new metadata
+                       const std::any Value    // [in] Value of new metadata
 ) {
    int RetVal = 0;
 
    if (hasEntry(Name)) {
-      LOG_ERROR("Failed to add the metadata '" + Name + "' because " +
-                "the field already has the metadata.");
+      LOG_ERROR("Failed to add the metadata {} to field {} because the field "
+                "already has an entry with that name.",
+                Name, FieldName);
 
       RetVal = -1;
 
@@ -137,19 +185,23 @@ int MetaData::addEntry(const std::string Name, /// Name of new metadata to add
    return RetVal;
 }
 
-int MetaData::removeEntry(const std::string Name /// Name of metadata to remove
+//----------------------------------------------------------------------------//
+// Removes a metadata entry with the given name
+int MetaData::removeEntry(const std::string Name // [in] Name of metadata to rm
 ) {
 
    int RetVal = 0;
 
    if (!hasEntry(Name)) {
-      LOG_ERROR("Failed to remove the metadata '" + Name + "' because " +
-                "the metadata name does not exist.");
+      LOG_ERROR("Failed to remove the metadata {} from field {} because an "
+                "entry with that name does not exist.",
+                Name, FieldName);
       RetVal = -1;
 
    } else {
       if (MetaMap.erase(Name) != 1) {
-         LOG_ERROR("Metadata, '" + Name + "', is not correctly removed.");
+         LOG_ERROR("Unknown error trying to erase metadata {} from field {}",
+                   Name, FieldName);
          RetVal = -2;
       }
    }
@@ -157,13 +209,44 @@ int MetaData::removeEntry(const std::string Name /// Name of metadata to remove
    return RetVal;
 }
 
-int MetaData::getEntry(const std::string Name, /// Name of metadata to get
-                       I4 &Value               /// I4 Value of metadata
+//----------------------------------------------------------------------------//
+// Returns the number of dimensions for an array field
+int MetaData::getNumDims() { return NDims; }
+
+//----------------------------------------------------------------------------//
+// Returns a vector of dimension names associated with each dimension
+// of an array field. Returns an error code.
+int MetaData::getDimNames(
+    std::vector<std::string> &Dimensions // [out] list of dimensions
+) {
+   int RetVal = 0;
+
+   if (NDims > 0) { // This field is an array
+
+      Dimensions.resize(NDims); // make sure the vector has correct size
+      // Copy dimension names into result
+      for (int IDim = 0; IDim < NDims; ++IDim) {
+         Dimensions[IDim] = DimNames[IDim];
+      }
+
+   } else { // not an array so clear the vector of names
+      Dimensions.clear();
+   }
+
+   return RetVal;
+}
+
+//----------------------------------------------------------------------------//
+// Retrieves the value of the metadata associated with a given name
+// This specific version of the overloaded interface coerces the value
+// to an I4 type
+int MetaData::getEntry(const std::string Name, // [in] Name of metadata to get
+                       I4 &Value               // [out] I4 Value of metadata
 ) {
    int RetVal = 0;
 
    if (!hasEntry(Name)) {
-      LOG_ERROR("Metadata '" + Name + "' does not exist.");
+      LOG_ERROR("Metadata {} does not exist for field {}.", Name, FieldName);
       RetVal = -1;
 
    } else {
@@ -173,13 +256,17 @@ int MetaData::getEntry(const std::string Name, /// Name of metadata to get
    return RetVal;
 }
 
-int MetaData::getEntry(const std::string Name, /// Name of metadata to get
-                       I8 &Value               /// I8 Value of metadata
+//----------------------------------------------------------------------------//
+// Retrieves the value of the metadata associated with a given name
+// This specific version of the overloaded interface coerces the value
+// to an I8 type
+int MetaData::getEntry(const std::string Name, // [in] Name of metadata to get
+                       I8 &Value               // [out] I8 Value of metadata
 ) {
    int RetVal = 0;
 
    if (!hasEntry(Name)) {
-      LOG_ERROR("Metadata '" + Name + "' does not exist.");
+      LOG_ERROR("Metadata {} does not exist for field {}.", Name, FieldName);
       RetVal = -1;
 
    } else {
@@ -189,13 +276,17 @@ int MetaData::getEntry(const std::string Name, /// Name of metadata to get
    return RetVal;
 }
 
-int MetaData::getEntry(const std::string Name, /// Name of metadata to get
-                       R4 &Value               /// R4 Value of metadata
+//----------------------------------------------------------------------------//
+// Retrieves the value of the metadata associated with a given name
+// This specific version of the overloaded interface coerces the value
+// to an R4 type
+int MetaData::getEntry(const std::string Name, // [in] Name of metadata to get
+                       R4 &Value               // [out] R4 Value of metadata
 ) {
    int RetVal = 0;
 
    if (!hasEntry(Name)) {
-      LOG_ERROR("Metadata '" + Name + "' does not exist.");
+      LOG_ERROR("Metadata {} does not exist for field {}.", Name, FieldName);
       RetVal = -1;
 
    } else {
@@ -205,13 +296,17 @@ int MetaData::getEntry(const std::string Name, /// Name of metadata to get
    return RetVal;
 }
 
-int MetaData::getEntry(const std::string Name, /// Name of metadata to get
-                       R8 &Value               /// R8 Value of metadata
+//----------------------------------------------------------------------------//
+// Retrieves the value of the metadata associated with a given name
+// This specific version of the overloaded interface coerces the value
+// to an R8 type
+int MetaData::getEntry(const std::string Name, // [in] Name of metadata to get
+                       R8 &Value               // [out] R8 Value of metadata
 ) {
    int RetVal = 0;
 
    if (!hasEntry(Name)) {
-      LOG_ERROR("Metadata '" + Name + "' does not exist.");
+      LOG_ERROR("Metadata {} does not exist for field {}.", Name, FieldName);
       RetVal = -1;
 
    } else {
@@ -221,13 +316,17 @@ int MetaData::getEntry(const std::string Name, /// Name of metadata to get
    return RetVal;
 }
 
-int MetaData::getEntry(const std::string Name, /// Name of metadata to get
-                       bool &Value             /// Bool Value of metadata
+//----------------------------------------------------------------------------//
+// Retrieves the value of the metadata associated with a given name
+// This specific version of the overloaded interface coerces the value
+// to a bool type
+int MetaData::getEntry(const std::string Name, // [in] Name of metadata to get
+                       bool &Value             // [out] Bool Value of metadata
 ) {
    int RetVal = 0;
 
    if (!hasEntry(Name)) {
-      LOG_ERROR("Metadata '" + Name + "' does not exist.");
+      LOG_ERROR("Metadata {} does not exist for field {}.", Name, FieldName);
       RetVal = -1;
 
    } else {
@@ -237,13 +336,17 @@ int MetaData::getEntry(const std::string Name, /// Name of metadata to get
    return RetVal;
 }
 
-int MetaData::getEntry(const std::string Name, /// Name of metadata to get
-                       std::string &Value      /// String Value of metadata
+//----------------------------------------------------------------------------//
+// Retrieves the value of the metadata associated with a given name
+// This specific version of the overloaded interface coerces the value
+// to an string type
+int MetaData::getEntry(const std::string Name, // [in] Name of metadata to get
+                       std::string &Value      // [out] String Value of metadata
 ) {
    int RetVal = 0;
 
    if (!hasEntry(Name)) {
-      LOG_ERROR("Metadata '" + Name + "' does not exist.");
+      LOG_ERROR("Metadata {} does not exist for field {}.", Name, FieldName);
       RetVal = -1;
 
    } else {
@@ -253,42 +356,64 @@ int MetaData::getEntry(const std::string Name, /// Name of metadata to get
    return RetVal;
 }
 
+//----------------------------------------------------------------------------//
+// Returns the pointer to the metadata map of all entries
 std::map<std::string, std::any> *MetaData::getAllEntries() { return &MetaMap; }
 
-bool MetaDim::has(const std::string Name /// Name of dimension
+//----------------------------------------------------------------------------//
+// Determines whether the dimension exists or has been defined
+bool MetaDim::has(const std::string Name // [in] Name of dimension
 ) {
    return (AllDims.find(Name) != AllDims.end());
 }
 
+//----------------------------------------------------------------------------//
+// Creates dimension metadata and adds it to list of all defined dimensions
+// If a dimension with the same name and same length has already been
+// defined, this function returns the previously defined dimension.
 std::shared_ptr<MetaDim>
-MetaDim::create(const std::string Name, // Name of dimension
-                const I4 Length         // Length of dimension
+MetaDim::create(const std::string Name, // [in] Name of dimension
+                const I4 Length         // [in] Length of dimension
 ) {
-   if (has(Name)) {
-      throw std::runtime_error("Failed to create a MetaDim instance because '" +
-                               Name + "' already exists.");
+
+   auto Dim = std::make_shared<MetaDim>(); // create empty dim
+
+   if (has(Name)) { // Dimension already exists
+
+      Dim = get(Name); // retrieve previously defined dim
+      // If already-defined dim has a different length, write error msg
+      if (Dim->Length != Length) {
+         LOG_ERROR("Attempt to create dimension {} but a dimension with"
+                   " that name already exists with different length",
+                   Name);
+         Dim = nullptr;
+      }
+
+   } else { // a new dimension, fill data members
+
+      Dim->DimName  = Name;
+      Dim->Length   = Length;
+      AllDims[Name] = Dim;
    }
-
-   auto Dim    = std::make_shared<MetaDim>();
-   Dim->Length = Length;
-
-   AllDims[Name] = Dim;
 
    return Dim;
 }
 
-int MetaDim::destroy(const std::string Name // Name of dimension
+//----------------------------------------------------------------------------//
+// Destroys dimension metadata and removes it from the list
+int MetaDim::destroy(const std::string Name // [in] Name of dimension
 ) {
    int RetVal = 0;
 
    if (!has(Name)) {
-      LOG_ERROR("Failed to destroy the dimension '" + Name + "' because " +
-                "the dimension name does not exist.");
+      LOG_ERROR("Failed to destroy the dimension {} because "
+                "the dimension name does not exist.",
+                Name);
       RetVal = -1;
 
    } else {
       if (AllDims.erase(Name) != 1) {
-         LOG_ERROR("Dimension, '" + Name + "', was not successfully removed.");
+         LOG_ERROR("Unknown error erasing Dimension {}", Name);
          RetVal = -1;
       }
    }
@@ -296,59 +421,104 @@ int MetaDim::destroy(const std::string Name // Name of dimension
    return RetVal;
 }
 
+//----------------------------------------------------------------------------//
+// Removes all defined dimension info
+void MetaDim::clear() {
+   AllDims.clear(); // uses map clear function to remove all entries
+}
+
+//----------------------------------------------------------------------------//
+// Retrieves dimension metadata by name
 std::shared_ptr<MetaDim>
-MetaDim::get(const std::string Name /// Name of dimension
+MetaDim::get(const std::string Name // [in] Name of dimension
 ) {
    if (!has(Name)) {
-      throw std::runtime_error(
-          "Failed to retrieve a MetaDim instance because '" + Name +
-          "' does not exist.");
+      LOG_ERROR("Failed to retrieve dimension {} because it does not exist"
+                " or has not net been defined",
+                Name);
+      return nullptr;
    }
 
    return AllDims[Name];
 }
 
-int MetaDim::getLength(I4 &Length // Length of dimension
+//----------------------------------------------------------------------------//
+// Retrieves the length of the dimension
+I4 MetaDim::getLength() { return Length; }
+
+//----------------------------------------------------------------------------//
+// Retrieves the length of the dimension by name
+I4 MetaDim::getDimLength(const std::string &Name // [in] Name of dimension
 ) {
-   int RetVal = 0;
+   I4 Length;
 
-   Length = this->Length;
+   if (has(Name)) {
+      std::shared_ptr<MetaDim> ThisDim = AllDims[Name];
+      Length                           = ThisDim->Length;
 
-   return RetVal;
+   } else {
+      LOG_ERROR("Cannot get length of dimension {}: "
+                "dimension does not exist or has not been defined",
+                Name);
+      Length = -1;
+   }
+
+   return Length;
 }
 
-bool MetaGroup::has(const std::string Name /// Name of group
+//----------------------------------------------------------------------------//
+// Retrieves the number of currently defined dimensions
+int MetaDim::getNumDefinedDims() { return AllDims.size(); }
+
+//----------------------------------------------------------------------------//
+// Returns an iterator to the first dimension stored in AllDims
+MetaDim::Iter MetaDim::begin() { return MetaDim::AllDims.begin(); }
+
+//----------------------------------------------------------------------------//
+// Returns an iterator to the last dimension stored in AllDims
+MetaDim::Iter MetaDim::end() { return MetaDim::AllDims.end(); }
+
+//----------------------------------------------------------------------------//
+// Determines whether a group of a given name exists
+bool MetaGroup::has(const std::string Name // [in] Name of group
 ) {
    return (AllGroups.find(Name) != AllGroups.end());
 }
 
+//----------------------------------------------------------------------------//
+// Creates an empty metadata group with a given name
 std::shared_ptr<MetaGroup>
-MetaGroup::create(const std::string Name // Name of group
+MetaGroup::create(const std::string Name // [in] Name of group
 ) {
    if (has(Name)) {
-      return get(Name);
+      LOG_ERROR("Attempt to create a metadata group {} that already exists.",
+                Name);
+      return nullptr;
 
    } else {
       auto Group = std::make_shared<MetaGroup>();
 
+      Group->GrpName  = Name;
       AllGroups[Name] = Group;
 
       return Group;
    }
 }
 
-int MetaGroup::destroy(const std::string Name // Name of group
+//----------------------------------------------------------------------------//
+// Removes a metadata group
+int MetaGroup::destroy(const std::string Name // [in] Name of group
 ) {
    int RetVal = 0;
 
    if (!has(Name)) {
-      LOG_ERROR("Failed to destroy the group '" + Name + "' because " +
-                "the group name does not exist.");
+      LOG_ERROR("Failed to destroy the metadata group {}: group not found",
+                Name);
       RetVal = -1;
 
    } else {
       if (AllGroups.erase(Name) != 1) {
-         LOG_ERROR("Group, '" + Name + "', is not correctly removed.");
+         LOG_ERROR("Unknown error trying to erase metadata group {}.", Name);
          RetVal = -2;
       }
    }
@@ -356,79 +526,95 @@ int MetaGroup::destroy(const std::string Name // Name of group
    return RetVal;
 }
 
+//----------------------------------------------------------------------------//
+// Retrieves a pointer to a metadata group by name
 std::shared_ptr<MetaGroup>
-MetaGroup::get(const std::string Name /// Name of dimension
+MetaGroup::get(const std::string Name // [in] Name of group to retrieve
 ) {
    if (!has(Name)) {
-      throw std::runtime_error(
-          "Failed to retrieve a MetaGroup instance because '" + Name +
-          "' does not exist.");
+      LOG_ERROR("Failed to retrieve MetaGroup {}: group does not exist.", Name);
+      return nullptr;
    }
 
    return AllGroups[Name];
 }
 
-bool MetaGroup::hasField(const std::string FieldName /// Name of field
+//----------------------------------------------------------------------------//
+// Determines whether a field of a given name exists in the group
+bool MetaGroup::hasField(const std::string FieldName // [in] Name of field
 ) {
    return (Fields.find(FieldName) != Fields.end());
 }
 
-int MetaGroup::addField(const std::string FieldName // Name of field to add
+//----------------------------------------------------------------------------//
+// Adds a field to the group
+int MetaGroup::addField(const std::string FieldName // [in] Name of field to add
 ) {
    int RetVal = 0;
 
-   if (hasField(FieldName)) {
-      LOG_ERROR("Failed to add the field '" + FieldName + "' because " +
-                "the group already has the field.");
-      RetVal = -1; // The field already exists in the group.
-
-   } else if (MetaData::has(FieldName)) {
-      Fields[FieldName] = MetaData::get(FieldName);
-
-   } else {
-      LOG_ERROR("Failed to add the field '" + FieldName + "' because " +
-                "the field does not exist.");
+   // Make sure the field metadata has already been defined
+   if (not MetaData::has(FieldName)) {
+      LOG_ERROR("Cannot add the field {} to Group {}: Field not defined",
+                FieldName, GrpName);
       RetVal = -2; // The field name does not exist.
    }
+
+   // Add field name to the list of fields. If this is a duplicate, the
+   // insert function knows not to repeat an entry so nothing happens.
+   Fields.insert(FieldName);
 
    return RetVal;
 }
 
+//----------------------------------------------------------------------------//
+// Retrieves a field's metadata from a group
 std::shared_ptr<MetaData>
-MetaGroup::getField(const std::string FieldName /// Name of field to add
+MetaGroup::getField(const std::string FieldName // [in] Name of field to add
 ) {
    if (!hasField(FieldName)) {
-      throw std::runtime_error("Failed to get a MetaData instance because "
-                               "the group does not have '" +
-                               FieldName + "'.");
+      LOG_ERROR("Failed to get field {} from group {}: field not in group.",
+                FieldName, GrpName);
+      return nullptr;
    }
 
-   return Fields[FieldName];
+   return MetaData::get(FieldName);
 }
 
+//----------------------------------------------------------------------------//
+// Removes a field from a group
 int MetaGroup::removeField(
-    const std::string FieldName // Name of field to remove
+    const std::string FieldName // [in] Name of field to remove
 ) {
    int RetVal = 0;
 
    if (!hasField(FieldName)) {
-      LOG_ERROR("Failed to get remove MetaData instance because "
-                "the group does not have '" +
-                FieldName + "'.");
+      LOG_ERROR("Failed to remove field {} from group {} "
+                "because the field is not a group member",
+                FieldName, GrpName);
       RetVal = -1;
 
    } else {
       if (Fields.erase(FieldName) != 1) {
-         LOG_ERROR("Field, '" + FieldName + "', is not correctly removed.");
+         LOG_ERROR("Unknown error erasing field {} from group {}.", FieldName,
+                   GrpName);
          RetVal = -2;
       }
    }
 
    return RetVal;
-}
+} // end removeField from group
 
-std::map<std::string, std::shared_ptr<MetaData>> *MetaGroup::getAllFields() {
-   return &Fields;
+//----------------------------------------------------------------------------//
+// Returns a list of all fields in a group - the list is a copy of the group
+// field list so the internal list is not affected
+std::set<std::string> MetaGroup::getFieldList() {
+
+   std::set<std::string> List;
+   for (auto It = Fields.begin(); It != Fields.end(); ++It) {
+      List.insert(*It);
+   }
+
+   return List;
 }
 
 } // Namespace OMEGA

--- a/components/omega/src/infra/MetaData.h
+++ b/components/omega/src/infra/MetaData.h
@@ -1,25 +1,37 @@
 #ifndef OMEGA_METADATA_H
 #define OMEGA_METADATA_H
-//===-- infra/MetaData.h - metadata classes --*- C++ -*-===//
+//===-- infra/MetaData.h - Omega metadata classes ---------------*- C++ -*-===//
 //
 /// \file
 /// \brief Defines metadata classes
 ///
-/// This header defines classes for metadata.
+/// This header defines classes and functions for defining and storing metadata
+/// associated with Omega fields. These are then used to output metadata for
+/// self-describing files. Fields can also be combined into groups to provide a
+/// more compact way of referring to a set of fields that are commonly used
+/// together.
 //===----------------------------------------------------------------------===//
 
 #include "DataTypes.h"
 #include <any>
 #include <map>
+#include <set>
 
 namespace OMEGA {
 
-static const std::string CodeMeta{"code"};
-static const std::string SimMeta{"simulation"};
+static const std::string CodeMeta{"code"};      ///< name for code metadata
+static const std::string SimMeta{"simulation"}; ///< name for sim metatdata
 
+//------------------------------------------------------------------------------
+/// The MetaDim class stores dimension information. The information is stored
+/// in a (name,length) map pair and iterators are provided for looping through
+/// all defined dimensions.
 class MetaDim {
 
  private:
+   /// Name of the dimension
+   std::string DimName;
+
    /// The length of the dimension. Use 0 for unlimited length.
    I4 Length;
 
@@ -27,146 +39,246 @@ class MetaDim {
    static std::map<std::string, std::shared_ptr<MetaDim>> AllDims;
 
  public:
+   /// Creates dimension metadata and adds it to list of all defined dimensions
+   /// If a dimension with the same name and same length has already been
+   /// defined, this function returns the previously defined dimension.
    static std::shared_ptr<MetaDim>
-   create(const std::string Name, /// Name of dimension
-          const I4 Length         /// length of dimension
+   create(const std::string Name, ///< [in] Name of dimension
+          const I4 Length         ///< [in] Length (global) of dimension
    );
 
-   static int destroy(const std::string Name /// Name of dimension
+   /// Destroys dimension metadata and removes it from the list
+   static int destroy(const std::string Name ///< [in] Name of dimension
    );
 
+   /// Retrieves dimension metadata by name
    static std::shared_ptr<MetaDim>
-   get(const std::string Name /// Name of dimension
+   get(const std::string Name ///< [in] Name of dimension
    );
 
-   static bool has(const std::string Name /// Name of dimension
+   /// Determines whether the dimension exist or has been defined
+   static bool has(const std::string Name ///< [in] Name of dimension
    );
 
-   int getLength(I4 &Length /// length of dimension
+   /// Retrieves the length of the dimension
+   I4 getLength();
+
+   /// Retrieves the length of the dimension by name
+   static I4 getDimLength(const std::string &Name ///< [in] Name of dimension
    );
+
+   /// Retrieves the number of currently defined dimensions
+   static int getNumDefinedDims();
+
+   /// An iterator can be used to loop through all defined dimensions
+   using Iter = std::map<std::string, std::shared_ptr<MetaDim>>::iterator;
+
+   /// Returns an iterator to the first dimension stored in AllDims
+   static Iter begin();
+
+   /// Returns an iterator to the last dimension stored in AllDims
+   static Iter end();
+
+   /// Removes all defined dimension info
+   static void clear();
 };
 
+//------------------------------------------------------------------------------
+/// The MetaData class stores field metadata in a map of (string,value) pairs
+/// Dimension information is also stored here for array fields since it is
+/// treated differently in file metadata and I/O ops
 class MetaData {
  protected:
-   /// metadata stored in map
+   /// Name of field that this MetaData describes
+   std::string FieldName;
+
+   /// Most metadata stored in map
    std::map<std::string, std::any> MetaMap;
 
-   /// Store and maintain all defined metadata in this vector
+   /// Number of dimensions for the field (0 if scalar field or global metadata)
+   int NDims;
+
+   /// Dimension names for retrieval of dimension info
+   /// These must be in the same index order as the stored data
+   std::vector<std::string> DimNames;
+
+   /// Store and maintain metadata for all defined fields in this map container
    static std::map<std::string, std::shared_ptr<MetaData>> AllFields;
 
  public:
+   /// Creates the metadata for an array field. This is the preferred
+   /// interface for most fields in Omega. It enforces a list of required
+   /// metadata. Note that if input parameters don't exist
+   /// (eg stdName) or don't make sense (eg min/max or fill) for a
+   /// given field, empty or 0 entries can be provided. Similarly
+   /// for scalars, NumDims can be 0 and an emtpy MetaDim vector can be
+   /// supplied.
    static std::shared_ptr<MetaData>
-   create(const std::string Name /// Name of field
+   create(const std::string Name,        ///< [in] Name of variable/field
+          const std::string Description, ///< [in] long Name or description
+          const std::string Units,       ///< [in] units
+          const std::string StdName,     ///< [in] CF standard Name
+          const std::any ValidMin,       ///< [in] min valid field value
+          const std::any ValidMax,       ///< [in] max valid field value
+          const std::any FillValue,      ///< [in] scalar for undefined entries
+          const int NumDims,             ///< [in] number of dimensions
+          const std::vector<std::string> Dimensions ///< dim names for each dim
    );
 
+   /// Creates an empty metadata container for a field with input name
    static std::shared_ptr<MetaData>
-   create(const std::string Name,
-          const std::initializer_list<std::pair<std::string, std::any>>
-              &MetaPairs);
+   create(const std::string Name ///< [in] Name of field
+   );
 
+   /// Creates metadata for a scalar field with given name and list of
+   /// (name,value) pairs
+   static std::shared_ptr<MetaData>
+   create(const std::string Name, ///< [in] Name of field
+          const std::initializer_list<std::pair<std::string, std::any>>
+              &MetaPairs /// < [in] List of (name,value) metadata pairs
+   );
+
+   /// Removes the metadata associated with a field of a given name
    static int destroy(const std::string Name /// Name of field to remove
    );
 
-   static std::shared_ptr<MetaData> get(const std::string Name /// Name of field
-   );
+   /// Removes all defined metadata for all fields
+   static void clear();
 
-   static bool has(const std::string Name /// Name of field
-   );
-
-   bool hasEntry(const std::string MetaName /// Name of metadata
-   );
-
-   int addEntry(const std::string MetaName, /// Name of new metadata to add
-                const std::any Value        /// Value of new metadata to add
-   );
-
-   int removeEntry(const std::string MetaName /// Name of metadata to remove
-   );
-
-   int getEntry(const std::string MetaName, /// Name of metadata to get
-                I4 &Value                   /// I4 Value of metadata
-   );
-
-   int getEntry(const std::string MetaName, /// Name of metadata to get
-                I8 &Value                   /// I8 Value of metadata
-   );
-
-   int getEntry(const std::string MetaName, /// Name of metadata to get
-                R4 &Value                   ///  R4 Value of metadata
-   );
-
-   int getEntry(const std::string MetaName, /// Name of metadata to get
-                R8 &Value                   /// R8 Value of metadata
-   );
-
-   int getEntry(const std::string MetaName, /// Name of metadata to get
-                bool &Value                 /// bool Value of metadata
-   );
-
-   int getEntry(const std::string MetaName, /// Name of metadata to get
-                std::string &Value          /// string Value of metadata
-   );
-
-   /// returns the pointer to the metadata map
-   std::map<std::string, std::any> *getAllEntries();
-};
-
-class ArrayMetaData : public MetaData {
-
- public:
+   /// Retrieves all metadata for a field with a given name
    static std::shared_ptr<MetaData>
-   create(const std::string Name,        /// Name of var
-          const std::string Description, /// long Name or description
-          const std::string Units,       /// units
-          const std::string StdName,     /// CF standard Name
-          const std::any ValidMin,       /// min valid field value
-          const std::any ValidMax,       /// max valid field value
-          const std::any FillValue,      /// scalar used for undefined entries
-          const int NDims,               /// number of dimensions
-          const std::vector<std::shared_ptr<MetaDim>> Dimensions // dim pointers
+   get(const std::string Name ///< [in] Name of field
    );
-};
 
+   /// Checks for the existence of a field with the given name
+   static bool has(const std::string Name ///< [in] Name of field
+   );
+
+   /// Checks for the existence of a metadata entry with the given name
+   bool hasEntry(const std::string Name ///< [in] Name of metadata entry
+   );
+
+   /// Adds a metadata entry with the (name,value) pair
+   int addEntry(const std::string Name, ///< [in] Name of new metadata
+                const std::any Value    ///< [in] Value of new metadata
+   );
+
+   /// Removes a metadata entry with the given name
+   int removeEntry(const std::string Name ///< [in] Name of entry to remove
+   );
+
+   /// Returns the number of dimensions for the field
+   int getNumDims();
+
+   /// Returns a vector of dimension names associated with each dimension
+   /// of an array field. Returns an error code.
+   int getDimNames(
+       std::vector<std::string> &Dimensions ///< [out] list of dimensions
+   );
+
+   /// Retrieves the value of the metadata associated with a given name
+   /// This specific version of the overloaded interface coerces the value
+   /// to an I4 type
+   int getEntry(const std::string Name, ///< [in] Name of metadata to get
+                I4 &Value               ///< [out] I4 Value of metadata
+   );
+
+   /// Retrieves the value of the metadata associated with a given name
+   /// This specific version of the overloaded interface coerces the value
+   /// to an I8 type
+   int getEntry(const std::string Name, ///< [in] Name of metadata to get
+                I8 &Value               ///< [out] I8 Value of metadata
+   );
+
+   /// Retrieves the value of the metadata associated with a given name
+   /// This specific version of the overloaded interface coerces the value
+   /// to an R4 type
+   int getEntry(const std::string Name, ///< [in] Name of metadata to get
+                R4 &Value               ///< [out]  R4 Value of metadata
+   );
+
+   /// Retrieves the value of the metadata associated with a given name
+   /// This specific version of the overloaded interface coerces the value
+   /// to an R8 type
+   int getEntry(const std::string Name, ///< [in] Name of metadata to get
+                R8 &Value               ///< [out] R8 Value of metadata
+   );
+
+   /// Retrieves the value of the metadata associated with a given name
+   /// This specific version of the overloaded interface coerces the value
+   /// to a bool type
+   int getEntry(const std::string Name, ///< [in] Name of metadata to get
+                bool &Value             ///< [out] bool Value of metadata
+   );
+
+   /// Retrieves the value of the metadata associated with a given name
+   /// This specific version of the overloaded interface coerces the value
+   /// to a string type
+   int getEntry(const std::string Name, ///< [in] Name of metadata to get
+                std::string &Value      ///< [out] string Value of metadata
+   );
+
+   /// returns a pointer to the metadata map of all entries
+   std::map<std::string, std::any> *getAllEntries();
+
+}; // end MetaData class
+
+//----------------------------------------------------------------------------//
+/// The MetaGroup class allows fields and their metadata to be grouped together
+/// and referred to by a single name. This helps to reduce the length and
+/// complexity of input lists and contents lists.
 class MetaGroup {
 
  private:
-   /// map of fields in group
-   std::map<std::string, std::shared_ptr<MetaData>> Fields;
+   /// Name of group
+   std::string GrpName;
 
-   /// Store and maintain all defined groups
+   /// List of fields in group - only names are needed
+   std::set<std::string> Fields;
+
+   /// Store and maintain all defined groups in map container
    static std::map<std::string, std::shared_ptr<MetaGroup>> AllGroups;
 
  public:
+   /// Creates an empty metadata group with a given name
    static std::shared_ptr<MetaGroup>
-   create(const std::string Name /// Name of group
+   create(const std::string Name ///< [in] Name of group to create
    );
 
-   static int destroy(const std::string Name /// Name of group
+   /// Removes a metadata group
+   static int destroy(const std::string Name ///< [in] Name of group to destroy
    );
 
+   /// Retrieves a pointer to a metadata group by name
    static std::shared_ptr<MetaGroup>
-   get(const std::string Name /// Name of group
+   get(const std::string Name ///< [in] Name of group to retrieve
    );
 
-   static bool has(const std::string Name /// Name of group
+   /// Determines whether a group of a given name exists
+   static bool has(const std::string Name ///< [in] Name of group
    );
 
-   bool hasField(const std::string FieldName /// Name of field to add
+   /// Determins whether a field of a given name exists in the group
+   bool hasField(const std::string Name ///< [in] Name of field
    );
 
-   int addField(const std::string FieldName /// Name of field to add
+   /// Adds a field to the group
+   int addField(const std::string Name ///< [in] Name of field to add
    );
 
+   /// Retrieves a field's metadata from a group
    std::shared_ptr<MetaData>
-   getField(const std::string FieldName /// Name of field to add
+   getField(const std::string Name ///< [in] Name of field to retrieve
    );
 
-   int removeField(const std::string FieldName /// Name of field to remove
+   /// Removes a field from a group
+   int removeField(const std::string Name ///< [in] Name of field to remove
    );
 
-   /// returns the pointer to the metagroup map
-   std::map<std::string, std::shared_ptr<MetaData>> *getAllFields();
-};
+   /// Returns a list of fields in a group
+   std::set<std::string> getFieldList();
+
+}; // end class MetaGroup
 
 } // namespace OMEGA
 

--- a/components/omega/test/infra/IOFieldTest.cpp
+++ b/components/omega/test/infra/IOFieldTest.cpp
@@ -29,10 +29,10 @@ int initIOFieldTest() {
    OMEGA::I4 NVertLevels = 64;
    auto CellDim          = OMEGA::MetaDim::create("NCells", NCellsSize);
    auto VertDim          = OMEGA::MetaDim::create("NVertLevels", NVertLevels);
-   std::vector<std::shared_ptr<OMEGA::MetaDim>> Dimensions{CellDim, VertDim};
+   std::vector<std::string> Dimensions{"NCells", "NVertLevels"};
 
    // Define field metadata for all fields
-   auto FieldMetaI4H = OMEGA::ArrayMetaData::create(
+   auto FieldMetaI4H = OMEGA::MetaData::create(
        "FieldI4H",
        "Test IO Field for I4 Host", /// long Name or description
        "unitless",                  /// units
@@ -44,7 +44,7 @@ int initIOFieldTest() {
        Dimensions                   /// dim pointers
    );
 
-   auto FieldMetaI4D = OMEGA::ArrayMetaData::create(
+   auto FieldMetaI4D = OMEGA::MetaData::create(
        "FieldI4D",
        "Test IO Field for I4 Device", /// long Name or description
        "unitless",                    /// units
@@ -56,7 +56,7 @@ int initIOFieldTest() {
        Dimensions                     /// dim pointers
    );
 
-   auto FieldMetaR8H = OMEGA::ArrayMetaData::create(
+   auto FieldMetaR8H = OMEGA::MetaData::create(
        "FieldR8H",
        "Test IO Field for R8 Host", /// long Name or description
        "m",                         /// units
@@ -68,7 +68,7 @@ int initIOFieldTest() {
        Dimensions                   /// dim pointers
    );
 
-   auto FieldMetaR8D = OMEGA::ArrayMetaData::create(
+   auto FieldMetaR8D = OMEGA::MetaData::create(
        "FieldR8D",
        "Test IO Field for R8 Device", /// long Name or description
        "m",                           /// units


### PR DESCRIPTION
Dimension metadata is often treated differently so separating dimension info from other metadata and adding new dimension-related functions was necessary
   - makes dimensions a separate class member in MetaData classes
   - adds some related functions and an iterator to manage dimensions
   - required elimination of ArrayMetaData class and merging it with regular MetaData class
   - adds related tests to unit test routine
   - modifies documentation to include new functions and to make it more consistent with other documentation sections
   - added more comments and some function delimiters

Passes unit tests on Chrysalis. Will also test Frontier

Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. 



