### PR TITLE
Change build location for docs CI

### DIFF
--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -66,12 +66,14 @@ jobs:
           cd gh-pages
           # Create `.nojekyll` (if it doesn't already exist) for proper GH Pages configuration.
           touch .nojekyll
+          # Create an omega directory to store the documentation
+          mkdir omega
           # Add `index.html` to point to the `main` branch automatically.
-          printf '<meta http-equiv="refresh" content="0; url=./develop/index.html" />' > index.html
+          printf '<meta http-equiv="refresh" content="0; url=./develop/index.html" />' > omega/index.html
           # Replace `develop` docs with latest changes
-          rm -rf develop
-          mkdir develop
-          cp -r ../_build/html/* develop/
+          rm -rf omega/develop
+          mkdir omega/develop
+          cp -r ../_build/html/* omega/develop/
           # Configure git using GitHub Actions credentials.
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -67,7 +67,7 @@ jobs:
           # Create `.nojekyll` (if it doesn't already exist) for proper GH Pages configuration.
           touch .nojekyll
           # Create an omega directory to store the documentation
-          mkdir omega
+          mkdir -p omega
           # Add `index.html` to point to the `main` branch automatically.
           printf '<meta http-equiv="refresh" content="0; url=./develop/index.html" />' > omega/index.html
           # Replace `develop` docs with latest changes


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
The docs are currently built in `develop`, which is causing a conflict between Omega's docs and E3SM's docs. This PR changes the build location to `omega/develop` which removes the conflict.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


