### PR TITLE
Update paths Metis/Parmetis libraries

### DIFF
--- a/components/omega/doc/devGuide/QuickStart.md
+++ b/components/omega/doc/devGuide/QuickStart.md
@@ -198,36 +198,36 @@ ctest log file located at `$BUILD_DIR/Testing/Temporary/LastTest.log`.
 The following table shows locations for Metis and Parmetis libraries on
 supported E3SM machines.  The pattern is:
 ```
-<polaris_base>/<machine>/spack/dev_polaris_0_3_0_<compiler>_<mpi>/var/spack/environments/dev_polaris_0_3_0_<compiler>_<mpi>/.spack-env/view
+<polaris_base>/<machine>/spack/dev_polaris_0_4_0_<compiler>_<mpi>/var/spack/environments/dev_polaris_0_4_0_<compiler>_<mpi>/.spack-env/view
 ```
 
 ```{eval-rst}
 +--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Machine      | Compiler     | Parmetis path                                                                                                                                                     |
 +==============+==============+===================================================================================================================================================================+
-| chicoma-cpu  | gnu          | /usr/projects/e3sm/polaris/chicoma-cpu/spack/dev_polaris_0_3_0_gnu_mpich/var/spack/environments/dev_polaris_0_3_0_gnu_mpich/.spack-env/view                       |
+| chicoma-cpu  | gnu          | /usr/projects/e3sm/polaris/chicoma-cpu/spack/dev_polaris_0_4_0_gnu_mpich/var/spack/environments/dev_polaris_0_4_0_gnu_mpich/.spack-env/view                       |
 +--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| chrysalis    | intel        | /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_0_3_0_intel_openmpi/var/spack/environments/dev_polaris_0_3_0_intel_openmpi/.spack-env/view                 |
+| chrysalis    | intel        | /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_0_4_0_intel_openmpi/var/spack/environments/dev_polaris_0_4_0_intel_openmpi/.spack-env/view                 |
 |              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | gnu          | /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_0_3_0_gnu_openmpi/var/spack/environments/dev_polaris_0_3_0_gnu_openmpi/.spack-env/view                     |
+|              | gnu          | /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_0_4_0_gnu_openmpi/var/spack/environments/dev_polaris_0_4_0_gnu_openmpi/.spack-env/view                     |
 +--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| frontier     | gnu          | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_3_0_gnu_mpich/var/spack/environments/dev_polaris_0_3_0_gnu_mpich/.spack-env/view                   |
+| frontier     | gnu          | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_4_0_gnu_mpich/var/spack/environments/dev_polaris_0_4_0_gnu_mpich/.spack-env/view                   |
 |              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | gnugpu       | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_3_0_gnugpu_mpich/var/spack/environments/dev_polaris_0_3_0_gnugpu_mpich/.spack-env/view             |
+|              | gnugpu       | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_4_0_gnugpu_mpich/var/spack/environments/dev_polaris_0_4_0_gnugpu_mpich/.spack-env/view             |
 |              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | crayclang    | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_3_0_crayclang_mpich/var/spack/environments/dev_polaris_0_3_0_crayclang_mpich/.spack-env/view       |
+|              | crayclang    | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_4_0_crayclang_mpich/var/spack/environments/dev_polaris_0_4_0_crayclang_mpich/.spack-env/view       |
 |              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | crayclanggpu | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_3_0_crayclanggpu_mpich/var/spack/environments/dev_polaris_0_3_0_crayclanggpu_mpich/.spack-env/view |
+|              | crayclanggpu | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_4_0_crayclanggpu_mpich/var/spack/environments/dev_polaris_0_4_0_crayclanggpu_mpich/.spack-env/view |
 +--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| pm-cpu       | gnu          | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_3_0_gnu_mpich/var/spack/environments/dev_polaris_0_3_0_gnu_mpich/.spack-env/view               |
+| pm-cpu       | gnu          | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_4_0_gnu_mpich/var/spack/environments/dev_polaris_0_4_0_gnu_mpich/.spack-env/view               |
 |              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | intel        | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_3_0_intel_mpich/var/spack/environments/dev_polaris_0_3_0_intel_mpich/.spack-env/view           |
+|              | intel        | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_4_0_intel_mpich/var/spack/environments/dev_polaris_0_4_0_intel_mpich/.spack-env/view           |
 |              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | nvidia       | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_3_0_nvidia_mpich/var/spack/environments/dev_polaris_0_3_0_nvidia_mpich/.spack-env/view         |
+|              | nvidia       | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_4_0_nvidia_mpich/var/spack/environments/dev_polaris_0_4_0_nvidia_mpich/.spack-env/view         |
 +--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| pm-gpu       | gnugpu       | /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_0_3_0_gnugpu_mpich/var/spack/environments/dev_polaris_0_3_0_gnugpu_mpich/.spack-env/view         |
+| pm-gpu       | gnugpu       | /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_0_4_0_gnugpu_mpich/var/spack/environments/dev_polaris_0_4_0_gnugpu_mpich/.spack-env/view         |
 |              +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | nvidiagpu    | /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_0_3_0_nvidiagpu_mpich/var/spack/environments/dev_polaris_0_3_0_nvidiagpu_mpich/.spack-env/view   |
+|              | nvidiagpu    | /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_0_4_0_nvidiagpu_mpich/var/spack/environments/dev_polaris_0_4_0_nvidiagpu_mpich/.spack-env/view   |
 +--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 


### PR DESCRIPTION
New libraries have been built for a new version of Polaris.  The version of Metis/Parmetis in these builds now uses 64-bit integers, required for correctly partitioning large meshes.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


