### PR TITLE
Adds a new dimension class for Omega

### DIFF
--- a/components/omega/doc/devGuide/Dimension.md
+++ b/components/omega/doc/devGuide/Dimension.md
@@ -1,0 +1,91 @@
+(omega-dev-dimension)=
+
+## Dimension
+
+When performing IO for fields in OMEGA, some metadata associated with each
+dimension of multi-dimensional arrays are required. The Dimension class is
+a container that stores this dimension information and a Dimension instance
+must be created for each dimension in OMEGA. Most of these will be created
+by the Mesh or Decomposition classes, but if developers introduce a new
+dimension, the dimension must be created.
+
+For dimensions that are distributed across the parallel machine, the creation
+must provide length and an offset array that describes the global index offset
+for each local point along the dimension. Typically this is the zero-based
+ID of the location in the global mesh. A negative value is used for any halo
+regions that will not participate in IO. For example, the NCells dimension
+is created using:
+```c++
+   Decomp *DefDecomp = Decomp::getDefault();
+
+   I4 NCellsSize   = DefDecomp->NCellsSize; // Local dim length
+   I4 NCellsGlobal = DefDecomp->NCellsGlobal; // Global dim length
+   I4 NCellsOwned  = DefDecomp->NCellsOwned;
+
+   HostArray1DI4 CellOffset("NCellsOffset", NCellsSize);
+
+   for (int N = 0; N < NCellsSize; ++N) {
+      if (N < NCellsOwned) {
+         CellOffset(N) = DefDecomp->CellIDH(N) - 1; // Offset is zero-based
+      } else {
+         CellOffset(N) = -1; // Denotes halo cells not to be used in IO
+      }
+   }
+
+   std::shared_ptr<Dimension> CellDim =
+      Dimension::create("NCells", NCellsGlobal, NCellsSize, CellOffset);
+```
+
+For dimensions that are local (eg the vertical dimension or MaxEdgeOnCell),
+only the name and length are needed for creation using:
+```c++
+   std::shared_ptr<Dimension> LocalDim =
+      Dimension::create("MyDimName", LengthOfDim);
+```
+The offset array is computed internally for these dimensions and is simply
+the array index along the dimension.
+
+Each Dimension stores the global and local length of the dimension as well
+as the offset array. It also stores a flag to denote whether the dimension
+is distributed or not. This information is used primarily by the IOStreams
+class to write dimension metadata and define offsets for parallel IO. It is
+not expected to be used elsewhere in OMEGA.
+
+Dimension information is available through retrieval functions. These can be
+retrieved by dimension name as in:
+```c++
+   I4 LengthGlob  = Dimension::getDimLengthGlobal("MyDimName");
+   I4 LengthLoc   = Dimension::getDimLengthLocal("MyDimName");
+   bool DistrbDim = Dimension::isDistributedDim("MyDimName");
+   HostArray1DI4 MyOffset = Dimension::getDimOffset("MyDimName");
+```
+or it can be retrieved from an instance directly using member retrieval
+functions:
+```c++
+   std::shared_ptr<Dimension> MyDim = Dimension::get("MyDimName");
+   I4 LengthGlob = MyDim->getLengthGlobal();
+   I4 LengthLoc  = MyDim->getLengthLocal();
+   bool DistrbDim = MyDim->isDistributed();
+   HostArray1DI4 MyOffset = MyDim->getOffset();
+```
+An iterator is also provided to enable looping over all defined dimensions:
+```c++
+   for (auto Iter = Dimension::begin(); Iter != Dimension::end(); ++Iter) {
+      std::string MyDimName = Iter->first;
+      std::shared_ptr<Dimension> ThisDim = Iter->second;
+      I4 LengthLoc = ThisDim->getLengthLocal();
+      // other retrievals, etc
+   }
+```
+
+As in other classes, a Dimension can be removed using:
+```c++
+   Dimension::destroy("MyDimName");
+```
+and all dimensions should be removed during OMEGA finalization before exiting
+the Kokkos environment using:
+```c++
+   Dimension::clear();
+```
+
+Examples of the use of Dimensions can be found in the Dimension unit test.

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -28,6 +28,7 @@ userGuide/Config
 userGuide/Broadcast
 userGuide/Logging
 userGuide/Decomp
+userGuide/Dimension
 userGuide/MetaData
 userGuide/IO
 userGuide/IOField
@@ -58,6 +59,7 @@ devGuide/Broadcast
 devGuide/CMakeBuild
 devGuide/Logging
 devGuide/Decomp
+devGuide/Dimension
 devGuide/MetaData
 devGuide/IO
 devGuide/IOField

--- a/components/omega/doc/userGuide/Dimension.md
+++ b/components/omega/doc/userGuide/Dimension.md
@@ -1,0 +1,9 @@
+(omega-user-dimension)=
+
+## Dimension
+
+When performing IO, some metadata associated with each dimension in OMEGA
+must be defined. We provide a Dimension class to hold this metadata for use by
+the IO and Streams classes. This metadata is defined internally in OMEGA and
+there are no user-configurable options. More detail is proved in
+{ref}`omega-dev-dimension`.

--- a/components/omega/src/infra/Dimension.cpp
+++ b/components/omega/src/infra/Dimension.cpp
@@ -1,0 +1,274 @@
+//===-- infra/Dimension.cpp - OMEGA dimension implementation -----*- C++ -*-===//
+//
+// Implementation of the field dimension class used by the multi-dimensional
+// Field class
+//
+// The Dimension class defines dimension information for array fields.
+// Dimensions can be either distributed (most horizontal dimensions) or
+// non-distributed (eg vertical). The dimension primarily defines lengths
+// and offsets that are used for parallel IO and as dimension metadata in
+// self-describing files.
+//
+//===----------------------------------------------------------------------===//
+
+#include "DataTypes.h"
+#include "Dimension.h"
+#include "Logging.h"
+#include "OmegaKokkos.h"
+#include <map>
+#include <memory>
+#include <string>
+
+namespace OMEGA {
+
+// Create static class members that store instantiations of metadata
+std::map<std::string, std::shared_ptr<Dimension>> Dimension::AllDims;
+
+//------------------------------------------------------------------------------
+// Creates a distributed dimension given a name, global (unpartitioned)
+// length, size of local partition (including ghost cells and padding),
+// and GlobalID/index for each local entry. Entries that should not be
+// used in IO (eg ghost cells) should be given a GlobalID of -1.
+// The created dimension will be added to the list of defined dimensions.
+// If a dimension has already been defined for a dimension of the same
+// name and global/local length, the existing dimension will be returned.
+std::shared_ptr<Dimension> Dimension::create(
+      const std::string &Name,  // [in] name of dimension
+      const I4 GlobalLength,    // [in] global (unpartitioned) size of dim
+      const I4 LocalLength,     // [in] size of dim in local partition
+      HostArray1DI4 Offset      // [in] glob indx offset for each local indx  
+) {
+
+   auto Dim = std::make_shared<Dimension>(); // create empty dim
+
+   if (exists(Name)) { // Dimension already exists
+
+      // Retrieve the previously defined dim and use that unless...
+      Dim = get(Name);
+
+      // The already-defined dim has different properties, so the dimensions
+      // are not the same and we have a conflict
+      if ((Dim->GlobalLength != GlobalLength) or
+          (Dim->LocalLength != LocalLength) or !Dim->Distributed) {
+         LOG_ERROR("Attempt to create dimension {} but a dimension with"
+                   " that name already exists with different properties",
+                   Name);
+         Dim = nullptr;
+      }
+
+   } else { // a new dimension, fill data members
+
+      Dim->DimName       = Name;
+      Dim->GlobalLength  = GlobalLength;
+      Dim->LocalLength   = LocalLength;
+      Dim->Offset        = Offset;
+      Dim->Distributed   = true;
+      AllDims[Name] = Dim; // add to list of dims
+   }
+
+   return Dim;
+
+} // end create distributed
+
+//------------------------------------------------------------------------------
+// Creates a non-distributed dimension given a name and length
+std::shared_ptr<Dimension> Dimension::create(
+      const std::string Name,  // [in] name of dimension
+      const I4 GlobalLength    // [in] length of dimension
+) {
+   auto Dim = std::make_shared<Dimension>(); // create empty dim
+
+   if (exists(Name)) { // Dimension already exists
+
+      // Retrieve the previously defined dim and use that unless...
+      Dim = get(Name);
+
+      // The already-defined dim has different properties, so the dimensions
+      // are not the same and we have a conflict
+      if ((Dim->GlobalLength != GlobalLength) or
+          (Dim->LocalLength != GlobalLength) or Dim->Distributed) {
+         LOG_ERROR("Attempt to create dimension {} but a dimension with"
+                   " that name already exists with different properties",
+                   Name);
+         Dim = nullptr;
+      }
+
+   } else { // a new dimension, fill data members
+
+      Dim->DimName       = Name;
+      Dim->GlobalLength  = GlobalLength;
+      Dim->LocalLength   = GlobalLength;
+      Dim->Distributed   = false;
+      std::string OffsetName = Name + "Offset";
+      HostArray1DI4 NewOffset(OffsetName, GlobalLength);
+      for (int I = 0; I < GlobalLength; ++I) {
+         NewOffset(I) = I;
+      }
+      Dim->Offset = NewOffset;
+      AllDims[Name] = Dim; // add to list of dims
+   }
+
+   return Dim;
+
+} // end create non-distributed
+
+//------------------------------------------------------------------------------
+// Checks to see if a dim of this name exists
+bool Dimension::exists(
+         const std::string &Name // [in] name of dimension to check
+) {
+   return (AllDims.find(Name) != AllDims.end());
+} // end exists
+
+//------------------------------------------------------------------------------
+// Destroys a dimension
+void Dimension::destroy(
+         const std::string Name // [in] name of dimension to destroy
+) {
+   if (exists(Name)) {
+      AllDims.erase(Name);
+   } else {
+      LOG_ERROR("Attempt to destroy the dimension {} failed: "
+                "dimension does not exist or has not been defined.",
+                Name);
+   }
+
+} // end destroy
+
+//------------------------------------------------------------------------------
+// Destroys all defined dimensions
+void Dimension::clear() { AllDims.clear(); Kokkos::fence(); }
+
+//----------------------------------------------------------------------------//
+// Retrieves full dimension instance by name
+std::shared_ptr<Dimension>
+Dimension::get(const std::string Name // [in] Name of dimension
+) {
+   if (exists(Name)) {
+      return AllDims[Name];
+   } else {
+      LOG_ERROR("Cannot retrieve dimension {}: dimension does not exist"
+                " or has not net been defined",
+                Name);
+      return nullptr;
+   }
+
+} // end get full dimension instance
+
+//------------------------------------------------------------------------------
+// Get name of dimension from instance (iterator)
+std::string Dimension::getName() { return DimName; }
+
+//------------------------------------------------------------------------------
+// Check whether dimension is distributed
+bool Dimension::isDistributed() { return Distributed; }
+
+//------------------------------------------------------------------------------
+// Check whether dimension is distributed by dimension name
+bool Dimension::isDistributedDim(
+         const std::string &Name // [in] name of dimension
+) {
+   // Make sure dimension exists
+   if (exists(Name)) {
+      std::shared_ptr<Dimension> ThisDim = AllDims[Name];
+      return ThisDim->Distributed;
+
+   } else {
+      LOG_ERROR("Cannot check distribution of dimension {}: "
+                "dimension does not exist or has not been defined",
+                Name);
+      return false;
+   }
+
+}
+
+//------------------------------------------------------------------------------
+// Get global dimension from instance
+I4 Dimension::getLengthGlobal() { return GlobalLength; }
+
+//------------------------------------------------------------------------------
+// Get global dimension length by name
+I4 Dimension::getDimLengthGlobal(
+         const std::string &Name // [in] name of dimension
+) {
+   I4 Length;
+
+   // Make sure dimension exists
+   if (exists(Name)) {
+      std::shared_ptr<Dimension> ThisDim = AllDims[Name];
+      Length                            = ThisDim->GlobalLength;
+
+   } else {
+      LOG_ERROR("Cannot get global length of dimension {}: "
+                "dimension does not exist or has not been defined",
+                Name);
+      Length = -1;
+   }
+
+   return Length;
+
+} // end getDimLengthGlobal
+
+//------------------------------------------------------------------------------
+// Get length dimension in local partition from instance
+I4 Dimension::getLengthLocal() { return LocalLength; }
+
+//------------------------------------------------------------------------------
+// Get length dimension in local partition by name
+I4 Dimension::getDimLengthLocal(
+         const std::string &Name // [in] name of dimension
+) {
+   I4 Length;
+
+   // Make sure dimension exists
+   if (exists(Name)) {
+      std::shared_ptr<Dimension> ThisDim = AllDims[Name];
+      Length                            = ThisDim->LocalLength;
+
+   } else {
+      LOG_ERROR("Cannot get local length of dimension {}: "
+                "dimension does not exist or has not been defined",
+                Name);
+      Length = -1;
+   }
+
+   return Length;
+
+} // end get DimLengthLocal
+
+//------------------------------------------------------------------------------
+// Get global offset for each local address from dim instance
+HostArray1DI4 Dimension::getOffset() { return Offset; }
+
+//------------------------------------------------------------------------------
+// Get global offset for each local address given a dim name
+HostArray1DI4 Dimension::getDimOffset(
+         const std::string &Name // [in] name of dimension
+) {
+
+   // Make sure dimension exists
+   if (exists(Name)) {
+      std::shared_ptr<Dimension> ThisDim = AllDims[Name];
+      return ThisDim->Offset;
+
+   } else {
+      LOG_ERROR("Cannot get offset array for dimension {}: "
+                "dimension does not exist or has not been defined",
+                Name);
+   }
+
+} // end getDimOffset
+
+//----------------------------------------------------------------------------//
+// Retrieves the number of currently defined dimensions
+int Dimension::getNumDefinedDims() { return AllDims.size(); }
+
+//------------------------------------------------------------------------------
+// Returns an iterator to the first dimension stored in AllDims
+Dimension::Iter Dimension::begin() { return Dimension::AllDims.begin(); }
+
+//------------------------------------------------------------------------------
+// Returns an iterator to the last dimension stored in AllDims
+Dimension::Iter Dimension::end() { return Dimension::AllDims.end(); }
+
+} // namespace OMEGA

--- a/components/omega/src/infra/Dimension.cpp
+++ b/components/omega/src/infra/Dimension.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<Dimension> Dimension::create(
 // Creates a non-distributed dimension given a name and length
 std::shared_ptr<Dimension>
 Dimension::create(const std::string &Name, // [in] name of dimension
-                  const I4 GlobalLength   // [in] length of dimension
+                  const I4 GlobalLength    // [in] length of dimension
 ) {
    auto Dim = std::make_shared<Dimension>(); // create empty dim
 
@@ -138,10 +138,7 @@ void Dimension::destroy(
 
 //------------------------------------------------------------------------------
 // Destroys all defined dimensions
-void Dimension::clear() {
-   AllDims.clear();
-   Kokkos::fence();
-}
+void Dimension::clear() { AllDims.clear(); }
 
 //----------------------------------------------------------------------------//
 // Retrieves full dimension instance by name

--- a/components/omega/src/infra/Dimension.cpp
+++ b/components/omega/src/infra/Dimension.cpp
@@ -1,4 +1,5 @@
-//===-- infra/Dimension.cpp - OMEGA dimension implementation -----*- C++ -*-===//
+//===-- infra/Dimension.cpp - OMEGA dimension implementation -----*- C++
+//-*-===//
 //
 // Implementation of the field dimension class used by the multi-dimensional
 // Field class
@@ -11,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "DataTypes.h"
 #include "Dimension.h"
+#include "DataTypes.h"
 #include "Logging.h"
 #include "OmegaKokkos.h"
 #include <map>
@@ -33,10 +34,10 @@ std::map<std::string, std::shared_ptr<Dimension>> Dimension::AllDims;
 // If a dimension has already been defined for a dimension of the same
 // name and global/local length, the existing dimension will be returned.
 std::shared_ptr<Dimension> Dimension::create(
-      const std::string &Name,  // [in] name of dimension
-      const I4 GlobalLength,    // [in] global (unpartitioned) size of dim
-      const I4 LocalLength,     // [in] size of dim in local partition
-      HostArray1DI4 Offset      // [in] glob indx offset for each local indx  
+    const std::string &Name, // [in] name of dimension
+    const I4 GlobalLength,   // [in] global (unpartitioned) size of dim
+    const I4 LocalLength,    // [in] size of dim in local partition
+    HostArray1DI4 Offset     // [in] glob indx offset for each local indx
 ) {
 
    auto Dim = std::make_shared<Dimension>(); // create empty dim
@@ -58,12 +59,12 @@ std::shared_ptr<Dimension> Dimension::create(
 
    } else { // a new dimension, fill data members
 
-      Dim->DimName       = Name;
-      Dim->GlobalLength  = GlobalLength;
-      Dim->LocalLength   = LocalLength;
-      Dim->Offset        = Offset;
-      Dim->Distributed   = true;
-      AllDims[Name] = Dim; // add to list of dims
+      Dim->DimName      = Name;
+      Dim->GlobalLength = GlobalLength;
+      Dim->LocalLength  = LocalLength;
+      Dim->Offset       = Offset;
+      Dim->Distributed  = true;
+      AllDims[Name]     = Dim; // add to list of dims
    }
 
    return Dim;
@@ -72,9 +73,9 @@ std::shared_ptr<Dimension> Dimension::create(
 
 //------------------------------------------------------------------------------
 // Creates a non-distributed dimension given a name and length
-std::shared_ptr<Dimension> Dimension::create(
-      const std::string Name,  // [in] name of dimension
-      const I4 GlobalLength    // [in] length of dimension
+std::shared_ptr<Dimension>
+Dimension::create(const std::string Name, // [in] name of dimension
+                  const I4 GlobalLength   // [in] length of dimension
 ) {
    auto Dim = std::make_shared<Dimension>(); // create empty dim
 
@@ -95,16 +96,16 @@ std::shared_ptr<Dimension> Dimension::create(
 
    } else { // a new dimension, fill data members
 
-      Dim->DimName       = Name;
-      Dim->GlobalLength  = GlobalLength;
-      Dim->LocalLength   = GlobalLength;
-      Dim->Distributed   = false;
+      Dim->DimName           = Name;
+      Dim->GlobalLength      = GlobalLength;
+      Dim->LocalLength       = GlobalLength;
+      Dim->Distributed       = false;
       std::string OffsetName = Name + "Offset";
       HostArray1DI4 NewOffset(OffsetName, GlobalLength);
       for (int I = 0; I < GlobalLength; ++I) {
          NewOffset(I) = I;
       }
-      Dim->Offset = NewOffset;
+      Dim->Offset   = NewOffset;
       AllDims[Name] = Dim; // add to list of dims
    }
 
@@ -115,7 +116,7 @@ std::shared_ptr<Dimension> Dimension::create(
 //------------------------------------------------------------------------------
 // Checks to see if a dim of this name exists
 bool Dimension::exists(
-         const std::string &Name // [in] name of dimension to check
+    const std::string &Name // [in] name of dimension to check
 ) {
    return (AllDims.find(Name) != AllDims.end());
 } // end exists
@@ -123,7 +124,7 @@ bool Dimension::exists(
 //------------------------------------------------------------------------------
 // Destroys a dimension
 void Dimension::destroy(
-         const std::string Name // [in] name of dimension to destroy
+    const std::string Name // [in] name of dimension to destroy
 ) {
    if (exists(Name)) {
       AllDims.erase(Name);
@@ -137,7 +138,10 @@ void Dimension::destroy(
 
 //------------------------------------------------------------------------------
 // Destroys all defined dimensions
-void Dimension::clear() { AllDims.clear(); Kokkos::fence(); }
+void Dimension::clear() {
+   AllDims.clear();
+   Kokkos::fence();
+}
 
 //----------------------------------------------------------------------------//
 // Retrieves full dimension instance by name
@@ -166,7 +170,7 @@ bool Dimension::isDistributed() { return Distributed; }
 //------------------------------------------------------------------------------
 // Check whether dimension is distributed by dimension name
 bool Dimension::isDistributedDim(
-         const std::string &Name // [in] name of dimension
+    const std::string &Name // [in] name of dimension
 ) {
    // Make sure dimension exists
    if (exists(Name)) {
@@ -179,7 +183,6 @@ bool Dimension::isDistributedDim(
                 Name);
       return false;
    }
-
 }
 
 //------------------------------------------------------------------------------
@@ -189,14 +192,14 @@ I4 Dimension::getLengthGlobal() { return GlobalLength; }
 //------------------------------------------------------------------------------
 // Get global dimension length by name
 I4 Dimension::getDimLengthGlobal(
-         const std::string &Name // [in] name of dimension
+    const std::string &Name // [in] name of dimension
 ) {
    I4 Length;
 
    // Make sure dimension exists
    if (exists(Name)) {
       std::shared_ptr<Dimension> ThisDim = AllDims[Name];
-      Length                            = ThisDim->GlobalLength;
+      Length                             = ThisDim->GlobalLength;
 
    } else {
       LOG_ERROR("Cannot get global length of dimension {}: "
@@ -216,14 +219,14 @@ I4 Dimension::getLengthLocal() { return LocalLength; }
 //------------------------------------------------------------------------------
 // Get length dimension in local partition by name
 I4 Dimension::getDimLengthLocal(
-         const std::string &Name // [in] name of dimension
+    const std::string &Name // [in] name of dimension
 ) {
    I4 Length;
 
    // Make sure dimension exists
    if (exists(Name)) {
       std::shared_ptr<Dimension> ThisDim = AllDims[Name];
-      Length                            = ThisDim->LocalLength;
+      Length                             = ThisDim->LocalLength;
 
    } else {
       LOG_ERROR("Cannot get local length of dimension {}: "
@@ -242,8 +245,8 @@ HostArray1DI4 Dimension::getOffset() { return Offset; }
 
 //------------------------------------------------------------------------------
 // Get global offset for each local address given a dim name
-HostArray1DI4 Dimension::getDimOffset(
-         const std::string &Name // [in] name of dimension
+HostArray1DI4
+Dimension::getDimOffset(const std::string &Name // [in] name of dimension
 ) {
 
    // Make sure dimension exists

--- a/components/omega/src/infra/Dimension.cpp
+++ b/components/omega/src/infra/Dimension.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<Dimension> Dimension::create(
 //------------------------------------------------------------------------------
 // Creates a non-distributed dimension given a name and length
 std::shared_ptr<Dimension>
-Dimension::create(const std::string Name, // [in] name of dimension
+Dimension::create(const std::string &Name, // [in] name of dimension
                   const I4 GlobalLength   // [in] length of dimension
 ) {
    auto Dim = std::make_shared<Dimension>(); // create empty dim
@@ -124,7 +124,7 @@ bool Dimension::exists(
 //------------------------------------------------------------------------------
 // Destroys a dimension
 void Dimension::destroy(
-    const std::string Name // [in] name of dimension to destroy
+    const std::string &Name // [in] name of dimension to destroy
 ) {
    if (exists(Name)) {
       AllDims.erase(Name);
@@ -146,7 +146,7 @@ void Dimension::clear() {
 //----------------------------------------------------------------------------//
 // Retrieves full dimension instance by name
 std::shared_ptr<Dimension>
-Dimension::get(const std::string Name // [in] Name of dimension
+Dimension::get(const std::string &Name // [in] Name of dimension
 ) {
    if (exists(Name)) {
       return AllDims[Name];
@@ -161,11 +161,11 @@ Dimension::get(const std::string Name // [in] Name of dimension
 
 //------------------------------------------------------------------------------
 // Get name of dimension from instance (iterator)
-std::string Dimension::getName() { return DimName; }
+std::string Dimension::getName() const { return DimName; }
 
 //------------------------------------------------------------------------------
 // Check whether dimension is distributed
-bool Dimension::isDistributed() { return Distributed; }
+bool Dimension::isDistributed() const { return Distributed; }
 
 //------------------------------------------------------------------------------
 // Check whether dimension is distributed by dimension name
@@ -187,7 +187,7 @@ bool Dimension::isDistributedDim(
 
 //------------------------------------------------------------------------------
 // Get global dimension from instance
-I4 Dimension::getLengthGlobal() { return GlobalLength; }
+I4 Dimension::getLengthGlobal() const { return GlobalLength; }
 
 //------------------------------------------------------------------------------
 // Get global dimension length by name
@@ -214,7 +214,7 @@ I4 Dimension::getDimLengthGlobal(
 
 //------------------------------------------------------------------------------
 // Get length dimension in local partition from instance
-I4 Dimension::getLengthLocal() { return LocalLength; }
+I4 Dimension::getLengthLocal() const { return LocalLength; }
 
 //------------------------------------------------------------------------------
 // Get length dimension in local partition by name
@@ -241,7 +241,7 @@ I4 Dimension::getDimLengthLocal(
 
 //------------------------------------------------------------------------------
 // Get global offset for each local address from dim instance
-HostArray1DI4 Dimension::getOffset() { return Offset; }
+HostArray1DI4 Dimension::getOffset() const { return Offset; }
 
 //------------------------------------------------------------------------------
 // Get global offset for each local address given a dim name

--- a/components/omega/src/infra/Dimension.h
+++ b/components/omega/src/infra/Dimension.h
@@ -1,6 +1,7 @@
 #ifndef OMEGA_DIMENSION_H
 #define OMEGA_DIMENSION_H
-//===-- infra/Dimension.h - OMEGA dimension class ----------------*- C++ -*-===//
+//===-- infra/Dimension.h - OMEGA dimension class ----------------*- C++
+//-*-===//
 //
 /// \file
 /// \brief Defines a dimension class used by the multi-dimensional Field class
@@ -35,7 +36,7 @@ class Dimension {
    /// Flag to identify whether this is a distributed dimension or not
    bool Distributed;
 
-   /// Global length (length of full unpartitioned dimension) 
+   /// Global length (length of full unpartitioned dimension)
    I4 GlobalLength;
 
    /// Local length (size of local partition for this dim)
@@ -47,7 +48,6 @@ class Dimension {
    HostArray1DI4 Offset;
 
  public:
-
    //---------------------------------------------------------------------------
    /// Creates a distributed dimension given a name, global (unpartitioned)
    /// length, size of local partition (including ghost cells and padding),
@@ -57,30 +57,29 @@ class Dimension {
    /// If a dimension has already been defined for a dimension of the same
    /// name and global/local length, the existing dimension will be returned.
    static std::shared_ptr<Dimension>
-   create(
-      const std::string &Name,  ///< [in] name of dimension
-      const I4 GlobalLength,    ///< [in] global (unpartitioned) size of dim
-      const I4 LocalLength,     ///< [in] size of dim in local partition
-      HostArray1DI4 Offset      ///< [in] glob indx offset for each local pt  
+   create(const std::string &Name, ///< [in] name of dimension
+          const I4 GlobalLength,   ///< [in] global (unpartitioned) size of dim
+          const I4 LocalLength,    ///< [in] size of dim in local partition
+          HostArray1DI4 Offset     ///< [in] glob indx offset for each local pt
    );
 
    //---------------------------------------------------------------------------
    /// Creates a non-distributed dimension given a name and length
    static std::shared_ptr<Dimension>
-   create(const std::string Name,  ///< [in] name of dimension
-          const I4 GlobalLength    ///< [in] length of dimension
+   create(const std::string Name, ///< [in] name of dimension
+          const I4 GlobalLength   ///< [in] length of dimension
    );
 
    //---------------------------------------------------------------------------
    // Checks to see if a dim of this name exists
-   static bool exists(
-         const std::string &Name ///< [in] name of dimension to check
+   static bool
+   exists(const std::string &Name ///< [in] name of dimension to check
    );
 
    //---------------------------------------------------------------------------
    // Destroys a dimension
-   static void destroy(
-         const std::string Name ///< [in] name of dimension to destroy
+   static void
+   destroy(const std::string Name ///< [in] name of dimension to destroy
    );
 
    //---------------------------------------------------------------------------
@@ -89,8 +88,8 @@ class Dimension {
 
    //---------------------------------------------------------------------------
    // Retrieves full dimension instance by name
-   static std::shared_ptr<Dimension> get(
-         const std::string Name // [in] Name of dimension
+   static std::shared_ptr<Dimension>
+   get(const std::string Name // [in] Name of dimension
    );
 
    //---------------------------------------------------------------------------
@@ -103,8 +102,8 @@ class Dimension {
 
    //---------------------------------------------------------------------------
    /// Check distributed property of dimension given its name
-   static bool isDistributedDim(
-         const std::string &Name ///< [in] name of dimension
+   static bool
+   isDistributedDim(const std::string &Name ///< [in] name of dimension
    );
 
    //---------------------------------------------------------------------------
@@ -113,8 +112,8 @@ class Dimension {
 
    //---------------------------------------------------------------------------
    /// Get global dimension length by name
-   static I4 getDimLengthGlobal(
-         const std::string &Name ///< [in] name of dimension
+   static I4
+   getDimLengthGlobal(const std::string &Name ///< [in] name of dimension
    );
 
    //---------------------------------------------------------------------------
@@ -123,8 +122,8 @@ class Dimension {
 
    //---------------------------------------------------------------------------
    /// Get length of dimension in local partition by name
-   static I4 getDimLengthLocal(
-         const std::string &Name ///< [in] name of dimension
+   static I4
+   getDimLengthLocal(const std::string &Name ///< [in] name of dimension
    );
 
    //---------------------------------------------------------------------------
@@ -133,8 +132,8 @@ class Dimension {
 
    //---------------------------------------------------------------------------
    /// Get global offset for each local address given a dim name
-   static HostArray1DI4 getDimOffset(
-         const std::string &Name ///< [in] name of dimension
+   static HostArray1DI4
+   getDimOffset(const std::string &Name ///< [in] name of dimension
    );
 
    //----------------------------------------------------------------------------//
@@ -144,7 +143,7 @@ class Dimension {
    //---------------------------------------------------------------------------
    /// An iterator can be used to loop through all defined dimensions
    using Iter =
-      std::map<std::string, std::shared_ptr<Dimension>>::const_iterator;
+       std::map<std::string, std::shared_ptr<Dimension>>::const_iterator;
 
    /// Returns an iterator to the first dimension stored in AllDims
    static Iter begin();

--- a/components/omega/src/infra/Dimension.h
+++ b/components/omega/src/infra/Dimension.h
@@ -1,0 +1,159 @@
+#ifndef OMEGA_DIMENSION_H
+#define OMEGA_DIMENSION_H
+//===-- infra/Dimension.h - OMEGA dimension class ----------------*- C++ -*-===//
+//
+/// \file
+/// \brief Defines a dimension class used by the multi-dimensional Field class
+///
+/// The Dimension class defines dimension information for array fields.
+/// Dimensions can be either distributed (most horizontal dimensions) or
+/// non-distributed (eg vertical). The dimension primarily defines lengths
+/// and offsets that are used for parallel IO and as dimension metadata in
+/// self-describing files.
+///
+//===----------------------------------------------------------------------===//
+
+#include "DataTypes.h"
+#include "Logging.h"
+#include <map>
+#include <memory>
+#include <set>
+
+namespace OMEGA {
+
+//------------------------------------------------------------------------------
+/// The Dimension class manages dimension information for fields that are needed
+/// for parallel IO and metadata
+class Dimension {
+ private:
+   /// Store and maintain all defined dimensions
+   static std::map<std::string, std::shared_ptr<Dimension>> AllDims;
+
+   /// Name of dimension
+   std::string DimName;
+
+   /// Flag to identify whether this is a distributed dimension or not
+   bool Distributed;
+
+   /// Global length (length of full unpartitioned dimension) 
+   I4 GlobalLength;
+
+   /// Local length (size of local partition for this dim)
+   I4 LocalLength;
+
+   /// Offset for parallel IO - this is the memory offset in the global
+   /// index space for each local address along this dimension
+   /// This is typically the 0-based global ID (eg CellID - 1).
+   HostArray1DI4 Offset;
+
+ public:
+
+   //---------------------------------------------------------------------------
+   /// Creates a distributed dimension given a name, global (unpartitioned)
+   /// length, size of local partition (including ghost cells and padding),
+   /// and GlobalID/index for each local entry. Entries that should not be
+   /// used in IO (eg ghost cells) should be given a GlobalID of -1.
+   /// The created dimension will be added to the list of defined dimensions.
+   /// If a dimension has already been defined for a dimension of the same
+   /// name and global/local length, the existing dimension will be returned.
+   static std::shared_ptr<Dimension>
+   create(
+      const std::string &Name,  ///< [in] name of dimension
+      const I4 GlobalLength,    ///< [in] global (unpartitioned) size of dim
+      const I4 LocalLength,     ///< [in] size of dim in local partition
+      HostArray1DI4 Offset      ///< [in] glob indx offset for each local pt  
+   );
+
+   //---------------------------------------------------------------------------
+   /// Creates a non-distributed dimension given a name and length
+   static std::shared_ptr<Dimension>
+   create(const std::string Name,  ///< [in] name of dimension
+          const I4 GlobalLength    ///< [in] length of dimension
+   );
+
+   //---------------------------------------------------------------------------
+   // Checks to see if a dim of this name exists
+   static bool exists(
+         const std::string &Name ///< [in] name of dimension to check
+   );
+
+   //---------------------------------------------------------------------------
+   // Destroys a dimension
+   static void destroy(
+         const std::string Name ///< [in] name of dimension to destroy
+   );
+
+   //---------------------------------------------------------------------------
+   // Destroys all defined dimensions
+   static void clear();
+
+   //---------------------------------------------------------------------------
+   // Retrieves full dimension instance by name
+   static std::shared_ptr<Dimension> get(
+         const std::string Name // [in] Name of dimension
+   );
+
+   //---------------------------------------------------------------------------
+   /// Get name of dimension from instance (iterator)
+   std::string getName();
+
+   //---------------------------------------------------------------------------
+   /// Check distributed property of a dimension from instance
+   bool isDistributed();
+
+   //---------------------------------------------------------------------------
+   /// Check distributed property of dimension given its name
+   static bool isDistributedDim(
+         const std::string &Name ///< [in] name of dimension
+   );
+
+   //---------------------------------------------------------------------------
+   /// Get global dimension from instance
+   I4 getLengthGlobal();
+
+   //---------------------------------------------------------------------------
+   /// Get global dimension length by name
+   static I4 getDimLengthGlobal(
+         const std::string &Name ///< [in] name of dimension
+   );
+
+   //---------------------------------------------------------------------------
+   /// Get length of dimension in local partition from instance
+   I4 getLengthLocal();
+
+   //---------------------------------------------------------------------------
+   /// Get length of dimension in local partition by name
+   static I4 getDimLengthLocal(
+         const std::string &Name ///< [in] name of dimension
+   );
+
+   //---------------------------------------------------------------------------
+   /// Get global offset for each local address from dim instance
+   HostArray1DI4 getOffset();
+
+   //---------------------------------------------------------------------------
+   /// Get global offset for each local address given a dim name
+   static HostArray1DI4 getDimOffset(
+         const std::string &Name ///< [in] name of dimension
+   );
+
+   //----------------------------------------------------------------------------//
+   // Retrieves the total number of currently defined dimensions
+   static int getNumDefinedDims();
+
+   //---------------------------------------------------------------------------
+   /// An iterator can be used to loop through all defined dimensions
+   using Iter =
+      std::map<std::string, std::shared_ptr<Dimension>>::const_iterator;
+
+   /// Returns an iterator to the first dimension stored in AllDims
+   static Iter begin();
+
+   /// Returns an iterator to the last dimension stored in AllDims
+   static Iter end();
+
+}; // end class Dimension
+
+} // namespace OMEGA
+
+#endif // OMEGA_DIMENSION_H

--- a/components/omega/src/infra/Dimension.h
+++ b/components/omega/src/infra/Dimension.h
@@ -66,7 +66,7 @@ class Dimension {
    //---------------------------------------------------------------------------
    /// Creates a non-distributed dimension given a name and length
    static std::shared_ptr<Dimension>
-   create(const std::string Name, ///< [in] name of dimension
+   create(const std::string &Name, ///< [in] name of dimension
           const I4 GlobalLength   ///< [in] length of dimension
    );
 
@@ -79,7 +79,7 @@ class Dimension {
    //---------------------------------------------------------------------------
    // Destroys a dimension
    static void
-   destroy(const std::string Name ///< [in] name of dimension to destroy
+   destroy(const std::string &Name ///< [in] name of dimension to destroy
    );
 
    //---------------------------------------------------------------------------
@@ -89,16 +89,16 @@ class Dimension {
    //---------------------------------------------------------------------------
    // Retrieves full dimension instance by name
    static std::shared_ptr<Dimension>
-   get(const std::string Name // [in] Name of dimension
+   get(const std::string &Name // [in] Name of dimension
    );
 
    //---------------------------------------------------------------------------
    /// Get name of dimension from instance (iterator)
-   std::string getName();
+   std::string getName() const;
 
    //---------------------------------------------------------------------------
    /// Check distributed property of a dimension from instance
-   bool isDistributed();
+   bool isDistributed() const;
 
    //---------------------------------------------------------------------------
    /// Check distributed property of dimension given its name
@@ -108,7 +108,7 @@ class Dimension {
 
    //---------------------------------------------------------------------------
    /// Get global dimension from instance
-   I4 getLengthGlobal();
+   I4 getLengthGlobal() const;
 
    //---------------------------------------------------------------------------
    /// Get global dimension length by name
@@ -118,7 +118,7 @@ class Dimension {
 
    //---------------------------------------------------------------------------
    /// Get length of dimension in local partition from instance
-   I4 getLengthLocal();
+   I4 getLengthLocal() const;
 
    //---------------------------------------------------------------------------
    /// Get length of dimension in local partition by name
@@ -128,7 +128,7 @@ class Dimension {
 
    //---------------------------------------------------------------------------
    /// Get global offset for each local address from dim instance
-   HostArray1DI4 getOffset();
+   HostArray1DI4 getOffset() const;
 
    //---------------------------------------------------------------------------
    /// Get global offset for each local address given a dim name
@@ -143,7 +143,7 @@ class Dimension {
    //---------------------------------------------------------------------------
    /// An iterator can be used to loop through all defined dimensions
    using Iter =
-       std::map<std::string, std::shared_ptr<Dimension>>::const_iterator;
+       std::map<std::string, std::shared_ptr<Dimension>>::iterator;
 
    /// Returns an iterator to the first dimension stored in AllDims
    static Iter begin();

--- a/components/omega/src/infra/Dimension.h
+++ b/components/omega/src/infra/Dimension.h
@@ -67,7 +67,7 @@ class Dimension {
    /// Creates a non-distributed dimension given a name and length
    static std::shared_ptr<Dimension>
    create(const std::string &Name, ///< [in] name of dimension
-          const I4 GlobalLength   ///< [in] length of dimension
+          const I4 GlobalLength    ///< [in] length of dimension
    );
 
    //---------------------------------------------------------------------------
@@ -142,8 +142,7 @@ class Dimension {
 
    //---------------------------------------------------------------------------
    /// An iterator can be used to loop through all defined dimensions
-   using Iter =
-       std::map<std::string, std::shared_ptr<Dimension>>::iterator;
+   using Iter = std::map<std::string, std::shared_ptr<Dimension>>::iterator;
 
    /// Returns an iterator to the first dimension stored in AllDims
    static Iter begin();

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -102,6 +102,17 @@ add_omega_test(
     "-n;8"
 )
 
+##################
+# Dimension test
+##################
+
+add_omega_test(
+    DIMENSION_TEST
+    testDimension.exe
+    infra/DimensionTest.cpp
+    "-n;8"
+)
+
 ################
 # HorzMesh test
 ################
@@ -168,6 +179,7 @@ target_compile_definitions(
   AUXVARS_TEST_SPHERE
 )
 
+################
 # AuxState test
 ################
 

--- a/components/omega/test/infra/DimensionTest.cpp
+++ b/components/omega/test/infra/DimensionTest.cpp
@@ -1,0 +1,303 @@
+//===-- Test driver for OMEGA Dimension class ---------------------*- C++ -*-===/
+//
+/// \file
+/// \brief Test driver for OMEGA Dimension class
+///
+/// This driver tests the capabilities for OMEGA to manage dimension information
+/// for use by Fields and IO.
+//
+//===-----------------------------------------------------------------------===/
+
+#include "DataTypes.h"
+#include "Decomp.h"
+#include "Dimension.h"
+#include "IO.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "OmegaKokkos.h"
+#include "mpi.h"
+
+#include <vector>
+#include <memory>
+
+using namespace OMEGA;
+
+//------------------------------------------------------------------------------
+// Initialization routine to create dimensions
+int initDimensionTest() {
+
+   int Err = 0;
+
+   // Initialize various environments
+   MachEnv::init(MPI_COMM_WORLD);
+   MachEnv *DefEnv = MachEnv::getDefault();
+   initLogging(DefEnv);
+   MPI_Comm DefComm = DefEnv->getComm();
+   Err = IO::init(DefComm);
+   if (Err != 0) {
+      LOG_ERROR("IO initialization failed");
+      return Err;
+   }
+
+   // Initialize decomposition
+   Decomp::init();
+   Decomp *DefDecomp = Decomp::getDefault();
+
+   // Create offsets for dimension definition
+   I4 NCellsSize   = DefDecomp->NCellsSize;
+   I4 NCellsOwned  = DefDecomp->NCellsOwned;
+   I4 NCellsGlobal = DefDecomp->NCellsGlobal;
+   I4 NEdgesSize   = DefDecomp->NEdgesSize;
+   I4 NEdgesOwned  = DefDecomp->NEdgesOwned;
+   I4 NEdgesGlobal = DefDecomp->NEdgesGlobal;
+   HostArray1DI4 CellOffset("NCellsOffset", NCellsSize);
+   HostArray1DI4 EdgeOffset("NEdgesOffset", NEdgesSize);
+   for (int N = 0; N < NCellsSize; ++N) {
+      if (N < NCellsOwned) {
+         CellOffset(N) = DefDecomp->CellIDH(N) - 1; // Offset must be zero-based
+      } else {
+         CellOffset(N) = -1; // Denotes cells that are not to be used
+      }
+   } 
+   for (int N = 0; N < NEdgesSize; ++N) {
+      if (N < NEdgesOwned) {
+         EdgeOffset(N) = DefDecomp->EdgeIDH(N) - 1; // Offset must be zero-based
+      } else {
+         EdgeOffset(N) = -1; // Denotes edges that are not to be used
+      }
+   } 
+
+   // Define dimensions
+   std::shared_ptr<Dimension> CellDim =
+      Dimension::create("NCells", NCellsGlobal, NCellsSize, CellOffset);
+   std::shared_ptr<Dimension> EdgeDim =
+      Dimension::create("NEdges", NEdgesGlobal, NEdgesSize, EdgeOffset);
+   I4 NVertLevels = 100;
+   std::shared_ptr<Dimension> VertDim =
+      Dimension::create("NVertLevels", NVertLevels);
+
+   return Err;
+
+} // End initialization of Dimensions
+
+//------------------------------------------------------------------------------
+// Main driver for testing Dimension class interfaces.
+
+int main(int argc, char **argv) {
+
+   int Err  = 0;
+
+   // Initialize the global MPI environment
+   // We do not actually use message passing but need to test the
+   // array types and behavior within the distributed environment
+   MPI_Init(&argc, &argv);
+   Kokkos::initialize();
+
+   {
+      int Err1 = 0;
+      // Call initialization to create sample dimensions
+      Err1 = initDimensionTest();
+      if (Err1 != 0) {
+         LOG_ERROR("Error initializating dimensions");
+         ++Err;
+      }
+
+      // Retrieve the default domain decomposition and set reference values
+      Decomp *DefDecomp = Decomp::getDefault();
+
+      I4 NCellsLocRef = DefDecomp->NCellsSize;
+      I4 NCellsGlbRef = DefDecomp->NCellsGlobal;
+      I4 NCellsOwned  = DefDecomp->NCellsOwned ;
+      I4 NEdgesLocRef = DefDecomp->NEdgesSize;
+      I4 NEdgesGlbRef = DefDecomp->NEdgesGlobal;
+      I4 NEdgesOwned  = DefDecomp->NEdgesOwned ;
+      I4 NVertLvlsRef = 100;
+
+      // Retrieve the number of defined dimensions
+      I4 NDimsRef = 3;
+      I4 NDims = Dimension::getNumDefinedDims();
+      if (NDims == NDimsRef) {
+         LOG_INFO("Retrieve number of dimensions: PASS");
+      } else {
+         LOG_ERROR("Retrieve number of dimensions: FAIL");
+         ++Err;
+      }
+
+      // Check to see if expected dimensions exist (and a non-existent one doesn't)
+      if (Dimension::exists("NCells") and Dimension::exists("NEdges") and
+          Dimension::exists("NVertLevels") and !Dimension::exists("Garbage")) {
+         LOG_INFO("Test dimension existence function: PASS");
+      } else {
+         LOG_ERROR("Test dimension existence function: FAIL");
+      }
+
+      // Test length retrieval by name 
+
+      I4 NCellsGlb = Dimension::getDimLengthGlobal("NCells");
+      I4 NCellsLoc = Dimension::getDimLengthLocal("NCells");
+      if (NCellsGlb == NCellsGlbRef and NCellsLoc == NCellsLocRef) {
+         LOG_INFO("Length retrievals for NCells: PASS");
+      } else {
+         LOG_ERROR("Length retrievals for NCells: FAIL");
+         ++Err;
+      }
+
+      I4 NEdgesGlb = Dimension::getDimLengthGlobal("NEdges");
+      I4 NEdgesLoc = Dimension::getDimLengthLocal("NEdges");
+      if (NEdgesGlb == NEdgesGlbRef and NEdgesLoc == NEdgesLocRef) {
+         LOG_INFO("Length retrievals for NEdges: PASS");
+      } else {
+         LOG_ERROR("Length retrievals for NEdges: FAIL");
+         ++Err;
+      }
+
+      I4 NVertLvlsGlb = Dimension::getDimLengthGlobal("NVertLevels");
+      I4 NVertLvlsLoc = Dimension::getDimLengthLocal("NVertLevels");
+      if (NVertLvlsGlb == NVertLvlsRef and NVertLvlsLoc == NVertLvlsRef) {
+         LOG_INFO("Length retrievals for NVertLevels: PASS");
+      } else {
+         LOG_ERROR("Length retrievals for NVertLevels: FAIL");
+         ++Err;
+      }
+
+      // Test distributed property by name
+      if (Dimension::isDistributedDim("NCells") and
+          Dimension::isDistributedDim("NEdges") and
+         !Dimension::isDistributedDim("NVertLevels")) {
+         LOG_INFO("Test distributed property by name: PASS");
+      } else {
+         LOG_ERROR("Test distributed property by name: FAIL");
+         ++Err;
+      }
+
+      // Test get offset array by dim name
+      HostArray1DI4 OffsetCell = Dimension::getDimOffset("NCells");
+      HostArray1DI4 OffsetEdge = Dimension::getDimOffset("NEdges");
+      HostArray1DI4 OffsetVert = Dimension::getDimOffset("NVertLevels");
+      I4 Count = 0;
+      for (int N = 0; N < NCellsLocRef; ++N) {
+         if (N < NCellsOwned) {
+            if (OffsetCell(N) != DefDecomp->CellIDH(N) - 1) ++Count;
+         } else {
+            if (OffsetCell(N) != -1) ++Count;
+         }
+      } 
+      for (int N = 0; N < NEdgesLocRef; ++N) {
+         if (N < NEdgesOwned) {
+            if (OffsetEdge(N) != DefDecomp->EdgeIDH(N) - 1) ++Count;
+         } else {
+            if (OffsetEdge(N) != -1) ++Count;
+         }
+      } 
+      for (int N = 0; N < NVertLvlsRef; ++N) {
+         if (OffsetVert(N) != N) ++Count;
+      } 
+      if (Count == 0) {
+         LOG_INFO("Offset retrieval by name: PASS");
+      } else {
+         LOG_ERROR("Offset retrieval by name: FAIL");
+         ++Err;
+      }
+
+      // Test iterators and also retrieval by instance
+      for (auto Iter = Dimension::begin(); Iter != Dimension::end(); ++Iter) {
+         std::string ThisName = Iter->first;
+         std::shared_ptr<Dimension> ThisDim = Iter->second;
+         std::string MyName = ThisDim->getName();
+         I4 LengthLoc = ThisDim->getLengthLocal();
+         I4 LengthGlb = ThisDim->getLengthGlobal();
+         bool Distrib = ThisDim->isDistributed();
+         HostArray1DI4 OffsetTest = ThisDim->getOffset();
+
+         bool ScalarPass = false;
+         bool OffsetPass = false;
+         if (MyName == "NCells") {
+            if (LengthLoc == NCellsLocRef and LengthGlb == NCellsGlbRef and
+                Distrib) ScalarPass = true;
+            Count = 0;
+            for (int N = 0; N < NCellsLocRef; ++N) {
+               if (N < NCellsOwned) {
+                  if (OffsetTest(N) != DefDecomp->CellIDH(N) - 1) ++Count;
+               } else {
+                  if (OffsetTest(N) != -1) ++Count;
+               }
+            } 
+            if (Count == 0) OffsetPass = true;
+         } else if (MyName == "NEdges") {
+            if (LengthLoc == NEdgesLocRef and LengthGlb == NEdgesGlbRef and
+                Distrib) ScalarPass = true;
+            Count = 0;
+            for (int N = 0; N < NEdgesLocRef; ++N) {
+               if (N < NEdgesOwned) {
+                  if (OffsetTest(N) != DefDecomp->EdgeIDH(N) - 1) ++Count;
+               } else {
+                  if (OffsetTest(N) != -1) ++Count;
+               }
+            } 
+            if (Count == 0) OffsetPass = true;
+         } else if (MyName == "NVertLevels") {
+            if (LengthLoc == NVertLvlsRef and LengthGlb == NVertLvlsRef and
+                !Distrib) ScalarPass = true;
+            Count = 0;
+            for (int N = 0; N < NVertLvlsRef; ++N) {
+               if (OffsetTest(N) != N) ++Count;
+            } 
+            if (Count == 0) OffsetPass = true;
+         } else {
+            LOG_ERROR("Unknown dimension name in iteration loop: FAIL");
+            ++Err;
+         }
+         if (ScalarPass and OffsetPass) {
+            LOG_INFO("Retrieval by instance in loop: PASS");
+         } else {
+            LOG_ERROR("Retrieval by instance in loop: FAIL");
+            ++Err;
+         }
+      } // end iteration over dimensions
+
+      // Check retrieval of full dimension by name - just check scalars since
+      // other tests should have picked up offset errors
+      std::shared_ptr<Dimension> TestDim = Dimension::get("NCells");
+      NCellsGlb = TestDim->getLengthGlobal();
+      NCellsLoc = TestDim->getLengthLocal();
+      if (NCellsGlb == NCellsGlbRef and NCellsLoc == NCellsLocRef and
+          TestDim->isDistributed()) {
+         LOG_INFO("Retrieval of full dim: PASS");
+      } else {
+         LOG_ERROR("Retrieval of full dim: FAIL");
+         ++Err;
+      }
+
+      // Destroy a dimension
+      Dimension::destroy("NCells");
+      if (Dimension::exists("NCells")) {
+         LOG_ERROR("Dimension destroy test: FAIL");
+         ++Err;
+      } else {
+         LOG_INFO("Dimension destroy test: PASS");
+      }
+   
+      // Test removal of all dims
+      Dimension::clear();
+      NDims = Dimension::getNumDefinedDims();
+      if (NDims == 0) {
+         LOG_INFO("Dimension clear test: PASS");
+      } else {
+         LOG_ERROR("Dimension clear test: FAIL");
+         ++Err;
+      }
+   }
+
+   // Clean up environments
+   Decomp::clear();
+   Kokkos::finalize();
+   MPI_Finalize();
+
+   if (Err >= 256)
+      Err = 255;
+
+   // End of testing
+   return Err;
+
+}
+//===--- End test driver for Dimension --------------------------------------===/

--- a/components/omega/test/infra/DimensionTest.cpp
+++ b/components/omega/test/infra/DimensionTest.cpp
@@ -1,4 +1,5 @@
-//===-- Test driver for OMEGA Dimension class ---------------------*- C++ -*-===/
+//===-- Test driver for OMEGA Dimension class ---------------------*- C++
+//-*-===/
 //
 /// \file
 /// \brief Test driver for OMEGA Dimension class
@@ -8,17 +9,17 @@
 //
 //===-----------------------------------------------------------------------===/
 
+#include "Dimension.h"
 #include "DataTypes.h"
 #include "Decomp.h"
-#include "Dimension.h"
 #include "IO.h"
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 #include "mpi.h"
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 using namespace OMEGA;
 
@@ -33,7 +34,7 @@ int initDimensionTest() {
    MachEnv *DefEnv = MachEnv::getDefault();
    initLogging(DefEnv);
    MPI_Comm DefComm = DefEnv->getComm();
-   Err = IO::init(DefComm);
+   Err              = IO::init(DefComm);
    if (Err != 0) {
       LOG_ERROR("IO initialization failed");
       return Err;
@@ -58,23 +59,23 @@ int initDimensionTest() {
       } else {
          CellOffset(N) = -1; // Denotes cells that are not to be used
       }
-   } 
+   }
    for (int N = 0; N < NEdgesSize; ++N) {
       if (N < NEdgesOwned) {
          EdgeOffset(N) = DefDecomp->EdgeIDH(N) - 1; // Offset must be zero-based
       } else {
          EdgeOffset(N) = -1; // Denotes edges that are not to be used
       }
-   } 
+   }
 
    // Define dimensions
    std::shared_ptr<Dimension> CellDim =
-      Dimension::create("NCells", NCellsGlobal, NCellsSize, CellOffset);
+       Dimension::create("NCells", NCellsGlobal, NCellsSize, CellOffset);
    std::shared_ptr<Dimension> EdgeDim =
-      Dimension::create("NEdges", NEdgesGlobal, NEdgesSize, EdgeOffset);
+       Dimension::create("NEdges", NEdgesGlobal, NEdgesSize, EdgeOffset);
    I4 NVertLevels = 100;
    std::shared_ptr<Dimension> VertDim =
-      Dimension::create("NVertLevels", NVertLevels);
+       Dimension::create("NVertLevels", NVertLevels);
 
    return Err;
 
@@ -85,7 +86,7 @@ int initDimensionTest() {
 
 int main(int argc, char **argv) {
 
-   int Err  = 0;
+   int Err = 0;
 
    // Initialize the global MPI environment
    // We do not actually use message passing but need to test the
@@ -107,15 +108,15 @@ int main(int argc, char **argv) {
 
       I4 NCellsLocRef = DefDecomp->NCellsSize;
       I4 NCellsGlbRef = DefDecomp->NCellsGlobal;
-      I4 NCellsOwned  = DefDecomp->NCellsOwned ;
+      I4 NCellsOwned  = DefDecomp->NCellsOwned;
       I4 NEdgesLocRef = DefDecomp->NEdgesSize;
       I4 NEdgesGlbRef = DefDecomp->NEdgesGlobal;
-      I4 NEdgesOwned  = DefDecomp->NEdgesOwned ;
+      I4 NEdgesOwned  = DefDecomp->NEdgesOwned;
       I4 NVertLvlsRef = 100;
 
       // Retrieve the number of defined dimensions
       I4 NDimsRef = 3;
-      I4 NDims = Dimension::getNumDefinedDims();
+      I4 NDims    = Dimension::getNumDefinedDims();
       if (NDims == NDimsRef) {
          LOG_INFO("Retrieve number of dimensions: PASS");
       } else {
@@ -123,7 +124,8 @@ int main(int argc, char **argv) {
          ++Err;
       }
 
-      // Check to see if expected dimensions exist (and a non-existent one doesn't)
+      // Check to see if expected dimensions exist (and a non-existent one
+      // doesn't)
       if (Dimension::exists("NCells") and Dimension::exists("NEdges") and
           Dimension::exists("NVertLevels") and !Dimension::exists("Garbage")) {
          LOG_INFO("Test dimension existence function: PASS");
@@ -131,7 +133,7 @@ int main(int argc, char **argv) {
          LOG_ERROR("Test dimension existence function: FAIL");
       }
 
-      // Test length retrieval by name 
+      // Test length retrieval by name
 
       I4 NCellsGlb = Dimension::getDimLengthGlobal("NCells");
       I4 NCellsLoc = Dimension::getDimLengthLocal("NCells");
@@ -163,7 +165,7 @@ int main(int argc, char **argv) {
       // Test distributed property by name
       if (Dimension::isDistributedDim("NCells") and
           Dimension::isDistributedDim("NEdges") and
-         !Dimension::isDistributedDim("NVertLevels")) {
+          !Dimension::isDistributedDim("NVertLevels")) {
          LOG_INFO("Test distributed property by name: PASS");
       } else {
          LOG_ERROR("Test distributed property by name: FAIL");
@@ -174,24 +176,29 @@ int main(int argc, char **argv) {
       HostArray1DI4 OffsetCell = Dimension::getDimOffset("NCells");
       HostArray1DI4 OffsetEdge = Dimension::getDimOffset("NEdges");
       HostArray1DI4 OffsetVert = Dimension::getDimOffset("NVertLevels");
-      I4 Count = 0;
+      I4 Count                 = 0;
       for (int N = 0; N < NCellsLocRef; ++N) {
          if (N < NCellsOwned) {
-            if (OffsetCell(N) != DefDecomp->CellIDH(N) - 1) ++Count;
+            if (OffsetCell(N) != DefDecomp->CellIDH(N) - 1)
+               ++Count;
          } else {
-            if (OffsetCell(N) != -1) ++Count;
+            if (OffsetCell(N) != -1)
+               ++Count;
          }
-      } 
+      }
       for (int N = 0; N < NEdgesLocRef; ++N) {
          if (N < NEdgesOwned) {
-            if (OffsetEdge(N) != DefDecomp->EdgeIDH(N) - 1) ++Count;
+            if (OffsetEdge(N) != DefDecomp->EdgeIDH(N) - 1)
+               ++Count;
          } else {
-            if (OffsetEdge(N) != -1) ++Count;
+            if (OffsetEdge(N) != -1)
+               ++Count;
          }
-      } 
+      }
       for (int N = 0; N < NVertLvlsRef; ++N) {
-         if (OffsetVert(N) != N) ++Count;
-      } 
+         if (OffsetVert(N) != N)
+            ++Count;
+      }
       if (Count == 0) {
          LOG_INFO("Offset retrieval by name: PASS");
       } else {
@@ -201,48 +208,59 @@ int main(int argc, char **argv) {
 
       // Test iterators and also retrieval by instance
       for (auto Iter = Dimension::begin(); Iter != Dimension::end(); ++Iter) {
-         std::string ThisName = Iter->first;
+         std::string ThisName               = Iter->first;
          std::shared_ptr<Dimension> ThisDim = Iter->second;
-         std::string MyName = ThisDim->getName();
-         I4 LengthLoc = ThisDim->getLengthLocal();
-         I4 LengthGlb = ThisDim->getLengthGlobal();
-         bool Distrib = ThisDim->isDistributed();
-         HostArray1DI4 OffsetTest = ThisDim->getOffset();
+         std::string MyName                 = ThisDim->getName();
+         I4 LengthLoc                       = ThisDim->getLengthLocal();
+         I4 LengthGlb                       = ThisDim->getLengthGlobal();
+         bool Distrib                       = ThisDim->isDistributed();
+         HostArray1DI4 OffsetTest           = ThisDim->getOffset();
 
          bool ScalarPass = false;
          bool OffsetPass = false;
          if (MyName == "NCells") {
             if (LengthLoc == NCellsLocRef and LengthGlb == NCellsGlbRef and
-                Distrib) ScalarPass = true;
+                Distrib)
+               ScalarPass = true;
             Count = 0;
             for (int N = 0; N < NCellsLocRef; ++N) {
                if (N < NCellsOwned) {
-                  if (OffsetTest(N) != DefDecomp->CellIDH(N) - 1) ++Count;
+                  if (OffsetTest(N) != DefDecomp->CellIDH(N) - 1)
+                     ++Count;
                } else {
-                  if (OffsetTest(N) != -1) ++Count;
+                  if (OffsetTest(N) != -1)
+                     ++Count;
                }
-            } 
-            if (Count == 0) OffsetPass = true;
+            }
+            if (Count == 0)
+               OffsetPass = true;
          } else if (MyName == "NEdges") {
             if (LengthLoc == NEdgesLocRef and LengthGlb == NEdgesGlbRef and
-                Distrib) ScalarPass = true;
+                Distrib)
+               ScalarPass = true;
             Count = 0;
             for (int N = 0; N < NEdgesLocRef; ++N) {
                if (N < NEdgesOwned) {
-                  if (OffsetTest(N) != DefDecomp->EdgeIDH(N) - 1) ++Count;
+                  if (OffsetTest(N) != DefDecomp->EdgeIDH(N) - 1)
+                     ++Count;
                } else {
-                  if (OffsetTest(N) != -1) ++Count;
+                  if (OffsetTest(N) != -1)
+                     ++Count;
                }
-            } 
-            if (Count == 0) OffsetPass = true;
+            }
+            if (Count == 0)
+               OffsetPass = true;
          } else if (MyName == "NVertLevels") {
             if (LengthLoc == NVertLvlsRef and LengthGlb == NVertLvlsRef and
-                !Distrib) ScalarPass = true;
+                !Distrib)
+               ScalarPass = true;
             Count = 0;
             for (int N = 0; N < NVertLvlsRef; ++N) {
-               if (OffsetTest(N) != N) ++Count;
-            } 
-            if (Count == 0) OffsetPass = true;
+               if (OffsetTest(N) != N)
+                  ++Count;
+            }
+            if (Count == 0)
+               OffsetPass = true;
          } else {
             LOG_ERROR("Unknown dimension name in iteration loop: FAIL");
             ++Err;
@@ -258,8 +276,8 @@ int main(int argc, char **argv) {
       // Check retrieval of full dimension by name - just check scalars since
       // other tests should have picked up offset errors
       std::shared_ptr<Dimension> TestDim = Dimension::get("NCells");
-      NCellsGlb = TestDim->getLengthGlobal();
-      NCellsLoc = TestDim->getLengthLocal();
+      NCellsGlb                          = TestDim->getLengthGlobal();
+      NCellsLoc                          = TestDim->getLengthLocal();
       if (NCellsGlb == NCellsGlbRef and NCellsLoc == NCellsLocRef and
           TestDim->isDistributed()) {
          LOG_INFO("Retrieval of full dim: PASS");
@@ -276,7 +294,7 @@ int main(int argc, char **argv) {
       } else {
          LOG_INFO("Dimension destroy test: PASS");
       }
-   
+
       // Test removal of all dims
       Dimension::clear();
       NDims = Dimension::getNumDefinedDims();
@@ -298,6 +316,6 @@ int main(int argc, char **argv) {
 
    // End of testing
    return Err;
-
 }
-//===--- End test driver for Dimension --------------------------------------===/
+//===--- End test driver for Dimension
+//--------------------------------------===/


### PR DESCRIPTION
The new Dimension class holds metadata and parallel IO offset information for each dimension in Omega. Also includes a unit test and documentation. This will eventually replace the MetaDim class during the Field/Metadata refactor and is required for IOStreams. 

All Ctests pass on chrysalis/Intel and frontier cpu (crayclang) and gpu (crayomegagpu)

Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.


