### PR TITLE
Avoid calling METIS for cell partitioning with one task

### DIFF
--- a/components/omega/src/base/Decomp.h
+++ b/components/omega/src/base/Decomp.h
@@ -75,6 +75,12 @@ class Decomp {
        const std::vector<I4> &CellsOnCellInit ///< [in] cell nbrs in init dstrb
    );
 
+   /// Trivially partition cells in the case of single task
+   /// It sets the NCells sizes (NCellsOwned,
+   /// NCellsHalo array, NCellsAll and NCellsSize) and the final CellID
+   /// and CellLoc arrays
+   void partCellsSingleTask();
+
    /// Partition the edges given the cell partition and edge connectivity
    /// The first cell ID associated with an edge in the CellsOnEdge array
    /// is assumed to own the edge. The inputs are the edge-cell connectivity

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -80,13 +80,24 @@ add_omega_test(
     "-n;8"
 )
 
-#############
-# Decomp test
-#############
+##########################
+# Decomp test using 1 task
+##########################
 
 add_omega_test(
-    DECOMP_TEST
-    testDecomp.exe
+    DECOMP_NTASK1_TEST
+    testDecompNTask1.exe
+    base/DecompTest.cpp
+    "-n;1"
+)
+
+###########################
+# Decomp test using 8 tasks
+###########################
+
+add_omega_test(
+    DECOMP_NTASK8_TEST
+    testDecompNTask8.exe
     base/DecompTest.cpp
     "-n;8"
 )


### PR DESCRIPTION
For debugging and performance testing it is sometimes useful to be able to run with just one MPI task. Right now attempting to do that on some machines (e.g. Frontier) results in a floating point exception inside METIS `PartGraphKway`. This seems to be a known issue: https://github.com/KarypisLab/METIS/issues/67.

This PR makes cell partitioning with a single task a special-case and simply directly assigns every cell to the one task.

Checklist
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


