### PR TITLE
Remove mamba(forge) from CI and dev conda instructions

### DIFF
--- a/.github/workflows/omega-build-workflow.yml
+++ b/.github/workflows/omega-build-workflow.yml
@@ -52,10 +52,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: "omega_ci"
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: strict
           auto-update-conda: true
@@ -64,10 +61,10 @@ jobs:
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install dependencies
         run: |
-          mamba create -n omega_dev --file components/omega/dev-conda.txt \
+          conda create -n omega_dev --file components/omega/dev-conda.txt \
               python=${{ matrix.python-version }}
           conda activate omega_dev
-          mamba list
+          conda list
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         id: file_changes

--- a/.github/workflows/omega-build-workflow.yml
+++ b/.github/workflows/omega-build-workflow.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  CANCEL_OTHERS: true
+  CANCEL_OTHERS: false
   PATHS_IGNORE: '["**/README.md", "**/doc/**"]'
 
 jobs:

--- a/.github/workflows/omega-docs-workflow.yml
+++ b/.github/workflows/omega-docs-workflow.yml
@@ -34,10 +34,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: "omega_ci"
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: strict
           auto-update-conda: true
@@ -46,10 +43,10 @@ jobs:
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install dependencies
         run: |
-          mamba create -n omega_dev --file components/omega/dev-conda.txt \
+          conda create -n omega_dev --file components/omega/dev-conda.txt \
               python=${{ matrix.python-version }}
           conda activate omega_dev
-          mamba list
+          conda list
 
       - name: Build Sphinx Docs
         run: |

--- a/components/omega/dev-conda.txt
+++ b/components/omega/dev-conda.txt
@@ -1,7 +1,7 @@
 # This file may be used to create an environment for linting Omega with
 # pre-commit using:
-# $ mamba create -n omega_dev --file <this file>
-# $ mamba activate omega_dev
+# $ conda create -n omega_dev --file <this file>
+# $ conda activate omega_dev
 # $ pre-commit install
 
 # linting


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

The `mamba` command and the Mambaforge installation are both obsolete and are being replaced with the `conda` command and the Miniforge3 installation, respectively.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


