### PR TITLE
Refactor creation of static variables

### DIFF
--- a/components/omega/doc/devGuide/Halo.md
+++ b/components/omega/doc/devGuide/Halo.md
@@ -29,9 +29,9 @@ Once initialized, a pointer to the default Halo can be retrieved with:
 OMEGA::Halo *DefHalo = OMEGA::Halo::getDefault();
 ```
 Additional Halo objects can be constructed for defined MachEnv and Decomp
-objects by calling the Halo constructor with a supplied `std::string` Name:
+objects by calling the Halo create method with a supplied `std::string` Name:
 ```c++
-OMEGA::Halo NewHalo(Name, NewEnv, NewDecomp);
+OMEGA::Halo::create(Name, NewEnv, NewDecomp);
 ```
 A pointer to each constructed Halo is stored in a `std::map` container, which
 can be retrieved by supplying the Name to `OMEGA::Halo::get(Name)`.

--- a/components/omega/doc/devGuide/MachEnv.md
+++ b/components/omega/doc/devGuide/MachEnv.md
@@ -53,7 +53,7 @@ environment from a strided set of tasks starting at the `Begin` Task
 (eg all odd tasks would have Begin=1 and Stride=2). The final
 interface creates a subset containing the selected tasks stored in
 a vector `Tasks`. Each new environment is given a `Name` and can be
-retrieved by name using `OMEGA::MachEnv::getEnv(Name)`. Once retrieved,
+retrieved by name using `OMEGA::MachEnv::get(Name)`. Once retrieved,
 the other get functions listed above are used to get each data member.
 Because the new environments are subsets of the default environment, one
 additional function `OMEGA::MachEnv::isMember()` is provided so that

--- a/components/omega/doc/devGuide/MachEnv.md
+++ b/components/omega/doc/devGuide/MachEnv.md
@@ -13,7 +13,7 @@ On model initiation, the initialization routine `OMEGA::MachEnv::init()`
 is called to set up the default MachEnv, which can be retrieved at
 any time using:
 ```c++
-OMEGA::MachEnv DefEnv = OMEGA::MachEnv::getDefaultEnv();
+OMEGA::MachEnv DefEnv = OMEGA::MachEnv::getDefault();
 ```
 that returns a pointer to the default environment.
 Once an environment has been retrieved, the individual data members

--- a/components/omega/doc/devGuide/OceanState.md
+++ b/components/omega/doc/devGuide/OceanState.md
@@ -10,14 +10,14 @@ Err = OMEGA::Decomp::init();
 Err = OMEGA::HorzMesh::init();
 Err = OMEGA::OceanState::init();
 ```
-The constructor:
+The create method:
 ```c++
-OceanState(const std::string &Name, ///< [in] Name for mesh
-           HorzMesh *Mesh,          ///< [in] Horizontal mesh
-           Decomp *MeshDecomp,      ///< [in] Decomp for Mesh
-           Halo *MeshHalo_,         ///< [in] Halo for Mesh
-           const int NVertLevels_,  ///< [in] Number of vertical levels
-           const int NTimeLevels_   ///< [in] Number of time levels
+OceanState::create(const std::string &Name, ///< [in] Name for mesh
+                   HorzMesh *Mesh,          ///< [in] Horizontal mesh
+                   Decomp *MeshDecomp,      ///< [in] Decomp for Mesh
+                   Halo *MeshHalo_,         ///< [in] Halo for Mesh
+                   const int NVertLevels_,  ///< [in] Number of vertical levels
+                   const int NTimeLevels_   ///< [in] Number of time levels
 );
 ```
 allocates the `NormalVelocity` and `LayerThickness` arrays for a given number of time levels.

--- a/components/omega/doc/userGuide/Broadcast.md
+++ b/components/omega/doc/userGuide/Broadcast.md
@@ -50,7 +50,7 @@ OMEGA::I4 MyVal      = 1;
 const int RootTask   = 1;
 
 // Get a specific Omega Machine Environment
-OMEGA::MachEnv *SubsetEnv = OMEGA::MachEnv::getEnv("Subset");
+OMEGA::MachEnv *SubsetEnv = OMEGA::MachEnv::get("Subset");
 
 // broadcast from the master task of SubsetEnv environment
 OMEGA::Broadcast(MyVal, SubsetEnv);

--- a/components/omega/src/base/Broadcast.cpp
+++ b/components/omega/src/base/Broadcast.cpp
@@ -26,7 +26,7 @@ int Broadcast(I4 &Value, const MachEnv *InEnv, const int RankBcast) {
 } // end Broadcast for I4 data type
 
 int Broadcast(I4 &Value, const int RankBcast) {
-   return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+   return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 } // end Broadcast for I4 data type
 
 //------------------------------------------------------------------------------
@@ -41,7 +41,7 @@ int Broadcast(I8 &Value, const MachEnv *InEnv, const int RankBcast) {
 } // end Broadcast for I8 data type
 
 int Broadcast(I8 &Value, const int RankBcast) {
-   return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+   return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 } // end Broadcast for I8 data type
 
 //------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ int Broadcast(R4 &Value, const MachEnv *InEnv, const int RankBcast) {
 } // end Broadcast
 
 int Broadcast(R4 &Value, const int RankBcast) {
-   return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+   return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 } // end Broadcast
 
 //------------------------------------------------------------------------------
@@ -71,7 +71,7 @@ int Broadcast(R8 &Value, const MachEnv *InEnv, const int RankBcast) {
 } // end Broadcast
 
 int Broadcast(R8 &Value, const int RankBcast) {
-   return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+   return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 } // end Broadcast
 
 //------------------------------------------------------------------------------
@@ -86,7 +86,7 @@ int Broadcast(bool &Value, const MachEnv *InEnv, const int RankBcast) {
 } // end Broadcast
 
 int Broadcast(bool &Value, const int RankBcast) {
-   return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+   return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 } // end Broadcast
 
 //------------------------------------------------------------------------------
@@ -112,7 +112,7 @@ int Broadcast(std::string &Value, const MachEnv *InEnv, const int RankBcast) {
 } // end Broadcast
 
 int Broadcast(std::string &Value, const int RankBcast) {
-   return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+   return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 } // end Broadcast
 
 //------------------------------------------------------------------------------
@@ -129,7 +129,7 @@ int Broadcast(std::vector<I4> &Value, const MachEnv *InEnv,
 } // end Broadcast
 
 int Broadcast(std::vector<I4> &Value, const int RankBcast) {
-   return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+   return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 } // end Broadcast
 
 //------------------------------------------------------------------------------
@@ -146,7 +146,7 @@ int Broadcast(std::vector<I8> &Value, const MachEnv *InEnv,
 } // end Broadcast
 
 int Broadcast(std::vector<I8> &Value, const int RankBcast) {
-   return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+   return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 } // end Broadcast
 
 //------------------------------------------------------------------------------
@@ -163,7 +163,7 @@ int Broadcast(std::vector<R4> &Value, const MachEnv *InEnv,
 } // end Broadcast
 
 int Broadcast(std::vector<R4> &Value, const int RankBcast) {
-   return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+   return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 } // end Broadcast
 
 //------------------------------------------------------------------------------
@@ -180,7 +180,7 @@ int Broadcast(std::vector<R8> &Value, const MachEnv *InEnv,
 } // end Broadcast
 
 int Broadcast(std::vector<R8> &Value, const int RankBcast) {
-   return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+   return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 }
 
 //------------------------------------------------------------------------------
@@ -198,7 +198,7 @@ int Broadcast(std::vector<R8> &Value, const int RankBcast) {
 //
 // int Broadcast(std::vector<bool> &Value, const int RankBcast
 //) {
-//    return Broadcast(Value, MachEnv::getDefaultEnv(), RankBcast);
+//    return Broadcast(Value, MachEnv::getDefault(), RankBcast);
 //}
 
 } // namespace OMEGA

--- a/components/omega/src/base/Broadcast.h
+++ b/components/omega/src/base/Broadcast.h
@@ -17,55 +17,54 @@
 namespace OMEGA {
 
 // blocking broadcast scalar
-int Broadcast(I4 &Value, const MachEnv *InEnv = MachEnv::getDefaultEnv(),
+int Broadcast(I4 &Value, const MachEnv *InEnv = MachEnv::getDefault(),
               const int RankBcast = -1);
 int Broadcast(I4 &Value, const int RankBcast);
 
-int Broadcast(I8 &Value, const MachEnv *InEnv = MachEnv::getDefaultEnv(),
+int Broadcast(I8 &Value, const MachEnv *InEnv = MachEnv::getDefault(),
               const int RankBcast = -1);
 int Broadcast(I8 &Value, const int RankBcast);
 
-int Broadcast(R4 &Value, const MachEnv *InEnv = MachEnv::getDefaultEnv(),
+int Broadcast(R4 &Value, const MachEnv *InEnv = MachEnv::getDefault(),
               const int RankBcast = -1);
 int Broadcast(R4 &Value, const int RankBcast);
 
-int Broadcast(R8 &Value, const MachEnv *InEnv = MachEnv::getDefaultEnv(),
+int Broadcast(R8 &Value, const MachEnv *InEnv = MachEnv::getDefault(),
               const int RankBcast = -1);
 int Broadcast(R8 &Value, const int RankBcast);
 
-int Broadcast(bool &Value, const MachEnv *InEnv = MachEnv::getDefaultEnv(),
+int Broadcast(bool &Value, const MachEnv *InEnv = MachEnv::getDefault(),
               const int RankBcast = -1);
 int Broadcast(bool &Value, const int RankBcast);
 
-int Broadcast(std::string &Value,
-              const MachEnv *InEnv = MachEnv::getDefaultEnv(),
-              const int RankBcast  = -1);
+int Broadcast(std::string &Value, const MachEnv *InEnv = MachEnv::getDefault(),
+              const int RankBcast = -1);
 int Broadcast(std::string &Value, const int RankBcast);
 
 // blocking broadcast array
 int Broadcast(std::vector<I4> &Value,
-              const MachEnv *InEnv = MachEnv::getDefaultEnv(),
+              const MachEnv *InEnv = MachEnv::getDefault(),
               const int RankBcast  = -1);
 int Broadcast(std::vector<I4> &Value, const int RankBcast);
 
 int Broadcast(std::vector<I8> &Value,
-              const MachEnv *InEnv = MachEnv::getDefaultEnv(),
+              const MachEnv *InEnv = MachEnv::getDefault(),
               const int RankBcast  = -1);
 int Broadcast(std::vector<I8> &Value, const int RankBcast);
 
 int Broadcast(std::vector<R4> &Value,
-              const MachEnv *InEnv = MachEnv::getDefaultEnv(),
+              const MachEnv *InEnv = MachEnv::getDefault(),
               const int RankBcast  = -1);
 int Broadcast(std::vector<R4> &Value, const int RankBcast);
 
 int Broadcast(std::vector<R8> &Value,
-              const MachEnv *InEnv = MachEnv::getDefaultEnv(),
+              const MachEnv *InEnv = MachEnv::getDefault(),
               const int RankBcast  = -1);
 int Broadcast(std::vector<R8> &Value, const int RankBcast);
 
 // NOTE: Elements of vector<bool> seem to be non-addressable
 // int Broadcast(std::vector<bool> &Value,
-//              const MachEnv *InEnv = MachEnv::getDefaultEnv(),
+//              const MachEnv *InEnv = MachEnv::getDefault(),
 //              const int RankBcast = -1);
 // int Broadcast(std::vector<bool> &Value, const int RankBcast);
 

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -32,7 +32,7 @@ namespace OMEGA {
 
 // create the static class members
 Decomp *Decomp::DefaultDecomp = nullptr;
-std::map<std::string, Decomp> Decomp::AllDecomps;
+std::map<std::string, std::unique_ptr<Decomp>> Decomp::AllDecomps;
 
 // Some useful local utility routines
 //------------------------------------------------------------------------------
@@ -337,12 +337,9 @@ int Decomp::init(const std::string &MeshFileName) {
    // Use one partition per MPI task as the default
    I4 NParts = DefEnv->getNumTasks();
 
-   // Create the default decomposition
-   Decomp DefDecomp("Default", DefEnv, NParts, Method, InHaloWidth,
-                    MeshFileName);
-
-   // Retrieve this environment and set pointer to DefaultDecomp
-   Decomp::DefaultDecomp = Decomp::get("Default");
+   // Create the default decomposition and set pointer to it
+   Decomp::DefaultDecomp = Decomp::create("Default", DefEnv, NParts, Method,
+                                          InHaloWidth, MeshFileName);
 
    return Err;
 
@@ -652,11 +649,36 @@ Decomp::Decomp(
 
    CellsOnVertex = createDeviceMirrorCopy(CellsOnVertexH);
    EdgesOnVertex = createDeviceMirrorCopy(EdgesOnVertexH);
-
-   // Assign this as the default decomposition
-   AllDecomps.emplace(Name, *this);
-
 } // end decomposition constructor
+
+// Creates a new decomposition using the constructor and puts it in the
+// AllDecomps map
+Decomp *Decomp::create(
+    const std::string &Name,        //< [in] Name for new decomposition
+    const MachEnv *Env,             //< [in] MachEnv for the new partition
+    I4 NParts,                      //< [in] num of partitions for new decomp
+    PartMethod Method,              //< [in] method for partitioning
+    I4 HaloWidth,                   //< [in] width of halo in new decomp
+    const std::string &MeshFileName //< [in] name of file with mesh info
+) {
+
+   // Check to see if a decomposition of the same name already exists and
+   // if so, exit with an error
+   if (AllDecomps.find(Name) != AllDecomps.end()) {
+      LOG_ERROR("Attempted to create a Decomp with name {} but a Decomp of "
+                "that name already exists",
+                Name);
+      return nullptr;
+   }
+
+   // create a new decomp on the heap and put it in a map of
+   // unique_ptrs, which will manage its lifetime
+   auto *NewDecomp =
+       new Decomp(Name, Env, NParts, Method, HaloWidth, MeshFileName);
+   AllDecomps.emplace(Name, NewDecomp);
+
+   return NewDecomp;
+} // end Decomp create
 
 // Destructor
 //------------------------------------------------------------------------------
@@ -704,7 +726,7 @@ Decomp *Decomp::get(const std::string Name ///< [in] Name of environment
 
    // if found, return the decomposition pointer
    if (it != AllDecomps.end()) {
-      return &(it->second);
+      return it->second.get();
 
       // otherwise print an error and return a null pointer
    } else {

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -332,7 +332,7 @@ int Decomp::init(const std::string &MeshFileName) {
    PartMethod Method        = getPartMethodFromStr(DecompMethod);
 
    // Retrieve the default machine environment
-   MachEnv *DefEnv = MachEnv::getDefaultEnv();
+   MachEnv *DefEnv = MachEnv::getDefault();
 
    // Use one partition per MPI task as the default
    I4 NParts = DefEnv->getNumTasks();

--- a/components/omega/src/base/Halo.cpp
+++ b/components/omega/src/base/Halo.cpp
@@ -115,7 +115,7 @@ int Halo::init() {
 
    I4 IErr{0}; // error code
 
-   MachEnv *DefEnv   = MachEnv::getDefaultEnv();
+   MachEnv *DefEnv   = MachEnv::getDefault();
    Decomp *DefDecomp = Decomp::getDefault();
 
    Halo::DefaultHalo = create("Default", DefEnv, DefDecomp);

--- a/components/omega/src/base/Halo.cpp
+++ b/components/omega/src/base/Halo.cpp
@@ -22,7 +22,7 @@ namespace OMEGA {
 
 // create the static class members
 Halo *Halo::DefaultHalo = nullptr;
-std::map<std::string, Halo> Halo::AllHalos;
+std::map<std::string, std::unique_ptr<Halo>> Halo::AllHalos;
 
 //------------------------------------------------------------------------------
 // Local routine that searches a std::vector<I4> for a particular entry and
@@ -118,9 +118,7 @@ int Halo::init() {
    MachEnv *DefEnv   = MachEnv::getDefaultEnv();
    Decomp *DefDecomp = Decomp::getDefault();
 
-   Halo DefHalo("Default", DefEnv, DefDecomp);
-
-   Halo::DefaultHalo = Halo::get("Default");
+   Halo::DefaultHalo = create("Default", DefEnv, DefDecomp);
 
    return IErr;
 
@@ -181,10 +179,28 @@ Halo::Halo(const std::string &Name, const MachEnv *InEnv,
                                    NeighborList[INghbr]));
    }
 
-   // Associate this instance with the input name
-   AllHalos.emplace(Name, *this);
-
 } // end Halo constructor
+
+/// Creates a new halo by calling the constructor and puts it in the AllHalos
+/// map
+Halo *Halo::create(const std::string &Name, const MachEnv *Env,
+                   const Decomp *Decomp) {
+   // Check to see if a halo of the same name already exists and
+   // if so, exit with an error
+   if (AllHalos.find(Name) != AllHalos.end()) {
+      LOG_ERROR("Attempted to create a Halo with name {} but a Halo of "
+                "that name already exists",
+                Name);
+      return nullptr;
+   }
+
+   // create a new halo on the heap and put it in a map of
+   // unique_ptrs, which will manage its lifetime
+   auto *NewHalo = new Halo(Name, Env, Decomp);
+   AllHalos.emplace(Name, NewHalo);
+
+   return NewHalo;
+} // end Halo create
 
 // Destructor
 //------------------------------------------------------------------------------
@@ -234,7 +250,7 @@ Halo *Halo::get(const std::string Name // name of Halo to retrieve
 
    // if found, return the Halo pointer
    if (it != AllHalos.end()) {
-      return &(it->second);
+      return it->second.get();
    } else {
       // otherwise print an error and retrun a null pointer
       LOG_ERROR("Halo::get: Attempt to retrieve non-existent Halo:");

--- a/components/omega/src/base/Halo.h
+++ b/components/omega/src/base/Halo.h
@@ -23,6 +23,7 @@
 #include "Logging.h"
 #include "MachEnv.h"
 #include "mpi.h"
+#include <memory>
 #include <numeric>
 
 namespace OMEGA {
@@ -54,7 +55,7 @@ class Halo {
 
    /// All halos are tracked/stored within the class as a map paired with a
    /// name for later retrieval.
-   static std::map<std::string, Halo> AllHalos;
+   static std::map<std::string, std::unique_ptr<Halo>> AllHalos;
 
    const Decomp *MyDecomp{nullptr}; /// Pointer to decomposition object
 
@@ -252,14 +253,23 @@ class Halo {
    int unpackBuffer(HostArray5DR4 &Array);
    int unpackBuffer(HostArray5DR8 &Array);
 
+   /// Construct a new halo labeled Name for the input MachEnv and Decomp
+   Halo(const std::string &Name, const MachEnv *InEnv, const Decomp *InDecomp);
+
+   // Forbid copy and move construction
+   Halo(const Halo &) = delete;
+   Halo(Halo &&)      = delete;
+
  public:
    // Methods
 
    /// initialize default Halo
    static int init();
 
-   /// Construct a new halo labeled Name for the input MachEnv and Decomp
-   Halo(const std::string &Name, const MachEnv *InEnv, const Decomp *InDecomp);
+   /// Creates a new halo by calling the constructor and puts it in the AllHalos
+   /// map
+   static Halo *create(const std::string &Name, const MachEnv *Env,
+                       const Decomp *Decomp);
 
    /// Destructor
    ~Halo();

--- a/components/omega/src/base/MachEnv.cpp
+++ b/components/omega/src/base/MachEnv.cpp
@@ -74,8 +74,9 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
 ) {
    // Check for valid master task input
    if (InMasterTask < 0 || InMasterTask >= NewSize) {
-      std::cerr << "Invalid MasterTask " << InMasterTask
-                << " sent to constructor: must be [0,NewSize-1]" << std::endl;
+      LOG_ERROR(
+          "Invalid MasterTask {} sent to constructor: must be [0,NewSize-1]",
+          InMasterTask);
       return;
    }
 
@@ -86,9 +87,9 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
    int OldSize;
    MPI_Comm_size(InComm, &OldSize);
    if (NewSize > OldSize) {
-      std::cerr << "Invalid NewSize in MachEnv constructor "
-                << "NewSize = " << NewSize << " is larger than old size"
-                << OldSize << std::endl;
+      LOG_ERROR("Invalid NewSize in MachEnv constructor NewSize = {} is larger "
+                "than old size {}",
+                NewSize, OldSize);
       return;
    }
 
@@ -108,8 +109,7 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
    // Create the communicator for the new group
    int Err = MPI_Comm_create(InComm, NewGroup, &Comm);
    if (Err != MPI_SUCCESS) {
-      std::cerr << "Error creating new communicator in MachEnv constructor"
-                << std::endl;
+      LOG_ERROR("Error creating new communicator in MachEnv constructor");
       return;
    }
 
@@ -163,8 +163,9 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
 ) {
    // Check for valid master task input
    if (InMasterTask < 0 || InMasterTask >= NewSize) {
-      std::cerr << "Invalid MasterTask " << InMasterTask
-                << " sent to constructor: must be [0,NewSize-1]" << std::endl;
+      LOG_ERROR(
+          "Invalid MasterTask {} sent to constructor: must be [0,NewSize-1]",
+          InMasterTask);
       return;
    }
 
@@ -183,9 +184,9 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
    int OldSize;
    MPI_Comm_size(InComm, &OldSize);
    if (LastTask >= OldSize) {
-      std::cerr << "Invalid range in strided MachEnv constructor "
-                << "LastTask = " << LastTask << " is larger than old size"
-                << OldSize << std::endl;
+      LOG_ERROR("Invalid range in strided MachEnv constructor LastTask = {} is "
+                "larger than old size {}",
+                LastTask, OldSize);
       return;
    }
 
@@ -196,8 +197,7 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
    // Create the communicator for the new group
    int Err = MPI_Comm_create(InComm, NewGroup, &Comm);
    if (Err != MPI_SUCCESS) {
-      std::cerr << "Error creating new communicator in MachEnv constructor"
-                << std::endl;
+      LOG_ERROR("Error creating new communicator in MachEnv constructor");
       return;
    }
 
@@ -253,8 +253,9 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
 
    // Check for valid master task input
    if (InMasterTask < 0 || InMasterTask >= NewSize) {
-      std::cerr << "Invalid MasterTask " << InMasterTask
-                << " sent to constructor: must be [0,NewSize-1]" << std::endl;
+      LOG_ERROR(
+          "Invalid MasterTask {} sent to constructor: must be [0,NewSize-1]",
+          InMasterTask);
       return;
    }
 
@@ -265,9 +266,9 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
    for (int i = 0; i < NewSize; ++i) {
       int ThisTask = Tasks[i];
       if (ThisTask < 0 || ThisTask >= OldSize) {
-         std::cerr << "Invalid task in MachEnv constructor "
-                   << "task = " << ThisTask << " is < 0 or larger than old size"
-                   << OldSize << std::endl;
+         LOG_ERROR("Invalid task in MachEnv constructor task = {} is < 0 or "
+                   "larger than old size {}",
+                   ThisTask, OldSize);
          return;
       }
    }
@@ -283,8 +284,7 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
    // Create the communicator for the new group
    int Err = MPI_Comm_create(InComm, NewGroup, &Comm);
    if (Err != MPI_SUCCESS) {
-      std::cerr << "Error creating new communicator in MachEnv constructor"
-                << std::endl;
+      LOG_ERROR("Error creating new communicator in MachEnv constructor");
       return;
    }
 
@@ -375,8 +375,9 @@ MachEnv *MachEnv::get(const std::string Name ///< [in] Name of environment
 
       // otherwise print an error and return a null pointer
    } else {
-      std::cerr << "Attempt to retrieve a non-existent MachEnv " << Name
-                << " has not been defined or has been removed";
+      LOG_ERROR("Attempt to retrieve a non-existent MachEnv {} has not been "
+                "defined or has been removed",
+                Name);
       return nullptr;
    }
 
@@ -428,8 +429,8 @@ int MachEnv::setMasterTask(const int TaskID) {
          MasterTaskFlag = false;
       }
    } else {
-      std::cerr << "Error: invalid TaskID sent to MachEnv.setMasterTask "
-                << TaskID << std::endl;
+      LOG_ERROR("Error: invalid TaskID sent to MachEnv.setMasterTask {}",
+                TaskID);
       Err = -1;
    }
    return Err;

--- a/components/omega/src/base/MachEnv.cpp
+++ b/components/omega/src/base/MachEnv.cpp
@@ -363,7 +363,7 @@ MachEnv *MachEnv::getDefault() { return MachEnv::DefaultEnv; }
 
 //------------------------------------------------------------------------------
 // Get environment by name
-MachEnv *MachEnv::getEnv(const std::string Name ///< [in] Name of environment
+MachEnv *MachEnv::get(const std::string Name ///< [in] Name of environment
 ) {
 
    // look for an instance of this name
@@ -380,7 +380,7 @@ MachEnv *MachEnv::getEnv(const std::string Name ///< [in] Name of environment
       return nullptr;
    }
 
-} // end getEnv
+} // end get
 
 //------------------------------------------------------------------------------
 // Get communicator for an environment

--- a/components/omega/src/base/MachEnv.cpp
+++ b/components/omega/src/base/MachEnv.cpp
@@ -359,7 +359,7 @@ void MachEnv::removeAll() {
 // Retrieval functions
 //------------------------------------------------------------------------------
 // Get default environment
-MachEnv *MachEnv::getDefaultEnv() { return MachEnv::DefaultEnv; }
+MachEnv *MachEnv::getDefault() { return MachEnv::DefaultEnv; }
 
 //------------------------------------------------------------------------------
 // Get environment by name

--- a/components/omega/src/base/MachEnv.cpp
+++ b/components/omega/src/base/MachEnv.cpp
@@ -442,14 +442,13 @@ int MachEnv::setMasterTask(const int TaskID) {
 
 void MachEnv::print() const {
 
-   std::cout << "  Comm           = " << Comm << std::endl;
-   std::cout << "  MyTask         = " << MyTask << std::endl;
-   std::cout << "  NumTasks       = " << NumTasks << std::endl;
-   std::cout << "  MasterTask     = " << MasterTask << std::endl;
-   std::cout << "  MasterTaskFlag = " << MasterTaskFlag << std::endl;
-   std::cout << "  MemberFlag     = " << MemberFlag << std::endl;
-   std::cout << "  NumThreads     = " << NumThreads << std::endl;
-   std::cout << "  VecLength      = " << VecLength << std::endl;
+   LOG_INFO("  MyTask         = {}", MyTask);
+   LOG_INFO("  NumTasks       = {}", NumTasks);
+   LOG_INFO("  MasterTask     = {}", MasterTask);
+   LOG_INFO("  MasterTaskFlag = {}", MasterTaskFlag);
+   LOG_INFO("  MemberFlag     = {}", MemberFlag);
+   LOG_INFO("  NumThreads     = {}", NumThreads);
+   LOG_INFO("  VecLength      = {}", VecLength);
 
 } // end print
 

--- a/components/omega/src/base/MachEnv.h
+++ b/components/omega/src/base/MachEnv.h
@@ -20,7 +20,11 @@
 #include "mpi.h"
 
 #include <map>
+#include <memory>
 #include <string>
+// Note that we should replace iostream and std::cerr with the logging
+// capability once that is enabled.
+#include <iostream>
 
 namespace OMEGA {
 
@@ -61,24 +65,16 @@ class MachEnv {
 
    /// All environments are tracked/stored within the class as a
    /// map paired with a name for later retrieval.
-   static std::map<std::string, MachEnv> AllEnvs;
+   static std::map<std::string, std::unique_ptr<MachEnv>> AllEnvs;
+
+   /// CONSTRUCTORS
+   /// All constructors are declared private to prevent accidental creation
+   /// of new environments, MachEnv::create is the only way to create a new
+   /// environment
 
    /// Constructor for environment based on input MPI communicator
-   /// This should only be used for the default environment so is
-   /// kept private and called from the init routine.
    MachEnv(const std::string Name, ///< [in] name of the environment
            const MPI_Comm inComm   ///< [in] MPI communicator to use
-   );
-
- public:
-   // Methods
-
-   /// Initializes the Machine Environment and creates the default
-   /// machine environment based on an input MPI communicator. In
-   /// standalone mode, this will typically be MPI_COMM_WORLD, but
-   /// in coupled mode, this is the communicator assigned to the
-   /// Omega component.
-   static void init(const MPI_Comm InComm ///< [in] MPI communicator to use
    );
 
    /// Constructs a new environment with a given name from a contiguous
@@ -111,6 +107,44 @@ class MachEnv {
            const int NewSize,         ///< [in] num tasks in new env
            const int Tasks[],         ///< [in] vector of parent tasks to incl
            const int InMasterTask = 0 ///< [in] optional task to use for master
+   );
+
+   // forbid copy and move construction
+   MachEnv(const MachEnv &) = delete;
+   MachEnv(MachEnv &&)      = delete;
+
+ public:
+   // Methods
+
+   // Creates a new environment by calling the constructor with the
+   // supplied arguments and stores it in the map of all environments.
+   // This a variadic template because MachEnv constructors have different
+   // numbers of arguments and we want to simply forward the supplied
+   // arguments to the constructor
+   template <class... ArgTypes>
+   static MachEnv *create(const std::string &Name, ArgTypes &&...Args) {
+      // Check to see if an environment of the same name already exists and
+      // if so, exit with an error
+      if (AllEnvs.find(Name) != AllEnvs.end()) {
+         std::cerr << "Attempted to create a MachEnv with name " << Name
+                   << " but an Env of that name already exists ";
+         return nullptr;
+      }
+
+      // create a new environment on the heap and put it in a map of
+      // unique_ptrs, which will manage its lifetime
+      auto *NewEnv = new MachEnv(Name, std::forward<ArgTypes>(Args)...);
+      AllEnvs.emplace(Name, NewEnv);
+
+      return getEnv(Name);
+   }
+
+   /// Initializes the Machine Environment and creates the default
+   /// machine environment based on an input MPI communicator. In
+   /// standalone mode, this will typically be MPI_COMM_WORLD, but
+   /// in coupled mode, this is the communicator assigned to the
+   /// Omega component.
+   static void init(const MPI_Comm InComm ///< [in] MPI communicator to use
    );
 
    /// Removes a MachEnv

--- a/components/omega/src/base/MachEnv.h
+++ b/components/omega/src/base/MachEnv.h
@@ -158,7 +158,7 @@ class MachEnv {
    // Retrieval functions
 
    /// Retrieve the default environment
-   static MachEnv *getDefaultEnv();
+   static MachEnv *getDefault();
 
    /// Retrieve any other environment by name
    static MachEnv *getEnv(const std::string Name ///< [in] name of environment

--- a/components/omega/src/base/MachEnv.h
+++ b/components/omega/src/base/MachEnv.h
@@ -19,12 +19,9 @@
 
 #include "mpi.h"
 
+#include "Logging.h"
 #include <map>
 #include <memory>
-#include <string>
-// Note that we should replace iostream and std::cerr with the logging
-// capability once that is enabled.
-#include <iostream>
 
 namespace OMEGA {
 
@@ -126,8 +123,9 @@ class MachEnv {
       // Check to see if an environment of the same name already exists and
       // if so, exit with an error
       if (AllEnvs.find(Name) != AllEnvs.end()) {
-         std::cerr << "Attempted to create a MachEnv with name " << Name
-                   << " but an Env of that name already exists ";
+         LOG_ERROR("Attempted to create a MachEnv with name {} but an Env of "
+                   "that name already exists",
+                   Name);
          return nullptr;
       }
 

--- a/components/omega/src/base/MachEnv.h
+++ b/components/omega/src/base/MachEnv.h
@@ -136,7 +136,7 @@ class MachEnv {
       auto *NewEnv = new MachEnv(Name, std::forward<ArgTypes>(Args)...);
       AllEnvs.emplace(Name, NewEnv);
 
-      return getEnv(Name);
+      return get(Name);
    }
 
    /// Initializes the Machine Environment and creates the default
@@ -161,7 +161,7 @@ class MachEnv {
    static MachEnv *getDefault();
 
    /// Retrieve any other environment by name
-   static MachEnv *getEnv(const std::string Name ///< [in] name of environment
+   static MachEnv *get(const std::string Name ///< [in] name of environment
    );
 
    /// Get communicator for an environment

--- a/components/omega/src/infra/Config.cpp
+++ b/components/omega/src/infra/Config.cpp
@@ -44,7 +44,7 @@ Config::Config(const std::string &InName // [in] name of config, node
 
    if (NotInitialized) {
       // Determine MPI variables
-      MachEnv *DefEnv = MachEnv::getDefaultEnv();
+      MachEnv *DefEnv = MachEnv::getDefault();
       I4 NumTasks     = DefEnv->getNumTasks();
       I4 MyTask       = DefEnv->getMyTask();
       ConfigComm      = DefEnv->getComm();
@@ -1083,7 +1083,7 @@ int Config::write(std::string FileName /// name of file for config
 ) {
    int Err = 0;
 
-   MachEnv *DefEnv = MachEnv::getDefaultEnv();
+   MachEnv *DefEnv = MachEnv::getDefault();
    if (DefEnv->isMasterTask()) {
       std::ofstream Outfile(FileName);
       if (Outfile.good()) {

--- a/components/omega/src/infra/Logging.cpp
+++ b/components/omega/src/infra/Logging.cpp
@@ -11,6 +11,7 @@
 #define _OMEGA_TOSTRING(x)  _OMEGA_STRINGIFY(x)
 
 #include "Logging.h"
+#include "MachEnv.h"
 #include <iostream>
 #include <spdlog/sinks/basic_file_sink.h>
 

--- a/components/omega/src/infra/Logging.h
+++ b/components/omega/src/infra/Logging.h
@@ -18,7 +18,6 @@
 #endif
 
 #include "LogFormatters.h"
-#include "MachEnv.h"
 #include <spdlog/spdlog.h>
 #include <string>
 
@@ -73,6 +72,8 @@
 #endif
 
 namespace OMEGA {
+
+class MachEnv;
 
 const std::string OmegaDefaultLogfile = "omega.log";
 

--- a/components/omega/src/ocn/HorzMesh.h
+++ b/components/omega/src/ocn/HorzMesh.h
@@ -15,6 +15,7 @@
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 
+#include <memory>
 #include <string>
 
 namespace OMEGA {
@@ -55,7 +56,16 @@ class HorzMesh {
 
    static HorzMesh *DefaultHorzMesh;
 
-   static std::map<std::string, HorzMesh> AllHorzMeshes;
+   static std::map<std::string, std::unique_ptr<HorzMesh>> AllHorzMeshes;
+
+   /// Construct a new local mesh for a given decomposition
+   HorzMesh(const std::string &Name, ///< [in] Name for mesh
+            Decomp *Decomp           ///< [in] Decomposition for mesh
+   );
+
+   // Forbid copy and move construction
+   HorzMesh(const HorzMesh &) = delete;
+   HorzMesh(HorzMesh &&)      = delete;
 
  public:
    // KOKKOS_LAMBDA does not allow to have parallel_* functions inside of a
@@ -227,9 +237,10 @@ class HorzMesh {
    /// Initialize Omega local mesh
    static int init();
 
-   /// Construct a new local mesh for a given decomposition
-   HorzMesh(const std::string &Name, ///< [in] Name for mesh
-            Decomp *Decomp           ///< [in] Decomposition for mesh
+   /// Creates a new mesh by calling the constructor and puts it in the
+   /// AllHorzMeshes map
+   static HorzMesh *create(const std::string &Name, ///< [in] Name for mesh
+                           Decomp *Decomp ///< [in] Decomposition for mesh
    );
 
    /// Destructor - deallocates all memory and deletes a HorzMesh

--- a/components/omega/src/ocn/OceanState.h
+++ b/components/omega/src/ocn/OceanState.h
@@ -42,7 +42,20 @@ class OceanState {
 
    static OceanState *DefaultOceanState;
 
-   static std::map<std::string, OceanState> AllOceanStates;
+   static std::map<std::string, std::unique_ptr<OceanState>> AllOceanStates;
+
+   /// Construct a new local state for a given decomposition
+   OceanState(const std::string &Name, ///< [in] Name for mesh
+              HorzMesh *Mesh,          ///< [in] Horizontal mesh
+              Decomp *MeshDecomp,      ///< [in] Decomp for Mesh
+              Halo *MeshHalo_,         ///< [in] Halo for Mesh
+              const int NVertLevels_,  ///< [in] Number of vertical levels
+              const int NTimeLevels_   ///< [in] Number of time levels
+   );
+
+   // Forbid copy and move construction
+   OceanState(const OceanState &) = delete;
+   OceanState(OceanState &&)      = delete;
 
  public:
    // Variables
@@ -96,13 +109,15 @@ class OceanState {
    /// Initialize Omega local state
    static int init();
 
-   /// Construct a new local state for a given decomposition
-   OceanState(const std::string &Name, ///< [in] Name for mesh
-              HorzMesh *Mesh,          ///< [in] Horizontal mesh
-              Decomp *MeshDecomp,      ///< [in] Decomp for Mesh
-              Halo *MeshHalo_,         ///< [in] Halo for Mesh
-              const int NVertLevels_,  ///< [in] Number of vertical levels
-              const int NTimeLevels_   ///< [in] Number of time levels
+   /// Create a new state by calling the constructor and put it in the
+   /// AllOceanStates map
+   static OceanState *
+   create(const std::string &Name, ///< [in] Name for mesh
+          HorzMesh *Mesh,          ///< [in] Horizontal mesh
+          Decomp *MeshDecomp,      ///< [in] Decomp for Mesh
+          Halo *MeshHalo,          ///< [in] Halo for Mesh
+          const int NVertLevels,   ///< [in] Number of vertical levels
+          const int NTimeLevels    ///< [in] Number of time levels
    );
 
    /// Swap time levels to update state arrays

--- a/components/omega/test/base/BroadcastTest.cpp
+++ b/components/omega/test/base/BroadcastTest.cpp
@@ -161,7 +161,7 @@ int main(int argc, char *argv[]) {
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
 
    // Get the Default environment
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
 
    // I4 Broadcast tests
    TestBroadcast<OMEGA::I4>(DefEnv, "I4", &RetVal);

--- a/components/omega/test/base/BroadcastTest.cpp
+++ b/components/omega/test/base/BroadcastTest.cpp
@@ -187,8 +187,8 @@ int main(int argc, char *argv[]) {
    // Initialize general subset environment
    int InclSize     = 4;
    int InclTasks[4] = {1, 2, 5, 7};
-   OMEGA::MachEnv tmpEnv1("Subset", DefEnv, InclSize, InclTasks);
-   OMEGA::MachEnv *SubsetEnv = OMEGA::MachEnv::getEnv("Subset");
+   OMEGA::MachEnv *SubsetEnv =
+       OMEGA::MachEnv::create("Subset", DefEnv, InclSize, InclTasks);
    OMEGA::I4 MyVal;
 
    const int MyTask = DefEnv->getMyTask();

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -32,7 +32,7 @@ int initDecompTest() {
    // the default MachEnv. Then retrieve the default environment and
    // some needed data members.
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
    MPI_Comm DefComm       = DefEnv->getComm();
 
    OMEGA::initLogging(DefEnv);
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
          LOG_CRITICAL("DecompTest: Error initializing");
 
       // Get MPI vars if needed
-      OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+      OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
       MPI_Comm Comm          = DefEnv->getComm();
       OMEGA::I4 MyTask       = DefEnv->getMyTask();
       OMEGA::I4 NumTasks     = DefEnv->getNumTasks();

--- a/components/omega/test/base/HaloTest.cpp
+++ b/components/omega/test/base/HaloTest.cpp
@@ -103,7 +103,7 @@ int initHaloTest() {
    // Initialize the machine environment and fetch the default environment
    // pointer and the MPI communicator
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
    MPI_Comm DefComm       = DefEnv->getComm();
 
    // Initialize the logging system

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -30,7 +30,7 @@ int initIOTest() {
    // the default MachEnv. Then retrieve the default environment and
    // some needed data members.
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
    MPI_Comm DefComm       = DefEnv->getComm();
 
    // Initialize the Logging system
@@ -69,7 +69,7 @@ int main(int argc, char *argv[]) {
          LOG_CRITICAL("IOTest: Error initializing");
 
       // Get MPI vars if needed
-      OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+      OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
       MPI_Comm Comm          = DefEnv->getComm();
       OMEGA::I4 MyTask       = DefEnv->getMyTask();
       OMEGA::I4 NumTasks     = DefEnv->getNumTasks();

--- a/components/omega/test/base/MachEnvTest.cpp
+++ b/components/omega/test/base/MachEnvTest.cpp
@@ -30,7 +30,7 @@ void InitMachEnvs() {
 
    // Initialize several environments in reverse order that they
    // are tested.  Use the default environment as the parent
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
 
    // Initialize the Logging system
    OMEGA::initLogging(DefEnv);
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
 
    // Verify retrieved values of the Default environment match the
    // expected reference values
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
 
    int MyTask = DefEnv->getMyTask();
    if (MyTask == WorldTask)

--- a/components/omega/test/base/MachEnvTest.cpp
+++ b/components/omega/test/base/MachEnvTest.cpp
@@ -38,16 +38,16 @@ void InitMachEnvs() {
    // Initialize general subset environment
    int InclSize     = 4;
    int InclTasks[4] = {1, 2, 5, 7};
-   OMEGA::MachEnv tmpEnv1("Subset", DefEnv, InclSize, InclTasks);
+   OMEGA::MachEnv::create("Subset", DefEnv, InclSize, InclTasks);
 
    // Initialize strided environment
-   OMEGA::MachEnv tmpEnv2("Stride", DefEnv, 4, 1, 2);
+   OMEGA::MachEnv::create("Stride", DefEnv, 4, 1, 2);
 
    // Initialize contiguous subset environment
-   OMEGA::MachEnv tmpEnv3("Contig", DefEnv, 4);
+   OMEGA::MachEnv::create("Contig", DefEnv, 4);
 
    // Initialize contiguous subset environment but different master task
-   OMEGA::MachEnv tmpEnv4("Contig2", DefEnv, 4, 2);
+   OMEGA::MachEnv::create("Contig2", DefEnv, 4, 2);
 
 } // end of InitMachEnvs
 

--- a/components/omega/test/base/MachEnvTest.cpp
+++ b/components/omega/test/base/MachEnvTest.cpp
@@ -176,7 +176,7 @@ int main(int argc, char *argv[]) {
    // Test contiguous subset environment (first four tasks of default)
 
    // Test retrieval of the contiguous environment
-   OMEGA::MachEnv *ContigEnv = OMEGA::MachEnv::getEnv("Contig");
+   OMEGA::MachEnv *ContigEnv = OMEGA::MachEnv::get("Contig");
 
    // Check membership in the new communicator
    if (MyTask < 4) {
@@ -250,7 +250,7 @@ int main(int argc, char *argv[]) {
    // in which the master task has been initialized to task 2
 
    // Test retrieval of the contiguous environment
-   OMEGA::MachEnv *Contig2Env = OMEGA::MachEnv::getEnv("Contig2");
+   OMEGA::MachEnv *Contig2Env = OMEGA::MachEnv::get("Contig2");
 
    // Check membership in the new communicator
    if (MyTask < 4) {
@@ -324,7 +324,7 @@ int main(int argc, char *argv[]) {
    // Test the strided constructor with only odd-numbered tasks
 
    // Test retrieval
-   OMEGA::MachEnv *StrideEnv = OMEGA::MachEnv::getEnv("Stride");
+   OMEGA::MachEnv *StrideEnv = OMEGA::MachEnv::get("Stride");
 
    // Check membership in the new communicator
    if (MyTask % 2 == 1) {
@@ -399,7 +399,7 @@ int main(int argc, char *argv[]) {
    int InclTasks[4] = {1, 2, 5, 7};
 
    // Test retrieval
-   OMEGA::MachEnv *SubsetEnv = OMEGA::MachEnv::getEnv("Subset");
+   OMEGA::MachEnv *SubsetEnv = OMEGA::MachEnv::get("Subset");
 
    // Check membership in the new communicator
    MyTask          = SubsetEnv->getMyTask();

--- a/components/omega/test/base/ReductionsTest.cpp
+++ b/components/omega/test/base/ReductionsTest.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
       MPI_Comm Comm;
       int MyTask, MySize, err;
       MachEnv::init(MPI_COMM_WORLD);
-      MachEnv *DefEnv = MachEnv::getDefaultEnv();
+      MachEnv *DefEnv = MachEnv::getDefault();
       Comm            = DefEnv->getComm();
       MyTask          = DefEnv->getMyTask();
       MySize          = DefEnv->getNumTasks();

--- a/components/omega/test/infra/ConfigTest.cpp
+++ b/components/omega/test/infra/ConfigTest.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
 
    // Initialize the Machine Environment and retrieve the default environment
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
    OMEGA::I4 MyTask       = DefEnv->getMyTask();
    bool IsMaster          = DefEnv->isMasterTask();
 

--- a/components/omega/test/infra/IOFieldTest.cpp
+++ b/components/omega/test/infra/IOFieldTest.cpp
@@ -12,6 +12,7 @@
 #include "IOField.h"
 #include "DataTypes.h"
 #include "Logging.h"
+#include "MachEnv.h"
 #include "MetaData.h"
 #include "OmegaKokkos.h"
 #include "mpi.h"

--- a/components/omega/test/infra/IOFieldTest.cpp
+++ b/components/omega/test/infra/IOFieldTest.cpp
@@ -26,7 +26,7 @@ int initIOFieldTest() {
 
    // Initialize the Machine Environment and retrieve the default environment
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
 
    // Initialize the Logging system
    OMEGA::initLogging(DefEnv);

--- a/components/omega/test/infra/LoggingTest.cpp
+++ b/components/omega/test/infra/LoggingTest.cpp
@@ -16,6 +16,7 @@
 #define _OMEGA_TOSTRING(x)  _OMEGA_STRINGIFY(x)
 
 #include "Logging.h"
+#include "MachEnv.h"
 
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/ringbuffer_sink.h"

--- a/components/omega/test/infra/LoggingTest.cpp
+++ b/components/omega/test/infra/LoggingTest.cpp
@@ -141,7 +141,7 @@ int main(int argc, char **argv) {
    MPI_Init(&argc, &argv);
 
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
    OMEGA::I4 TaskId       = DefEnv->getMyTask();
 
    std::string TasksStr = _OMEGA_TOSTRING(OMEGA_LOG_TASKS);

--- a/components/omega/test/infra/TimeMgrTest.cpp
+++ b/components/omega/test/infra/TimeMgrTest.cpp
@@ -4340,7 +4340,7 @@ int main(int argc, char *argv[]) {
 
    // Initialize the Machine Environment and retrieve the default environment
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
 
    // Initialize the Logging system
    OMEGA::initLogging(DefEnv);

--- a/components/omega/test/infra/TimeMgrTest.cpp
+++ b/components/omega/test/infra/TimeMgrTest.cpp
@@ -14,6 +14,7 @@
 #include "TimeMgr.h"
 #include "DataTypes.h"
 #include "Logging.h"
+#include "MachEnv.h"
 #include "mpi.h"
 
 //------------------------------------------------------------------------------

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -616,7 +616,7 @@ int initAuxVarsTest(const std::string &mesh) {
    int Err = 0;
 
    MachEnv::init(MPI_COMM_WORLD);
-   MachEnv *DefEnv  = MachEnv::getDefaultEnv();
+   MachEnv *DefEnv  = MachEnv::getDefault();
    MPI_Comm DefComm = DefEnv->getComm();
 
    // initialize logging

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -32,7 +32,7 @@ int initHorzMeshTest() {
    // the default MachEnv. Then retrieve the default environment and
    // some needed data members.
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
    MPI_Comm DefComm       = DefEnv->getComm();
 
    // Initialize the Logging system
@@ -148,7 +148,7 @@ int main(int argc, char *argv[]) {
          LOG_CRITICAL("HorzMeshTest: Error initializing");
 
       // Get MPI vars if needed
-      OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+      OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
       MPI_Comm Comm          = DefEnv->getComm();
       OMEGA::I4 MyTask       = DefEnv->getMyTask();
       OMEGA::I4 NumTasks     = DefEnv->getNumTasks();

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -361,7 +361,7 @@ int initOperatorsTest(const std::string &MeshFile) {
    int Err = 0;
 
    MachEnv::init(MPI_COMM_WORLD);
-   MachEnv *DefEnv  = MachEnv::getDefaultEnv();
+   MachEnv *DefEnv  = MachEnv::getDefault();
    MPI_Comm DefComm = DefEnv->getComm();
 
    // Initialize the Logging system

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -344,7 +344,7 @@ inline int computeErrors(ErrorMeasures &ErrorMeasures,
    const Real LInfScaleLoc = maxVal(LInfScaleElement);
    const Real L2ScaleLoc   = sum(L2ScaleElement);
 
-   MPI_Comm Comm = MachEnv::getDefaultEnv()->getComm();
+   MPI_Comm Comm = MachEnv::getDefault()->getComm();
    Real LInfError, LInfScale;
    Err +=
        MPI_Allreduce(&LInfErrorLoc, &LInfError, 1, MPI_RealKind, MPI_MAX, Comm);

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -35,7 +35,7 @@ int initStateTest() {
    // the default MachEnv. Then retrieve the default environment and
    // some needed data members.
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
    MPI_Comm DefComm       = DefEnv->getComm();
 
    // Initialize the IO system
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
          LOG_CRITICAL("State: Error initializing");
 
       // Get MPI vars if needed
-      OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefaultEnv();
+      OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
       MPI_Comm Comm          = DefEnv->getComm();
       OMEGA::I4 MyTask       = DefEnv->getMyTask();
       OMEGA::I4 NumTasks     = DefEnv->getNumTasks();

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -116,8 +116,8 @@ int main(int argc, char *argv[]) {
 
          } else {
 
-            OMEGA::OceanState DefOceanState("Default", DefHorzMesh, DefDecomp,
-                                            DefHalo, NVertLevels, NTimeLevels);
+            OMEGA::OceanState::create("Default", DefHorzMesh, DefDecomp,
+                                      DefHalo, NVertLevels, NTimeLevels);
          }
 
          // Test retrieval of the default state
@@ -130,8 +130,8 @@ int main(int argc, char *argv[]) {
          }
 
          // Create "test" state
-         OMEGA::OceanState TestOceanState("Test", DefHorzMesh, DefDecomp,
-                                          DefHalo, NVertLevels, NTimeLevels);
+         OMEGA::OceanState::create("Test", DefHorzMesh, DefDecomp, DefHalo,
+                                   NVertLevels, NTimeLevels);
 
          OMEGA::OceanState *TestState = OMEGA::OceanState::get("Test");
          if (TestState) { // true if non-null ptr

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -591,7 +591,7 @@ int initTendTest(const std::string &mesh) {
    I4 Err = 0;
 
    MachEnv::init(MPI_COMM_WORLD);
-   MachEnv *DefEnv  = MachEnv::getDefaultEnv();
+   MachEnv *DefEnv  = MachEnv::getDefault();
    MPI_Comm DefComm = DefEnv->getComm();
 
    // Initialize logging


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

@philipwjones This is my proposal to refactor the way we handle creation of static instances of main Omega classes. To present this, I changed the `MachEnv` class. The basic idea is to disallow calling constructors directly and only allow creating new instances by static `create` methods. Afterwards, the instances can only be manipulated through a pointer.

Some notes:
- Most other classes that use this pattern won't need `create` method implemented using variadic templates, at least initially, since they have only one constructor.
- it is still possible to disallow calling `MachEnv::create` with just a communicator for non-default environments. I did not do it, beacause I wanted to present the main idea as clearly as possible.