### PR TITLE
Add PIO include paths when building Omega

### DIFF
--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -9,6 +9,8 @@ target_include_directories(
     ${OMEGA_SOURCE_DIR}/src/base
     ${OMEGA_SOURCE_DIR}/src/infra
     ${OMEGA_SOURCE_DIR}/src/ocn
+    ${PIOC_SOURCE_DIR}
+    ${PIOC_BINARY_DIR}
     ${Parmetis_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
Add PIO include paths when building Omega to prevent the compiler error of not finding the "pio.h" header file.



