### PR TITLE
Indent YAMLs by 2 spaces, not 3.

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -1,27 +1,27 @@
 Omega:
-   TimeManagement:
-      StartTime: 0001-01-01_00:00:00
-      StopTime: 0001-01-01_02:00:00
-      RunDuration: none
-      CalendarType: No Leap
-   TimeIntegration:
-      TimeStepper: Forward-Backward
-      TimeStep: 0000_00:10:00
-   Dimension:
-      NVertLevels: 60
-   Decomp:
-      HaloWidth: 3
-      DecompMethod: MetisKWay
-   State:
-      NTimeLevels: 2
-   Advection:
-      FluxThicknessType: Center
-   Tendencies:
-      ThicknessFluxTendencyEnable: true
-      PVTendencyEnable: true
-      KETendencyEnable: true
-      SSHTendencyEnable: true
-      VelDiffTendencyEnable: true
-      ViscDel2: 1.0e3
-      VelHyperDiffTendencyEnable: true
-      ViscDel4: 1.2e11
+  TimeManagement:
+    StartTime: 0001-01-01_00:00:00
+    StopTime: 0001-01-01_02:00:00
+    RunDuration: none
+    CalendarType: No Leap
+  TimeIntegration:
+    TimeStepper: Forward-Backward
+    TimeStep: 0000_00:10:00
+  Dimension:
+    NVertLevels: 60
+  Decomp:
+    HaloWidth: 3
+    DecompMethod: MetisKWay
+  State:
+    NTimeLevels: 2
+  Advection:
+    FluxThicknessType: Center
+  Tendencies:
+    ThicknessFluxTendencyEnable: true
+    PVTendencyEnable: true
+    KETendencyEnable: true
+    SSHTendencyEnable: true
+    VelDiffTendencyEnable: true
+    ViscDel2: 1.0e3
+    VelHyperDiffTendencyEnable: true
+    ViscDel4: 1.2e11

--- a/components/omega/configs/UnitTests.yml
+++ b/components/omega/configs/UnitTests.yml
@@ -1,25 +1,25 @@
 Omega:
-   TimeManagement:
-      StartTime: 0001-01-01_00:00:00
-      StopTime: 0001-01-01_02:00:00
-      RunDuration: none
-      CalendarType: No Leap
-   TimeIntegration:
-      TimeStepper: Forward-Backward
-      TimeStep: 0000_00:30:00
-   Dimension:
-      NVertLevels: 60
-   Decomp:
-      HaloWidth: 3
-      DecompMethod: MetisKWay
-   Advection:
-      FluxThicknessType: Center
-   Tendencies:
-      ThicknessFluxTendencyEnable: true
-      PVTendencyEnable: true
-      KETendencyEnable: true
-      SSHTendencyEnable: true
-      VelDiffTendencyEnable: true
-      ViscDel2: 1.0
-      VelHyperDiffTendencyEnable: true
-      ViscDel4: 1.0
+  TimeManagement:
+    StartTime: 0001-01-01_00:00:00
+    StopTime: 0001-01-01_02:00:00
+    RunDuration: none
+    CalendarType: No Leap
+  TimeIntegration:
+    TimeStepper: Forward-Backward
+    TimeStep: 0000_00:30:00
+  Dimension:
+    NVertLevels: 60
+  Decomp:
+    HaloWidth: 3
+    DecompMethod: MetisKWay
+  Advection:
+    FluxThicknessType: Center
+  Tendencies:
+    ThicknessFluxTendencyEnable: true
+    PVTendencyEnable: true
+    KETendencyEnable: true
+    SSHTendencyEnable: true
+    VelDiffTendencyEnable: true
+    ViscDel2: 1.0
+    VelHyperDiffTendencyEnable: true
+    ViscDel4: 1.0


### PR DESCRIPTION
This is a pretty standard convention in my experience and it is what Polaris uses.  This may seems like a triviality but it makes copying and pasting from the default YAML to Polaris YAMLs unnecessarily difficult.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

