### PR TITLE
Change "OMEGA" to "Omega" in docs

### DIFF
--- a/components/omega/doc/README.md
+++ b/components/omega/doc/README.md
@@ -1,7 +1,7 @@
-# OMEGA doc directory
+# Omega doc directory
 
 This directory stores source files for various forms of documentation
-for the Ocean Model for E3SM Global Applications (OMEGA). Currently,
+for the Ocean Model for E3SM Global Applications (Omega). Currently,
 these are stored in three subdirectories for software requirements and
 design (design), a User's Guide (userGuide) and a reference manual or
 developer's guide (devGuide). These sources are generally built for

--- a/components/omega/doc/conf.py
+++ b/components/omega/doc/conf.py
@@ -11,7 +11,7 @@ import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
-project = "OMEGA"
+project = "Omega"
 copyright = f"{date.today().year}, Energy Exascale Earth System Model Project"
 author = "E3SM Development Team"
 

--- a/components/omega/doc/devGuide/AuxiliaryState.md
+++ b/components/omega/doc/devGuide/AuxiliaryState.md
@@ -2,11 +2,11 @@
 
 # Auxiliary State
 
-The `AuxiliaryState` class groups together all of OMEGA [auxiliary
+The `AuxiliaryState` class groups together all of Omega [auxiliary
 variables](#omega-dev-aux-vars). It is responsible for managing their lifetime,
 registering them with IOStreams, and providing functions that compute them,
 to be used in the tendency evaluation. It is possible
-to have multiple `AuxiliaryState` instances in OMEGA. Every instance has a name
+to have multiple `AuxiliaryState` instances in Omega. Every instance has a name
 and is tracked in a static C++ map called `AllAuxStates`.
 
 ## Initialization

--- a/components/omega/doc/devGuide/BuildDocs.md
+++ b/components/omega/doc/devGuide/BuildDocs.md
@@ -6,7 +6,7 @@ As long as you have followed the procedure in {ref}`omega-dev-conda-env` for
 setting up your conda environment, you will already have the packages available
 that you need to build the documentation.
 
-From the root of an OMEGA branch, run the following script to build the docs:
+From the root of an Omega branch, run the following script to build the docs:
 
 ```bash
 cd components/omega/docs

--- a/components/omega/doc/devGuide/DataTypes.md
+++ b/components/omega/doc/devGuide/DataTypes.md
@@ -2,11 +2,11 @@
 
 ## Data Types and Precision
 
-OMEGA supports all standard data types and uses some additional defined
+Omega supports all standard data types and uses some additional defined
 types to guarantee a specific level of precision. In particular, we
 define I4, I8, R4 and R8 types for 4-byte (32-bit) and 8-byte (64-bit)
 integer and floating point variables. Note that these exist in the
-OMEGA namespace so use the scoped form OMEGA::I4, etc.
+Omega namespace so use the scoped form OMEGA::I4, etc.
 In addition, we define a Real data type that is, by default,
 double precision (8 bytes/64-bit) but if the code is built with a
 `-DSINGLE_PRECISION` (see insert link to build system) preprocessor flag,
@@ -29,7 +29,7 @@ the inverse area of a cell using only the Real type as follows:
 The C++ language does not have native support for multi-dimensional
 arrays as part of the language standard, though there are a number
 of implementations as part of the Standard Template Library and
-elsewhere. OMEGA uses the [Kokkos](https://github.com/kokkos)
+elsewhere. Omega uses the [Kokkos](https://github.com/kokkos)
 framework for defining and allocating arrays on both the CPU host and
 any accelerator device that may be present. Because the syntax for
 defining such arrays is somewhat long, we instead define a number of
@@ -38,7 +38,7 @@ the array and TT is the data type (I4, I8, R4, R8 or Real) corresponding
 to the types described above. The dimension refers to the number of
 ranks in the array and not the physical dimension. Although Kokkos
 supports Fortran ordering, we will use C ordering for array indices.
-Within OMEGA the default location for an Array should be on the device
+Within Omega the default location for an Array should be on the device
 with a similar type HostArrayNDTT defined for arrays needed on the host.
 As an example, we can define and allocate a device and host array using:
 ```c++

--- a/components/omega/doc/devGuide/Decomp.md
+++ b/components/omega/doc/devGuide/Decomp.md
@@ -2,19 +2,19 @@
 
 ## Domain Decomposition (Decomp)
 
-In order to run across nodes in a parallel computer, OMEGA subdivides the
+In order to run across nodes in a parallel computer, Omega subdivides the
 horizontal domain into subdomains that are distributed across the machine
 and communicate using message passing via the Message Passing Interface (MPI).
 To decompose the domain, we utilize the
 [METIS](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) library.
-An OMEGA mesh is fully described by the
+An Omega mesh is fully described by the
 [MPAS Mesh Specification](https://mpas-dev.github.io/files/documents/MPAS-MeshSpec.pdf)
 which we will reproduce here eventually. The Decomp class decomposes
 the domain based on the index space and number of MPI tasks (currently
 one subdomain per task). Once decomposed, the Decomp class holds all
 of the index space information as described below.
 
-Within OMEGA, a default decomposition of the mesh is first created
+Within Omega, a default decomposition of the mesh is first created
 with the call:
 ```c++
  Decomp::init();

--- a/components/omega/doc/devGuide/Dimension.md
+++ b/components/omega/doc/devGuide/Dimension.md
@@ -2,10 +2,10 @@
 
 ## Dimension
 
-When performing IO for fields in OMEGA, some metadata associated with each
+When performing IO for fields in Omega, some metadata associated with each
 dimension of multi-dimensional arrays are required. The Dimension class is
 a container that stores this dimension information and a Dimension instance
-must be created for each dimension in OMEGA. Most of these will be created
+must be created for each dimension in Omega. Most of these will be created
 by the Mesh or Decomposition classes, but if developers introduce a new
 dimension, the dimension must be created.
 
@@ -49,7 +49,7 @@ Each Dimension stores the global and local length of the dimension as well
 as the offset array. It also stores a flag to denote whether the dimension
 is distributed or not. This information is used primarily by the IOStreams
 class to write dimension metadata and define offsets for parallel IO. It is
-not expected to be used elsewhere in OMEGA.
+not expected to be used elsewhere in Omega.
 
 Dimension information is available through retrieval functions. These can be
 retrieved by dimension name as in:
@@ -82,7 +82,7 @@ As in other classes, a Dimension can be removed using:
 ```c++
    Dimension::destroy("MyDimName");
 ```
-and all dimensions should be removed during OMEGA finalization before exiting
+and all dimensions should be removed during Omega finalization before exiting
 the Kokkos environment using:
 ```c++
    Dimension::clear();

--- a/components/omega/doc/devGuide/Docs.md
+++ b/components/omega/doc/devGuide/Docs.md
@@ -2,7 +2,7 @@
 
 # Documentation
 
-The OMEGA documentation is generated using the
+The Omega documentation is generated using the
 [Sphinx](https://www.sphinx-doc.org/en/master/) package and is written in
 [MyST](https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html)
 format.  We recommend these
@@ -14,7 +14,7 @@ code for the documentation:
 
 <https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc>
 
-Each time you add new features to OMEGA, the corresponding documentation must
+Each time you add new features to Omega, the corresponding documentation must
 be included with the pull request to add the code.  This includes documentation
 for both the User's Guide and the Developer's Guide. We will add some examples
 as the documentation gets fleshed out.
@@ -31,7 +31,7 @@ headings within the page whenever you think internal linking might be useful
 ...
 ```
 
-This is in anticipation of a future time when the OMEGA documentation might
+This is in anticipation of a future time when the Omega documentation might
 be combined with other components of E3SM.
 
 In the Developer's Guide, anchors should start with `omega-dev-`:
@@ -43,15 +43,15 @@ In the Developer's Guide, anchors should start with `omega-dev-`:
 ...
 ```
 
-Documentation for an OMEGA feature in the User's Guide should contain
-information that is needed for users who set up and run OMEGA, including:
+Documentation for an Omega feature in the User's Guide should contain
+information that is needed for users who set up and run Omega, including:
 
 - Background information on the feature (though not as much as in Developer's
   Guide and not referencing code) that gives the user an understanding of
   the configurable parameters.
 - Config options related to the feature that users can modify in a YAML file.
 - Flags related to the feature that a user can (or must) set when building
-  OMEGA.
+  Omega.
 
 The Developer's Guide should also serve as a reference manual.  Among other
 things, the documentation in the Developer's Guide needs to provide an easy way

--- a/components/omega/doc/devGuide/Halo.md
+++ b/components/omega/doc/devGuide/Halo.md
@@ -2,7 +2,7 @@
 
 # Halo Exchanges (Halo)
 
-OMEGA utilizes domain-based parallelism, where the domain is divided into
+Omega utilizes domain-based parallelism, where the domain is divided into
 partitions that run in parallel as separate tasks distributed across the
 resources of the machine. Arrays representing physical quantities that are
 defined throughout the domain are divided into overlapping chunks and
@@ -11,7 +11,7 @@ arrays are updated. Array elements that are needed by a task to evolve the
 model forward in time, but are defined on and updated by a neighboring task
 are halo elements. It is necessary for each parallel task to regularly send
 locally defined array elements that belong to the halos of neighboring tasks
-and to receive local halo elements owned by neighboring tasks. In OMEGA, these
+and to receive local halo elements owned by neighboring tasks. In Omega, these
 halo exchanges are perfromed using the Halo class which, once constructed,
 contains lists of indices to send to and receive from neighboring tasks, and
 methods to conduct the exchanges. The halo exchanges are carried out using

--- a/components/omega/doc/devGuide/HorzMesh.md
+++ b/components/omega/doc/devGuide/HorzMesh.md
@@ -2,7 +2,7 @@
 
 ## Horizontal Mesh
 
-The OMEGA horizontal mesh uses the [MPAS Mesh
+The Omega horizontal mesh uses the [MPAS Mesh
 Specification](https://mpas-dev.github.io/files/documents/MPAS-MeshSpec.pdf).
 A mesh object is created by the `init` method, which assumes that `Decomp` has
 already been initialized.

--- a/components/omega/doc/devGuide/IO.md
+++ b/components/omega/doc/devGuide/IO.md
@@ -2,7 +2,7 @@
 
 ## Parallel IO (IO)
 
-For input and output of data needed for OMEGA, we use the Software for
+For input and output of data needed for Omega, we use the Software for
 Caching Output and Reads for Parallel I/O
 ([SCORPIO](https://github.com/E3SM-Project/scorpio)) library. This
 library supports parallel reading and writing of distributed arrays in various
@@ -18,7 +18,7 @@ match underlying hardware like the network interfaces (NICs) on a node.
 Users and developers will generally access IO via
 [IOStreams](#omega-user-iostreams)
 and other interfaces. The base IO layer described here only provides
-an OMEGA-aware wrapper around SCORPIO calls.
+an Omega-aware wrapper around SCORPIO calls.
 
 The base interfaces provide functions for file operations (open/close),
 reading and writing of metadata, and reading and writing of data arrays.
@@ -26,7 +26,7 @@ Interfaces at this level utilize raw pointers to data and assume
 contiguous storage for arrays. SCORPIO utilizes integer handles
 to various files and data types so these must often be defined or
 retrieved for many operations. Although there is no IO class, we encapsulate
-the IO routines within the OMEGA and IO namespaces.
+the IO routines within the Omega and IO namespaces.
 
 Before using any IO functions, the parallel IO system must be initialized
 using:
@@ -34,7 +34,7 @@ using:
    int Err = IO::init(Comm);
 ```
 where Comm is an MPI communicator and should in most cases be the communicator
-from the OMEGA default MachEnv (see [MachEnv](#omega-dev-mach-env)). This
+from the Omega default MachEnv (see [MachEnv](#omega-dev-mach-env)). This
 function also extracts the user-defined variables from the model configuration,
 include the number of IO tasks, the IO task stride, the default data
 rearranger method, and the default file format
@@ -133,7 +133,7 @@ when the IO system was initialized, but can also be set explicitly to
 ``OMEGA::IO::RearrBox`` or ``OMEGA::IO::RearrSubset``. The box rearranger
 is generally preferred (see [UserGuide](#omega-user-IO)). The GlobalIndx
 array describes the global location (as a zero-based offset) of each
-local array entry. This can be computed from the OMEGA Default Decomp
+local array entry. This can be computed from the Omega Default Decomp
 arrays. For example, an array dimensioned (NCellsAll,NVertLevels) would
 have an offset computed using:
 ```c++
@@ -147,7 +147,7 @@ have an offset computed using:
    }
 ```
 Note that we exclude Halo layers by assigning an offset of -1. Finally,
-the data type of the array must be supplied. To map the standard OMEGA
+the data type of the array must be supplied. To map the standard Omega
 data types to the data types used in the IO subsystem, we define:
 ```c++
 enum IODataType {
@@ -160,7 +160,7 @@ enum IODataType {
 };
 ```
 so that in the above interface, we would supply for example ``IO::IOTypeI4``
-for an OMEGA I4 data type.
+for an Omega I4 data type.
 
 Now that dimensions and decompositions have been defined, a variable can
 be defined (this is required for writing only) using:
@@ -184,7 +184,7 @@ itself. To read/write metadata, use:
    int Err = IO::readMeta (MetaName, MetaValue, FileID, VarID);
 ```
 where MetaName is a ``std::string`` holding the name of the metadata and
-the MetaValue is the value of the MetaData. All supported OMEGA data types are
+the MetaValue is the value of the MetaData. All supported Omega data types are
 allowed except boolean which must be converted to an integer type. The FileID
 is once again the ID of the open data file and VarID is the variable to which
 this metadata is attached. For global file and simulation metadata not attached

--- a/components/omega/doc/devGuide/MachEnv.md
+++ b/components/omega/doc/devGuide/MachEnv.md
@@ -30,7 +30,7 @@ the master task is defined as task 0 in the environment, but if
 the master task is overloaded, there is a `setMasterTask` that can
 redefine any other task in the group as the master.
 
-If OMEGA has been built with OpenMP threading, a `getNumThreads`
+If Omega has been built with OpenMP threading, a `getNumThreads`
 function is available; it returns 1 if threading is not on.
 The MachEnv also has a public parameter `OMEGA::VecLength` that can
 be used to tune the vector length for CPU architectures. For

--- a/components/omega/doc/devGuide/OceanState.md
+++ b/components/omega/doc/devGuide/OceanState.md
@@ -2,7 +2,7 @@
 
 ## Ocean State
 
-The OMEGA `OceanState` class
+The Omega `OceanState` class
 A state object is created by the `init` method, which assumes that `Decomp` and `HorzMesh` have
 already been initialized.
 ```c++

--- a/components/omega/doc/devGuide/README.md
+++ b/components/omega/doc/devGuide/README.md
@@ -1,6 +1,6 @@
-# OMEGA doc/devGuide directory
+# Omega doc/devGuide directory
 
 This directory contains source files for the Ocean Model for E3SM
-Global Applications (OMEGA) Developer Guide, describing code and
+Global Applications (Omega) Developer Guide, describing code and
 algorithmic detail for those who require more information beyond
 how to configure and run the model.

--- a/components/omega/doc/devGuide/Reductions.md
+++ b/components/omega/doc/devGuide/Reductions.md
@@ -26,7 +26,7 @@ int globalSum(const ArrayTTDD array,
               TT *Result,
               const std::vector<I4> *indexRange = nullptr)
 ```
-`ArrayTTDD` is either a host or device OMEGA array of type I4, I8, R4 or R8
+`ArrayTTDD` is either a host or device Omega array of type I4, I8, R4 or R8
 and dimension DD ranging from 1D to 5D. The `indexRange` vector is of length
 2x the number of array dimensions: e.g. for a 2D array the min and
 max indexes for a local sum might be

--- a/components/omega/doc/devGuide/TimeMgr.md
+++ b/components/omega/doc/devGuide/TimeMgr.md
@@ -2,7 +2,7 @@
 
 # Time Manager (TimeMgr)
 
-The OMEGA Time Manager module tracks simulation time during a run and manages
+The Omega Time Manager module tracks simulation time during a run and manages
 alarms for triggering events at specified times This is handled by six
 interacting defined classes, each of which have a number of methods defined for
 accessing, comparing, and manipulating the class members.

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -1,15 +1,15 @@
 (omega-home)=
-# OMEGA
+# Omega
 
-The Ocean Model for E3SM Global Applications (OMEGA) initially is an eddy-resolving,
+The Ocean Model for E3SM Global Applications (Omega) initially is an eddy-resolving,
 global ocean model in the early stages of development by the
 [E3SM](https://e3sm.org/) ocean team.  The first release is planned for
 Summer 2026.  A non-eddying configuration will be released in early 2027.
 
 The model is written in c++ using the [Kokkos](https://github.com/kokkos)
-framework for performance portability.  OMEGA is based on the
+framework for performance portability.  Omega is based on the
 [TRSK formulation](https://doi.org/10.1016/j.jcp.2009.08.006) for geophysical
-models on unstructured meshes. The first version of OMEGA will primarily be a direct port
+models on unstructured meshes. The first version of Omega will primarily be a direct port
 of the [MPAS-Ocean](https://e3sm.org/model/e3sm-model-description/v1-description/v1-ocean-sea-ice-land-ice/)
 component of E3SM for comparison purposes.
 

--- a/components/omega/doc/userGuide/AuxiliaryState.md
+++ b/components/omega/doc/userGuide/AuxiliaryState.md
@@ -2,6 +2,6 @@
 
 ## Auxiliary State
 
-The `AuxiliaryState` class provides a container for the [auxiliary variables](#omega-user-aux-vars) in OMEGA.
+The `AuxiliaryState` class provides a container for the [auxiliary variables](#omega-user-aux-vars) in Omega.
 Upon creation of an `AuxiliaryState` instance, these variables are allocated and registered with the IO infrastructure.
 There are no user-configurable options.

--- a/components/omega/doc/userGuide/DataTypes.md
+++ b/components/omega/doc/userGuide/DataTypes.md
@@ -2,7 +2,7 @@
 
 ## Data Types and Precision
 
-OMEGA supports all standard data types and uses some specific defined
+Omega supports all standard data types and uses some specific defined
 types to guarantee a specific level of precision. There is only one
 user-configurable option for precision. When a specific floating point
 precision is not required, we use a Real data type that is, by default,

--- a/components/omega/doc/userGuide/Decomp.md
+++ b/components/omega/doc/userGuide/Decomp.md
@@ -2,7 +2,7 @@
 
 ## Domain Decomposition (Decomp)
 
-OMEGA is designed to be run in parallel across multiple nodes and cores
+Omega is designed to be run in parallel across multiple nodes and cores
 in a clustered architecture. As in many Earth System Models, we decompose
 the horizontal domain into subdomains that are distributed across the
 system. Communication between the domains is accomplished using the

--- a/components/omega/doc/userGuide/Dimension.md
+++ b/components/omega/doc/userGuide/Dimension.md
@@ -2,8 +2,8 @@
 
 ## Dimension
 
-When performing IO, some metadata associated with each dimension in OMEGA
+When performing IO, some metadata associated with each dimension in Omega
 must be defined. We provide a Dimension class to hold this metadata for use by
-the IO and Streams classes. This metadata is defined internally in OMEGA and
+the IO and Streams classes. This metadata is defined internally in Omega and
 there are no user-configurable options. More detail is proved in
 {ref}`omega-dev-dimension`.

--- a/components/omega/doc/userGuide/Halo.md
+++ b/components/omega/doc/userGuide/Halo.md
@@ -2,7 +2,7 @@
 
 # Halo Exchanges (Halo)
 
-When OMEGA is run in a parallel machine environment, the computaional domain
+When Omega is run in a parallel machine environment, the computaional domain
 is broken into subdomains that are distrubted among the computational nodes
 of the machine. It is necessary to regularly exchange data that is located
 at or near the interfaces of adjacent subdomains, these regions are called

--- a/components/omega/doc/userGuide/HorzMesh.md
+++ b/components/omega/doc/userGuide/HorzMesh.md
@@ -2,7 +2,7 @@
 
 ## Horizontal Mesh
 
-OMEGA uses the MPAS mesh specification found
+Omega uses the MPAS mesh specification found
 [here](https://mpas-dev.github.io/files/documents/MPAS-MeshSpec.pdf). The names
 of the mesh variables have been retained, with the caveat that they now begin
 with a capital letter.

--- a/components/omega/doc/userGuide/IO.md
+++ b/components/omega/doc/userGuide/IO.md
@@ -2,7 +2,7 @@
 
 ## Parallel IO (IO)
 
-For input and output of data needed for OMEGA, we use the Software for
+For input and output of data needed for Omega, we use the Software for
 Caching Output and Reads for Parallel I/O
 ([SCORPIO](https://github.com/E3SM-Project/scorpio)) library. This
 library supports parallel reading and writing of distributed arrays in various
@@ -17,7 +17,7 @@ for computation. For example, the user could specify the number of IO tasks to
 match underlying hardware like the network interfaces (NICs) on a node.
 Users will generally access IO via the [IOStreams](#omega-user-iostreams)
 and other interfaces and the base IO layer described here only provides
-an OMEGA-aware wrapper around SCORPIO calls.
+an Omega-aware wrapper around SCORPIO calls.
 
 There are some general parameters that must be set for IO performance and
 formatting via the input configuration file. These are:
@@ -53,11 +53,11 @@ See SCORPIO documentation for details.
 Finally, the user can specify the file format. The SCORPIO library
 supports all the various NetCDF formats, though the use of older
 NetCDF formats is strongly discouraged. NetCDF-4 is currently the E3SM
-default and is the default for OMEGA. In addition, SCORPIO supports
+default and is the default for Omega. In addition, SCORPIO supports
 native HDF5 files (note that the latest NetCDF formats are all implemented
 with HDF5 and are mostly compatible with HDF5) The ADIOS format is different
 since ADIOS writes each chunk of data to a separate file and these files must
 be combined later. E3SM provides the necessary tools to combine/convert
-ADIOS files to netcdf as part of pre/post-processing. For standalone OMEGA,
+ADIOS files to netcdf as part of pre/post-processing. For standalone Omega,
 users would need to become familiar with these tools if they wish to use
 ADIOS.

--- a/components/omega/doc/userGuide/IOField.md
+++ b/components/omega/doc/userGuide/IOField.md
@@ -2,7 +2,7 @@
 
 ## IO Fields (IOField)
 
-Within OMEGA, each module registers which fields are available for
+Within Omega, each module registers which fields are available for
 input and output.  The user then selects which fields they wish to
 include via the streams section of the input configuration. This is
 described further in the [IOStreams](#omega-user-iostreams) section.

--- a/components/omega/doc/userGuide/MachEnv.md
+++ b/components/omega/doc/userGuide/MachEnv.md
@@ -2,7 +2,7 @@
 
 ## Machine Environment (MachEnv)
 
-Within OMEGA, many aspects of the machine environment are stored
+Within Omega, many aspects of the machine environment are stored
 in a class called MachEnv. These include message-passing parameters
 like MPI communicators and task information, number of threads
 if threaded, vector length for CPUs, GPU and node information as

--- a/components/omega/doc/userGuide/OceanState.md
+++ b/components/omega/doc/userGuide/OceanState.md
@@ -2,7 +2,7 @@
 
 ## Ocean State
 
-The `OceanState` class provides a container for the non-tracer prognostic variables in OMEGA, namely `normalVelocity` and `layerThickness`.
+The `OceanState` class provides a container for the non-tracer prognostic variables in Omega, namely `normalVelocity` and `layerThickness`.
 Upon creation of a `OceanState` instance, these variables are allocated and registered with the IO infrastructure.
 The class contains a method to update the time levels for the state variables between timesteps.
 This involves a halo update, pointer swap, and updating the `IOFields` data references.

--- a/components/omega/doc/userGuide/OmegaBuild.md
+++ b/components/omega/doc/userGuide/OmegaBuild.md
@@ -19,7 +19,7 @@ The minimum version of CMake is 3.21.
 
 ## Standalone Build
 
-CMake and OMEGA prefer an out-of-source build. This enables a user to build
+CMake and Omega prefer an out-of-source build. This enables a user to build
 and maintain multiple executables from the same source directory.
 The standard practice is for a user to create a separate directory where
 the build should take place and the commands below should be launched from
@@ -33,7 +33,7 @@ default `PROJECT` defined, you can use `OMEGA_CIME_PROJECT` to specify an
 account to use as a placeholder during the Omega build.
 The values of `OMEGA_CIME_COMPILER` and `OMEGA_CIME_MACHINE` are defined in
 "${E3SM}/cime\_config/machines/config\_machines.xml".
-OMEGA requires some external libraries. Many of these are built automatically
+Omega requires some external libraries. Many of these are built automatically
 from the E3SM distribution. However, the METIS, ParMETIS, and, optionally,
 GKlib libraries must be built separately and the path must be supplied during
 the cmake invocation as shown below. If a `OMEGA_METIS_ROOT` is not supplied,

--- a/components/omega/doc/userGuide/QuickStart.md
+++ b/components/omega/doc/userGuide/QuickStart.md
@@ -3,6 +3,6 @@
 # Quick Start for Users
 
 :::{admonition} Quick Start for Users is coming soon
-OMEGA is still in the early stages of development, so we are not yet ready for
+Omega is still in the early stages of development, so we are not yet ready for
 outside users.  For now, please refer to the {ref}`omega-dev-quick-start`.
 :::

--- a/components/omega/doc/userGuide/README.md
+++ b/components/omega/doc/userGuide/README.md
@@ -1,5 +1,5 @@
-# OMEGA doc/userGuide directory
+# Omega doc/userGuide directory
 
 This directory contains source files for the Ocean Model for E3SM
-Global Applications (OMEGA) User Guide, describing how to configure
+Global Applications (Omega) User Guide, describing how to configure
 and run simulations.


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
In this PR I updated the docs to make all references to Omega stylized consistently as "Omega" rather than "OMEGA". This does not include the design documents, which I left unaltered. I built the documentation locally and everything looks good as far as I can tell.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


