### PR TITLE
Add Omega standalone driver

### DIFF
--- a/components/omega/OmegaBuild.cmake
+++ b/components/omega/OmegaBuild.cmake
@@ -287,7 +287,8 @@ macro(init_standalone_build)
   set(_RunScript ${OMEGA_BUILD_DIR}/omega_run.sh)
   file(WRITE ${_RunScript}  "#!/usr/bin/env bash\n\n")
   file(APPEND ${_RunScript} "source ./omega_env.sh\n\n")
-  file(APPEND ${_RunScript} "./src/omega.exe 1000\n\n")
+  list(JOIN OMEGA_MPI_ARGS " " OMEGA_MPI_ARGS_STR)
+  file(APPEND ${_RunScript} "${OMEGA_MPI_EXEC} ${OMEGA_MPI_ARGS_STR} -n 8 -- ./src/omega.exe\n\n")
 
   # create a ctest script
   set(_CtestScript ${OMEGA_BUILD_DIR}/omega_ctest.sh)

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -1,4 +1,4 @@
-omega:
+Omega:
    TimeManagement:
       StartTime: 0001-01-01_00:00:00
       StopTime: 0001-01-01_02:00:00

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -1,0 +1,27 @@
+omega:
+   TimeManagement:
+      StartTime: 0001-01-01_00:00:00
+      StopTime: 0001-01-01_02:00:00
+      RunDuration: none #0000_02:00:00.000
+      CalendarType: No Leap
+   TimeIntegration:
+      TimeStepper: Forward-Backward
+      TimeStep: 0000_00:10:00
+   Dimension:
+      NVertLevels: 60
+   Decomp:
+      HaloWidth: 3
+      DecompMethod: MetisKWay
+   State:
+      NTimeLevels: 2
+   Advection:
+      FluxThicknessType: Center
+   Tendencies:
+      ThicknessFluxTendencyEnable: true
+      PVTendencyEnable: true
+      KETendencyEnable: true
+      SSHTendencyEnable: true
+      VelDiffTendencyEnable: true
+      ViscDel2: 1.0e3
+      VelHyperDiffTendencyEnable: true
+      ViscDel4: 1.2e11

--- a/components/omega/configs/DriverTest.yml
+++ b/components/omega/configs/DriverTest.yml
@@ -1,0 +1,25 @@
+omega:
+   TimeManagement:
+      StartTime: 0001-01-01_00:00:00
+      StopTime: 0001-01-01_02:00:00
+      RunDuration: none
+      CalendarType: No Leap
+   TimeIntegration:
+      TimeStepper: Forward-Backward
+      TimeStep: 0000_00:30:00
+   Dimension:
+      NVertLevels: 1
+   Decomp:
+      HaloWidth: 3
+      DecompMethod: MetisKWay
+   Advection:
+      FluxThicknessType: Center
+   Tendencies:
+      ThicknessFluxTendencyEnable: true
+      PVTendencyEnable: true
+      KETendencyEnable: true
+      SSHTendencyEnable: true
+      VelDiffTendencyEnable: true
+      ViscDel2: 1.0
+      VelHyperDiffTendencyEnable: true
+      ViscDel4: 1.0

--- a/components/omega/configs/UnitTests.yml
+++ b/components/omega/configs/UnitTests.yml
@@ -8,7 +8,7 @@ omega:
       TimeStepper: Forward-Backward
       TimeStep: 0000_00:30:00
    Dimension:
-      NVertLevels: 1
+      NVertLevels: 60
    Decomp:
       HaloWidth: 3
       DecompMethod: MetisKWay

--- a/components/omega/configs/UnitTests.yml
+++ b/components/omega/configs/UnitTests.yml
@@ -1,4 +1,4 @@
-omega:
+Omega:
    TimeManagement:
       StartTime: 0001-01-01_00:00:00
       StopTime: 0001-01-01_02:00:00

--- a/components/omega/doc/devGuide/Driver.md
+++ b/components/omega/doc/devGuide/Driver.md
@@ -14,7 +14,7 @@ are developed and as Omega is integrated with E3SM.
 ### ocnInit
 
 The `ocnInit` method initializes everything needed to run the Omega ocean model,
-and has the following interace:
+and has the following interface:
 ```c++
 int ocnInit(MPI_Comm Comm, Calendar &OmegaCal, TimeInstant &StartTime, Alarm &EndAlarm);
 ```

--- a/components/omega/doc/devGuide/Driver.md
+++ b/components/omega/doc/devGuide/Driver.md
@@ -1,0 +1,58 @@
+(omega-dev-driver)=
+
+## Driver
+
+The Omega Driver consists of methods to run the Omega ocean model in either
+standalone mode or as a component of E3SM. In both cases, the execution of Omega
+is divided into three phases, carried out by the `ocnInit`, `ocnRun`, and
+`ocnFinalize` methods. An interface layer to translate data types of the parent
+model to and from internal Omega data types will also be needed for running
+Omega as a component. For standalone mode, a `main` function is defined to
+serve as the top-level driver. The driver methods will evolve as more modules
+are developed and as Omega is integrated with E3SM.
+
+### ocnInit
+
+The `ocnInit` method initializes everything needed to run the Omega ocean model,
+and has the following interace:
+```c++
+int ocnInit(MPI_Comm Comm, Calendar &OmegaCal, TimeInstant &StartTime, Alarm &EndAlarm);
+```
+It requires an MPI communicator as input, as well as a yaml configuration file
+named `omega.yml` in the directory Omega is launched from. Default configuration
+files are currently kept in the `configs` directory, eventually an automated
+tool will extract default configuration options from module header files and
+build the default config file. The `ocnInit` method will read the configuration
+options into the static `ConfigAll` object. The time management options that
+determine the duration of the simulation are read from the Config object and
+stored in `OmegaCal`, `StartTime`, and `EndAlarm`, which are output by the
+method. The `init()` methods for each Omega module necessary to run the ocean
+model are called. An integer error code is returned.
+
+### ocnRun
+
+The `ocnRun` method advances the model over the interval defined by time
+management options, integrating from the start time until the `EndAlarm` is
+ringing. The interface is:
+```c++
+int ocnRun(TimeInstant &CurrTime, Alarm &EndAlarm);
+```
+The `TimeStep` is retrieved from the default `TimeStepper` object initialized
+during `ocnInit` and used with the value of `CurrTime` on input to construct
+a `Clock` object which manages the time loop. The `EndAlarm` is attached to
+the `Clock` to signal the end of the time loop. Eventually, there will be
+periodic alarms also attached to the `Clock` to trigger forcings, writing
+output, restarts, etc. As the time loop advances, the `doStep` method of the
+`TimeStepper` object is called to update the ocean model until the `EndAlarm`
+is triggered. The updated `CurrTime` and status of `EndAlarm` are returned,
+along with an integer error code.
+
+### ocnFinalize
+
+The `ocnFinalize` method is needed to clean up all the objects allocated by the
+model. The interface is:
+```c++
+int ocnFinalize(TimeInstant &CurrTime);
+```
+The `CurrTime` is input in case a restart file needs to be written. An integer
+error code is returned.

--- a/components/omega/doc/devGuide/QuickStart.md
+++ b/components/omega/doc/devGuide/QuickStart.md
@@ -149,7 +149,8 @@ ln -sf  planar_test_mesh.nc test/OmegaPlanarMesh.nc
 
 ### Running CTests
 
-Omega includes several unit tests that run through CTest.  These need to be
+Omega includes several unit tests that run through CTest. Several tests require options read from a YAML configuration file. Before running the tests, copy
+the `UnitTest.yml` file from the `configs` directory in the Omega repo into the `test` directory, and rename it `omega.yml`. The unit tests need to be
 run on a compute node.
 
 To run the tests:

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -27,6 +27,7 @@ userGuide/MachEnv
 userGuide/Config
 userGuide/Broadcast
 userGuide/Logging
+userGuide/Driver
 userGuide/Decomp
 userGuide/Dimension
 userGuide/Field
@@ -56,6 +57,7 @@ devGuide/BuildDocs
 devGuide/DataTypes
 devGuide/MachEnv
 devGuide/Config
+devGuide/Driver
 devGuide/Broadcast
 devGuide/CMakeBuild
 devGuide/Logging

--- a/components/omega/doc/userGuide/Driver.md
+++ b/components/omega/doc/userGuide/Driver.md
@@ -1,0 +1,32 @@
+(omega-user-driver)=
+
+## Driver
+
+The Omega Driver manages the execution of the Omega ocean model. Currently,
+the only user-configurable parameters unique to the Driver relate to the
+time management of the simulation.
+```yaml
+   TimeManagement:
+      StartTime: 0001-01-01_00:00:00
+      StopTime: none
+      RunDuration: 0000_02:00:00.000
+      CalendarType: No Leap
+```
+The `StartTime` and `StopTime` should be formatted strings in the form
+`YYYY-MM-DD_HH:MM:SS.SSSS` and the `RunDuration` should be a formatted string in
+the form `DDDD_HH:MM:SS.SSSS` (the actual width of each unit can be arbitrary
+and the separators can be any single non-numeric character). Either the
+`StopTime` or `RunDuration` can be set to `none` in order to use the other to
+determine the duration of the run. If both are set and `StopTime - StartTime`
+is incosistent with `RunDuration`, then `RunDuration` is used for the
+simulation. The supported calendar types are:
+| Config option name | Calendar type |
+| ------------------ | ------------- |
+| Gregorian | Gregorian calendar |
+| No Leap | Gregorian without leap years |
+| Julian | Julian calendar |
+| Julian Day | Julian day |
+| Modified Julian Day | modified Julian day |
+| 360 Day | 12 months, 30 days each |
+| Custom | user-defined calendar |
+| No Calendar | tracks elapsed time only |

--- a/components/omega/doc/userGuide/TendencyTerms.md
+++ b/components/omega/doc/userGuide/TendencyTerms.md
@@ -17,7 +17,7 @@ tendency terms are currently implemented:
 
 Among the internal data stored by each functor is a `bool` which can enable or
 disable the contribution of that particular term to the tendency. These flags
-are default set to `false`, and need to be enabled by the configuration file:
+need to be provided in the configuration file:
 ```yaml
 Tendencies:
    ThicknessFluxTendencyEnable: true

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -61,7 +61,7 @@ target_link_libraries(
 if(OMEGA_BUILD_EXECUTABLE)
 
   set(EXESRC_FILES
-    drivers/DrvDummy.cpp
+    drivers/standalone/OceanDriver.cpp
   )
 
   # Create the executable target

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -333,21 +333,29 @@ int Decomp::init(const std::string &MeshFileName) {
 
    int Err = 0; // default successful return code
 
-   // Initialize decomposition options
-   I4 InHaloWidth              = 3;
-   std::string DecompMethodStr = "MetisKWay";
+   I4 InHaloWidth;
+   std::string DecompMethodStr;
 
-   // Retrieve options from Config if possible
+   // Retrieve options from Config
    Config *OmegaConfig = Config::getOmegaConfig();
+
    Config DecompConfig("Decomp");
-   if (OmegaConfig->existsGroup("Decomp")) {
-      Err = OmegaConfig->get(DecompConfig);
-      if (DecompConfig.existsVar("HaloWidth")) {
-         Err = DecompConfig.get("HaloWidth", InHaloWidth);
-      }
-      if (DecompConfig.existsVar("DecompMethod")) {
-         Err = DecompConfig.get("DecompMethod", DecompMethodStr);
-      }
+   Err = OmegaConfig->get(DecompConfig);
+   if (Err != 0) {
+      LOG_CRITICAL("Decomp: Decomp group not found in Config");
+      return Err;
+   }
+
+   Err = DecompConfig.get("HaloWidth", InHaloWidth);
+   if (Err != 0) {
+      LOG_CRITICAL("Decomp: HaloWidth not found in Decomp Config");
+      return Err;
+   }
+
+   Err = DecompConfig.get("DecompMethod", DecompMethodStr);
+   if (Err != 0) {
+      LOG_CRITICAL("Decomp: DecompMethod not found in Decomp Config");
+      return Err;
    }
 
    PartMethod Method = getPartMethodFromStr(DecompMethodStr);

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -224,7 +224,7 @@ int readMesh(const int MeshFileID, // file ID for open mesh file
          OnVertexOffset[Vrtx * VertexDegree + Cell] =
              VertexGlob * VertexDegree + Cell;
       } // end loop VertexDegree
-   }    // end loop NVerticesLocal
+   } // end loop NVerticesLocal
 
    // Create the parallel IO decompositions
    IO::Rearranger Rearr = IO::RearrBox;
@@ -807,7 +807,7 @@ int Decomp::partCellsKWay(
          for (int n = 0; n < CellsOnCellSize; ++n) {
             CellsOnCellBuf[n] = CellsOnCellInit[n];
          } // end loop CellsOnCell
-      }    // end if this is MyTask
+      } // end if this is MyTask
       Err = MPI_Bcast(&CellsOnCellBuf[0], CellsOnCellSize, MPI_INT32_T, Task,
                       Comm);
       if (Err != 0) {
@@ -837,7 +837,7 @@ int Decomp::partCellsKWay(
             }
          }
       } // end cell loop for buffer
-   }    // end task loop
+   } // end task loop
 
    AdjAdd[NCellsGlobal] = Add; // Add the ending address
 
@@ -925,7 +925,7 @@ int Decomp::partCellsKWay(
          CellLocTmp[2 * LocalAdd]     = TaskLoc;
          CellLocTmp[2 * LocalAdd + 1] = LocalAdd;
       } // end if my task
-   }    // end loop over all cells
+   } // end loop over all cells
 
    // Find and add the halo cells to the cell list. Here we use the
    // adjacency array to find the active neighbor cells and store if they
@@ -964,7 +964,7 @@ int Decomp::partCellsKWay(
                   HaloList.insert(NbrID);
                   CellsInList.insert(NbrID);
                } // end search for existing entry
-            }    // end if not on task
+            } // end if not on task
 
          } // end loop over neighbors
 
@@ -1195,8 +1195,8 @@ int Decomp::partEdges(
                ++HaloCount;
                EdgesAll.erase(EdgeGlob);
             } // end if valid edge
-         }    // end loop over cell edges
-      }       // end cell loop
+         } // end loop over cell edges
+      } // end cell loop
       // reset address range for next halo and set NEdgesHalo
       CellStart = CellEnd;
       if ((Halo + 1) < HaloWidth)
@@ -1600,8 +1600,8 @@ int Decomp::rearrangeCellArrays(
             }
             NEdgesOnCellTmp(LocCell) = EdgeCount;
          } // end if local cell
-      }    // end loop over chunk of global cells
-   }       // end loop over MPI tasks
+      } // end loop over chunk of global cells
+   } // end loop over MPI tasks
 
    // Copy to final location on host - wait to create device copies until
    // the entries are translated to local addresses rather than global IDs
@@ -1736,8 +1736,8 @@ int Decomp::rearrangeEdgeArrays(
             }
             NEdgesOnEdgeTmp(LocEdge) = EdgeCount;
          } // end if local cell
-      }    // end loop over chunk of global cells
-   }       // end loop over MPI tasks
+      } // end loop over chunk of global cells
+   } // end loop over MPI tasks
 
    // Copy to final location on host - wait to create device copies until
    // the entries are translated to local addresses rather than global IDs
@@ -1845,8 +1845,8 @@ int Decomp::rearrangeVertexArrays(
                ++BufAdd;
             }
          } // end if local cell
-      }    // end loop over chunk of global cells
-   }       // end loop over MPI tasks
+      } // end loop over chunk of global cells
+   } // end loop over MPI tasks
 
    // Copy to final location on host - wait to create device copies until
    // the entries are translated to local addresses rather than global IDs

--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -16,8 +16,8 @@
 int main(int argc, char **argv) {
 
    int ErrAll;
-   int Err1;
-   int Err2;
+   int ErrCurr;
+   int ErrFinalize;
 
    MPI_Init(&argc, &argv); // initialize MPI
    Kokkos::initialize();   // initialize Kokkos
@@ -27,23 +27,23 @@ int main(int argc, char **argv) {
    OMEGA::TimeInstant CurrTime;
    OMEGA::Alarm EndAlarm;
 
-   Err1 = OMEGA::ocnInit(MPI_COMM_WORLD, OmegaCal, CurrTime, EndAlarm);
-   if (Err1 != 0)
+   ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD, OmegaCal, CurrTime, EndAlarm);
+   if (ErrCurr != 0)
       LOG_ERROR("Error initializing OMEGA");
 
-   while (Err1 == 0 && !(EndAlarm.isRinging())) {
+   while (ErrCurr == 0 && !(EndAlarm.isRinging())) {
 
-      Err1 = OMEGA::ocnRun(CurrTime, EndAlarm);
+      ErrCurr = OMEGA::ocnRun(CurrTime, EndAlarm);
 
-      if (Err1 != 0)
+      if (ErrCurr != 0)
          LOG_ERROR("Error advancing Omega run interval");
    }
 
-   Err2 = OMEGA::ocnFinalize(CurrTime);
-   if (Err2 != 0)
+   ErrFinalize = OMEGA::ocnFinalize(CurrTime);
+   if (ErrFinalize != 0)
       LOG_ERROR("Error finalizing OMEGA");
 
-   ErrAll = abs(Err1) + abs(Err2);
+   ErrAll = abs(ErrCurr) + abs(ErrFinalize);
    if (ErrAll == 0) {
       LOG_INFO("OMEGA successfully completed");
    } else {

--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -1,0 +1,61 @@
+//===-- drivers/standalone/OceanDriver.cpp - Standalone driver --*- C++ -*-===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#include "OceanDriver.h"
+#include "DataTypes.h"
+#include "OceanState.h"
+#include "OmegaKokkos.h"
+#include "TimeMgr.h"
+
+#include "mpi.h"
+
+#include <iostream>
+
+int main(int argc, char **argv) {
+
+   int ErrAll;
+   int Err1;
+   int Err2;
+
+   MPI_Init(&argc, &argv); // initialize MPI
+   Kokkos::initialize();   // initialize Kokkos
+
+   // Time management objects
+   OMEGA::Calendar OmegaCal;
+   OMEGA::TimeInstant CurrTime;
+   OMEGA::Alarm EndAlarm;
+
+   Err1 = OMEGA::ocnInit(MPI_COMM_WORLD, OmegaCal, CurrTime, EndAlarm);
+   if (Err1 != 0)
+      LOG_ERROR("Error initializing OMEGA");
+
+   while (Err1 == 0 && !(EndAlarm.isRinging())) {
+
+      Err1 = OMEGA::ocnRun(CurrTime, EndAlarm);
+
+      if (Err1 != 0)
+         LOG_ERROR("Error advancing Omega run interval");
+   }
+
+   Err2 = OMEGA::ocnFinalize(CurrTime);
+   if (Err2 != 0)
+      LOG_ERROR("Error finalizing OMEGA");
+
+   ErrAll = abs(Err1) + abs(Err2);
+   if (ErrAll == 0) {
+      LOG_INFO("OMEGA successfully completed");
+   } else {
+      LOG_ERROR("OMEGA terminating due to error");
+   }
+
+   Kokkos::finalize();
+   MPI_Finalize();
+
+   if (ErrAll >= 256)
+      ErrAll = 255;
+   return ErrAll;
+}
+
+//===----------------------------------------------------------------------===//

--- a/components/omega/src/infra/Config.cpp
+++ b/components/omega/src/infra/Config.cpp
@@ -86,7 +86,7 @@ int Config::readAll(const std::string ConfigFile // [in] input YAML config file
 
    // Now give the full config the omega name and extract the
    // top-level omega node from the Root.
-   ConfigAll.Name = "omega";
+   ConfigAll.Name = "Omega";
 
    for (int ReadGroup = 0; ReadGroup < Config::NumReadGroups; ++ReadGroup) {
 
@@ -95,7 +95,7 @@ int Config::readAll(const std::string ConfigFile // [in] input YAML config file
          // Read temporary root node
          YAML::Node RootNode = YAML::LoadFile(ConfigFile);
          // Extract Omega node
-         ConfigAll.Node = RootNode["omega"];
+         ConfigAll.Node = RootNode["Omega"];
       }
       MPI_Barrier(ConfigComm);
    }

--- a/components/omega/src/infra/TimeMgr.cpp
+++ b/components/omega/src/infra/TimeMgr.cpp
@@ -2312,6 +2312,44 @@ TimeInterval::TimeInterval(
 } // end TimeInterval::TimeInterval real length/unit constructor
 
 //------------------------------------------------------------------------------
+// TimeInterval::TimeInterval
+// Construct a time interval from a standard string in the form
+// DDDD_HH:MM:SS.SSSS where the width of DD and SS strings can be of
+// arbitrary width (within reason) and the separators can be any single
+// non-numeric character
+TimeInterval::TimeInterval(
+    std::string &TimeString // [in] string form of time interval
+) {
+
+   // Not a calendar interval
+   IsCalendar  = false;
+   CalInterval = 0;
+
+   I4 Err{0};
+
+   // Extract variables from string
+   I8 Day     = 0;
+   I8 Hour    = 0;
+   I8 Minute  = 0;
+   R8 RSecond = 0.;
+
+   std::istringstream ss(TimeString);
+   char discard;
+   ss >> Day >> discard >> Hour >> discard >> Minute >> discard >> RSecond;
+
+   R8 SecondsSet = Day * SECONDS_PER_DAY + Hour * SECONDS_PER_HOUR +
+                   Minute * SECONDS_PER_MINUTE + RSecond;
+
+   // Use the set function to define the Time Interval
+   Err = this->set(SecondsSet, TimeUnits::Seconds);
+
+   if (Err != 0)
+      LOG_ERROR("TimeMgr: TimeInterval constructor from string error "
+                "using using set function to construct TimeInterval.");
+
+} // end TimeInterval::TimeInterval constructor from string
+
+//------------------------------------------------------------------------------
 // TimeInterval::~TimeInterval - destructor for time interval
 // Destructor for a time interval. No allocated space so does nothing.
 
@@ -3587,12 +3625,12 @@ TimeInstant::TimeInstant(Calendar *Cal,          //< [in] Calendar to use
    CalPtr = Cal;
 
    // Extract variables from string
-   I8 Year;
-   I8 Month;
-   I8 Day;
-   I8 Hour;
-   I8 Minute;
-   R8 RSecond;
+   I8 Year    = 0;
+   I8 Month   = 0;
+   I8 Day     = 0;
+   I8 Hour    = 0;
+   I8 Minute  = 0;
+   R8 RSecond = 0.;
 
    std::istringstream ss(TimeString);
    char discard;
@@ -3947,7 +3985,7 @@ std::string TimeInstant::getString(
    FmtString << ":";
    FmtString << "%02d"; // 2 digit minute with leading 0
    FmtString << ":";
-   FmtString << "%" << SecondWidth + 3 << "." << SecondWidth << "f"; // seconds
+   FmtString << "%0" << SecondWidth + 3 << "." << SecondWidth << "f"; // seconds
 
    // convert format string to an actual string for formatted write
    const std::string Tmp = FmtString.str();
@@ -3975,6 +4013,21 @@ std::string TimeInstant::getString(
 
 // Alarm constructors/destructors
 //------------------------------------------------------------------------------
+// Alarm::Alarm - default constructor
+// The default constructor creates an alarm with ring time equal to zero
+Alarm::Alarm(void) {
+
+   Name    = "";
+   Ringing = false;
+   Stopped = false;
+
+   Periodic = false;
+
+   TimeInstant AlarmTime;
+   RingTime = AlarmTime;
+
+} // end Alarm::Alarm - default
+
 // Alarm::Alarm - construct single instance alarm
 // Construct a single alarm using the input ring time.
 

--- a/components/omega/src/infra/TimeMgr.cpp
+++ b/components/omega/src/infra/TimeMgr.cpp
@@ -3985,7 +3985,12 @@ std::string TimeInstant::getString(
    FmtString << ":";
    FmtString << "%02d"; // 2 digit minute with leading 0
    FmtString << ":";
-   FmtString << "%0" << SecondWidth + 3 << "." << SecondWidth << "f"; // seconds
+   if (SecondWidth == 0) {
+      FmtString << "%02.0f"; // seconds with no decimal digits
+   } else {
+      // seconds with SecondWidth number of decimal digits
+      FmtString << "%0" << SecondWidth + 3 << "." << SecondWidth << "f";
+   }
 
    // convert format string to an actual string for formatted write
    const std::string Tmp = FmtString.str();

--- a/components/omega/src/infra/TimeMgr.h
+++ b/components/omega/src/infra/TimeMgr.h
@@ -450,6 +450,13 @@ class TimeInterval {
                 const TimeUnits InUnits ///< unit of time for interval
    );
 
+   /// Construct time interval from a standard string in the form
+   /// DDDD_HH:MM:SS.SSSS where the width of DD and SS strings can be of
+   /// arbitrary width (within reason) and the separators can be any single
+   /// non-numeric character
+   TimeInterval(std::string &TimeString ///< [in] string form of time interval
+   );
+
    /// Destructor for time interval
    ~TimeInterval(void);
 
@@ -704,7 +711,6 @@ class TimeInstant {
    /// Create a time interval by subtracting two time instants
    TimeInterval operator-(const TimeInstant &) const;
    /// Increment time in place by adding time interval
-   /// Increment time in place by adding time interval
    TimeInstant &operator+=(const TimeInterval &);
    /// Decrement time in place by subtracting time interval
    TimeInstant &operator-=(const TimeInterval &);
@@ -745,6 +751,9 @@ class Alarm {
 
  public:
    // constructors/destructors
+
+   /// Default alarm constructor
+   Alarm(void);
 
    /// Constructs a one-time alarm using the input ring time.
    Alarm(const std::string InName,   ///< [in] Name of alarm

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -1,4 +1,5 @@
 #include "AuxiliaryState.h"
+#include "Config.h"
 #include "Field.h"
 #include "Logging.h"
 
@@ -131,9 +132,17 @@ int AuxiliaryState::init() {
    int Err                 = 0;
    const HorzMesh *DefMesh = HorzMesh::getDefault();
 
-   // These hard-wired variable needs to be updated
-   // with retrivals/config options
-   const int NVertLevels = 60;
+   int NVertLevels = 60;
+
+   // Retrieve NVertLevels from Config if available
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config DimConfig("Dimension");
+   if (OmegaConfig->existsGroup("Dimension")) {
+      Err = OmegaConfig->get(DimConfig);
+      if (DimConfig.existsVar("NVertLevels")) {
+         Err = DimConfig.get("NVertLevels", NVertLevels);
+      }
+   }
 
    AuxiliaryState::DefaultAuxState =
        AuxiliaryState::create("Default", DefMesh, NVertLevels);

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -1,6 +1,7 @@
 #ifndef OMEGA_AUXSTATE_H
 #define OMEGA_AUXSTATE_H
 
+#include "Config.h"
 #include "DataTypes.h"
 #include "HorzMesh.h"
 #include "OceanState.h"
@@ -55,6 +56,9 @@ class AuxiliaryState {
 
    /// Remove all auxiliary states
    static void clear();
+
+   /// Read and set config options
+   int readConfigOptions(Config *OmegaConfig);
 
    /// Compute all auxiliary variables based on an ocean state at a given time
    /// level

--- a/components/omega/src/ocn/HorzMesh.h
+++ b/components/omega/src/ocn/HorzMesh.h
@@ -62,7 +62,8 @@ class HorzMesh {
 
    /// Construct a new local mesh for a given decomposition
    HorzMesh(const std::string &Name, ///< [in] Name for mesh
-            Decomp *Decomp           ///< [in] Decomposition for mesh
+            Decomp *Decomp,          ///< [in] Decomposition for mesh
+            I4 InNVertLevels         ///< [in] num vertical levels
    );
 
    // Forbid copy and move construction
@@ -89,6 +90,8 @@ class HorzMesh {
    // Sizes and global IDs
    // Note that all sizes are actual counts (1-based) so that loop extents
    // should always use the 0:NCellsXX-1 form.
+
+   I4 NVertLevels; ///< number of vertical levels
 
    Array1DI4 NCellsHalo;      ///< num cells owned+halo for halo layer
    HostArray1DI4 NCellsHaloH; ///< num cells owned+halo for halo layer
@@ -249,7 +252,8 @@ class HorzMesh {
    /// Creates a new mesh by calling the constructor and puts it in the
    /// AllHorzMeshes map
    static HorzMesh *create(const std::string &Name, ///< [in] Name for mesh
-                           Decomp *Decomp ///< [in] Decomposition for mesh
+                           Decomp *Decomp,  ///< [in] Decomposition for mesh
+                           I4 InNVertLevels ///< [in] num vertival levels
    );
 
    /// Destructor - deallocates all memory and deletes a HorzMesh

--- a/components/omega/src/ocn/OceanDriver.h
+++ b/components/omega/src/ocn/OceanDriver.h
@@ -1,0 +1,42 @@
+#ifndef OMEGA_DRIVER_H
+#define OMEGA_DRIVER_H
+//===-- ocn/OceanDriver.h ---------------------------------------*- C++ -*-===//
+//
+/// \file
+/// \brief Defines ocean driver methods
+///
+/// This Header defines methods to drive Omega. These methods are designed to
+/// run Omega as either a standalone ocean model or as a component of E3SM.
+/// This process is divided into three phases: init, run, and finalize.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Config.h"
+#include "TimeMgr.h"
+
+#include "mpi.h"
+
+namespace OMEGA {
+
+/// Read the config file and call all the inidividual initialization routines
+/// for each Omega module
+int ocnInit(MPI_Comm Comm, Calendar &OmegaCal, TimeInstant &StartTime,
+            Alarm &EndAlarm);
+
+/// Advance the model from starting from CurrTime until EndAlarm rings
+int ocnRun(TimeInstant &CurrTime, Alarm &EndAlarm);
+
+/// Clean up all Omega objects
+int ocnFinalize(const TimeInstant &CurrTime);
+
+/// Extract time management options from Config
+int initTimeManagement(Calendar &OmegaCal, TimeInstant &StartTime,
+                       Alarm &EndAlarm, Config *OmegaConfig);
+
+/// Initialize Omega modules needed to run ocean model
+int initOmegaModules(MPI_Comm Comm);
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif

--- a/components/omega/src/ocn/OceanFinal.cpp
+++ b/components/omega/src/ocn/OceanFinal.cpp
@@ -1,0 +1,48 @@
+//===-- ocn/OceanFinalize.cpp -----------------------------------*- C++ -*-===//
+//
+// The ocnFinalize method writes a restart file if necessary, and then cleans
+// up all Omega objects
+//
+//===----------------------------------------------------------------------===//
+
+#include "AuxiliaryState.h"
+#include "Decomp.h"
+#include "Field.h"
+#include "Halo.h"
+#include "HorzMesh.h"
+#include "IO.h"
+#include "MachEnv.h"
+#include "OceanDriver.h"
+#include "OceanState.h"
+#include "TendencyTerms.h"
+#include "TimeMgr.h"
+#include "TimeStepper.h"
+
+namespace OMEGA {
+
+int ocnFinalize(const TimeInstant &CurrTime ///< [in] current sim time
+) {
+
+   // error code
+   I4 RetVal = 0;
+
+   // Write restart file if necessary
+
+   // clean up all objects
+   TimeStepper::clear();
+   Tendencies::clear();
+   AuxiliaryState::clear();
+   OceanState::clear();
+   Dimension::clear();
+   Field::clear();
+   HorzMesh::clear();
+   Halo::clear();
+   Decomp::clear();
+   MachEnv::removeAll();
+
+   return RetVal;
+} // end ocnFinalize
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -1,0 +1,217 @@
+//===-- ocn/OceanInit.cpp - Ocean Initialization ----------------*- C++ -*-===//
+//
+// This file contians ocnInit and associated methods which initialize Omega.
+// The ocnInit process reads the config file and uses the config options to
+// initialize time management and call all the individual initialization
+// routines for each module in Omega.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AuxiliaryState.h"
+#include "Config.h"
+#include "DataTypes.h"
+#include "Decomp.h"
+#include "Field.h"
+#include "Halo.h"
+#include "HorzMesh.h"
+#include "IO.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "OceanDriver.h"
+#include "OceanState.h"
+#include "TendencyTerms.h"
+#include "TimeMgr.h"
+#include "TimeStepper.h"
+
+#include "mpi.h"
+
+namespace OMEGA {
+
+int ocnInit(MPI_Comm Comm,          ///< [in] ocean MPI communicator
+            Calendar &OmegaCal,     ///< [out] sim calendar
+            TimeInstant &StartTime, ///< [out] sim start time
+            Alarm &EndAlarm         ///< [out] alarm to end simulation
+) {
+
+   // Error codes
+   I4 RetErr = 0;
+   I4 Err    = 0;
+
+   // Init the default machine environment based on input MPI communicator
+   MachEnv::init(Comm);
+   MachEnv *DefEnv = MachEnv::getDefault();
+
+   // Initialize Omega logging
+   initLogging(DefEnv);
+
+   // Read config file into Config object
+   Config("omega");
+   Err = Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_ERROR("ocnInit: Error reading config file");
+      ++RetErr;
+   }
+   Config *OmegaConfig = Config::getOmegaConfig();
+
+   // read and save time management options from Config
+   Err = initTimeManagement(OmegaCal, StartTime, EndAlarm, OmegaConfig);
+   if (Err != 0) {
+      LOG_ERROR("ocnInit: Error initializing time management");
+      ++RetErr;
+   }
+
+   // initialize remaining Omega modules
+   Err = initOmegaModules(Comm);
+   if (Err != 0) {
+      LOG_ERROR("ocnInit: Error initializing Omega modules");
+      ++RetErr;
+   }
+
+   return RetErr;
+} // end ocnInit
+
+// Read time management options from config
+int initTimeManagement(Calendar &OmegaCal, TimeInstant &StartTime,
+                       Alarm &EndAlarm, Config *OmegaConfig) {
+
+   // error code
+   I4 RetErr = 0;
+
+   // create RunInterval and zero length interval for comparison
+   TimeInterval RunInterval, ZeroInterval;
+
+   // extract variables for time management group
+   Config TimeMgmtConfig("TimeManagement");
+   if (OmegaConfig->existsGroup("TimeManagement")) {
+      int Err1 = OmegaConfig->get(TimeMgmtConfig);
+      // check requested calendar is a valid option, return error if not found
+      if (TimeMgmtConfig.existsVar("CalendarType")) {
+         std::string ConfigCalStr;
+         CalendarKind ConfigCalKind = CalendarUnknown;
+         I4 Err1     = TimeMgmtConfig.get("CalendarType", ConfigCalStr);
+         I4 ICalType = 9;
+         for (I4 I = 0; I < NUM_SUPPORTED_CALENDARS; ++I) {
+            if (ConfigCalStr == CalendarKindName[I]) {
+               ICalType      = I;
+               ConfigCalKind = (CalendarKind)(ICalType + 1);
+               break;
+            }
+         }
+         if (ICalType == 9) {
+            LOG_ERROR("ocnInit: Requested Calendar type not found");
+            ++RetErr;
+            return RetErr;
+         }
+         // destroy default Calendar to keep static NumCalendars member
+         // accurate, then construct requested Calendar
+         OmegaCal.~Calendar();
+         OmegaCal = Calendar::Calendar(ConfigCalStr, ConfigCalKind);
+      }
+
+      // check for start time and set if found
+      if (TimeMgmtConfig.existsVar("StartTime")) {
+         std::string StartTimeStr;
+         I4 Err1 = TimeMgmtConfig.get("StartTime", StartTimeStr);
+
+         StartTime = TimeInstant::TimeInstant(&OmegaCal, StartTimeStr);
+      }
+
+      std::string NoneStr("none");
+      // set RunInterval by checking for StopTime and RunDuration in Config,
+      // if both are present and inconsistent, use RunDuration
+      if (TimeMgmtConfig.existsVar("StopTime")) {
+         std::string StopTimeStr;
+         I4 Err1 = TimeMgmtConfig.get("StopTime", StopTimeStr);
+         if (StopTimeStr != NoneStr) {
+            TimeInstant StopTime(&OmegaCal, StopTimeStr);
+            RunInterval = StopTime - StartTime;
+         }
+      }
+      if (TimeMgmtConfig.existsVar("RunDuration")) {
+         std::string RunDurationStr;
+         I4 Err1 = TimeMgmtConfig.get("RunDuration", RunDurationStr);
+         if (RunDurationStr != NoneStr) {
+            TimeInterval IntervalFromStr(RunDurationStr);
+            if (IntervalFromStr != RunInterval) {
+               LOG_WARN("ocnInit: RunDuration and StopTime are inconsistent: "
+                        "using RunDuration");
+               RunInterval = IntervalFromStr;
+            }
+         }
+      }
+   }
+
+   // return error if RunInterval set to zero
+   if (RunInterval == ZeroInterval) {
+      LOG_ERROR("ocnInit: Simulation run duration set to zero");
+      ++RetErr;
+   }
+
+   // set EndAlarm based on length of RunInterval
+   TimeInstant EndTime = StartTime + RunInterval;
+   EndAlarm            = Alarm::Alarm("End Alarm", EndTime);
+
+   return RetErr;
+} // end initTimeManagement
+
+// Call init routines for remaining Omega modules
+int initOmegaModules(MPI_Comm Comm) {
+
+   // error codes
+   I4 RetErr = 0;
+   I4 Err    = 0;
+
+   // initialize all necessary Omega modules
+   Err = IO::init(Comm);
+   if (Err != 0) {
+      LOG_ERROR("ocnInit: Error initializing parallel IO");
+      ++RetErr;
+   }
+
+   Err = Decomp::init();
+   if (Err != 0) {
+      LOG_ERROR("ocnInit: Error initializing default decomposition");
+      ++RetErr;
+   }
+
+   Err = Halo::init();
+   if (Err != 0) {
+      LOG_ERROR("ocnInit: Error initializing default halo");
+      ++RetErr;
+   }
+
+   Err = HorzMesh::init();
+   if (Err != 0) {
+      ++RetErr;
+      LOG_ERROR("ocnInit: Error initializing default mesh");
+   }
+
+   Err = AuxiliaryState::init();
+   if (Err != 0) {
+      ++RetErr;
+      LOG_ERROR("ocnInit: Error initializing default aux state");
+   }
+
+   Err = Tendencies::init();
+   if (Err != 0) {
+      ++RetErr;
+      LOG_ERROR("ocnInit: Error initializing default tendencies");
+   }
+
+   Err = TimeStepper::init();
+   if (Err != 0) {
+      ++RetErr;
+      LOG_ERROR("ocnInit: Error initializing default time stepper");
+   }
+
+   Err = OceanState::init();
+   if (Err != 0) {
+      ++RetErr;
+      LOG_ERROR("ocnInit: Error initializing default state");
+   }
+
+   return RetErr;
+} // end initOmegaModules
+
+} // end namespace OMEGA
+//===----------------------------------------------------------------------===//

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -105,7 +105,7 @@ int initTimeManagement(Calendar &OmegaCal, TimeInstant &StartTime,
          // destroy default Calendar to keep static NumCalendars member
          // accurate, then construct requested Calendar
          OmegaCal.~Calendar();
-         OmegaCal = Calendar::Calendar(ConfigCalStr, ConfigCalKind);
+         OmegaCal = Calendar(ConfigCalStr, ConfigCalKind);
       }
 
       // check for start time and set if found
@@ -113,7 +113,7 @@ int initTimeManagement(Calendar &OmegaCal, TimeInstant &StartTime,
          std::string StartTimeStr;
          I4 Err1 = TimeMgmtConfig.get("StartTime", StartTimeStr);
 
-         StartTime = TimeInstant::TimeInstant(&OmegaCal, StartTimeStr);
+         StartTime = TimeInstant(&OmegaCal, StartTimeStr);
       }
 
       std::string NoneStr("none");
@@ -149,7 +149,7 @@ int initTimeManagement(Calendar &OmegaCal, TimeInstant &StartTime,
 
    // set EndAlarm based on length of RunInterval
    TimeInstant EndTime = StartTime + RunInterval;
-   EndAlarm            = Alarm::Alarm("End Alarm", EndTime);
+   EndAlarm            = Alarm("End Alarm", EndTime);
 
    return RetErr;
 } // end initTimeManagement

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -43,7 +43,7 @@ int ocnInit(MPI_Comm Comm,          ///< [in] ocean MPI communicator
    initLogging(DefEnv);
 
    // Read config file into Config object
-   Config("omega");
+   Config("Omega");
    Err = Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("ocnInit: Error reading config file");

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -173,6 +173,12 @@ int initOmegaModules(MPI_Comm Comm) {
       return Err;
    }
 
+   Err = Field::init();
+   if (Err != 0) {
+      LOG_CRITICAL("ocnInit: Error initializing Fields");
+      return Err;
+   }
+
    Err = Decomp::init();
    if (Err != 0) {
       LOG_CRITICAL("ocnInit: Error initializing default decomposition");

--- a/components/omega/src/ocn/OceanRun.cpp
+++ b/components/omega/src/ocn/OceanRun.cpp
@@ -1,0 +1,63 @@
+//===-- ocn/OceanRun.cpp - Run Ocean Model ----------------------*- C++ -*-===//
+//
+// The ocnRun method advances the model forward from CurrTime until the
+// EndAlarm rings.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OceanDriver.h"
+#include "OceanState.h"
+#include "TimeStepper.h"
+
+namespace OMEGA {
+
+int ocnRun(TimeInstant &CurrTime, ///< [inout] current sim time
+           Alarm &EndAlarm        ///< [inout] alarm to end simulation
+) {
+
+   // error code
+   I4 Err = 0;
+
+   // fetch default OceanState and TimeStepper
+   OceanState *DefOceanState   = OceanState::getDefault();
+   TimeStepper *DefTimeStepper = TimeStepper::getDefault();
+
+   TimeInterval TimeStep, ZeroInterval;
+
+   // set simulation clock and attach EndAlarm
+   TimeStep = DefTimeStepper->getTimeStep();
+   Clock OmegaClock(CurrTime, TimeStep);
+   Err = OmegaClock.attachAlarm(&EndAlarm);
+
+   if (TimeStep == ZeroInterval) {
+      LOG_ERROR("ocnRun: TimeStep must be initialized");
+      ++Err;
+   }
+
+   I8 IStep = 0;
+
+   // time loop, integrate until EndAlarm or error encountered
+   while (Err == 0 && !(EndAlarm.isRinging())) {
+
+      // advance clock
+      OmegaClock.advance();
+      ++IStep;
+
+      // call forcing routines, anything needed pre-timestep
+
+      // do forward time step
+      TimeInstant SimTime = OmegaClock.getPreviousTime();
+      DefTimeStepper->doStep(DefOceanState, SimTime);
+
+      // write restart file/output, anything needed post-timestep
+
+      CurrTime = OmegaClock.getCurrentTime();
+      LOG_INFO("ocnRun: Time step {} complete, clock time: {}", IStep,
+               CurrTime.getString(4, 4, "-"));
+   }
+
+   return Err;
+
+} // end ocnRun
+
+} // end namespace OMEGA

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -36,17 +36,7 @@ int OceanState::init() {
    HorzMesh *DefHorzMesh = HorzMesh::getDefault();
    Halo *DefHalo         = Halo::getDefault();
 
-   int NVertLevels = 60;
-
-   // Retrieve NVertLevels from Config if available
-   Config *OmegaConfig = Config::getOmegaConfig();
-   Config DimConfig("Dimension");
-   if (OmegaConfig->existsGroup("Dimension")) {
-      Err = OmegaConfig->get(DimConfig);
-      if (DimConfig.existsVar("NVertLevels")) {
-         Err = DimConfig.get("NVertLevels", NVertLevels);
-      }
-   }
+   int NVertLevels = DefHorzMesh->NVertLevels;
 
    auto *DefTimeStepper = TimeStepper::getDefault();
    if (!DefTimeStepper) {

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -36,9 +36,17 @@ int OceanState::init() {
    HorzMesh *DefHorzMesh = HorzMesh::getDefault();
    Halo *DefHalo         = Halo::getDefault();
 
-   // This hard-wired variable needs to be updated
-   // with retrivals/config options
    int NVertLevels = 60;
+
+   // Retrieve NVertLevels from Config if available
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config DimConfig("Dimension");
+   if (OmegaConfig->existsGroup("Dimension")) {
+      Err = OmegaConfig->get(DimConfig);
+      if (DimConfig.existsVar("NVertLevels")) {
+         Err = DimConfig.get("NVertLevels", NVertLevels);
+      }
+   }
 
    auto *DefTimeStepper = TimeStepper::getDefault();
    if (!DefTimeStepper) {

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -107,7 +107,7 @@ int Tendencies::readTendConfig(Config *TendConfig ///< [in] Tendencies subconfig
       return TendGroupErr;
    }
 
-   I4 PotVortErr = 
+   I4 PotVortErr =
        TendConfig->get("PVTendencyEnable", this->PotientialVortHAdv.Enabled);
    if (PotVortErr != 0) {
       LOG_CRITICAL("Tendencies: PVTendencyEnable not found in TendConfig");

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -26,12 +26,30 @@ int Tendencies::init() {
    int Err = 0;
 
    HorzMesh *DefHorzMesh = HorzMesh::getDefault();
-   Config *TendConfig;
+
+   // Get TendConfig group if available
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config TendConfig("Tendencies");
+   if (OmegaConfig->existsGroup("Tendencies")) {
+      Err = OmegaConfig->get(TendConfig);
+   }
 
    int NVertLevels = 60;
 
+   // Retrieve NVertLevels from Config if available
+   Config DimConfig("Dimension");
+   if (OmegaConfig->existsGroup("Dimension")) {
+      Err = OmegaConfig->get(DimConfig);
+      if (DimConfig.existsVar("NVertLevels")) {
+         Err = DimConfig.get("NVertLevels", NVertLevels);
+      }
+   }
+
+   // TODO: move setMasks to HorzMesh constructor
+   DefHorzMesh->setMasks(NVertLevels);
+
    Tendencies::DefaultTendencies =
-       Tendencies::create("Default", DefHorzMesh, NVertLevels, TendConfig);
+       create("Default", DefHorzMesh, NVertLevels, &TendConfig);
 
    return Err;
 
@@ -289,52 +307,68 @@ void Tendencies::computeAllTendencies(
 
 // TODO: Implement Config options for all constructors
 ThicknessFluxDivOnCell::ThicknessFluxDivOnCell(const HorzMesh *Mesh,
-                                               Config *Options)
+                                               Config *TendConfig)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
       EdgeSignOnCell(Mesh->EdgeSignOnCell) {
 
-   // Options->get("ThicknessFluxTendencyEnable", Enabled);
+   if (TendConfig->existsVar("ThicknessFluxTendencyEnable")) {
+      TendConfig->get("ThicknessFluxTendencyEnable", Enabled);
+   }
 }
 
 PotentialVortHAdvOnEdge::PotentialVortHAdvOnEdge(const HorzMesh *Mesh,
-                                                 Config *Options)
+                                                 Config *TendConfig)
     : NEdgesOnEdge(Mesh->NEdgesOnEdge), EdgesOnEdge(Mesh->EdgesOnEdge),
       WeightsOnEdge(Mesh->WeightsOnEdge) {
 
-   // Options->get("PVTendencyEnable", Enabled);
+   if (TendConfig->existsVar("PVTendencyEnable")) {
+      TendConfig->get("PVTendencyEnable", Enabled);
+   }
 }
 
-KEGradOnEdge::KEGradOnEdge(const HorzMesh *Mesh, Config *Options)
+KEGradOnEdge::KEGradOnEdge(const HorzMesh *Mesh, Config *TendConfig)
     : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge) {
 
-   // Options->get("KETendencyEnable", Enabled);
+   if (TendConfig->existsVar("KETendencyEnable")) {
+      TendConfig->get("KETendencyEnable", Enabled);
+   }
 }
 
-SSHGradOnEdge::SSHGradOnEdge(const HorzMesh *Mesh, Config *Options)
+SSHGradOnEdge::SSHGradOnEdge(const HorzMesh *Mesh, Config *TendConfig)
     : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge) {
 
-   // Options->get("SSHTendencyEnable", Enabled);
+   if (TendConfig->existsVar("SSHTendencyEnable")) {
+      TendConfig->get("SSHTendencyEnable", Enabled);
+   }
 }
 
 VelocityDiffusionOnEdge::VelocityDiffusionOnEdge(const HorzMesh *Mesh,
-                                                 Config *Options)
+                                                 Config *TendConfig)
     : CellsOnEdge(Mesh->CellsOnEdge), VerticesOnEdge(Mesh->VerticesOnEdge),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge),
       MeshScalingDel2(Mesh->MeshScalingDel2), EdgeMask(Mesh->EdgeMask) {
 
-   // Options->get("VelDiffTendencyEnable", Enabled);
-   // Options->get("ViscDel2", ViscDel2);
+   if (TendConfig->existsVar("VelDiffTendencyEnable")) {
+      TendConfig->get("VelDiffTendencyEnable", Enabled);
+   }
+   if (TendConfig->existsVar("ViscDel2")) {
+      TendConfig->get("ViscDel2", ViscDel2);
+   }
 }
 
 VelocityHyperDiffOnEdge::VelocityHyperDiffOnEdge(const HorzMesh *Mesh,
-                                                 Config *Options)
+                                                 Config *TendConfig)
     : CellsOnEdge(Mesh->CellsOnEdge), VerticesOnEdge(Mesh->VerticesOnEdge),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge),
       MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(Mesh->EdgeMask) {
 
-   // Options->get("VelHyperDiffTendencyEnable", Enabled);
-   // Options->get("ViscDel4", ViscDel4);
+   if (TendConfig->existsVar("VelHyperDiffTendencyEnable")) {
+      TendConfig->get("VelHyperDiffTendencyEnable", Enabled);
+   }
+   if (TendConfig->existsVar("ViscDel4")) {
+      TendConfig->get("ViscDel4", ViscDel4);
+   }
 }
 
 } // end namespace OMEGA

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -107,8 +107,8 @@ int Tendencies::readTendConfig(Config *TendConfig ///< [in] Tendencies subconfig
       return TendGroupErr;
    }
 
-   I4 PotVortErr = TendConfig->get("PVTendencyEnable",
-                                   this->PotientialVortHAdv.Enabled);
+   I4 PotVortErr = 
+       TendConfig->get("PVTendencyEnable", this->PotientialVortHAdv.Enabled);
    if (PotVortErr != 0) {
       LOG_CRITICAL("Tendencies: PVTendencyEnable not found in TendConfig");
       return PotVortErr;

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -99,57 +99,58 @@ int Tendencies::readTendConfig(Config *TendConfig ///< [in] Tendencies subconfig
 ) {
    int Err = 0;
 
-   Err = TendConfig->get("ThicknessFluxTendencyEnable",
-                         this->ThicknessFluxDiv.Enabled);
-   if (Err != 0) {
+   I4 TendGroupErr = TendConfig->get("ThicknessFluxTendencyEnable",
+                                     this->ThicknessFluxDiv.Enabled);
+   if (TendGroupErr != 0) {
       LOG_CRITICAL("Tendencies: ThicknessFluxTendencyEnable not found in "
                    "TendConfig");
-      return Err;
+      return TendGroupErr;
    }
 
-   Err = TendConfig->get("PVTendencyEnable", this->PotientialVortHAdv.Enabled);
-   if (Err != 0) {
+   I4 PotVortErr = TendConfig->get("PVTendencyEnable",
+                                   this->PotientialVortHAdv.Enabled);
+   if (PotVortErr != 0) {
       LOG_CRITICAL("Tendencies: PVTendencyEnable not found in TendConfig");
-      return Err;
+      return PotVortErr;
    }
 
-   Err = TendConfig->get("KETendencyEnable", this->KEGrad.Enabled);
-   if (Err != 0) {
+   I4 KEGradErr = TendConfig->get("KETendencyEnable", this->KEGrad.Enabled);
+   if (KEGradErr != 0) {
       LOG_CRITICAL("Tendencies: KETendencyEnable not found in TendConfig");
-      return Err;
+      return KEGradErr;
    }
 
-   Err = TendConfig->get("SSHTendencyEnable", this->SSHGrad.Enabled);
-   if (Err != 0) {
+   I4 SSHGradErr = TendConfig->get("SSHTendencyEnable", this->SSHGrad.Enabled);
+   if (SSHGradErr != 0) {
       LOG_CRITICAL("Tendencies: SSHTendencyEnable not found in TendConfig");
-      return Err;
+      return SSHGradErr;
    }
 
-   Err = TendConfig->get("VelDiffTendencyEnable",
-                         this->VelocityDiffusion.Enabled);
-   if (Err != 0) {
+   I4 VelDiffErr = TendConfig->get("VelDiffTendencyEnable",
+                                   this->VelocityDiffusion.Enabled);
+   if (VelDiffErr != 0) {
       LOG_CRITICAL("Tendencies: VelDiffTendencyEnable not found in TendConfig");
-      return Err;
+      return VelDiffErr;
    }
 
-   I4 Err1 = TendConfig->get("ViscDel2", this->VelocityDiffusion.ViscDel2);
-   if (Err1 != 0 && this->VelocityDiffusion.Enabled) {
+   I4 ViscDel2 = TendConfig->get("ViscDel2", this->VelocityDiffusion.ViscDel2);
+   if (ViscDel2 != 0 && this->VelocityDiffusion.Enabled) {
       LOG_CRITICAL("Tendencies: ViscDel2 not found in TendConfig");
-      return Err1;
+      return ViscDel2;
    }
 
-   Err = TendConfig->get("VelHyperDiffTendencyEnable",
-                         this->VelocityHyperDiff.Enabled);
-   if (Err != 0) {
+   I4 VelHyperErr = TendConfig->get("VelHyperDiffTendencyEnable",
+                                    this->VelocityHyperDiff.Enabled);
+   if (VelHyperErr != 0) {
       LOG_CRITICAL("Tendencies: VelHyperDiffTendencyEnable not found in "
                    "TendConfig");
-      return Err;
+      return VelHyperErr;
    }
 
-   I4 Err2 = TendConfig->get("ViscDel4", this->VelocityHyperDiff.ViscDel4);
-   if (Err2 != 0 && this->VelocityHyperDiff.Enabled) {
+   I4 ViscDel4 = TendConfig->get("ViscDel4", this->VelocityHyperDiff.ViscDel4);
+   if (ViscDel4 != 0 && this->VelocityHyperDiff.Enabled) {
       LOG_CRITICAL("Tendencies: ViscDel4 not found in TendConfig");
-      return Err2;
+      return ViscDel4;
    }
 
    return Err;

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -26,10 +26,10 @@ namespace OMEGA {
 /// arrays
 class ThicknessFluxDivOnCell {
  public:
-   bool Enabled = false;
+   bool Enabled;
 
    /// constructor declaration
-   ThicknessFluxDivOnCell(const HorzMesh *Mesh, Config *Options);
+   ThicknessFluxDivOnCell(const HorzMesh *Mesh);
 
    /// The functor takes cell index, vertical chunk index, and thickness flux
    /// array as inputs, outputs the tendency array
@@ -70,10 +70,10 @@ class ThicknessFluxDivOnCell {
 /// momentum equation
 class PotentialVortHAdvOnEdge {
  public:
-   bool Enabled = false;
+   bool Enabled;
 
    /// constructor declaration
-   PotentialVortHAdvOnEdge(const HorzMesh *Mesh, Config *Options);
+   PotentialVortHAdvOnEdge(const HorzMesh *Mesh);
 
    /// The functor takes edge index, vertical chunk index, and arrays for
    /// normalized relative vorticity, normalized planetary vorticity, layer
@@ -117,10 +117,10 @@ class PotentialVortHAdvOnEdge {
 /// Gradient of kinetic energy defined on edges, for momentum equation
 class KEGradOnEdge {
  public:
-   bool Enabled = false;
+   bool Enabled;
 
    /// constructor declaration
-   KEGradOnEdge(const HorzMesh *Mesh, Config *Options);
+   KEGradOnEdge(const HorzMesh *Mesh);
 
    /// The functor takes edge index, vertical chunk index, and kinetic energy
    /// array as inputs, outputs the tendency array
@@ -147,10 +147,10 @@ class KEGradOnEdge {
 /// acceleration, for momentum equation
 class SSHGradOnEdge {
  public:
-   bool Enabled = false;
+   bool Enabled;
 
    /// constructor declaration
-   SSHGradOnEdge(const HorzMesh *Mesh, Config *Options);
+   SSHGradOnEdge(const HorzMesh *Mesh);
 
    /// The functor takes edge index, vertical chunk index, and array of
    /// layer thickness/SSH, outputs tendency array
@@ -178,10 +178,12 @@ class SSHGradOnEdge {
 /// Laplacian horizontal mixing, for momentum equation
 class VelocityDiffusionOnEdge {
  public:
-   bool Enabled = false;
+   bool Enabled;
+
+   R8 ViscDel2;
 
    /// constructor declaration
-   VelocityDiffusionOnEdge(const HorzMesh *Mesh, Config *Options);
+   VelocityDiffusionOnEdge(const HorzMesh *Mesh);
 
    /// The functor takes edge index, vertical chunk index, and arrays for
    /// divergence of horizontal velocity (defined at cell centers) and relative
@@ -213,7 +215,6 @@ class VelocityDiffusionOnEdge {
    }
 
  private:
-   R8 ViscDel2 = 1._Real;
    Array2DI4 CellsOnEdge;
    Array2DI4 VerticesOnEdge;
    Array1DR8 DcEdge;
@@ -225,10 +226,12 @@ class VelocityDiffusionOnEdge {
 /// Biharmonic horizontal mixing, for momentum equation
 class VelocityHyperDiffOnEdge {
  public:
-   bool Enabled = false;
+   bool Enabled;
+
+   Real ViscDel4;
 
    /// Constructor declaration
-   VelocityHyperDiffOnEdge(const HorzMesh *Mesh, Config *Options);
+   VelocityHyperDiffOnEdge(const HorzMesh *Mesh);
 
    /// The functor takes the edge index, vertical chunk index, and arrays for
    /// the laplacian of divergence of horizontal velocity and the laplacian of
@@ -260,7 +263,6 @@ class VelocityHyperDiffOnEdge {
    }
 
  private:
-   Real ViscDel4 = 1._Real;
    Array2DI4 CellsOnEdge;
    Array2DI4 VerticesOnEdge;
    Array1DR8 DcEdge;
@@ -351,6 +353,9 @@ class Tendencies {
    // get tendencies by name
    static Tendencies *get(const std::string &Name ///< [in]
    );
+
+   // read and set config options
+   int readTendConfig(Config *TendConfig);
 
  private:
    // Construct a new tendency object

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
@@ -1,4 +1,5 @@
 #include "LayerThicknessAuxVars.h"
+#include "Config.h"
 #include "Field.h"
 
 #include <limits>
@@ -13,7 +14,25 @@ LayerThicknessAuxVars::LayerThicknessAuxVars(const std::string &AuxStateSuffix,
       MeanLayerThickEdge("MeanLayerThickEdge" + AuxStateSuffix,
                          Mesh->NEdgesSize, NVertLevels),
       SshCell("SshCell" + AuxStateSuffix, Mesh->NCellsSize, NVertLevels),
-      CellsOnEdge(Mesh->CellsOnEdge), BottomDepth(Mesh->BottomDepth) {}
+      CellsOnEdge(Mesh->CellsOnEdge), BottomDepth(Mesh->BottomDepth) {
+
+   I4 Err = 0;
+
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config AdvectConfig("Advection");
+   if (OmegaConfig->existsGroup("Advection")) {
+      std::string FluxThickTypeStr;
+      Err = OmegaConfig->get(AdvectConfig);
+      if (AdvectConfig.existsVar("FluxThicknessType")) {
+         Err = AdvectConfig.get("FluxThicknessType", FluxThickTypeStr);
+         if (FluxThickTypeStr == "Center") {
+            FluxThickEdgeChoice = Center;
+         } else if (FluxThickTypeStr == "Upwind") {
+            FluxThickEdgeChoice = Upwind;
+         }
+      }
+   }
+}
 
 void LayerThicknessAuxVars::registerFields(const std::string &AuxGroupName,
                                            const std::string &MeshName) const {

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
@@ -14,25 +14,7 @@ LayerThicknessAuxVars::LayerThicknessAuxVars(const std::string &AuxStateSuffix,
       MeanLayerThickEdge("MeanLayerThickEdge" + AuxStateSuffix,
                          Mesh->NEdgesSize, NVertLevels),
       SshCell("SshCell" + AuxStateSuffix, Mesh->NCellsSize, NVertLevels),
-      CellsOnEdge(Mesh->CellsOnEdge), BottomDepth(Mesh->BottomDepth) {
-
-   I4 Err = 0;
-
-   Config *OmegaConfig = Config::getOmegaConfig();
-   Config AdvectConfig("Advection");
-   if (OmegaConfig->existsGroup("Advection")) {
-      std::string FluxThickTypeStr;
-      Err = OmegaConfig->get(AdvectConfig);
-      if (AdvectConfig.existsVar("FluxThicknessType")) {
-         Err = AdvectConfig.get("FluxThicknessType", FluxThickTypeStr);
-         if (FluxThickTypeStr == "Center") {
-            FluxThickEdgeChoice = Center;
-         } else if (FluxThickTypeStr == "Upwind") {
-            FluxThickEdgeChoice = Upwind;
-         }
-      }
-   }
-}
+      CellsOnEdge(Mesh->CellsOnEdge), BottomDepth(Mesh->BottomDepth) {}
 
 void LayerThicknessAuxVars::registerFields(const std::string &AuxGroupName,
                                            const std::string &MeshName) const {

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
@@ -17,7 +17,7 @@ class LayerThicknessAuxVars {
    Array2DReal MeanLayerThickEdge;
    Array2DReal SshCell;
 
-   FluxThickEdgeOption FluxThickEdgeChoice = Center;
+   FluxThickEdgeOption FluxThickEdgeChoice;
 
    LayerThicknessAuxVars(const std::string &AuxStateSuffix,
                          const HorzMesh *Mesh, int NVertLevels);

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
@@ -17,7 +17,6 @@ class LayerThicknessAuxVars {
    Array2DReal MeanLayerThickEdge;
    Array2DReal SshCell;
 
-   // TODO(mwarusz): get this from config
    FluxThickEdgeOption FluxThickEdgeChoice = Center;
 
    LayerThicknessAuxVars(const std::string &AuxStateSuffix,

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -93,7 +93,7 @@ int TimeStepper::init() {
       if (TimeIntConfig.existsVar("TimeStep")) {
          std::string TimeStepStr;
          Err      = TimeIntConfig.get("TimeStep", TimeStepStr);
-         TimeStep = TimeInterval::TimeInterval(TimeStepStr);
+         TimeStep = TimeInterval(TimeStepStr);
       }
       if (TimeIntConfig.existsVar("TimeStepper")) {
          std::string TimeStepperStr;

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -2,6 +2,7 @@
 //-*-===//
 
 #include "TimeStepper.h"
+#include "Config.h"
 #include "ForwardBackwardStepper.h"
 #include "RungeKutta2Stepper.h"
 #include "RungeKutta4Stepper.h"
@@ -12,6 +13,21 @@ namespace OMEGA {
 TimeStepper *TimeStepper::DefaultTimeStepper = nullptr;
 std::map<std::string, std::unique_ptr<TimeStepper>>
     TimeStepper::AllTimeSteppers;
+
+// convert string into TimeStepperType enum
+TimeStepperType getTimeStepperFromStr(const std::string &InString) {
+
+   TimeStepperType TimeStepperChoice;
+   if (InString == "Forward-Backward") {
+      TimeStepperChoice = TimeStepperType::ForwardBackward;
+   } else if (InString == "RungeKutta4") {
+      TimeStepperChoice = TimeStepperType::RungeKutta4;
+   } else if (InString == "RungeKutta2") {
+      TimeStepperChoice = TimeStepperType::RungeKutta2;
+   }
+
+   return TimeStepperChoice;
+}
 
 // Constructor. Construct a time stepper from name, type, tendencies, auxiliary
 // state, mesh and halo
@@ -65,9 +81,31 @@ int TimeStepper::init() {
    auto *DefHalo     = Halo::getDefault();
    auto *DefTend     = Tendencies::getDefault();
 
-   TimeStepper::DefaultTimeStepper =
-       create("Default", TimeStepperType::ForwardBackward, DefTend, DefAuxState,
-              DefMesh, DefHalo);
+   // Initialize default options
+   TimeInterval TimeStep;
+   TimeStepperType TimeStepperChoice = TimeStepperType::ForwardBackward;
+
+   // Retrieve TimeStepper options from Config if available
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config TimeIntConfig("TimeIntegration");
+   if (OmegaConfig->existsGroup("TimeIntegration")) {
+      Err = OmegaConfig->get(TimeIntConfig);
+      if (TimeIntConfig.existsVar("TimeStep")) {
+         std::string TimeStepStr;
+         Err      = TimeIntConfig.get("TimeStep", TimeStepStr);
+         TimeStep = TimeInterval::TimeInterval(TimeStepStr);
+      }
+      if (TimeIntConfig.existsVar("TimeStepper")) {
+         std::string TimeStepperStr;
+         Err               = TimeIntConfig.get("TimeStepper", TimeStepperStr);
+         TimeStepperChoice = getTimeStepperFromStr(TimeStepperStr);
+      }
+   }
+
+   TimeStepper::DefaultTimeStepper = create(
+       "Default", TimeStepperChoice, DefTend, DefAuxState, DefMesh, DefHalo);
+   DefaultTimeStepper->setTimeStep(TimeStep);
+
    return Err;
 }
 

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -81,26 +81,32 @@ int TimeStepper::init() {
    auto *DefHalo     = Halo::getDefault();
    auto *DefTend     = Tendencies::getDefault();
 
-   // Initialize default options
    TimeInterval TimeStep;
-   TimeStepperType TimeStepperChoice = TimeStepperType::ForwardBackward;
+   TimeStepperType TimeStepperChoice;
 
    // Retrieve TimeStepper options from Config if available
    Config *OmegaConfig = Config::getOmegaConfig();
    Config TimeIntConfig("TimeIntegration");
-   if (OmegaConfig->existsGroup("TimeIntegration")) {
-      Err = OmegaConfig->get(TimeIntConfig);
-      if (TimeIntConfig.existsVar("TimeStep")) {
-         std::string TimeStepStr;
-         Err      = TimeIntConfig.get("TimeStep", TimeStepStr);
-         TimeStep = TimeInterval(TimeStepStr);
-      }
-      if (TimeIntConfig.existsVar("TimeStepper")) {
-         std::string TimeStepperStr;
-         Err               = TimeIntConfig.get("TimeStepper", TimeStepperStr);
-         TimeStepperChoice = getTimeStepperFromStr(TimeStepperStr);
-      }
+   Err = OmegaConfig->get(TimeIntConfig);
+   if (Err != 0) {
+      LOG_CRITICAL("TimeStepper: TimeIntegration group not found in Config");
+      return Err;
    }
+   std::string TimeStepStr;
+   Err = TimeIntConfig.get("TimeStep", TimeStepStr);
+   if (Err != 0) {
+      LOG_CRITICAL("TimeStepper: TimeStep not found in TimeIntConfig");
+      return Err;
+   }
+   TimeStep = TimeInterval(TimeStepStr);
+
+   std::string TimeStepperStr;
+   Err = TimeIntConfig.get("TimeStepper", TimeStepperStr);
+   if (Err != 0) {
+      LOG_CRITICAL("TimeStepper: TimeStepper not found in TimeIntConfig");
+      return Err;
+   }
+   TimeStepperChoice = getTimeStepperFromStr(TimeStepperStr);
 
    TimeStepper::DefaultTimeStepper = create(
        "Default", TimeStepperChoice, DefTend, DefAuxState, DefMesh, DefHalo);

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -29,6 +29,11 @@ namespace OMEGA {
 /// needs to extended every time a new time stepper is added
 enum class TimeStepperType { ForwardBackward, RungeKutta4, RungeKutta2 };
 
+/// Translate string for time stepper type into enum
+TimeStepperType getTimeStepperFromStr(
+    const std::string &InString ///< [in] choice of time stepping method
+);
+
 //------------------------------------------------------------------------------
 /// A base class for Omega time steppers
 ///

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -316,3 +316,14 @@ add_omega_test(
     infra/OmegaKokkosTest.cpp
     "-n;1"
 )
+
+##################
+# Driver test
+##################
+
+add_omega_test(
+    DRIVER_TEST
+    testDriver.exe
+    drivers/StandaloneDriverTest.cpp
+    "-n;8"
+)

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -39,7 +39,7 @@ int initDecompTest() {
    OMEGA::initLogging(DefEnv);
 
    // Open config file
-   OMEGA::Config("omega");
+   OMEGA::Config("Omega");
    Err = OMEGA::Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("DecompTest: Error reading config file");

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -12,6 +12,7 @@
 //===-----------------------------------------------------------------------===/
 
 #include "Decomp.h"
+#include "Config.h"
 #include "DataTypes.h"
 #include "IO.h"
 #include "Logging.h"
@@ -36,6 +37,14 @@ int initDecompTest() {
    MPI_Comm DefComm       = DefEnv->getComm();
 
    OMEGA::initLogging(DefEnv);
+
+   // Open config file
+   OMEGA::Config("omega");
+   Err = OMEGA::Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("DecompTest: Error reading config file");
+      return Err;
+   }
 
    // Initialize the IO system
    Err = OMEGA::IO::init(DefComm);

--- a/components/omega/test/base/HaloTest.cpp
+++ b/components/omega/test/base/HaloTest.cpp
@@ -111,7 +111,7 @@ int initHaloTest() {
    OMEGA::initLogging(DefEnv);
 
    // Open config file
-   OMEGA::Config("omega");
+   OMEGA::Config("Omega");
    IErr = OMEGA::Config::readAll("omega.yml");
    if (IErr != 0) {
       LOG_CRITICAL("HaloTest: Error reading config file");

--- a/components/omega/test/base/HaloTest.cpp
+++ b/components/omega/test/base/HaloTest.cpp
@@ -15,6 +15,7 @@
 //===-----------------------------------------------------------------------===/
 
 #include "Halo.h"
+#include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "IO.h"
@@ -108,6 +109,14 @@ int initHaloTest() {
 
    // Initialize the logging system
    OMEGA::initLogging(DefEnv);
+
+   // Open config file
+   OMEGA::Config("omega");
+   IErr = OMEGA::Config::readAll("omega.yml");
+   if (IErr != 0) {
+      LOG_CRITICAL("HaloTest: Error reading config file");
+      return IErr;
+   }
 
    // Initialize the IO system
    IErr = OMEGA::IO::init(DefComm);

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -38,7 +38,7 @@ int initIOTest() {
    OMEGA::initLogging(DefEnv);
 
    // Open config file
-   OMEGA::Config("omega");
+   OMEGA::Config("Omega");
    Err = OMEGA::Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("IOTest: Error reading config file");

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -10,6 +10,7 @@
 //===-----------------------------------------------------------------------===/
 
 #include "IO.h"
+#include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "Logging.h"
@@ -35,6 +36,14 @@ int initIOTest() {
 
    // Initialize the Logging system
    OMEGA::initLogging(DefEnv);
+
+   // Open config file
+   OMEGA::Config("omega");
+   Err = OMEGA::Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("IOTest: Error reading config file");
+      return Err;
+   }
 
    // Initialize the IO system
    Err = OMEGA::IO::init(DefComm);

--- a/components/omega/test/drivers/StandaloneDriverTest.cpp
+++ b/components/omega/test/drivers/StandaloneDriverTest.cpp
@@ -1,0 +1,73 @@
+//===-- Test driver for Omega standalone driver  -----------------*- C++ -*-===/
+//
+/// \file
+/// \brief Test driver for Omega standalone driver
+///
+/// This driver runs the standalone model to confirm that the initialization
+/// phase builds all the necessary modules, the run phase successfully
+/// integrates the model a few time steps, and the finalization phase
+/// successfully cleans up all objects and exits without error.
+///
+//
+//===-----------------------------------------------------------------------===/
+
+#include "OceanDriver.h"
+#include "OmegaKokkos.h"
+#include "TimeMgr.h"
+
+#include "mpi.h"
+
+//------------------------------------------------------------------------------
+// The test driver for the standalone driver
+//
+int main(int argc, char *argv[]) {
+
+   OMEGA::I4 ErrAll;
+   OMEGA::I4 Err1;
+   OMEGA::I4 Err2;
+
+   MPI_Init(&argc, &argv); // initialize MPI
+   Kokkos::initialize();   // initialize Kokkos
+
+   // Time management objects
+   OMEGA::Calendar OmegaCal;
+   OMEGA::TimeInstant CurrTime;
+   OMEGA::Alarm EndAlarm;
+
+   Err1 = OMEGA::ocnInit(MPI_COMM_WORLD, OmegaCal, CurrTime, EndAlarm);
+   if (Err1 == 0) {
+      LOG_INFO("DriverTest: Omega initialize PASS");
+   } else {
+      LOG_INFO("DriverTest: Omega initialize FAIL");
+   }
+
+   if (Err1 == 0) {
+      Err1 = OMEGA::ocnRun(CurrTime, EndAlarm);
+   }
+   if (Err1 == 0) {
+      LOG_INFO("DriverTest: Omega model run PASS");
+   } else {
+      LOG_INFO("DriverTest: Omega model run FAIL");
+   }
+
+   Err2 = OMEGA::ocnFinalize(CurrTime);
+   if (Err2 == 0) {
+      LOG_INFO("DriverTest: Omega finalize PASS");
+   } else {
+      LOG_INFO("DriverTest: Omega finalize FAIL");
+   }
+
+   ErrAll = abs(Err1) + abs(Err2);
+   if (ErrAll == 0) {
+      LOG_INFO("DriverTest: Successful completion");
+   }
+
+   Kokkos::finalize();
+   MPI_Finalize();
+
+   if (ErrAll >= 256)
+      ErrAll = 255;
+   return ErrAll;
+
+} // end of main
+//===-----------------------------------------------------------------------===/

--- a/components/omega/test/drivers/StandaloneDriverTest.cpp
+++ b/components/omega/test/drivers/StandaloneDriverTest.cpp
@@ -23,8 +23,8 @@
 int main(int argc, char *argv[]) {
 
    OMEGA::I4 ErrAll;
-   OMEGA::I4 Err1;
-   OMEGA::I4 Err2;
+   OMEGA::I4 ErrCurr;
+   OMEGA::I4 ErrFinalize;
 
    MPI_Init(&argc, &argv); // initialize MPI
    Kokkos::initialize();   // initialize Kokkos
@@ -34,30 +34,30 @@ int main(int argc, char *argv[]) {
    OMEGA::TimeInstant CurrTime;
    OMEGA::Alarm EndAlarm;
 
-   Err1 = OMEGA::ocnInit(MPI_COMM_WORLD, OmegaCal, CurrTime, EndAlarm);
-   if (Err1 == 0) {
+   ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD, OmegaCal, CurrTime, EndAlarm);
+   if (ErrCurr == 0) {
       LOG_INFO("DriverTest: Omega initialize PASS");
    } else {
       LOG_INFO("DriverTest: Omega initialize FAIL");
    }
 
-   if (Err1 == 0) {
-      Err1 = OMEGA::ocnRun(CurrTime, EndAlarm);
+   if (ErrCurr == 0) {
+      ErrCurr = OMEGA::ocnRun(CurrTime, EndAlarm);
    }
-   if (Err1 == 0) {
+   if (ErrCurr == 0) {
       LOG_INFO("DriverTest: Omega model run PASS");
    } else {
       LOG_INFO("DriverTest: Omega model run FAIL");
    }
 
-   Err2 = OMEGA::ocnFinalize(CurrTime);
-   if (Err2 == 0) {
+   ErrFinalize = OMEGA::ocnFinalize(CurrTime);
+   if (ErrFinalize == 0) {
       LOG_INFO("DriverTest: Omega finalize PASS");
    } else {
       LOG_INFO("DriverTest: Omega finalize FAIL");
    }
 
-   ErrAll = abs(Err1) + abs(Err2);
+   ErrAll = abs(ErrCurr) + abs(ErrFinalize);
    if (ErrAll == 0) {
       LOG_INFO("DriverTest: Successful completion");
    }

--- a/components/omega/test/infra/ConfigTest.cpp
+++ b/components/omega/test/infra/ConfigTest.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[]) {
    // Define some variables for a reference configuration
    // These are meant to create a hierachy that tests at least two levels
    // and includes a variable of each supported type.
-   // omega:
+   // Omega:
    //   Hmix:
    //     HmixOn: true
    //     HmixI4: 3
@@ -109,8 +109,8 @@ int main(int argc, char *argv[]) {
                                     "fifth"};
 
    // Build up a reference configuration
-   OMEGA::Config ConfigOmegaAll("omegaroot");
-   OMEGA::Config ConfigOmegaRef("omega");
+   OMEGA::Config ConfigOmegaAll("Omegaroot");
+   OMEGA::Config ConfigOmegaRef("Omega");
    OMEGA::Config ConfigHmixRef("Hmix");
    OMEGA::Config ConfigHmixDel2Ref("HmixDel2");
    OMEGA::Config ConfigVmixRef("Vmix");

--- a/components/omega/test/infra/DimensionTest.cpp
+++ b/components/omega/test/infra/DimensionTest.cpp
@@ -10,6 +10,7 @@
 //===-----------------------------------------------------------------------===/
 
 #include "Dimension.h"
+#include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "IO.h"
@@ -37,6 +38,14 @@ int initDimensionTest() {
    Err              = IO::init(DefComm);
    if (Err != 0) {
       LOG_ERROR("IO initialization failed");
+      return Err;
+   }
+
+   // Open config file
+   OMEGA::Config("omega");
+   Err = OMEGA::Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("DimensionTest: Error reading config file");
       return Err;
    }
 

--- a/components/omega/test/infra/DimensionTest.cpp
+++ b/components/omega/test/infra/DimensionTest.cpp
@@ -42,7 +42,7 @@ int initDimensionTest() {
    }
 
    // Open config file
-   OMEGA::Config("omega");
+   OMEGA::Config("Omega");
    Err = OMEGA::Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("DimensionTest: Error reading config file");

--- a/components/omega/test/infra/FieldTest.cpp
+++ b/components/omega/test/infra/FieldTest.cpp
@@ -63,7 +63,7 @@ int initFieldTest() {
    }
 
    // Open config file
-   OMEGA::Config("omega");
+   OMEGA::Config("Omega");
    Err = OMEGA::Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("FieldTest: Error reading config file");

--- a/components/omega/test/infra/FieldTest.cpp
+++ b/components/omega/test/infra/FieldTest.cpp
@@ -10,6 +10,7 @@
 //===-----------------------------------------------------------------------===/
 
 #include "Field.h"
+#include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "Dimension.h"
@@ -58,6 +59,14 @@ int initFieldTest() {
    Err              = IO::init(DefComm);
    if (Err != 0) {
       LOG_ERROR("IO initialization failed");
+      return Err;
+   }
+
+   // Open config file
+   OMEGA::Config("omega");
+   Err = OMEGA::Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("FieldTest: Error reading config file");
       return Err;
    }
 

--- a/components/omega/test/infra/TimeMgrTest.cpp
+++ b/components/omega/test/infra/TimeMgrTest.cpp
@@ -2952,6 +2952,19 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: isPositive: FAIL");
    }
 
+   // Test time interval constructor from string
+   std::string TiStr = "1001_11:23:45.375";
+   OMEGA::TimeInterval TiTstStr(TiStr);
+   RRef = 86527425.375;
+   Err1 = TiTstStr.get(RTst, OMEGA::TimeUnits::Seconds);
+
+   if (Err1 == 0 && RTst == RRef) {
+      LOG_INFO("TimeMgrTest/TimeInterval: string constructor: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInterval: string constructor: FAIL");
+   }
+
    return ErrAll;
 
 } // end testTimeInterval

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -76,7 +76,7 @@ int initAuxStateTest(const std::string &mesh) {
    initLogging(DefEnv);
 
    // Open config file
-   Config("omega");
+   Config("Omega");
    Err = Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("AuxStateTest: Error reading config file");

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -1,4 +1,5 @@
 #include "AuxiliaryState.h"
+#include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "Dimension.h"
@@ -71,6 +72,16 @@ int initAuxStateTest(const std::string &mesh) {
    MachEnv::init(MPI_COMM_WORLD);
    MachEnv *DefEnv  = MachEnv::getDefault();
    MPI_Comm DefComm = DefEnv->getComm();
+
+   initLogging(DefEnv);
+
+   // Open config file
+   Config("omega");
+   Err = Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("AuxStateTest: Error reading config file");
+      return Err;
+   }
 
    int IOErr = IO::init(DefComm);
    if (IOErr != 0) {

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -634,7 +634,7 @@ int initAuxVarsTest(const std::string &mesh) {
    initLogging(DefEnv);
 
    // Open config file
-   OMEGA::Config("omega");
+   OMEGA::Config("Omega");
    Err = OMEGA::Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("AuxVarsTest: Error reading config file");

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -1,3 +1,4 @@
+#include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "Dimension.h"
@@ -631,6 +632,14 @@ int initAuxVarsTest(const std::string &mesh) {
 
    // initialize logging
    initLogging(DefEnv);
+
+   // Open config file
+   OMEGA::Config("omega");
+   Err = OMEGA::Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("AuxVarsTest: Error reading config file");
+      return Err;
+   }
 
    int IOErr = IO::init(DefComm);
    if (IOErr != 0) {

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -9,6 +9,7 @@
 //===-----------------------------------------------------------------------===/
 
 #include "HorzMesh.h"
+#include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "Dimension.h"
@@ -38,6 +39,14 @@ int initHorzMeshTest() {
 
    // Initialize the Logging system
    OMEGA::initLogging(DefEnv);
+
+   // Open config file
+   OMEGA::Config("omega");
+   Err = OMEGA::Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("HorzMeshTest: Error reading config file");
+      return Err;
+   }
 
    // Initialize the IO system
    Err = OMEGA::IO::init(DefComm);

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -41,7 +41,7 @@ int initHorzMeshTest() {
    OMEGA::initLogging(DefEnv);
 
    // Open config file
-   OMEGA::Config("omega");
+   OMEGA::Config("Omega");
    Err = OMEGA::Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("HorzMeshTest: Error reading config file");

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -371,7 +371,7 @@ int initOperatorsTest(const std::string &MeshFile) {
    initLogging(DefEnv);
 
    // Open config file
-   OMEGA::Config("omega");
+   OMEGA::Config("Omega");
    Err = OMEGA::Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("OperatorsTest: Error reading config file");

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -1,4 +1,5 @@
 #include "HorzOperators.h"
+#include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "Dimension.h"
@@ -368,6 +369,14 @@ int initOperatorsTest(const std::string &MeshFile) {
 
    // Initialize the Logging system
    initLogging(DefEnv);
+
+   // Open config file
+   OMEGA::Config("omega");
+   Err = OMEGA::Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("OperatorsTest: Error reading config file");
+      return Err;
+   }
 
    int IOErr = IO::init(DefComm);
    if (IOErr != 0) {

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -9,6 +9,7 @@
 //
 //===-----------------------------------------------------------------------===/
 
+#include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "Dimension.h"
@@ -39,6 +40,16 @@ int initStateTest() {
    OMEGA::MachEnv::init(MPI_COMM_WORLD);
    OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
    MPI_Comm DefComm       = DefEnv->getComm();
+
+   OMEGA::initLogging(DefEnv);
+
+   // Open config file
+   OMEGA::Config("omega");
+   Err = OMEGA::Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("State: Error reading config file");
+      return Err;
+   }
 
    // Initialize the IO system
    Err = OMEGA::IO::init(DefComm);

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -44,7 +44,7 @@ int initStateTest() {
    OMEGA::initLogging(DefEnv);
 
    // Open config file
-   OMEGA::Config("omega");
+   OMEGA::Config("Omega");
    Err = OMEGA::Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("State: Error reading config file");

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -156,7 +156,7 @@ int testTendencies() {
 
    const auto *Mesh = HorzMesh::getDefault();
    // test creation of another tendencies
-   Config *Options;
+   Config *Options = Config::getOmegaConfig();
    Tendencies::create("TestTendencies", Mesh, 12, Options);
 
    // test retrievel of another tendencies

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -74,6 +74,16 @@ int initTendenciesTest(const std::string &mesh) {
    MachEnv *DefEnv  = MachEnv::getDefault();
    MPI_Comm DefComm = DefEnv->getComm();
 
+   initLogging(DefEnv);
+
+   // Open config file
+   Config("omega");
+   Err = Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("TendenciesTest: Error reading config file");
+      return Err;
+   }
+
    int IOErr = IO::init(DefComm);
    if (IOErr != 0) {
       Err++;

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -77,7 +77,7 @@ int initTendenciesTest(const std::string &mesh) {
    initLogging(DefEnv);
 
    // Open config file
-   Config("omega");
+   Config("Omega");
    Err = Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("TendenciesTest: Error reading config file");

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -196,8 +196,8 @@ int testThickFluxDiv(int NVertLevels, Real RTol) {
    TestSetup Setup;
 
    const auto Mesh = HorzMesh::getDefault();
-   // TODO: implement config, dummy config for now
-   Config *TendConfig;
+
+   Config *TendConfig = Config::getOmegaConfig();
 
    // Compute exact result
    Array2DReal ExactThickFluxDiv("ExactThickFluxDiv", Mesh->NCellsOwned,
@@ -260,8 +260,8 @@ int testPotVortHAdv(int NVertLevels, Real RTol) {
    TestSetup Setup;
 
    const auto Mesh = HorzMesh::getDefault();
-   // TODO: implement config, dummy config for now
-   Config *TendConfig;
+
+   Config *TendConfig = Config::getOmegaConfig();
 
    // Compute exact result
    Array2DReal ExactPotVortHAdv("ExactPotVortHAdv", Mesh->NEdgesOwned,
@@ -344,8 +344,8 @@ int testKEGrad(int NVertLevels, Real RTol) {
    TestSetup Setup;
 
    const auto Mesh = HorzMesh::getDefault();
-   // TODO: implement config, dummy config for now
-   Config *TendConfig;
+
+   Config *TendConfig = Config::getOmegaConfig();
 
    // Compute exact result
    Array2DReal ExactKEGrad("ExactKEGrad", Mesh->NEdgesOwned, NVertLevels);
@@ -403,8 +403,8 @@ int testSSHGrad(int NVertLevels, Real RTol) {
    TestSetup Setup;
 
    const auto Mesh = HorzMesh::getDefault();
-   // TODO: implement config, dummy config for now
-   Config *TendConfig;
+
+   Config *TendConfig = Config::getOmegaConfig();
 
    // Compute exact result
    Array2DReal ExactSSHGrad("ExactSSHGrad", Mesh->NEdgesOwned, NVertLevels);
@@ -462,8 +462,8 @@ int testVelDiff(int NVertLevels, Real RTol) {
    TestSetup Setup;
 
    const auto Mesh = HorzMesh::getDefault();
-   // TODO: implement config, dummy config for now
-   Config *TendConfig;
+
+   Config *TendConfig = Config::getOmegaConfig();
 
    // TODO: move to Mesh constructor
    Mesh->setMasks(NVertLevels);
@@ -530,8 +530,8 @@ int testVelHyperDiff(int NVertLevels, Real RTol) {
    TestSetup Setup;
 
    const auto Mesh = HorzMesh::getDefault();
-   // TODO: implement config, dummy config for now
-   Config *TendConfig;
+
+   Config *TendConfig = Config::getOmegaConfig();
 
    // TODO: move to Mesh constructor
    Mesh->setMasks(NVertLevels);

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -613,7 +613,7 @@ int initTendTest(const std::string &mesh) {
    initLogging(DefEnv);
 
    // Open config file
-   Config("omega");
+   Config("Omega");
    Err = Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("TendencyTermsTest: Error reading config file");

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -195,7 +195,6 @@ int initTimeStepperTest(const std::string &mesh) {
    Config Options;
 
    // Creating non-default tendencies with custom velocity tendencies
-   // All other tendencies are disabled by default
    auto *TestTendencies = Tendencies::create(
        "TestTendencies", DefMesh, NVertLevels, &Options,
        Tendencies::CustomTendencyType{}, DecayVelocityTendency{});
@@ -203,6 +202,14 @@ int initTimeStepperTest(const std::string &mesh) {
       Err++;
       LOG_ERROR("TimeStepperTest: error creating test tendencies");
    }
+
+   // Disable all other tendencies
+   TestTendencies->ThicknessFluxDiv.Enabled   = false;
+   TestTendencies->PotientialVortHAdv.Enabled = false;
+   TestTendencies->KEGrad.Enabled             = false;
+   TestTendencies->SSHGrad.Enabled            = false;
+   TestTendencies->VelocityDiffusion.Enabled  = false;
+   TestTendencies->VelocityHyperDiff.Enabled  = false;
 
    return Err;
 }

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -133,6 +133,16 @@ int initTimeStepperTest(const std::string &mesh) {
 
    // Default init
 
+   initLogging(DefEnv);
+
+   // Open config file
+   OMEGA::Config("omega");
+   Err = OMEGA::Config::readAll("omega.yml");
+   if (Err != 0) {
+      LOG_CRITICAL("TimeStepperTest: Error reading config file");
+      return Err;
+   }
+
    int IOErr = IO::init(DefComm);
    if (IOErr != 0) {
       Err++;

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -136,7 +136,7 @@ int initTimeStepperTest(const std::string &mesh) {
    initLogging(DefEnv);
 
    // Open config file
-   OMEGA::Config("omega");
+   OMEGA::Config("Omega");
    Err = OMEGA::Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("TimeStepperTest: Error reading config file");


### PR DESCRIPTION
Implements a standalone driver for Omega. Changes include:
 
- Adds ocnInit, ocnRun, and ocnFinalize methods
- Top-level standalone driver with `main` function
- Standalone driver unit test
- Edits several Omega modules to check for configuration options
- Edits CMake build to use standalone driver to build omega.exe
- Fixes and updates for TimeMgr module
- Add configs directory with default yaml config files

Unit tests pass on Chrysalis and Perlmutter CPU & GPU. The unit tests now require a yaml config file named omega.yml in the test directory, copy the UnitTests.yml config file from the configs directory into the test directory and rename it omega.yml:
`cp {omega_repo}/components/omega/configs/UnitTests.yml {build_dir}/test/omega.yml`

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


