### PR TITLE
Remove unused config option `NVertLevels`

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -7,8 +7,6 @@ Omega:
   TimeIntegration:
     TimeStepper: Forward-Backward
     TimeStep: 0000_00:10:00
-  Dimension:
-    NVertLevels: 60
   Decomp:
     HaloWidth: 3
     DecompMethod: MetisKWay


### PR DESCRIPTION
Also remove unused config group `Dimension`

This was removed from the code in https://github.com/E3SM-Project/Omega/pull/123/commits/2c5996e2712b5d267d8515132d186661d3e584c4 but didn't get removed from the config file.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Testing
  * [ ] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [ ] Unit tests have passed.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


