### PR TITLE
Add tracer tendency terms and auxiliary variables

### DIFF
--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -384,6 +384,23 @@ VelocityHyperDiffOnEdge::VelocityHyperDiffOnEdge(const HorzMesh *Mesh)
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge),
       MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(Mesh->EdgeMask) {}
 
+TracerHorzAdvOnCell::TracerHorzAdvOnCell(const HorzMesh *Mesh)
+    : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
+      CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
+      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell) {}
+
+TracerDiffOnCell::TracerDiffOnCell(const HorzMesh *Mesh)
+    : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
+      CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
+      DvEdge(Mesh->DvEdge), DcEdge(Mesh->DcEdge), AreaCell(Mesh->AreaCell),
+      MeshScalingDel2(Mesh->MeshScalingDel2) {}
+
+TracerHyperDiffOnCell::TracerHyperDiffOnCell(const HorzMesh *Mesh)
+    : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
+      CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
+      DvEdge(Mesh->DvEdge), DcEdge(Mesh->DcEdge), AreaCell(Mesh->AreaCell),
+      MeshScalingDel4(Mesh->MeshScalingDel4) {}
+
 } // end namespace OMEGA
 
 //===----------------------------------------------------------------------===//

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -282,7 +282,7 @@ class TracerHorzAdvOnCell {
                                    I4 KChunk, const Array2DR8 &NormVelEdge,
                                    const Array3DR8 &HTracersOnEdge) const {
 
-      const I4 KStart  = KChunk * VecLength;
+      const I4 KStart        = KChunk * VecLength;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real HAdvTmp[VecLength] = {0};
@@ -325,7 +325,7 @@ class TracerDiffOnCell {
                                    I4 KChunk, const Array3DR8 &TracerCell,
                                    const Array2DR8 &MeanLayerThickEdge) const {
 
-      const I4 KStart  = KChunk * VecLength;
+      const I4 KStart        = KChunk * VecLength;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real DiffTmp[VecLength] = {0};
@@ -378,7 +378,7 @@ class TracerHyperDiffOnCell {
                                    I4 KChunk,
                                    const Array3DR8 &TrDel2Cell) const {
 
-      const I4 KStart  = KChunk * VecLength;
+      const I4 KStart        = KChunk * VecLength;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real HypTmp[VecLength] = {0};

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -283,7 +283,7 @@ class TracerHorzAdvOnCell {
                                    const Array3DR8 &HTracersOnEdge) const {
 
       const I4 KStart  = KChunk * VecLength;
-      Real InvAreaCell = 1._Real / AreaCell(ICell);
+      const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real HAdvTmp[VecLength] = {0};
 
@@ -326,7 +326,7 @@ class TracerDiffOnCell {
                                    const Array2DR8 &MeanLayerThickEdge) const {
 
       const I4 KStart  = KChunk * VecLength;
-      Real InvAreaCell = 1. / AreaCell(ICell);
+      const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real DiffTmp[VecLength] = {0};
 
@@ -379,7 +379,7 @@ class TracerHyperDiffOnCell {
                                    const Array3DR8 &TrDel2Cell) const {
 
       const I4 KStart  = KChunk * VecLength;
-      Real InvAreaCell = 1. / AreaCell(ICell);
+      const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real HypTmp[VecLength] = {0};
 

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
@@ -1,0 +1,19 @@
+#include "TracerAuxVars.h"
+#include "Field.h"
+
+#include <limits>
+
+namespace OMEGA {
+
+TracerAuxVars::TracerAuxVars(const std::string &AuxStateSuffix,
+                             const HorzMesh *Mesh, const I4 NVertLevels,
+                             const I4 NTracers)
+    : HTracersOnEdge("ThickTracersOnEdge" + AuxStateSuffix, NTracers,
+                     Mesh->NEdgesSize, NVertLevels),
+      Del2TracersOnCell("Del2TracerOnCell" + AuxStateSuffix, NTracers,
+                        Mesh->NCellsSize, NVertLevels),
+      NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
+      CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
+      DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell) {}
+
+} // namespace OMEGA

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
@@ -16,4 +16,85 @@ TracerAuxVars::TracerAuxVars(const std::string &AuxStateSuffix,
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell) {}
 
+void TracerAuxVars::registerFields(const std::string &AuxGroupName,
+                                   const std::string &MeshName) const {
+
+   int Err = 0; // error code
+
+   // Create fields
+   const Real FillValue = -9.99e30;
+   int NDims            = 3;
+   std::vector<std::string> DimNames(NDims);
+   std::string DimSuffix;
+   if (MeshName == "Default") {
+      DimSuffix = "";
+   } else {
+      DimSuffix = MeshName;
+   }
+
+   // Thickness-weighted tracers on Edge
+   DimNames[0]            = "NTracers";
+   DimNames[1]            = "NEdges" + DimSuffix;
+   DimNames[2]            = "NVertLevels";
+   auto HTracersEdgeField = Field::create(
+       HTracersOnEdge.label(), // field name
+       "thickness-weighted tracers at edges. May be centered, upwinded, or a "
+       "combination of the two."         // long name or description
+       "",                               // units
+       "",                               // CF standard name
+       0,                                // min valid value
+       std::numeric_limits<Real>::max(), // max valid value
+       FillValue,                        // scalar for undefined entries
+       NDims,                            // number of dimensions
+       DimNames                          // dimension names
+   );
+
+   // Del2 tracers on Cell
+   DimNames[1]               = "NCells" + DimSuffix;
+   auto Del2TracersCellField = Field::create(
+       Del2TracersOnCell.label(),                                // field name
+       "laplacian of thickness-weighted tracers at cell center", // long name or
+                                                                 // description
+       "",                                                       // units
+       "",                               // CF standard name
+       std::numeric_limits<Real>::min(), // min valid value
+       std::numeric_limits<Real>::max(), // max valid value
+       FillValue,                        // scalar for undefined entries
+       NDims,                            // number of dimensions
+       DimNames                          // dimension names
+   );
+
+   // Add fields to Aux Field group
+   Err = FieldGroup::addFieldToGroup(HTracersEdge.label(), AuxGroupName);
+   if (Err != 0)
+      LOG_ERROR("Error adding field {} to group {}", HTracersEdge.label(),
+                AuxGroupName);
+
+   Err = FieldGroup::addFieldToGroup(Del2TracersCell.label(), AuxGroupName);
+   if (Err != 0)
+      LOG_ERROR("Error adding field {} to group {}", Del2TracersCell.label(),
+                AuxGroupName);
+
+   // Attach data to fields
+   Err = HTracersEdgeField->attachData<Array3DReal>(HTracersEdge);
+   if (Err != 0)
+      LOG_ERROR("Error attaching data to field {}", HTracersEdge.label());
+
+   Err = Del2TracersCellField->attachData<Array3DReal>(Del2TracersCell);
+   if (Err != 0)
+      LOG_ERROR("Error attaching data to field {}", Del2TracersCell.label());
+}
+
+void TracerAuxVars::unregisterFields() const {
+   int Err = 0;
+
+   Err = Field::destroy(HTracersEdge.label());
+   if (Err != 0)
+      LOG_ERROR("Error destroying field {}", HTracersEdge.label());
+
+   Err = Field::destroy(Del2TracersCell.label());
+   if (Err != 0)
+      LOG_ERROR("Error destroying field {}", Del2TracersCell.label());
+}
+
 } // namespace OMEGA

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
@@ -39,7 +39,7 @@ void TracerAuxVars::registerFields(const std::string &AuxGroupName,
    auto HTracersEdgeField = Field::create(
        HTracersOnEdge.label(), // field name
        "thickness-weighted tracers at edges. May be centered, upwinded, or a "
-       "combination of the two."         // long name or description
+       "combination of the two.",        // long name or description
        "",                               // units
        "",                               // CF standard name
        0,                                // min valid value
@@ -65,36 +65,36 @@ void TracerAuxVars::registerFields(const std::string &AuxGroupName,
    );
 
    // Add fields to Aux Field group
-   Err = FieldGroup::addFieldToGroup(HTracersEdge.label(), AuxGroupName);
+   Err = FieldGroup::addFieldToGroup(HTracersOnEdge.label(), AuxGroupName);
    if (Err != 0)
-      LOG_ERROR("Error adding field {} to group {}", HTracersEdge.label(),
+      LOG_ERROR("Error adding field {} to group {}", HTracersOnEdge.label(),
                 AuxGroupName);
 
-   Err = FieldGroup::addFieldToGroup(Del2TracersCell.label(), AuxGroupName);
+   Err = FieldGroup::addFieldToGroup(Del2TracersOnCell.label(), AuxGroupName);
    if (Err != 0)
-      LOG_ERROR("Error adding field {} to group {}", Del2TracersCell.label(),
+      LOG_ERROR("Error adding field {} to group {}", Del2TracersOnCell.label(),
                 AuxGroupName);
 
    // Attach data to fields
-   Err = HTracersEdgeField->attachData<Array3DReal>(HTracersEdge);
+   Err = HTracersEdgeField->attachData<Array3DReal>(HTracersOnEdge);
    if (Err != 0)
-      LOG_ERROR("Error attaching data to field {}", HTracersEdge.label());
+      LOG_ERROR("Error attaching data to field {}", HTracersOnEdge.label());
 
-   Err = Del2TracersCellField->attachData<Array3DReal>(Del2TracersCell);
+   Err = Del2TracersCellField->attachData<Array3DReal>(Del2TracersOnCell);
    if (Err != 0)
-      LOG_ERROR("Error attaching data to field {}", Del2TracersCell.label());
+      LOG_ERROR("Error attaching data to field {}", Del2TracersOnCell.label());
 }
 
 void TracerAuxVars::unregisterFields() const {
    int Err = 0;
 
-   Err = Field::destroy(HTracersEdge.label());
+   Err = Field::destroy(HTracersOnEdge.label());
    if (Err != 0)
-      LOG_ERROR("Error destroying field {}", HTracersEdge.label());
+      LOG_ERROR("Error destroying field {}", HTracersOnEdge.label());
 
-   Err = Field::destroy(Del2TracersCell.label());
+   Err = Field::destroy(Del2TracersOnCell.label());
    if (Err != 0)
-      LOG_ERROR("Error destroying field {}", Del2TracersCell.label());
+      LOG_ERROR("Error destroying field {}", Del2TracersOnCell.label());
 }
 
 } // namespace OMEGA

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
@@ -1,0 +1,101 @@
+#ifndef OMEGA_AUX_TRACER_H
+#define OMEGA_AUX_TRACER_H
+
+#include "DataTypes.h"
+#include "HorzMesh.h"
+#include "OmegaKokkos.h"
+#include "auxiliaryVars/LayerThicknessAuxVars.h"
+
+#include <string>
+
+namespace OMEGA {
+
+class TracerAuxVars {
+ public:
+   Array3DReal HTracersOnEdge;
+   Array3DReal Del2TracersOnCell;
+
+   FluxThickEdgeOption TracersOnEdgeChoice = Center;
+
+   TracerAuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
+                 const I4 NVertLevels, const I4 NTracers);
+
+   KOKKOS_FUNCTION void computeVarsOnEdge(int L, int IEdge, int KChunk,
+                                          const Array2DReal &NormalVelEdge,
+                                          const Array2DReal &HCell,
+                                          const Array3DReal &TrCell) const {
+      const int KStart = KChunk * VecLength;
+      const int JCell0 = CellsOnEdge(IEdge, 0);
+      const int JCell1 = CellsOnEdge(IEdge, 1);
+
+      switch (TracersOnEdgeChoice) {
+      case Center:
+         for (int KVec = 0; KVec < VecLength; ++KVec) {
+            const int K = KStart + KVec;
+            HTracersOnEdge(L, IEdge, K) =
+                0.5_Real * (HCell(JCell0, K) * TrCell(L, JCell0, K) +
+                            HCell(JCell1, K) * TrCell(L, JCell1, K));
+         }
+         break;
+      case Upwind:
+         for (int KVec = 0; KVec < VecLength; ++KVec) {
+            const int K = KStart + KVec;
+            if (NormalVelEdge(IEdge, K) > 0) {
+               HTracersOnEdge(L, IEdge, K) =
+                   HCell(JCell0, K) * TrCell(L, JCell0, K);
+            } else if (NormalVelEdge(IEdge, K) < 0) {
+               HTracersOnEdge(L, IEdge, K) =
+                   HCell(JCell1, K) * TrCell(L, JCell1, K);
+            } else {
+               HTracersOnEdge(L, IEdge, K) =
+                   Kokkos::max(HCell(JCell0, K) * TrCell(L, JCell0, K),
+                               HCell(JCell1, K) * TrCell(L, JCell1, K));
+            }
+         }
+         break;
+      }
+   }
+
+   KOKKOS_FUNCTION void
+   computeVarsOnCells(int L, int ICell, int KChunk,
+                      const Array2DReal &LayerThickEdgeMean,
+                      const Array3DReal &TrCell) const {
+
+      const int KStart       = KChunk * VecLength;
+      const Real InvAreaCell = 1._Real / AreaCell(ICell);
+
+      Real Del2TrCellTmp[VecLength] = {0};
+
+      for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
+         const int JEdge = EdgesOnCell(ICell, J);
+
+         const int JCell0 = CellsOnEdge(JEdge, 0);
+         const int JCell1 = CellsOnEdge(JEdge, 1);
+
+         const Real DvDcEdge = DvEdge(JEdge) / DcEdge(JEdge);
+
+         for (int KVec = 0; KVec < VecLength; ++KVec) {
+            const int K           = KStart + KVec;
+            const Real TracerGrad = TrCell(L, JCell1, K) - TrCell(L, JCell0, K);
+            Del2TrCellTmp[KVec] -= EdgeSignOnCell(ICell, J) * DvDcEdge *
+                                   LayerThickEdgeMean(JEdge, K) * TracerGrad;
+         }
+      }
+      for (int KVec = 0; KVec < VecLength; ++KVec) {
+         const int K                    = KStart + KVec;
+         Del2TracersOnCell(L, ICell, K) = Del2TrCellTmp[KVec] * InvAreaCell;
+      }
+   }
+
+ private:
+   Array1DI4 NEdgesOnCell;
+   Array2DI4 EdgesOnCell;
+   Array2DI4 CellsOnEdge;
+   Array2DR8 EdgeSignOnCell;
+   Array1DR8 DcEdge;
+   Array1DR8 DvEdge;
+   Array1DR8 AreaCell;
+};
+
+} // namespace OMEGA
+#endif

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
@@ -87,6 +87,10 @@ class TracerAuxVars {
       }
    }
 
+   void registerFields(const std::string &AuxGroupName,
+                       const std::string &MeshName) const;
+   void unregisterFields() const;
+
  private:
    Array1DI4 NEdgesOnCell;
    Array2DI4 EdgesOnCell;

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
@@ -2,6 +2,7 @@
 #define OMEGA_AUX_TRACER_H
 
 #include "DataTypes.h"
+#include "Field.h"
 #include "HorzMesh.h"
 #include "OmegaKokkos.h"
 #include "auxiliaryVars/LayerThicknessAuxVars.h"


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

Added functors to `omega/src/ocn/TendencyTerms.cpp` for computing horizontal advection, del2 mixing, and del4 mixing tendency terms for Tracers, and `TracerAuxVars` class to `omega/src/ocn/auxiliaryVars` to compute auxiliary variables needed by these tendency terms.

Unit tests passed on Chrysalis and Perlmutter CPU & GPU

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist

* [x] Testing
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


