### PR TITLE
Remove comment from Default.yml

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -2,7 +2,7 @@ Omega:
    TimeManagement:
       StartTime: 0001-01-01_00:00:00
       StopTime: 0001-01-01_02:00:00
-      RunDuration: none #0000_02:00:00.000
+      RunDuration: none
       CalendarType: No Leap
    TimeIntegration:
       TimeStepper: Forward-Backward


### PR DESCRIPTION
This comment persists even if the config option is updated, which proves confusing, e.g.:
```yaml
Omega:
  TimeManagement:
    StartTime: 0001-01-01_00:00:00
    StopTime: none
    RunDuration: 0000_10:00:00.000 #0000_02:00:00.000
    CalendarType: No Leap
  TimeIntegration:
    TimeStepper: Forward-Backward
    TimeStep: 0000_01:40:00.000
  Dimension:
    NVertLevels: 60
  Decomp:
    HaloWidth: 3
    DecompMethod: MetisKWay

```

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


