### PR TITLE
Update recent unit test drivers with changes in logging and fix linting in old design docs

### DIFF
--- a/components/omega/doc/design/State.md
+++ b/components/omega/doc/design/State.md
@@ -15,7 +15,7 @@ The state class will have a method to register the progostic variables with IOSt
 ### 2.2 Requirement: Update timestep
 A method will be responsible for advancing the prognostic variables prior to the beginning of a new timestep.
 The left-most index of the prognostic variables will be a time index, which will facilitate flexibility with timestepping schemes.
-The time level update will include a halo exchange and an exchange of time level. 
+The time level update will include a halo exchange and an exchange of time level.
 
 ### 2.3 Requirement: Can be used as a common data type for tendency and provis variables
 The timestepping scheme will require storage for the tendency terms and the intermediate stage. The state class can also be used to fulfill this need.

--- a/components/omega/doc/design/TimeStepping.md
+++ b/components/omega/doc/design/TimeStepping.md
@@ -97,7 +97,7 @@ Design specifics will be added at a later time.
 
 The timestepping will be tested with a time-only convergence test on the equations
 $$
-\frac{\partial \boldsymbol{u}}{\partial t} = 
+\frac{\partial \boldsymbol{u}}{\partial t} =
  -Ra \, \boldsymbol{u}
 \hspace{1cm}   (1)
 $$
@@ -108,7 +108,7 @@ $$
 $$
 
 $$
-\frac{\partial h \phi}{\partial t} = 
+\frac{\partial h \phi}{\partial t} =
 - \frac{h}{\tau} \left( \phi - \phi_0 \right)
 \hspace{1cm}   (3)
 $$

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -619,6 +619,9 @@ int initAuxVarsTest(const std::string &mesh) {
    MachEnv *DefEnv  = MachEnv::getDefaultEnv();
    MPI_Comm DefComm = DefEnv->getComm();
 
+   // initialize logging
+   initLogging(DefEnv);
+
    int IOErr = IO::init(DefComm);
    if (IOErr != 0) {
       Err++;

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -594,6 +594,9 @@ int initTendTest(const std::string &mesh) {
    MachEnv *DefEnv  = MachEnv::getDefaultEnv();
    MPI_Comm DefComm = DefEnv->getComm();
 
+   // Initialize logging
+   initLogging(DefEnv);
+
    I4 IOErr = IO::init(DefComm);
    if (IOErr != 0) {
       Err++;


### PR DESCRIPTION

The recent merge of #102 missed two recent unit test drivers that had been merged while in review, so this PR updates those test drivers to properly initialize the Logging. In addition, some linting errors that appear on some design docs were also fixed.

Checklist
* [x] Documentation:
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
after.


