### PR TITLE
Fix reductions ctest

### DIFF
--- a/components/omega/src/base/Reductions.h
+++ b/components/omega/src/base/Reductions.h
@@ -635,7 +635,7 @@ globalSum(const std::vector<Kokkos::View<T, ML, MS>> arrays,
 template <typename T, typename IT, typename ML, typename MS>
 std::enable_if_t<std::is_same_v<IT, typename Kokkos::View<T>::value_type>, int>
 globalMinVal(const Kokkos::View<T, ML, MS> arr, const MPI_Comm Comm,
-             IT GlobalMinVal, const std::vector<I4> *IndxRange = nullptr) {
+             IT *GlobalMinVal, const std::vector<I4> *IndxRange = nullptr) {
    int dim = arr.rank;
    int i, imin, imax, ierr;
    if (IndxRange == nullptr) {
@@ -653,16 +653,16 @@ globalMinVal(const Kokkos::View<T, ML, MS> arr, const MPI_Comm Comm,
    }
 
    if (typeid(IT) == typeid(I4)) {
-      ierr = MPI_Allreduce(&LocalMinVal, &GlobalMinVal, 1, MPI_INT32_T, MPI_MIN,
+      ierr = MPI_Allreduce(&LocalMinVal, GlobalMinVal, 1, MPI_INT32_T, MPI_MIN,
                            Comm);
    } else if (typeid(IT) == typeid(I8)) {
-      ierr = MPI_Allreduce(&LocalMinVal, &GlobalMinVal, 1, MPI_INT64_T, MPI_MIN,
+      ierr = MPI_Allreduce(&LocalMinVal, GlobalMinVal, 1, MPI_INT64_T, MPI_MIN,
                            Comm);
    } else if (typeid(IT) == typeid(R4)) {
-      ierr = MPI_Allreduce(&LocalMinVal, &GlobalMinVal, 1, MPI_FLOAT, MPI_MIN,
+      ierr = MPI_Allreduce(&LocalMinVal, GlobalMinVal, 1, MPI_FLOAT, MPI_MIN,
                            Comm);
    } else if (typeid(IT) == typeid(R8)) {
-      ierr = MPI_Allreduce(&LocalMinVal, &GlobalMinVal, 1, MPI_DOUBLE, MPI_MIN,
+      ierr = MPI_Allreduce(&LocalMinVal, GlobalMinVal, 1, MPI_DOUBLE, MPI_MIN,
                            Comm);
    }
    return ierr;
@@ -673,7 +673,7 @@ template <typename T, typename IT, typename ML, typename MS>
 std::enable_if_t<std::is_same_v<IT, typename Kokkos::View<T>::value_type>, int>
 globalMinVal(const Kokkos::View<T, ML, MS> arr,
              const Kokkos::View<T, ML, MS> arr2, const MPI_Comm Comm,
-             IT GlobalMinVal, const std::vector<I4> *IndxRange = nullptr) {
+             IT *GlobalMinVal, const std::vector<I4> *IndxRange = nullptr) {
    int dim = arr.rank;
    int i, imin, imax, ierr;
    if (IndxRange == nullptr) {
@@ -692,16 +692,16 @@ globalMinVal(const Kokkos::View<T, ML, MS> arr,
    }
 
    if (typeid(IT) == typeid(I4)) {
-      ierr = MPI_Allreduce(&LocalMinVal, &GlobalMinVal, 1, MPI_INT32_T, MPI_MIN,
+      ierr = MPI_Allreduce(&LocalMinVal, GlobalMinVal, 1, MPI_INT32_T, MPI_MIN,
                            Comm);
    } else if (typeid(IT) == typeid(I8)) {
-      ierr = MPI_Allreduce(&LocalMinVal, &GlobalMinVal, 1, MPI_INT64_T, MPI_MIN,
+      ierr = MPI_Allreduce(&LocalMinVal, GlobalMinVal, 1, MPI_INT64_T, MPI_MIN,
                            Comm);
    } else if (typeid(IT) == typeid(R4)) {
-      ierr = MPI_Allreduce(&LocalMinVal, &GlobalMinVal, 1, MPI_FLOAT, MPI_MIN,
+      ierr = MPI_Allreduce(&LocalMinVal, GlobalMinVal, 1, MPI_FLOAT, MPI_MIN,
                            Comm);
    } else if (typeid(IT) == typeid(R8)) {
-      ierr = MPI_Allreduce(&LocalMinVal, &GlobalMinVal, 1, MPI_DOUBLE, MPI_MIN,
+      ierr = MPI_Allreduce(&LocalMinVal, GlobalMinVal, 1, MPI_DOUBLE, MPI_MIN,
                            Comm);
    }
    return ierr;
@@ -755,7 +755,7 @@ globalMinVal(const std::vector<Kokkos::View<T, ML, MS>> arrays,
 template <typename T, typename IT, typename ML, typename MS>
 std::enable_if_t<std::is_same_v<IT, typename Kokkos::View<T>::value_type>, int>
 globalMaxVal(const Kokkos::View<T, ML, MS> arr, const MPI_Comm Comm,
-             IT GlobalMaxVal, const std::vector<I4> *IndxRange = nullptr) {
+             IT *GlobalMaxVal, const std::vector<I4> *IndxRange = nullptr) {
    int dim = arr.rank;
    int i, imin, imax, ierr;
    if (IndxRange == nullptr) {
@@ -773,16 +773,16 @@ globalMaxVal(const Kokkos::View<T, ML, MS> arr, const MPI_Comm Comm,
    }
 
    if (typeid(IT) == typeid(I4)) {
-      ierr = MPI_Allreduce(&LocalMaxVal, &GlobalMaxVal, 1, MPI_INT32_T, MPI_MAX,
+      ierr = MPI_Allreduce(&LocalMaxVal, GlobalMaxVal, 1, MPI_INT32_T, MPI_MAX,
                            Comm);
    } else if (typeid(IT) == typeid(I8)) {
-      ierr = MPI_Allreduce(&LocalMaxVal, &GlobalMaxVal, 1, MPI_INT64_T, MPI_MAX,
+      ierr = MPI_Allreduce(&LocalMaxVal, GlobalMaxVal, 1, MPI_INT64_T, MPI_MAX,
                            Comm);
    } else if (typeid(IT) == typeid(R4)) {
-      ierr = MPI_Allreduce(&LocalMaxVal, &GlobalMaxVal, 1, MPI_FLOAT, MPI_MAX,
+      ierr = MPI_Allreduce(&LocalMaxVal, GlobalMaxVal, 1, MPI_FLOAT, MPI_MAX,
                            Comm);
    } else if (typeid(IT) == typeid(R8)) {
-      ierr = MPI_Allreduce(&LocalMaxVal, &GlobalMaxVal, 1, MPI_DOUBLE, MPI_MAX,
+      ierr = MPI_Allreduce(&LocalMaxVal, GlobalMaxVal, 1, MPI_DOUBLE, MPI_MAX,
                            Comm);
    }
    return ierr;
@@ -793,7 +793,7 @@ template <typename T, typename IT, typename ML, typename MS>
 std::enable_if_t<std::is_same_v<IT, typename Kokkos::View<T>::value_type>, int>
 globalMaxVal(const Kokkos::View<T, ML, MS> arr,
              const Kokkos::View<T, ML, MS> arr2, const MPI_Comm Comm,
-             IT GlobalMaxVal, const std::vector<I4> *IndxRange = nullptr) {
+             IT *GlobalMaxVal, const std::vector<I4> *IndxRange = nullptr) {
    int dim = arr.rank;
    int i, imin, imax, ierr;
    if (IndxRange == nullptr) {
@@ -812,16 +812,16 @@ globalMaxVal(const Kokkos::View<T, ML, MS> arr,
    }
 
    if (typeid(IT) == typeid(I4)) {
-      ierr = MPI_Allreduce(&LocalMaxVal, &GlobalMaxVal, 1, MPI_INT32_T, MPI_MAX,
+      ierr = MPI_Allreduce(&LocalMaxVal, GlobalMaxVal, 1, MPI_INT32_T, MPI_MAX,
                            Comm);
    } else if (typeid(IT) == typeid(I8)) {
-      ierr = MPI_Allreduce(&LocalMaxVal, &GlobalMaxVal, 1, MPI_INT64_T, MPI_MAX,
+      ierr = MPI_Allreduce(&LocalMaxVal, GlobalMaxVal, 1, MPI_INT64_T, MPI_MAX,
                            Comm);
    } else if (typeid(IT) == typeid(R4)) {
-      ierr = MPI_Allreduce(&LocalMaxVal, &GlobalMaxVal, 1, MPI_FLOAT, MPI_MAX,
+      ierr = MPI_Allreduce(&LocalMaxVal, GlobalMaxVal, 1, MPI_FLOAT, MPI_MAX,
                            Comm);
    } else if (typeid(IT) == typeid(R8)) {
-      ierr = MPI_Allreduce(&LocalMaxVal, &GlobalMaxVal, 1, MPI_DOUBLE, MPI_MAX,
+      ierr = MPI_Allreduce(&LocalMaxVal, GlobalMaxVal, 1, MPI_DOUBLE, MPI_MAX,
                            Comm);
    }
    return ierr;

--- a/components/omega/src/base/Reductions.h
+++ b/components/omega/src/base/Reductions.h
@@ -93,7 +93,7 @@ globalSum(const Kokkos::View<T, ML, MS> arr, const MPI_Comm Comm, IT *GlobalSum,
           const std::vector<I4> *IndxRange = nullptr) {
    IT LocalSum = 0;
    int dim     = arr.rank;
-   int i, imin, imax;
+   int i, imin, imax, ierr;
    if (IndxRange == nullptr) {
       imin = 0;
       imax = arr.size();
@@ -111,7 +111,12 @@ globalSum(const Kokkos::View<T, ML, MS> arr, const MPI_Comm Comm, IT *GlobalSum,
           {imax}, KOKKOS_LAMBDA(int i, IT &Accum) { Accum += arr.data()[i]; },
           LocalSum);
    }
-   return MPI_Allreduce(&LocalSum, GlobalSum, 1, MPI_INT64_T, MPI_SUM, Comm);
+   if (typeid(IT) == typeid(I4)) {
+      ierr = MPI_Allreduce(&LocalSum, GlobalSum, 1, MPI_INT32_T, MPI_SUM, Comm);
+   } else {
+      ierr = MPI_Allreduce(&LocalSum, GlobalSum, 1, MPI_INT64_T, MPI_SUM, Comm);
+   }
+   return ierr;
 }
 
 // R4 array
@@ -198,7 +203,7 @@ globalSum(const Kokkos::View<T, ML, MS> arr, const Kokkos::View<T, ML, MS> arr2,
           const std::vector<I4> *IndxRange = nullptr) {
    T LocalSum = 0;
    int dim    = arr.rank;
-   int i, imin, imax;
+   int i, imin, imax, ierr;
    if (IndxRange == nullptr) {
       imin = 0;
       imax = arr.size();
@@ -219,7 +224,12 @@ globalSum(const Kokkos::View<T, ML, MS> arr, const Kokkos::View<T, ML, MS> arr2,
           },
           LocalSum);
    }
-   return MPI_Allreduce(&LocalSum, GlobalSum, 1, MPI_INT64_T, MPI_SUM, Comm);
+   if (typeid(IT) == typeid(I4)) {
+      ierr = MPI_Allreduce(&LocalSum, GlobalSum, 1, MPI_INT32_T, MPI_SUM, Comm);
+   } else {
+      ierr = MPI_Allreduce(&LocalSum, GlobalSum, 1, MPI_INT64_T, MPI_SUM, Comm);
+   }
+   return ierr;
 }
 
 // R4 array

--- a/components/omega/test/base/ReductionsTest.cpp
+++ b/components/omega/test/base/ReductionsTest.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[]) {
       Real MyReal = 5.000001;
 
       // test SUM for scalars
-      err       = globalSum(&MyInt4, Comm, &MyResI4);
-      I4 expI4  = MyInt4 * MySize;
-      char *res = "FAIL";
+      err             = globalSum(&MyInt4, Comm, &MyResI4);
+      I4 expI4        = MyInt4 * MySize;
+      char const *res = "FAIL";
       if (err == 0 && MyResI4 == expI4)
          res = "PASS";
       else
@@ -97,49 +97,49 @@ int main(int argc, char *argv[]) {
       I4 NumCells = 10, NumVertLvls = 10, c = 0;
       HostArray1DI4 HostArr1DI4("HostArrD1", NumCells);
       HostArray2DI4 HostArr2DI4("HostArrD2", NumCells, NumVertLvls);
-      I8 Sum1D = 0, Sum2D = 0;
+      I4 Sum1DI4 = 0, Sum2DI4 = 0;
       for (i = 0; i < NumCells; i++) {
          HostArr1DI4(i) = i;
-         Sum1D += i;
+         Sum1DI4 += i;
          for (j = 0; j < NumVertLvls; j++) {
             HostArr2DI4(i, j) = c;
-            Sum2D += c;
+            Sum2DI4 += c;
             c++;
          }
       }
       err   = globalSum(HostArr1DI4, Comm, &MyResI4);
-      expI4 = Sum1D * MySize;
+      expI4 = Sum1DI4 * MySize;
       res   = "FAIL";
       if (err == 0 && MyResI4 == expI4)
          res = "PASS";
       else
          RetVal += 1;
-      printf("Global sum A1DI4: %s (exp,act=%ld,%d)\n", res, expI4, MyResI4);
+      printf("Global sum A1DI4: %s (exp,act=%d,%d)\n", res, expI4, MyResI4);
 
       err   = globalSum(HostArr2DI4, Comm, &MyResI4);
-      expI4 = Sum2D * MySize;
+      expI4 = Sum2DI4 * MySize;
       res   = "FAIL";
       if (err == 0 && MyResI4 == expI4)
          res = "PASS";
       else
          RetVal += 1;
-      printf("Global sum A2DI4: %s (exp,act=%ld,%d)\n", res, expI4, MyResI4);
+      printf("Global sum A2DI4: %s (exp,act=%d,%d)\n", res, expI4, MyResI4);
 
       // test SUM of I8 arrays
       HostArray1DI8 HostArr1DI8("HostArrD1I8", NumCells);
       HostArray2DI8 HostArr2DI8("HostArrD2I8", NumCells, NumVertLvls);
-      Sum1D = 0, Sum2D = 0, c = 0;
+      I8 Sum1DI8 = 0, Sum2DI8 = 0, c8 = 0;
       for (i = 0; i < NumCells; i++) {
          HostArr1DI8(i) = i;
-         Sum1D += i;
+         Sum1DI8 += i;
          for (j = 0; j < NumVertLvls; j++) {
-            HostArr2DI8(i, j) = c;
-            Sum2D += c;
-            c++;
+            HostArr2DI8(i, j) = c8;
+            Sum2DI8 += c8;
+            c8++;
          }
       }
       err   = globalSum(HostArr1DI8, Comm, &MyResI8);
-      expI8 = Sum1D * MySize;
+      expI8 = Sum1DI8 * MySize;
       res   = "FAIL";
       if (err == 0 && MyResI8 == expI8)
          res = "PASS";
@@ -148,7 +148,7 @@ int main(int argc, char *argv[]) {
       printf("Global sum A1DI8: %s (exp,act=%ld,%ld)\n", res, expI8, MyResI8);
 
       err   = globalSum(HostArr2DI8, Comm, &MyResI8);
-      expI8 = Sum2D * MySize;
+      expI8 = Sum2DI8 * MySize;
       res   = "FAIL";
       if (err == 0 && MyResI8 == expI8)
          res = "PASS";
@@ -333,23 +333,23 @@ int main(int argc, char *argv[]) {
       Kokkos::fence();
 
       err   = globalSum(DevArr1DI4, Comm, &MyResI4);
-      expI4 = Sum1D * MySize;
+      expI4 = Sum1DI4 * MySize;
       res   = "FAIL";
       if (err == 0 && MyResI4 == expI4)
          res = "PASS";
       else
          RetVal += 1;
-      printf("Global sum device A1DI4: %s (exp,act=%ld,%d)\n", res, expI4,
+      printf("Global sum device A1DI4: %s (exp,act=%d,%d)\n", res, expI4,
              MyResI4);
 
       err   = globalSum(DevArr2DI4, Comm, &MyResI4);
-      expI4 = Sum2D * MySize;
+      expI4 = Sum2DI4 * MySize;
       res   = "FAIL";
       if (err == 0 && MyResI4 == expI4)
          res = "PASS";
       else
          RetVal += 1;
-      printf("Global sum device A2DI4: %s (exp,act=%ld,%d)\n", res, expI4,
+      printf("Global sum device A2DI4: %s (exp,act=%d,%d)\n", res, expI4,
              MyResI4);
 
       // test SUM of R4 arrays on device


### PR DESCRIPTION
This fixes a global reductions ctest that was failing due to incorrect disambiguation between int32 vs. int64 data-types. This also fixes some typos in min-max calls.

Checklist
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.

Fixes E3SM-Project/Omega#99
