### PR TITLE
Changes IO dimension inquiry and removes precision at base IO level

### DIFF
--- a/components/omega/doc/devGuide/IO.md
+++ b/components/omega/doc/devGuide/IO.md
@@ -49,7 +49,7 @@ files for reading/writing, use:
 ```
 or
 ```c++
-   int Err = IO::openFile(FileID, Filename, Mode, Format, IfExists, Precision);
+   int Err = IO::openFile(FileID, Filename, Mode, Format, IfExists);
    Err = IO::closeFile(FileID);
 ```
 In both case, an integer FileID is assigned to the open file which is then
@@ -79,18 +79,11 @@ enum class IfExists {
    Append,  /// Append to the existing file
 };
 
-/// Floating point precision to allow reduced precision to save space
-enum class Precision {
-   Double, /// Maintain full double precision (64-bit) for reals
-   Single, /// Reduce all floating point variables to 32-bit reals
-};
 ```
-with the defaults for each being ``IO::FmtDefault``, ``IO::IfExists::Fail``,
-and ``IO::Precision::Double``. The E3SM standard format is currently
+with the defaults for each being ``IO::FmtDefault``, and
+``IO::IfExists::Fail``. The E3SM standard format is currently
 NetCDF4. Earlier NetCDF formats should be avoided, but are provided in
-case an input file is in an earlier format. The Precision argument is
-for output files only and determines whether double-precision (R8) variables
-should be reduced to single precision during output.
+case an input file is in an earlier format.
 
 Once the file is open, data is read/written using:
 ```c++
@@ -117,12 +110,12 @@ where FileID is the ID of an open file, the DimName is a ``std::string``
 with the dimension name (eg NCells, NEdges, NVertices, NVertLevels or
 NTracers), length is the length of the full global array and DimID is
 the ID assigned to this dimension. Note that for reading a file, we
-do have a function:
+supply the function:
 ```c++
-   int Length = IO::getDimLength(FileID, DimName);
+   int Err = IO::getDimFromFile(FileID, DimName, DimID, DimLength);
 ```
-that can be used to inquire about the dimension length and check for
-consistency, but the full dimension must still be defined.
+that can be used to inquire about the dimension length and retrieve the
+dimension ID from the file.
 
 Once the dimensions are defined, the decomposition of an array must
 be defined using:

--- a/components/omega/doc/userGuide/OmegaBuild.md
+++ b/components/omega/doc/userGuide/OmegaBuild.md
@@ -30,7 +30,7 @@ file (`config_machines.xml`), employ the `OMEGA_CIME_COMPILER` CMake variable,
 as illustrated below. In some cases, you may also want to add `OMEGA_CIME_MACHINE`
 to specify which system you intend to use. On systems where there is not a
 default `PROJECT` defined, you can use `OMEGA_CIME_PROJECT` to specify an
-account to use as a placeholder during the Omega build. 
+account to use as a placeholder during the Omega build.
 The values of `OMEGA_CIME_COMPILER` and `OMEGA_CIME_MACHINE` are defined in
 "${E3SM}/cime\_config/machines/config\_machines.xml".
 OMEGA requires some external libraries. Many of these are built automatically

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -223,7 +223,7 @@ int readMesh(const int MeshFileID, // file ID for open mesh file
          OnVertexOffset[Vrtx * VertexDegree + Cell] =
              VertexGlob * VertexDegree + Cell;
       } // end loop VertexDegree
-   }    // end loop NVerticesLocal
+   } // end loop NVerticesLocal
 
    // Create the parallel IO decompositions
    IO::Rearranger Rearr = IO::RearrBox;
@@ -771,7 +771,7 @@ int Decomp::partCellsKWay(
          for (int n = 0; n < CellsOnCellSize; ++n) {
             CellsOnCellBuf[n] = CellsOnCellInit[n];
          } // end loop CellsOnCell
-      }    // end if this is MyTask
+      } // end if this is MyTask
       Err = MPI_Bcast(&CellsOnCellBuf[0], CellsOnCellSize, MPI_INT32_T, Task,
                       Comm);
       if (Err != 0) {
@@ -800,8 +800,8 @@ int Decomp::partCellsKWay(
                ++Add; // increment address counter
             }
          }
-      }                        // end cell loop for buffer
-   }                           // end task loop
+      } // end cell loop for buffer
+   } // end task loop
    AdjAdd[NCellsGlobal] = Add; // Add the ending address
 
    // Set up remaining partitioning variables
@@ -888,7 +888,7 @@ int Decomp::partCellsKWay(
          CellLocTmp[2 * LocalAdd]     = TaskLoc;
          CellLocTmp[2 * LocalAdd + 1] = LocalAdd;
       } // end if my task
-   }    // end loop over all cells
+   } // end loop over all cells
 
    // Find and add the halo cells to the cell list. Here we use the
    // adjacency array to find the active neighbor cells and store if they
@@ -927,7 +927,7 @@ int Decomp::partCellsKWay(
                   HaloList.insert(NbrID);
                   CellsInList.insert(NbrID);
                } // end search for existing entry
-            }    // end if not on task
+            } // end if not on task
 
          } // end loop over neighbors
 
@@ -1158,8 +1158,8 @@ int Decomp::partEdges(
                ++HaloCount;
                EdgesAll.erase(EdgeGlob);
             } // end if valid edge
-         }    // end loop over cell edges
-      }       // end cell loop
+         } // end loop over cell edges
+      } // end cell loop
       // reset address range for next halo and set NEdgesHalo
       CellStart = CellEnd;
       if ((Halo + 1) < HaloWidth)
@@ -1563,8 +1563,8 @@ int Decomp::rearrangeCellArrays(
             }
             NEdgesOnCellTmp(LocCell) = EdgeCount;
          } // end if local cell
-      }    // end loop over chunk of global cells
-   }       // end loop over MPI tasks
+      } // end loop over chunk of global cells
+   } // end loop over MPI tasks
 
    // Copy to final location on host - wait to create device copies until
    // the entries are translated to local addresses rather than global IDs
@@ -1699,8 +1699,8 @@ int Decomp::rearrangeEdgeArrays(
             }
             NEdgesOnEdgeTmp(LocEdge) = EdgeCount;
          } // end if local cell
-      }    // end loop over chunk of global cells
-   }       // end loop over MPI tasks
+      } // end loop over chunk of global cells
+   } // end loop over MPI tasks
 
    // Copy to final location on host - wait to create device copies until
    // the entries are translated to local addresses rather than global IDs
@@ -1808,8 +1808,8 @@ int Decomp::rearrangeVertexArrays(
                ++BufAdd;
             }
          } // end if local cell
-      }    // end loop over chunk of global cells
-   }       // end loop over MPI tasks
+      } // end loop over chunk of global cells
+   } // end loop over MPI tasks
 
    // Copy to final location on host - wait to create device copies until
    // the entries are translated to local addresses rather than global IDs

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -131,20 +131,27 @@ int readMesh(const int MeshFileID, // file ID for open mesh file
 
    // Read in mesh size information - these are dimension lengths in
    // the input mesh file
-   NCellsGlobal = IO::getDimLength(MeshFileID, "nCells");
-   if (NCellsGlobal <= 0)
+   I4 NCellsID;
+   Err = IO::getDimFromFile(MeshFileID, "nCells", NCellsID, NCellsGlobal);
+   if (Err != 0 or NCellsGlobal <= 0)
       LOG_CRITICAL("Decomp: error reading nCells");
-   NEdgesGlobal = IO::getDimLength(MeshFileID, "nEdges");
-   if (NEdgesGlobal <= 0)
+   I4 NEdgesID;
+   Err = IO::getDimFromFile(MeshFileID, "nEdges", NEdgesID, NEdgesGlobal);
+   if (Err != 0 or NEdgesGlobal <= 0)
       LOG_CRITICAL("Decomp: error reading NEdges");
-   NVerticesGlobal = IO::getDimLength(MeshFileID, "nVertices");
-   if (NVerticesGlobal <= 0)
+   I4 NVerticesID;
+   Err = IO::getDimFromFile(MeshFileID, "nVertices", NVerticesID,
+                            NVerticesGlobal);
+   if (Err != 0 or NVerticesGlobal <= 0)
       LOG_CRITICAL("Decomp: error reading NVertices");
-   MaxEdges = IO::getDimLength(MeshFileID, "maxEdges");
-   if (MaxEdges <= 0)
+   I4 MaxEdgesID;
+   Err = IO::getDimFromFile(MeshFileID, "maxEdges", MaxEdgesID, MaxEdges);
+   if (Err != 0 or MaxEdges <= 0)
       LOG_CRITICAL("Decomp: error reading MaxEdges");
-   VertexDegree = IO::getDimLength(MeshFileID, "vertexDegree");
-   if (VertexDegree <= 0)
+   I4 VertexDegreeID;
+   Err = IO::getDimFromFile(MeshFileID, "vertexDegree", VertexDegreeID,
+                            VertexDegree);
+   if (Err != 0 or VertexDegree <= 0)
       LOG_CRITICAL("Decomp: error reading VertexDegree");
    MaxCellsOnEdge    = 2;            // currently always 2
    I4 MaxEdgesOnEdge = 2 * MaxEdges; // 2*MaxCellsOnEdge
@@ -216,7 +223,7 @@ int readMesh(const int MeshFileID, // file ID for open mesh file
          OnVertexOffset[Vrtx * VertexDegree + Cell] =
              VertexGlob * VertexDegree + Cell;
       } // end loop VertexDegree
-   } // end loop NVerticesLocal
+   }    // end loop NVerticesLocal
 
    // Create the parallel IO decompositions
    IO::Rearranger Rearr = IO::RearrBox;
@@ -764,7 +771,7 @@ int Decomp::partCellsKWay(
          for (int n = 0; n < CellsOnCellSize; ++n) {
             CellsOnCellBuf[n] = CellsOnCellInit[n];
          } // end loop CellsOnCell
-      } // end if this is MyTask
+      }    // end if this is MyTask
       Err = MPI_Bcast(&CellsOnCellBuf[0], CellsOnCellSize, MPI_INT32_T, Task,
                       Comm);
       if (Err != 0) {
@@ -793,8 +800,8 @@ int Decomp::partCellsKWay(
                ++Add; // increment address counter
             }
          }
-      } // end cell loop for buffer
-   } // end task loop
+      }                        // end cell loop for buffer
+   }                           // end task loop
    AdjAdd[NCellsGlobal] = Add; // Add the ending address
 
    // Set up remaining partitioning variables
@@ -881,7 +888,7 @@ int Decomp::partCellsKWay(
          CellLocTmp[2 * LocalAdd]     = TaskLoc;
          CellLocTmp[2 * LocalAdd + 1] = LocalAdd;
       } // end if my task
-   } // end loop over all cells
+   }    // end loop over all cells
 
    // Find and add the halo cells to the cell list. Here we use the
    // adjacency array to find the active neighbor cells and store if they
@@ -920,7 +927,7 @@ int Decomp::partCellsKWay(
                   HaloList.insert(NbrID);
                   CellsInList.insert(NbrID);
                } // end search for existing entry
-            } // end if not on task
+            }    // end if not on task
 
          } // end loop over neighbors
 
@@ -1151,8 +1158,8 @@ int Decomp::partEdges(
                ++HaloCount;
                EdgesAll.erase(EdgeGlob);
             } // end if valid edge
-         } // end loop over cell edges
-      } // end cell loop
+         }    // end loop over cell edges
+      }       // end cell loop
       // reset address range for next halo and set NEdgesHalo
       CellStart = CellEnd;
       if ((Halo + 1) < HaloWidth)
@@ -1556,8 +1563,8 @@ int Decomp::rearrangeCellArrays(
             }
             NEdgesOnCellTmp(LocCell) = EdgeCount;
          } // end if local cell
-      } // end loop over chunk of global cells
-   } // end loop over MPI tasks
+      }    // end loop over chunk of global cells
+   }       // end loop over MPI tasks
 
    // Copy to final location on host - wait to create device copies until
    // the entries are translated to local addresses rather than global IDs
@@ -1692,8 +1699,8 @@ int Decomp::rearrangeEdgeArrays(
             }
             NEdgesOnEdgeTmp(LocEdge) = EdgeCount;
          } // end if local cell
-      } // end loop over chunk of global cells
-   } // end loop over MPI tasks
+      }    // end loop over chunk of global cells
+   }       // end loop over MPI tasks
 
    // Copy to final location on host - wait to create device copies until
    // the entries are translated to local addresses rather than global IDs
@@ -1801,8 +1808,8 @@ int Decomp::rearrangeVertexArrays(
                ++BufAdd;
             }
          } // end if local cell
-      } // end loop over chunk of global cells
-   } // end loop over MPI tasks
+      }    // end loop over chunk of global cells
+   }       // end loop over MPI tasks
 
    // Copy to final location on host - wait to create device copies until
    // the entries are translated to local addresses rather than global IDs

--- a/components/omega/src/base/IO.h
+++ b/components/omega/src/base/IO.h
@@ -85,12 +85,6 @@ enum class IfExists {
    Append,  /// Append to the existing file
 };
 
-/// Floating point precision to allow reduced precision to save space
-enum class Precision {
-   Double, /// Maintain full double precision (64-bit) for reals
-   Single, /// Reduce all floating point variables to 32-bit reals
-};
-
 /// Data types for PIO corresponding to Omega types
 enum IODataType {
    IOTypeI4      = PIO_INT,    /// 32-bit integer
@@ -131,10 +125,6 @@ Mode ModeFromString(
 IfExists IfExistsFromString(
     const std::string &IfExists ///< [in] choice of behavior on file existence
 );
-/// Converts string choice for floating point precision to an enum
-Precision PrecisionFromString(
-    const std::string &Precision ///< [in] choice of floating point precision
-);
 
 // Methods
 
@@ -152,12 +142,11 @@ int init(const MPI_Comm &InComm ///< [in] MPI communicator to use
 /// used if the file already exists, and the precision of any floating point
 /// variables. Returns an error code.
 int openFile(
-    int &FileID,                      ///< [out] returned fileID for this file
-    const std::string &Filename,      ///< [in] name (incl path) of file to open
-    Mode Mode,                        ///< [in] mode (read or write)
-    FileFmt Format      = FmtDefault, ///< [in] (optional) file format
-    IfExists IfExists   = IfExists::Fail,   ///< [in] behavior if file exists
-    Precision Precision = Precision::Double ///< [in] precision of floats
+    int &FileID,                    ///< [out] returned fileID for this file
+    const std::string &Filename,    ///< [in] name (incl path) of file to open
+    Mode Mode,                      ///< [in] mode (read or write)
+    FileFmt Format    = FmtDefault, ///< [in] (optional) file format
+    IfExists IfExists = IfExists::Fail ///< [in] behavior if file exists
 );
 
 /// Closes an open file using the fileID, returns an error code
@@ -167,8 +156,10 @@ int closeFile(int &FileID /// [in] ID of the file to be closed
 /// Retrieves a dimension length from an input file, given the name
 /// of the dimension. Returns the length if exists, but returns a negative
 /// value if a dimension of that length is not found in the file.
-int getDimLength(int FileID, ///< [in] ID of the file containing dim
-                 const std::string &DimName ///< [in] name of dimension
+int getDimFromFile(int FileID, ///< [in] ID of the file containing dim
+                   const std::string &DimName, ///< [in] name of dimension
+                   int &DimID,    ///< [out] ID assigned to this dimension
+                   int &DimLength ///< [out] global length of the dimension
 );
 
 /// Defines a dimension for an output file. Returns a dimension id to

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -264,9 +264,9 @@ int main(int argc, char *argv[]) {
 
       // Open a file for output
       int OutFileID;
-      Err = OMEGA::IO::openFile(
-          OutFileID, "IOTest.nc", OMEGA::IO::ModeWrite, OMEGA::IO::FmtDefault,
-          OMEGA::IO::IfExists::Replace, OMEGA::IO::Precision::Double);
+      Err = OMEGA::IO::openFile(OutFileID, "IOTest.nc", OMEGA::IO::ModeWrite,
+                                OMEGA::IO::FmtDefault,
+                                OMEGA::IO::IfExists::Replace);
       if (Err != 0) {
          RetVal += 1;
          LOG_ERROR("IOTest: error opening file for output FAIL");
@@ -584,33 +584,44 @@ int main(int argc, char *argv[]) {
       }
 
       // Get dimension lengths to verify read/write of dimension info
-      OMEGA::I4 NVertLevelsNew =
-          OMEGA::IO::getDimLength(InFileID, "NVertLevels");
-      if (NVertLevelsNew == NVertLevels) {
+      OMEGA::I4 NVertLevelsID;
+      OMEGA::I4 NVertLevelsNew;
+      Err = OMEGA::IO::getDimFromFile(InFileID, "NVertLevels", NVertLevelsID,
+                                      NVertLevelsNew);
+      if (Err == 0 and NVertLevelsNew == NVertLevels) {
          LOG_INFO("IOTest: read/write vert dimension test PASS");
       } else {
          RetVal += 1;
          LOG_INFO("IOTest: read/write vert dimension test FAIL");
       }
 
-      OMEGA::I4 NCellsNew = OMEGA::IO::getDimLength(InFileID, "NCells");
-      if (NCellsNew == NCellsGlobal) {
+      OMEGA::I4 NCellsNewID;
+      OMEGA::I4 NCellsNew;
+      Err =
+          OMEGA::IO::getDimFromFile(InFileID, "NCells", NCellsNewID, NCellsNew);
+      if (Err == 0 and NCellsNew == NCellsGlobal) {
          LOG_INFO("IOTest: read/write cell dimension test PASS");
       } else {
          RetVal += 1;
          LOG_INFO("IOTest: read/write cell dimension test FAIL");
       }
 
-      OMEGA::I4 NEdgesNew = OMEGA::IO::getDimLength(InFileID, "NEdges");
-      if (NEdgesNew == NEdgesGlobal) {
+      OMEGA::I4 NEdgesNewID;
+      OMEGA::I4 NEdgesNew;
+      Err =
+          OMEGA::IO::getDimFromFile(InFileID, "NEdges", NEdgesNewID, NEdgesNew);
+      if (Err == 0 and NEdgesNew == NEdgesGlobal) {
          LOG_INFO("IOTest: read/write edge dimension test PASS");
       } else {
          RetVal += 1;
          LOG_INFO("IOTest: read/write edge dimension test FAIL");
       }
 
-      OMEGA::I4 NVerticesNew = OMEGA::IO::getDimLength(InFileID, "NVertices");
-      if (NVerticesNew == NVerticesGlobal) {
+      OMEGA::I4 NVerticesNewID;
+      OMEGA::I4 NVerticesNew;
+      Err = OMEGA::IO::getDimFromFile(InFileID, "NVertices", NVerticesNewID,
+                                      NVerticesNew);
+      if (Err == 0 and NVerticesNew == NVerticesGlobal) {
          LOG_INFO("IOTest: read/write vertex dimension test PASS");
       } else {
          RetVal += 1;


### PR DESCRIPTION
- Changes the dimension inquiry function for input files to return both length and ID
- Removes the precision enum and precision arguments since they are not used at the base IO level
- Updated the docs
- Some formatting changes to please the linter

These changes are needed for upcoming IOStreams. All Ctest tests pass on Chrysalis/Intel.

Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.



