### PR TITLE
Add Tendencies class

### DIFF
--- a/components/omega/doc/design/Tendencies.md
+++ b/components/omega/doc/design/Tendencies.md
@@ -1,0 +1,128 @@
+(omega-design-tendencies)=
+# Tendencies
+
+## 1 Overview
+
+The tendencies class will provide a container for the tendency terms
+on a subdomain within OMEGA. It will provide methods for computing the
+terms for the layer thickness and normal velocity tendencies.
+
+## 2 Requirements
+
+### 2.1 Requirement: Computation of tendency terms
+Methods to compute the tendency terms will be provided. This will include
+functions to compute the layer thickness tendencies, normal velocity tendencies,
+and all tendencies. This will also involve calling the compute function for the
+auxiliary state.
+
+### 2.2 Requirement: Multiple tendencies can be present
+There will be methods to create and remove non-default tendencies instances, that
+can be associated with different meshes.
+
+## 3 Algorithmic Formulation
+
+No algorithms are required
+
+## 4 Design
+
+### 4.1 Data types and parameters
+#### 4.1.1 Parameters
+No parameters are required.
+
+
+#### 4.1.2 Class/structs/data types
+The tendencies class is an object representing a group of tendency terms and
+arrays for the accumulated tendency calculations. Additionally, it will have
+a static map of all tendencies and a pointer to the default tendencies instance for quick
+retrieval.
+
+```c++
+class Tendencies{
+ public:
+   Array2DReal LayerThicknessTend;
+   Array2DReal NormalVelocityTend;
+   ThicknessFluxDivOnCell ThicknessFluxDiv;
+   PotentialVortHAdvOnEdge PotientialVortHAdv;
+   KEGradOnEdge KEGrad;
+   SSHGradOnEdge SSHGrad;
+   VelocityDiffusionOnEdge VelocityDiffusion;
+   VelocityHyperDiffOnEdge VelocityHyperDiff;
+ private:
+   static Tendencies *DefaultTendencies;
+   static std::map<std::string, std::unique_ptr<Tendencies>> AllTendencies;
+};
+```
+
+### 4.2 Methods
+
+There will be a constructor and destructor for the class and several public
+methods. The constructor will be be private to make sure that every tendencies instance
+is properly stored in the map. However, a static method to create new
+tendencies instance, enforcing this requirement, will be provided.
+
+#### 4.2.1 Creation
+The constructor will be responsible for:
+  * initializing tendency term functors
+  * allocating tendency arrays
+
+```c++
+Tendencies(const std::string &Name, const HorzMesh *Mesh, int NVertLevels, Config *Options);
+```
+
+The create method will take the same arguments as the constructor, use it to
+create a new tendencies instance, and put it in the static map of all tendencies.
+It will return a pointer to the newly created object.
+```c++
+Tendencies* Tendencies::create(const std::string &Name, const HorzMesh *Mesh, int NVertLevels, Config *Options);
+```
+
+#### 4.2.2 Initialization
+The init method will create the default tendencies and return an error code:
+```c++
+int Tendencies::init();
+```
+
+#### 4.2.3 Retrieval
+There will be methods for getting the default and non-default tendencies instances:
+```c++
+Tendencies *Tendencies::getDefault();
+Tendencies *Tendencies::get(const std::string &Name);
+```
+
+#### 4.2.4 Computation
+The 'computeAll' method will compute and accumulate all layer thickness and normal velocity tendencies using the ocean
+state and auxiliary state from a given time level:
+```c++
+void Tendencies::computeAllTendencies(const OceanState *State, const AuxilaryState *AuxState, int TimeLevel);
+```
+The layer thickness tendencies will be computed with a method:
+```c++
+void Tendencies::computeThicknessTendencies(const OceanState *State, const AuxilaryState *AuxState, int TimeLevel);
+```
+The normal velocity tendencies will be computed with a method:
+```c++
+void Tendencies::computeVelocityTendencies(const OceanState *State, const AuxilaryState *AuxState, int TimeLevel);
+```
+
+
+#### 4.2.5 Destruction and removal
+No operations are needed in the destructor as the Kokkos arrays are removed
+when they are no longer in scope. The erase method
+will remove a named tendencies instance, whereas the clear method will remove all of
+them. Both will call the destructor in the process.
+```c++
+void Tendencies::erase(const std::string &Name);
+void Tendencies::clear();
+```
+
+## 5 Verification and Testing
+
+### 5.1 Test multiple tendencies instances 
+
+There will be a test checking that multiple tendencies objects can be
+created and that removing them works properly.
+
+### 5.2 Test computation
+
+There will be a test to ensure all of the tendencies are correctly computed by
+the compute method.

--- a/components/omega/doc/design/Tendencies.md
+++ b/components/omega/doc/design/Tendencies.md
@@ -117,7 +117,7 @@ void Tendencies::clear();
 
 ## 5 Verification and Testing
 
-### 5.1 Test multiple tendencies instances 
+### 5.1 Test multiple tendencies instances
 
 There will be a test checking that multiple tendencies objects can be
 created and that removing them works properly.

--- a/components/omega/doc/devGuide/Tendencies.md
+++ b/components/omega/doc/devGuide/Tendencies.md
@@ -1,0 +1,63 @@
+(omega-dev-tendencies)=
+
+# Tendencies
+
+The `Tendencies` class groups together all of the OMEGA [tendency terms](#omega-dev-tend-terms).
+It is responsible for managing their lifetime and providing functions that compute the 
+tendency terms and the [auxiliary state](#omega-dev-aux-state).
+It is possible to have multiple `Tendencies` instances in OMEGA. Every instance has a name
+and is tracked in a static C++ map called `AllTendencies`.
+
+## Initialization
+
+An instance of the `Tendencies` class requires a [`HorzMesh`](#omega-dev-horz-mesh), so
+the mesh class and all of its dependencies need to be initialized before the `Tendencies` class
+can be. The static method:
+```c++
+OMEGA::Tendencies::init();
+```
+initializes the default `Tendencies`. A pointer to it can be retrieved at any time using:
+```c++
+OMEGA::Tendencies* DefTendencies = OMEGA::Tendencies::getDefault();
+```
+The constructor of the `Tendencies` class initializes member instances of each of the
+tendency terms, which each store constant mesh information as private member variables.
+
+## Creation of non-default tendencies
+
+A non-default tendency group can be created from a string `Name`, horizontal mesh `Mesh`, number of
+vertical levels `NVertLevels`, and a configuration `Options`:
+```c++
+OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, NVertLevels, Options);
+```
+For convenience, this returns a pointer to the newly created instance.
+Given its name, a pointer to a named tendency group
+can be obtained at any time by calling the static `get` method:
+```c++
+OMEGA::Tendencies* NewTendencies = OMEGA::Tendencies::get(Name);
+```
+
+## Computation of tendencies
+To compute all tendencies for both layer thickness and normal velocity equations,
+given ocean state, `State`, and a group of auxiliary variables, `AuxState`, do:
+```c++
+Tendencies.computeAllTendencies(State, AuxState);
+```
+To call only the layer thickness tendency terms:
+```c++
+Tendencies.computeThicknessTendencies(State, AuxState);
+```
+To call only the normal velocity tendency terms:
+```c++
+Tendencies.computeVelocityTendencies(State, AuxState);
+```
+
+## Removal of tendencies
+To erase a specific named tendencies instance use `erase`
+```c++
+OMEGA::Tendencies::erase(Name);
+```
+To clear all instances do:
+```c++
+OMEGA::Tendencies::clear();
+```

--- a/components/omega/doc/devGuide/Tendencies.md
+++ b/components/omega/doc/devGuide/Tendencies.md
@@ -3,7 +3,7 @@
 # Tendencies
 
 The `Tendencies` class groups together all of the OMEGA [tendency terms](#omega-dev-tend-terms).
-It is responsible for managing their lifetime and providing functions that compute the 
+It is responsible for managing their lifetime and providing functions that compute the
 tendency terms and the [auxiliary state](#omega-dev-aux-state).
 It is possible to have multiple `Tendencies` instances in OMEGA. Every instance has a name
 and is tracked in a static C++ map called `AllTendencies`.

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -37,6 +37,7 @@ userGuide/HorzOperators
 userGuide/AuxiliaryVariables
 userGuide/AuxiliaryState
 userGuide/TendencyTerms
+userGuide/Tendencies
 userGuide/OceanState
 userGuide/TimeMgr
 userGuide/Reductions
@@ -67,6 +68,7 @@ devGuide/HorzOperators
 devGuide/AuxiliaryVariables
 devGuide/AuxiliaryState
 devGuide/TendencyTerms
+devGuide/Tendencies
 devGuide/OceanState
 devGuide/TimeMgr
 devGuide/Reductions

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -94,6 +94,7 @@ design/Reductions
 design/ShallowWaterOmega0
 design/State
 design/Tendency
+design/Tendencies
 design/AuxiliaryVariables
 design/AuxiliaryState
 design/TimeMgr

--- a/components/omega/doc/userGuide/Tendencies.md
+++ b/components/omega/doc/userGuide/Tendencies.md
@@ -1,0 +1,8 @@
+(omega-user-tendencies)=
+
+## Tendencies
+
+The `Tendencies` class provides a container for the [tendency terms](#omega-user-tend-terms) in OMEGA.
+Upon creation of an `Tendencies` instance, these functors are initialized and arrays for the
+accumulated tendencies are allocated.
+There are no user-configurable options beyond those for the tendency term functors.

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -92,6 +92,13 @@ void AuxiliaryState::computeAll(const OceanState *State, int TimeLevel) const {
        KOKKOS_LAMBDA(int ICell, int KChunk) {
           LocVelocityDel2Aux.computeVarsOnCell(ICell, KChunk);
        });
+
+   parallelFor(
+       "cellAuxState3", {Mesh->NCellsHaloH(1), NChunks},
+       KOKKOS_LAMBDA(int ICell, int KChunk) {
+          LocLayerThicknessAux.computeVarsOnCells(ICell, KChunk,
+                                                  LayerThickCell);
+       });
 }
 
 // Create a non-default auxiliary state

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -66,7 +66,7 @@ Tendencies *Tendencies::getDefault() {
 } // end get default
 
 //------------------------------------------------------------------------------
-// Get state by name
+// Get tendencies by name
 Tendencies *Tendencies::get(const std::string Name ///< [in] Name of tendencies
 ) {
 
@@ -81,7 +81,7 @@ Tendencies *Tendencies::get(const std::string Name ///< [in] Name of tendencies
       return nullptr;
     }
 
-} // end get state
+} // end get tendencies
 
 //------------------------------------------------------------------------------
 // Construct a new group of tendencies
@@ -117,16 +117,16 @@ void Tendencies::computeThicknessTendencies(
     OceanState *State ///< [in] State variables
 ) {
 
-   OMEGA_SCOPE(o_LayerThicknessTend, LayerThicknessTend);
-   OMEGA_SCOPE(o_NCellsOwned, NCellsOwned);
-   OMEGA_SCOPE(o_NChunks, NChunks);
-   OMEGA_SCOPE(o_ThicknessFluxDiv, ThicknessFluxDiv);
+   OMEGA_SCOPE(LocLayerThicknessTend, LayerThicknessTend);
+   OMEGA_SCOPE(LocNCellsOwned, NCellsOwned);
+   OMEGA_SCOPE(LocNChunks, NChunks);
+   OMEGA_SCOPE(LocThicknessFluxDiv, ThicknessFluxDiv);
 
    // Compute thickness flux divergence
    Array2DReal ThickFluxEdge;
    parallelFor(
-       {o_NCellsOwned, o_NChunks}, KOKKOS_LAMBDA(int ICell, int KChunk) {
-          o_ThicknessFluxDiv(o_LayerThicknessTend, ICell, KChunk, ThickFluxEdge);
+       {LocNCellsOwned, LocNChunks}, KOKKOS_LAMBDA(int ICell, int KChunk) {
+          LocThicknessFluxDiv(LocLayerThicknessTend, ICell, KChunk, ThickFluxEdge);
        });
 
 } // end thickness tehndency compute
@@ -138,14 +138,14 @@ void Tendencies::computeVelocityTendencies(
     OceanState *State ///< [in] State variables
 ) {
 
-   OMEGA_SCOPE(o_NormalVelocityTend, NormalVelocityTend);
-   OMEGA_SCOPE(o_NEdgesOwned, NEdgesOwned);
-   OMEGA_SCOPE(o_NChunks, NChunks);
-   OMEGA_SCOPE(o_PotientialVortHAdv, PotientialVortHAdv);
-   OMEGA_SCOPE(o_KEGrad, KEGrad);
-   OMEGA_SCOPE(o_SHHGrad, SHHGrad);
-   OMEGA_SCOPE(o_VelocityDiffusion, VelocityDiffusion);
-   OMEGA_SCOPE(o_VelocityHyperDiff, VelocityHyperDiff);
+   OMEGA_SCOPE(LocNormalVelocityTend, NormalVelocityTend);
+   OMEGA_SCOPE(LocNEdgesOwned, NEdgesOwned);
+   OMEGA_SCOPE(LocNChunks, NChunks);
+   OMEGA_SCOPE(LocPotientialVortHAdv, PotientialVortHAdv);
+   OMEGA_SCOPE(LocKEGrad, KEGrad);
+   OMEGA_SCOPE(LocSHHGrad, SHHGrad);
+   OMEGA_SCOPE(LocVelocityDiffusion, VelocityDiffusion);
+   OMEGA_SCOPE(LocVelocityHyperDiff, VelocityHyperDiff);
 
    // Compute potential vorticity horizontal advection
    Array2DReal FluxLayerThickEdge; // TODO get variables from AuxState
@@ -153,31 +153,31 @@ void Tendencies::computeVelocityTendencies(
    Array2DReal NormFEdge;          // TODO get variables from AuxState
    Array2DReal TangentVelEdge;     // TODO get variables from AuxState
    parallelFor(
-       {o_NEdgesOwned, o_NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          o_PotientialVortHAdv(o_NormalVelocityTend, IEdge, KChunk, NormRVortEdge,
+       {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          LocPotientialVortHAdv(LocNormalVelocityTend, IEdge, KChunk, NormRVortEdge,
                              NormFEdge, FluxLayerThickEdge, TangentVelEdge);
        });
 
    // Compute kinetic energy gradient
    Array2DReal KECell; // TODO get variables from AuxState
    parallelFor(
-       {o_NEdgesOwned, o_NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          o_KEGrad(o_NormalVelocityTend, IEdge, KChunk, KECell);
+       {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          LocKEGrad(LocNormalVelocityTend, IEdge, KChunk, KECell);
        });
 
    // Compute sea surface height gradient
    Array2DReal SSH; // TODO get variables from AuxState
    parallelFor(
-       {o_NEdgesOwned, o_NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          o_SHHGrad(o_NormalVelocityTend, IEdge, KChunk, SSH);
+       {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          LocSHHGrad(LocNormalVelocityTend, IEdge, KChunk, SSH);
        });
 
    // Compute del2 horizontal diffusion
    Array2DReal DivCell;     // TODO get variables from AuxState
    Array2DReal RVortVertex; // TODO get variables from AuxState
    parallelFor(
-       {o_NEdgesOwned, o_NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          o_VelocityDiffusion(o_NormalVelocityTend, IEdge, KChunk, DivCell,
+       {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          LocVelocityDiffusion(LocNormalVelocityTend, IEdge, KChunk, DivCell,
                             RVortVertex);
        });
 
@@ -185,8 +185,8 @@ void Tendencies::computeVelocityTendencies(
    Array2DReal Del2DivCell;     // TODO get variables from AuxState
    Array2DReal Del2RVortVertex; // TODO get variables from AuxState
    parallelFor(
-       {o_NEdgesOwned, o_NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          o_VelocityHyperDiff(o_NormalVelocityTend, IEdge, KChunk, Del2DivCell,
+       {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          LocVelocityHyperDiff(LocNormalVelocityTend, IEdge, KChunk, Del2DivCell,
                             Del2RVortVertex);
        });
 

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -206,6 +206,7 @@ void Tendencies::computeAllTendencies(
     AuxiliaryState *AuxState ///< [in] Auxilary state variables
 ) {
 
+   AuxState->computeAll(State, 0);
    computeThicknessTendencies(State, AuxState);
    computeVelocityTendencies(State, AuxState);
 

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -51,9 +51,9 @@ void Tendencies::clear() { AllTendencies.clear(); } // end clear
 
 //------------------------------------------------------------------------------
 // Removes tendencies from list by name
-void Tendencies::erase(const std::string Name){
+void Tendencies::erase(const std::string Name) {
 
-    AllTendencies.erase(Name);
+   AllTendencies.erase(Name);
 
 } // end erase
 
@@ -72,14 +72,14 @@ Tendencies *Tendencies::get(const std::string Name ///< [in] Name of tendencies
 
    auto it = AllTendencies.find(Name);
 
-    if (it != AllTendencies.end()) {
+   if (it != AllTendencies.end()) {
       return &(it->second);
-    } else {
+   } else {
       LOG_ERROR(
           "Tendencies::get: Attempt to retrieve non-existent tendencies:");
       LOG_ERROR("{} has not been defined or has been removed", Name);
       return nullptr;
-    }
+   }
 
 } // end get tendencies
 
@@ -126,7 +126,8 @@ void Tendencies::computeThicknessTendencies(
    Array2DReal ThickFluxEdge;
    parallelFor(
        {LocNCellsOwned, LocNChunks}, KOKKOS_LAMBDA(int ICell, int KChunk) {
-          LocThicknessFluxDiv(LocLayerThicknessTend, ICell, KChunk, ThickFluxEdge);
+          LocThicknessFluxDiv(LocLayerThicknessTend, ICell, KChunk,
+                              ThickFluxEdge);
        });
 
 } // end thickness tehndency compute
@@ -154,8 +155,9 @@ void Tendencies::computeVelocityTendencies(
    Array2DReal TangentVelEdge;     // TODO get variables from AuxState
    parallelFor(
        {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          LocPotientialVortHAdv(LocNormalVelocityTend, IEdge, KChunk, NormRVortEdge,
-                             NormFEdge, FluxLayerThickEdge, TangentVelEdge);
+          LocPotientialVortHAdv(LocNormalVelocityTend, IEdge, KChunk,
+                                NormRVortEdge, NormFEdge, FluxLayerThickEdge,
+                                TangentVelEdge);
        });
 
    // Compute kinetic energy gradient
@@ -178,7 +180,7 @@ void Tendencies::computeVelocityTendencies(
    parallelFor(
        {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
           LocVelocityDiffusion(LocNormalVelocityTend, IEdge, KChunk, DivCell,
-                            RVortVertex);
+                               RVortVertex);
        });
 
    // Compute del4 horizontal diffusion
@@ -186,8 +188,8 @@ void Tendencies::computeVelocityTendencies(
    Array2DReal Del2RVortVertex; // TODO get variables from AuxState
    parallelFor(
        {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          LocVelocityHyperDiff(LocNormalVelocityTend, IEdge, KChunk, Del2DivCell,
-                            Del2RVortVertex);
+          LocVelocityHyperDiff(LocNormalVelocityTend, IEdge, KChunk,
+                               Del2DivCell, Del2RVortVertex);
        });
 
 } // end velocity tendency compute
@@ -195,7 +197,8 @@ void Tendencies::computeVelocityTendencies(
 //------------------------------------------------------------------------------
 // Compute both layer thickness and normal velocity tendencies
 // TODO Add AuxilaryState as argument
-void Tendencies::computeAllTendencies(OceanState *State ///< [in] State variables
+void Tendencies::computeAllTendencies(
+    OceanState *State ///< [in] State variables
 ) {
 
    computeThicknessTendencies(State);

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -12,8 +12,196 @@
 #include "Config.h"
 #include "DataTypes.h"
 #include "HorzMesh.h"
+#include "OceanState.h"
 
 namespace OMEGA {
+
+Tendencies *Tendencies::DefaultTendencies = nullptr;
+std::map<std::string, Tendencies> Tendencies::AllTendencies;
+
+//------------------------------------------------------------------------------
+// Initialize the tendencies. Assumes that HorzMesh as alread been initialized.
+int Tendencies::init() {
+   int Err = 0;
+
+   HorzMesh *DefHorzMesh = HorzMesh::getDefault();
+   Config *TendConfig;
+
+   int NVertLevels = 60;
+
+   Tendencies DefTendencies("Default", DefHorzMesh, NVertLevels, TendConfig);
+
+   Tendencies::DefaultTendencies = get("Default");
+
+   return Err;
+
+} // end init
+
+//------------------------------------------------------------------------------
+// Destroys the tendencies
+Tendencies::~Tendencies() {
+
+   // No operations needed, Kokkos arrays removed when no longer in scope
+
+} // end destructor
+
+//------------------------------------------------------------------------------
+// Removes all tendencies instances before exit
+void Tendencies::clear() { AllTendencies.clear(); } // end clear
+
+//------------------------------------------------------------------------------
+// Removes tendencies from list by name
+void Tendencies::erase(const std::string Name){
+
+    AllTendencies.erase(Name);
+
+} // end erase
+
+//------------------------------------------------------------------------------
+// Get default tendencies
+Tendencies *Tendencies::getDefault() {
+
+   return Tendencies::DefaultTendencies;
+
+} // end get default
+
+//------------------------------------------------------------------------------
+// Get state by name
+Tendencies *Tendencies::get(const std::string Name ///< [in] Name of tendencies
+) {
+
+   auto it = AllTendencies.find(Name);
+
+    if (it != AllTendencies.end()) {
+      return &(it->second);
+    } else {
+      LOG_ERROR(
+          "Tendencies::get: Attempt to retrieve non-existent tendencies:");
+      LOG_ERROR("{} has not been defined or has been removed", Name);
+      return nullptr;
+    }
+
+} // end get state
+
+//------------------------------------------------------------------------------
+// Construct a new group of tendencies
+Tendencies::Tendencies(const std::string &Name, ///< [in] Name for tendencies
+                       const HorzMesh *Mesh,    ///< [in] Horizontal mesh
+                       int NVertLevels, ///< [in] Number of vertical levels
+                       Config *Options  ///< [in] Configuration options
+                       )
+    : ThicknessFluxDiv(Mesh, Options), PotientialVortHAdv(Mesh, Options),
+      KEGrad(Mesh, Options), SHHGrad(Mesh, Options),
+      VelocityDiffusion(Mesh, Options), VelocityHyperDiff(Mesh, Options) {
+
+   // Tendency arrays
+   LayerThicknessTend =
+       Array2DReal("LayerThicknessTend", Mesh->NCellsSize, NVertLevels);
+   NormalVelocityTend =
+       Array2DReal("NormalVelocityTend", Mesh->NEdgesSize, NVertLevels);
+
+   //
+   NCellsOwned = Mesh->NCellsOwned;
+   NEdgesOwned = Mesh->NEdgesOwned;
+   NChunks     = NVertLevels / VecLength;
+
+   // Associate this instance with a name
+   AllTendencies.emplace(Name, *this);
+
+} // end constructor
+
+//------------------------------------------------------------------------------
+// Compute tendencies for layer thickness equation
+// TODO Add AuxilaryState as argument
+void Tendencies::computeThicknessTendencies(
+    OceanState *State ///< [in] State variables
+) {
+
+   OMEGA_SCOPE(o_LayerThicknessTend, LayerThicknessTend);
+   OMEGA_SCOPE(o_NCellsOwned, NCellsOwned);
+   OMEGA_SCOPE(o_NChunks, NChunks);
+   OMEGA_SCOPE(o_ThicknessFluxDiv, ThicknessFluxDiv);
+
+   // Compute thickness flux divergence
+   Array2DReal ThickFluxEdge;
+   parallelFor(
+       {o_NCellsOwned, o_NChunks}, KOKKOS_LAMBDA(int ICell, int KChunk) {
+          o_ThicknessFluxDiv(o_LayerThicknessTend, ICell, KChunk, ThickFluxEdge);
+       });
+
+} // end thickness tehndency compute
+
+//------------------------------------------------------------------------------
+// Compute tendencies for normal velocity equation
+// TODO Add AuxilaryState as argument
+void Tendencies::computeVelocityTendencies(
+    OceanState *State ///< [in] State variables
+) {
+
+   OMEGA_SCOPE(o_NormalVelocityTend, NormalVelocityTend);
+   OMEGA_SCOPE(o_NEdgesOwned, NEdgesOwned);
+   OMEGA_SCOPE(o_NChunks, NChunks);
+   OMEGA_SCOPE(o_PotientialVortHAdv, PotientialVortHAdv);
+   OMEGA_SCOPE(o_KEGrad, KEGrad);
+   OMEGA_SCOPE(o_SHHGrad, SHHGrad);
+   OMEGA_SCOPE(o_VelocityDiffusion, VelocityDiffusion);
+   OMEGA_SCOPE(o_VelocityHyperDiff, VelocityHyperDiff);
+
+   // Compute potential vorticity horizontal advection
+   Array2DReal FluxLayerThickEdge; // TODO get variables from AuxState
+   Array2DReal NormRVortEdge;      // TODO get variables from AuxState
+   Array2DReal NormFEdge;          // TODO get variables from AuxState
+   Array2DReal TangentVelEdge;     // TODO get variables from AuxState
+   parallelFor(
+       {o_NEdgesOwned, o_NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          o_PotientialVortHAdv(o_NormalVelocityTend, IEdge, KChunk, NormRVortEdge,
+                             NormFEdge, FluxLayerThickEdge, TangentVelEdge);
+       });
+
+   // Compute kinetic energy gradient
+   Array2DReal KECell; // TODO get variables from AuxState
+   parallelFor(
+       {o_NEdgesOwned, o_NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          o_KEGrad(o_NormalVelocityTend, IEdge, KChunk, KECell);
+       });
+
+   // Compute sea surface height gradient
+   Array2DReal SSH; // TODO get variables from AuxState
+   parallelFor(
+       {o_NEdgesOwned, o_NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          o_SHHGrad(o_NormalVelocityTend, IEdge, KChunk, SSH);
+       });
+
+   // Compute del2 horizontal diffusion
+   Array2DReal DivCell;     // TODO get variables from AuxState
+   Array2DReal RVortVertex; // TODO get variables from AuxState
+   parallelFor(
+       {o_NEdgesOwned, o_NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          o_VelocityDiffusion(o_NormalVelocityTend, IEdge, KChunk, DivCell,
+                            RVortVertex);
+       });
+
+   // Compute del4 horizontal diffusion
+   Array2DReal Del2DivCell;     // TODO get variables from AuxState
+   Array2DReal Del2RVortVertex; // TODO get variables from AuxState
+   parallelFor(
+       {o_NEdgesOwned, o_NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          o_VelocityHyperDiff(o_NormalVelocityTend, IEdge, KChunk, Del2DivCell,
+                            Del2RVortVertex);
+       });
+
+} // end velocity tendency compute
+
+//------------------------------------------------------------------------------
+// Compute both layer thickness and normal velocity tendencies
+// TODO Add AuxilaryState as argument
+void Tendencies::computeAllTendencies(OceanState *State ///< [in] State variables
+) {
+
+   computeThicknessTendencies(State);
+   computeVelocityTendencies(State);
+
+} // end all tendency compute
 
 // TODO: Implement Config options for all constructors
 ThicknessFluxDivOnCell::ThicknessFluxDivOnCell(const HorzMesh *Mesh,

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -146,11 +146,14 @@ void Tendencies::computeThicknessTendencies(
    // Compute thickness flux divergence
    const Array2DReal &ThickFluxEdge =
        AuxState->LayerThicknessAux.FluxLayerThickEdge;
-   parallelFor(
-       {LocNCellsOwned, LocNChunks}, KOKKOS_LAMBDA(int ICell, int KChunk) {
-          LocThicknessFluxDiv(LocLayerThicknessTend, ICell, KChunk,
-                              ThickFluxEdge);
-       });
+
+   if (LocThicknessFluxDiv.Enabled) {
+      parallelFor(
+          {LocNCellsOwned, LocNChunks}, KOKKOS_LAMBDA(int ICell, int KChunk) {
+             LocThicknessFluxDiv(LocLayerThicknessTend, ICell, KChunk,
+                                 ThickFluxEdge);
+          });
+   }
 
 } // end thickness tendency compute
 
@@ -178,45 +181,55 @@ void Tendencies::computeVelocityTendencies(
    const Array2DReal &NormRVortEdge = AuxState->VorticityAux.NormRelVortEdge;
    const Array2DReal &NormFEdge     = AuxState->VorticityAux.NormPlanetVortEdge;
    const Array2DReal &NormVelEdge   = State->NormalVelocity[0];
-   parallelFor(
-       {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          LocPotientialVortHAdv(LocNormalVelocityTend, IEdge, KChunk,
-                                NormRVortEdge, NormFEdge, FluxLayerThickEdge,
-                                NormVelEdge);
-       });
+   if (LocPotientialVortHAdv.Enabled) {
+      parallelFor(
+          {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+             LocPotientialVortHAdv(LocNormalVelocityTend, IEdge, KChunk,
+                                   NormRVortEdge, NormFEdge, FluxLayerThickEdge,
+                                   NormVelEdge);
+          });
+   }
 
    // Compute kinetic energy gradient
    const Array2DReal &KECell = AuxState->KineticAux.KineticEnergyCell;
-   parallelFor(
-       {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          LocKEGrad(LocNormalVelocityTend, IEdge, KChunk, KECell);
-       });
+   if (LocKEGrad.Enabled) {
+      parallelFor(
+          {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+             LocKEGrad(LocNormalVelocityTend, IEdge, KChunk, KECell);
+          });
+   }
 
    // Compute sea surface height gradient
    const Array2DReal &SSHCell = AuxState->LayerThicknessAux.SshCell;
-   parallelFor(
-       {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          LocSHHGrad(LocNormalVelocityTend, IEdge, KChunk, SSHCell);
-       });
+   if (LocSHHGrad.Enabled) {
+      parallelFor(
+          {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+             LocSHHGrad(LocNormalVelocityTend, IEdge, KChunk, SSHCell);
+          });
+   }
 
    // Compute del2 horizontal diffusion
    const Array2DReal &DivCell     = AuxState->KineticAux.VelocityDivCell;
    const Array2DReal &RVortVertex = AuxState->VorticityAux.RelVortVertex;
-   parallelFor(
-       {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          LocVelocityDiffusion(LocNormalVelocityTend, IEdge, KChunk, DivCell,
-                               RVortVertex);
-       });
+   if (LocVelocityDiffusion.Enabled) {
+      parallelFor(
+          {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+             LocVelocityDiffusion(LocNormalVelocityTend, IEdge, KChunk, DivCell,
+                                  RVortVertex);
+          });
+   }
 
    // Compute del4 horizontal diffusion
    const Array2DReal &Del2DivCell = AuxState->VelocityDel2Aux.Del2DivCell;
    const Array2DReal &Del2RVortVertex =
        AuxState->VelocityDel2Aux.Del2RelVortVertex;
-   parallelFor(
-       {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          LocVelocityHyperDiff(LocNormalVelocityTend, IEdge, KChunk,
-                               Del2DivCell, Del2RVortVertex);
-       });
+   if (LocVelocityHyperDiff.Enabled) {
+      parallelFor(
+          {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+             LocVelocityHyperDiff(LocNormalVelocityTend, IEdge, KChunk,
+                                  Del2DivCell, Del2RVortVertex);
+          });
+   }
 
 } // end velocity tendency compute
 

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -141,6 +141,8 @@ void Tendencies::computeThicknessTendencies(
    OMEGA_SCOPE(LocNChunks, NChunks);
    OMEGA_SCOPE(LocThicknessFluxDiv, ThicknessFluxDiv);
 
+   deepCopy(LocLayerThicknessTend, 0);
+
    // Compute thickness flux divergence
    const Array2DReal &ThickFluxEdge =
        AuxState->LayerThicknessAux.FluxLayerThickEdge;
@@ -167,6 +169,8 @@ void Tendencies::computeVelocityTendencies(
    OMEGA_SCOPE(LocSHHGrad, SHHGrad);
    OMEGA_SCOPE(LocVelocityDiffusion, VelocityDiffusion);
    OMEGA_SCOPE(LocVelocityHyperDiff, VelocityHyperDiff);
+
+   deepCopy(LocNormalVelocityTend, 0);
 
    // Compute potential vorticity horizontal advection
    const Array2DReal &FluxLayerThickEdge =

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -110,7 +110,7 @@ Tendencies::Tendencies(const std::string &Name, ///< [in] Name for tendencies
                        Config *Options  ///< [in] Configuration options
                        )
     : ThicknessFluxDiv(Mesh, Options), PotientialVortHAdv(Mesh, Options),
-      KEGrad(Mesh, Options), SHHGrad(Mesh, Options),
+      KEGrad(Mesh, Options), SSHGrad(Mesh, Options),
       VelocityDiffusion(Mesh, Options), VelocityHyperDiff(Mesh, Options) {
 
    // Tendency arrays
@@ -166,7 +166,7 @@ void Tendencies::computeVelocityTendencies(
    OMEGA_SCOPE(LocNChunks, NChunks);
    OMEGA_SCOPE(LocPotientialVortHAdv, PotientialVortHAdv);
    OMEGA_SCOPE(LocKEGrad, KEGrad);
-   OMEGA_SCOPE(LocSHHGrad, SHHGrad);
+   OMEGA_SCOPE(LocSSHGrad, SSHGrad);
    OMEGA_SCOPE(LocVelocityDiffusion, VelocityDiffusion);
    OMEGA_SCOPE(LocVelocityHyperDiff, VelocityHyperDiff);
 
@@ -198,10 +198,10 @@ void Tendencies::computeVelocityTendencies(
 
    // Compute sea surface height gradient
    const Array2DReal &SSHCell = AuxState->LayerThicknessAux.SshCell;
-   if (LocSHHGrad.Enabled) {
+   if (LocSSHGrad.Enabled) {
       parallelFor(
           {LocNEdgesOwned, LocNChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-             LocSHHGrad(LocNormalVelocityTend, IEdge, KChunk, SSHCell);
+             LocSSHGrad(LocNormalVelocityTend, IEdge, KChunk, SSHCell);
           });
    }
 

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -30,8 +30,8 @@ int Tendencies::init() {
 
    int NVertLevels = 60;
 
-   Tendencies::DefaultTendencies = Tendencies::create("Default", DefHorzMesh,
-                                                      NVertLevels, TendConfig);
+   Tendencies::DefaultTendencies =
+       Tendencies::create("Default", DefHorzMesh, NVertLevels, TendConfig);
 
    return Err;
 
@@ -85,16 +85,14 @@ Tendencies *Tendencies::get(const std::string &Name ///< [in] Name of tendencies
 
 //------------------------------------------------------------------------------
 // Create a non-default group of tendencies
-Tendencies *Tendencies::create(const std::string &Name,
-                               const HorzMesh *Mesh,
-                               int NVertLevels,
-                               Config *Options
-                               ) {
+Tendencies *Tendencies::create(const std::string &Name, const HorzMesh *Mesh,
+                               int NVertLevels, Config *Options) {
 
    if (AllTendencies.find(Name) != AllTendencies.end()) {
-     LOG_ERROR("Attempted to create a new Tendencies with name {} but it "
-               "already exists", Name);
-     return nullptr;
+      LOG_ERROR("Attempted to create a new Tendencies with name {} but it "
+                "already exists",
+                Name);
+      return nullptr;
    }
 
    auto *NewTendencies = new Tendencies(Name, Mesh, NVertLevels, Options);
@@ -130,7 +128,6 @@ Tendencies::Tendencies(const std::string &Name, ///< [in] Name for tendencies
 
 //------------------------------------------------------------------------------
 // Compute tendencies for layer thickness equation
-// TODO Add AuxilaryState as argument
 void Tendencies::computeThicknessTendencies(
     const OceanState *State,       ///< [in] State variables
     const AuxiliaryState *AuxState ///< [in] Auxilary state variables

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -17,7 +17,6 @@
 
 namespace OMEGA {
 
-
 /// Divergence of thickness flux at cell centers, for updating layer thickness
 /// arrays
 class ThicknessFluxDivOnCell {

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -289,10 +289,11 @@ class Tendencies {
                              const AuxiliaryState *AuxState);
 
    // Create a non-default tendencies
-   static Tendencies *create(const std::string &Name, ///< [in] Name for tendencies
-                             const HorzMesh *Mesh,    ///< [in] Horizontal mesh
-                             int NVertLevels,         ///< [in] Number of vertical levels
-                             Config *Options          ///< [in] Configuration options
+   static Tendencies *
+   create(const std::string &Name, ///< [in] Name for tendencies
+          const HorzMesh *Mesh,    ///< [in] Horizontal mesh
+          int NVertLevels,         ///< [in] Number of vertical levels
+          Config *Options          ///< [in] Configuration options
    );
 
    // Destructor

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -281,15 +281,18 @@ class Tendencies {
 
    // Methods to compute tendency groups
    // TODO Add AuxilaryState as calling argument
-   void computeThicknessTendencies(OceanState *State, AuxiliaryState *AuxState);
-   void computeVelocityTendencies(OceanState *State, AuxiliaryState *AuxState);
-   void computeAllTendencies(OceanState *State, AuxiliaryState *AuxState);
+   void computeThicknessTendencies(const OceanState *State,
+                                   const AuxiliaryState *AuxState);
+   void computeVelocityTendencies(const OceanState *State,
+                                  const AuxiliaryState *AuxState);
+   void computeAllTendencies(const OceanState *State,
+                             const AuxiliaryState *AuxState);
 
-   // Construct a new tendency object
-   Tendencies(const std::string &Name, ///< [in] Name for tendencies
-              const HorzMesh *Mesh,    ///< [in] Horizontal mesh
-              int NVertLevels,         ///< [in] Number of vertical levels
-              Config *Options          ///< [in] Configuration options
+   // Create a non-default tendencies
+   static Tendencies *create(const std::string &Name, ///< [in] Name for tendencies
+                             const HorzMesh *Mesh,    ///< [in] Horizontal mesh
+                             int NVertLevels,         ///< [in] Number of vertical levels
+                             Config *Options          ///< [in] Configuration options
    );
 
    // Destructor
@@ -302,14 +305,14 @@ class Tendencies {
    static void clear();
 
    // Remove tendencies object by name
-   static void erase(std::string InName ///< [in]
+   static void erase(const std::string &Name ///< [in]
    );
 
    // get default tendencies
    static Tendencies *getDefault();
 
    // get tendencies by name
-   static Tendencies *get(std::string name ///< [in]
+   static Tendencies *get(const std::string &Name ///< [in]
    );
 
  private:
@@ -318,11 +321,18 @@ class Tendencies {
    I4 NEdgesOwned; ///< Number of edges owned by this task
    I4 NChunks;     ///< Number of vertical level chunks
 
+   // Construct a new tendency object
+   Tendencies(const std::string &Name, ///< [in] Name for tendencies
+              const HorzMesh *Mesh,    ///< [in] Horizontal mesh
+              int NVertLevels,         ///< [in] Number of vertical levels
+              Config *Options          ///< [in] Configuration options
+   );
+
    // Pointer to default tendencies
    static Tendencies *DefaultTendencies;
 
    // Map of all tendency objects
-   static std::map<std::string, Tendencies> AllTendencies;
+   static std::map<std::string, std::unique_ptr<Tendencies>> AllTendencies;
 
 }; // end class Tendencies
 

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -275,7 +275,7 @@ class Tendencies {
    ThicknessFluxDivOnCell ThicknessFluxDiv;
    PotentialVortHAdvOnEdge PotientialVortHAdv;
    KEGradOnEdge KEGrad;
-   SSHGradOnEdge SHHGrad;
+   SSHGradOnEdge SSHGrad;
    VelocityDiffusionOnEdge VelocityDiffusion;
    VelocityHyperDiffOnEdge VelocityHyperDiff;
 

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
@@ -15,6 +15,7 @@ class LayerThicknessAuxVars {
  public:
    Array2DReal FluxLayerThickEdge;
    Array2DReal MeanLayerThickEdge;
+   Array2DReal SshCell;
 
    // TODO(mwarusz): get this from config
    FluxThickEdgeOption FluxThickEdgeChoice = Center;
@@ -60,11 +61,33 @@ class LayerThicknessAuxVars {
       }
    }
 
+   KOKKOS_FUNCTION void
+   computeVarsOnCells(int ICell, int KChunk,
+                      const Array2DReal &LayerThickCell) const {
+
+      // Temporary for stacked shallow water
+      const int KStart = KChunk * VecLength;
+      for (int KVec = 0; KVec < VecLength; ++KVec) {
+         const int K       = KStart + KVec;
+         SshCell(ICell, K) = LayerThickCell(ICell, K) - BottomDepth(ICell);
+      }
+
+      /*
+      Real TotalThickness = 0.0;
+      for (int K = 0; K < NVertLevels; K++) {
+         TotalThickness += LayerThickCell(ICell, K);
+      }
+
+      SshCell(ICell) = TotalThickness - BottomDepth(ICell);
+      */
+   }
+
    void registerFields(const std::string &AuxGroupName) const;
    void unregisterFields() const;
 
  private:
    Array2DI4 CellsOnEdge;
+   Array1DReal BottomDepth;
 
    void addMetaData(const std::string &AuxGroupName) const;
    void defineIOFields() const;

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -250,6 +250,16 @@ target_compile_definitions(
   TENDENCYTERMS_TEST_SPHERE
 )
 
+#################
+# Tendencies test
+#################
+
+add_omega_test(
+    TENDENCIES_TEST
+    testTendencies.exe
+    ocn/TendenciesTest.cpp
+    "-n;8"
+)
 
 ##################
 # State test

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -135,7 +135,7 @@ int testTendencies() {
    DefTendencies->ThicknessFluxDiv.Enabled   = true;
    DefTendencies->PotientialVortHAdv.Enabled = true;
    DefTendencies->KEGrad.Enabled             = true;
-   DefTendencies->SHHGrad.Enabled            = true;
+   DefTendencies->SSHGrad.Enabled            = true;
 
    // TODO need to get visc values from config
    DefTendencies->VelocityDiffusion.Enabled = false;

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -1,0 +1,256 @@
+#include "AuxiliaryState.h"
+#include "Config.h"
+#include "DataTypes.h"
+#include "Decomp.h"
+#include "Halo.h"
+#include "HorzMesh.h"
+#include "IO.h"
+#include "IOField.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "MetaData.h"
+#include "OceanTestCommon.h"
+#include "OmegaKokkos.h"
+#include "TendencyTerms.h"
+#include "mpi.h"
+
+#include <cmath>
+#include <iomanip>
+
+using namespace OMEGA;
+
+struct TestSetup {
+   Real Radius = 6371220;
+
+   KOKKOS_FUNCTION Real layerThickness(Real Lon, Real Lat) const {
+      return (2 + std::cos(Lon) * std::pow(std::cos(Lat), 4));
+   }
+
+   KOKKOS_FUNCTION Real velocityX(Real Lon, Real Lat) const {
+      return -Radius * std::pow(std::sin(Lon), 2) * std::pow(std::cos(Lat), 3);
+   }
+
+   KOKKOS_FUNCTION Real velocityY(Real Lon, Real Lat) const {
+      return -4 * Radius * std::sin(Lon) * std::cos(Lon) *
+             std::pow(std::cos(Lat), 3) * std::sin(Lat);
+   }
+};
+
+constexpr Geometry Geom   = Geometry::Spherical;
+constexpr int NVertLevels = 60;
+
+int initState() {
+   int Err = 0;
+
+   TestSetup Setup;
+   auto *Mesh  = HorzMesh::getDefault();
+   auto *State = OceanState::getDefault();
+
+   const auto &LayerThickCell = State->LayerThickness[0];
+   const auto &NormalVelEdge  = State->NormalVelocity[0];
+
+   Err += setScalar(
+       KOKKOS_LAMBDA(Real X, Real Y) { return Setup.layerThickness(X, Y); },
+       LayerThickCell, Geom, Mesh, OnCell, NVertLevels);
+
+   Err += setVectorEdge(
+       KOKKOS_LAMBDA(Real(&VecField)[2], Real Lon, Real Lat) {
+          VecField[0] = Setup.velocityX(Lon, Lat);
+          VecField[1] = Setup.velocityY(Lon, Lat);
+       },
+       NormalVelEdge, EdgeComponent::Normal, Geom, Mesh, NVertLevels,
+       ExchangeHalos::Yes, CartProjection::No);
+
+   return Err;
+}
+
+//------------------------------------------------------------------------------
+// The initialization routine for tendencies testing
+int initTendenciesTest(const std::string &mesh) {
+   int Err = 0;
+
+   MachEnv::init(MPI_COMM_WORLD);
+   MachEnv *DefEnv  = MachEnv::getDefault();
+   MPI_Comm DefComm = DefEnv->getComm();
+
+   int IOErr = IO::init(DefComm);
+   if (IOErr != 0) {
+      Err++;
+      LOG_ERROR("TendenciesTest: error initializing parallel IO");
+   }
+
+   int DecompErr = Decomp::init(mesh);
+   if (DecompErr != 0) {
+      Err++;
+      LOG_ERROR("TendenciesTest: error initializing default decomposition");
+   }
+
+   int HaloErr = Halo::init();
+   if (HaloErr != 0) {
+      Err++;
+      LOG_ERROR("TendenciesTest: error initializing default halo");
+   }
+
+   int MeshErr = HorzMesh::init();
+   if (MeshErr != 0) {
+      Err++;
+      LOG_ERROR("TendenciesTest: error initializing default mesh");
+   }
+
+   const auto &Mesh = HorzMesh::getDefault();
+   MetaDim::create("NCells", Mesh->NCellsSize);
+   MetaDim::create("NVertices", Mesh->NVerticesSize);
+   MetaDim::create("NEdges", Mesh->NEdgesSize);
+   MetaDim::create("NVertLevels", NVertLevels);
+
+   int StateErr = OceanState::init();
+   if (StateErr != 0) {
+      Err++;
+      LOG_ERROR("TendenciesTest: error initializing default state");
+   }
+
+   int AuxStateErr = AuxiliaryState::init();
+   if (AuxStateErr != 0) {
+      Err++;
+      LOG_ERROR("TendenciesTest: error initializing default aux state");
+   }
+
+   return Err;
+}
+
+int testTendencies() {
+   int Err = 0;
+
+   // test initialization
+   int TendenciesErr = Tendencies::init();
+   if (TendenciesErr != 0) {
+      Err++;
+      LOG_ERROR("TendenciesTest: error initializing default tendencies");
+   }
+
+   // test retrievel of default
+   Tendencies *DefTendencies = Tendencies::getDefault();
+
+   // turn on tendency terms
+   DefTendencies->ThicknessFluxDiv.Enabled   = true;
+   DefTendencies->PotientialVortHAdv.Enabled = true;
+   DefTendencies->KEGrad.Enabled             = true;
+   DefTendencies->SHHGrad.Enabled            = true;
+
+   // TODO need to get visc values from config
+   DefTendencies->VelocityDiffusion.Enabled = false;
+   DefTendencies->VelocityHyperDiff.Enabled = false;
+
+   if (DefTendencies) {
+      LOG_INFO("TendenciesTest: Default tendencies retrieval PASS");
+   } else {
+      Err++;
+      LOG_INFO("TendenciesTest: Default tendencies retrieval FAIL");
+      return -1;
+   }
+
+   const auto *Mesh = HorzMesh::getDefault();
+   // test creation of another tendencies
+   Config *Options;
+   Tendencies::create("TestTendencies", Mesh, 12, Options);
+
+   // test retrievel of another tendencies
+   if (Tendencies::get("TestTendencies")) {
+      LOG_INFO("TendenciesTest: Non-default tendencies retrieval PASS");
+   } else {
+      Err++;
+      LOG_INFO("TendenciesTest: Non-default tendencies retrieval FAIL");
+   }
+
+   // test erase
+   Tendencies::erase("TestTendencies");
+
+   if (Tendencies::get("TestTendencies")) {
+      Err++;
+      LOG_INFO("TendenciesTest: Non-default tendencies erase FAIL");
+   } else {
+      LOG_INFO("TendenciesTest: Non-default tendencies erase PASS");
+   }
+
+   // put NANs in every tendency variables
+   deepCopy(DefTendencies->LayerThicknessTend, NAN);
+   deepCopy(DefTendencies->NormalVelocityTend, NAN);
+
+   // compute tendencies
+   const auto *State    = OceanState::getDefault();
+   const auto *AuxState = AuxiliaryState::getDefault();
+   DefTendencies->computeAllTendencies(State, AuxState);
+
+   // check that everything got computed correctly
+   int NCellsOwned    = Mesh->NCellsOwned;
+   int NEdgesOwned    = Mesh->NEdgesOwned;
+   int NVerticesOwned = Mesh->NVerticesOwned;
+
+   const Real LayerThickTendSum =
+       sum(DefTendencies->LayerThicknessTend, NCellsOwned);
+   if (!Kokkos::isfinite(LayerThickTendSum) || LayerThickTendSum == 0) {
+      Err++;
+      LOG_ERROR("TendenciesTest: LayerThickTend FAIL");
+   }
+
+   const Real NormVelTendSum =
+       sum(DefTendencies->NormalVelocityTend, NEdgesOwned);
+   if (!Kokkos::isfinite(NormVelTendSum) || NormVelTendSum == 0) {
+      Err++;
+      LOG_ERROR("TendenciesTest: NormVelTendSum FAIL");
+   }
+
+   Tendencies::clear();
+
+   return Err;
+}
+
+void finalizeTendenciesTest() {
+   AuxiliaryState::clear();
+   OceanState::clear();
+   IOField::clear();
+   HorzMesh::clear();
+   Halo::clear();
+   Decomp::clear();
+   MachEnv::removeAll();
+}
+
+int tendenciesTest(const std::string &MeshFile = "OmegaMesh.nc") {
+   int Err = initTendenciesTest(MeshFile);
+   if (Err != 0) {
+      LOG_CRITICAL("TendenciesTest: Error initializing");
+   }
+
+   const auto &Mesh = HorzMesh::getDefault();
+
+   Err += initState();
+
+   Err += testTendencies();
+
+   if (Err == 0) {
+      LOG_INFO("TendenciesTest: Successful completion");
+   }
+   finalizeTendenciesTest();
+
+   return Err;
+}
+
+int main(int argc, char *argv[]) {
+
+   int RetVal = 0;
+
+   MPI_Init(&argc, &argv);
+   Kokkos::initialize(argc, argv);
+
+   RetVal += tendenciesTest();
+
+   Kokkos::finalize();
+   MPI_Finalize();
+
+   if (RetVal >= 256)
+      RetVal = 255;
+
+   return RetVal;
+
+} // end of main
+//===-----------------------------------------------------------------------===/


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
This PR adds a class that provides routines to compute groups of tendencies for thickness and velocity. It is dependent on the completion of `AuxilaryState` so I've put it up as a draft PR for now.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Design document has been generated and added to the docs
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
before and after.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


