### PR TITLE
Add `OMEGA_CIME_PROJECT` cmake variable

### DIFF
--- a/components/omega/OmegaBuild.cmake
+++ b/components/omega/OmegaBuild.cmake
@@ -71,6 +71,10 @@ macro(read_cime_config)
     set(NEWCASE_COMMAND "${NEWCASE_COMMAND} --compiler ${OMEGA_CIME_COMPILER}")
   endif()
 
+  if(NOT "${OMEGA_CIME_PROJECT}" STREQUAL "")
+    set(NEWCASE_COMMAND "${NEWCASE_COMMAND} --project ${OMEGA_CIME_PROJECT}")
+  endif()
+
   run_bash_command("${NEWCASE_COMMAND}" NEWCASE_OUTPUT)
   run_bash_command("cd ${CASEROOT} && ./case.setup" CASESETUP_OUTPUT)
   run_bash_command("source ${CASEROOT}/.env_mach_specific.sh && env" ENV_OUTPUT)

--- a/components/omega/doc/devGuide/CMakeBuild.md
+++ b/components/omega/doc/devGuide/CMakeBuild.md
@@ -53,6 +53,7 @@ OMEGA_C_COMPILER: C compiler
 OMEGA_Fortran_COMPILER: Fortran compiler
 OMEGA_CIME_COMPILER: E3SM compiler name defined in config_machines.xml
 OMEGA_CIME_MACHINE: E3SM machine name defined in config_machines.xml
+OMEGA_CIME_PROJECT: Slurm account passed to CIME during Omega build
 OMEGA_CXX_FLAGS: a list for C++ compiler flags
 OMEGA_LINK_OPTIONS: a list for linker flags
 OMEGA_BUILD_EXECUTABLE: Enable building the Omega executable

--- a/components/omega/doc/userGuide/OmegaBuild.md
+++ b/components/omega/doc/userGuide/OmegaBuild.md
@@ -28,8 +28,10 @@ that directory.
 To utilize a compiler name that's defined in the E3SM machine configuration
 file (`config_machines.xml`), employ the `OMEGA_CIME_COMPILER` CMake variable,
 as illustrated below. In some cases, you may also want to add `OMEGA_CIME_MACHINE`
-to specify which system you intend to use. The values of `OMEGA_CIME_COMPILER`
-and `OMEGA_CIME_MACHINE` are defined in
+to specify which system you intend to use. On systems where there is not a
+default `PROJECT` defined, you can use `OMEGA_CIME_PROJECT` to specify an
+account to use as a placeholder during the Omega build. 
+The values of `OMEGA_CIME_COMPILER` and `OMEGA_CIME_MACHINE` are defined in
 "${E3SM}/cime\_config/machines/config\_machines.xml".
 OMEGA requires some external libraries. Many of these are built automatically
 from the E3SM distribution. However, the METIS, ParMETIS, and, optionally,


### PR DESCRIPTION
This is needed on machines that don't have a default project in order for the `create_newcase` command to work in the Omega build.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
* [x] Testing
  * [x] Unit tests have passed.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

fixes #106 
