### PR TITLE
Fix warning when `RunDuration` and `StopTime` are inconsistent

### DIFF
--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -140,8 +140,10 @@ int initTimeManagement(Calendar &OmegaCal, TimeInstant &StartTime,
    } else if (RunDurationStr != NoneStr) {
       TimeInterval IntervalFromStr(RunDurationStr);
       if (IntervalFromStr != RunInterval) {
-         LOG_WARN("ocnInit: RunDuration and StopTime are inconsistent: "
-                  "using RunDuration");
+         if (StopTimeStr != NoneStr) {
+            LOG_WARN("ocnInit: RunDuration and StopTime are inconsistent: "
+                     "using RunDuration");
+         }
          RunInterval = IntervalFromStr;
       }
    }


### PR DESCRIPTION
This warning should only be displayed if `StopTime` is not `'none'`.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [ ] CTest unit tests for new features have been added per the approved design. 

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


