### PR TITLE
Fix decomp call to ParMETIS to handle 64-bit idx_t

### DIFF
--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -825,12 +825,16 @@ int Decomp::partCellsKWay(
    std::vector<idx_t> CellTask(NCellsGlobal);
    idx_t Edgecut = 0;
 
+   // Convert to idx_t from Omega::I4, in case these aren't the same
+   idx_t NCellsMetis   = NCellsGlobal;
+   idx_t NumTasksMetis = NumTasks;
+
    // Call METIS routine to partition the mesh
    // METIS routines are C code that expect pointers, so we use the
    // idiom &Var[0] to extract the pointer to the data in std::vector
-   int MetisErr = METIS_PartGraphKway(&NCellsGlobal, &NConstraints, &AdjAdd[0],
+   int MetisErr = METIS_PartGraphKway(&NCellsMetis, &NConstraints, &AdjAdd[0],
                                       &Adjacency[0], VrtxWgtPtr, VrtxSize,
-                                      EdgeWgtPtr, &NumTasks, TpWgts, Ubvec,
+                                      EdgeWgtPtr, &NumTasksMetis, TpWgts, Ubvec,
                                       Options, &Edgecut, &CellTask[0]);
 
    if (MetisErr != METIS_OK) {


### PR DESCRIPTION
This merge makes copies of 2 `Omega::I4` as ParMETIS `idx_t` variables so they can be passed as pointers to
`METIS_PartGraphKway()`

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] Unit tests have passed.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

fixes #100 

