### PR TITLE
fixed a bug in logging for Kokkos data types

### DIFF
--- a/components/omega/src/infra/LogFormatters.h
+++ b/components/omega/src/infra/LogFormatters.h
@@ -13,38 +13,48 @@
 #include <spdlog/spdlog.h>
 
 #ifdef OMEGA_DEBUG
-#define GENERATE_FORMATTER(D, T)                                               \
+#define GENERATE_FORMATTER(ARR, DIM, TYPE)                                     \
    template <>                                                                 \
-   struct fmt::formatter<OMEGA::Array##D##T> : fmt::formatter<std::string> {   \
-      auto format(OMEGA::Array##D##T my,                                       \
+   struct fmt::formatter<OMEGA::ARR##DIM##TYPE>                                \
+       : fmt::formatter<std::string> {                                         \
+      auto format(OMEGA::ARR##DIM##TYPE my,                                    \
                   format_context &ctx) -> decltype(ctx.out()) {                \
          return fmt::format_to(ctx.out(), "{}({}D:{})", my.label(), my.rank(), \
                                my.size());                                     \
       }                                                                        \
    };
 #else
-#define GENERATE_FORMATTER(D, T)                                             \
-   template <>                                                               \
-   struct fmt::formatter<OMEGA::Array##D##T> : fmt::formatter<std::string> { \
-      auto format(OMEGA::Array##D##T my,                                     \
-                  format_context &ctx) -> decltype(ctx.out()) {              \
-         return fmt::format_to(ctx.out(), "{}", my.label());                 \
-      }                                                                      \
+#define GENERATE_FORMATTER(ARR, DIM, TYPE)                      \
+   template <>                                                  \
+   struct fmt::formatter<OMEGA::ARR##DIM##TYPE>                 \
+       : fmt::formatter<std::string> {                          \
+      auto format(OMEGA::ARR##DIM##TYPE my,                     \
+                  format_context &ctx) -> decltype(ctx.out()) { \
+         return fmt::format_to(ctx.out(), "{}", my.label());    \
+      }                                                         \
    };
 #endif
 
-#define GENERATE_FORMATTER_DIM(D) \
-   GENERATE_FORMATTER(D, I4)      \
-   GENERATE_FORMATTER(D, I8)      \
-   GENERATE_FORMATTER(D, R4)      \
-   GENERATE_FORMATTER(D, R8)
+#define GENERATE_FORMATTER_DIM(ARR, DIM) \
+   GENERATE_FORMATTER(ARR, DIM, I4)      \
+   GENERATE_FORMATTER(ARR, DIM, I8)      \
+   GENERATE_FORMATTER(ARR, DIM, R4)      \
+   GENERATE_FORMATTER(ARR, DIM, R8)
 
-GENERATE_FORMATTER_DIM(1D)
-GENERATE_FORMATTER_DIM(2D)
-GENERATE_FORMATTER_DIM(3D)
-GENERATE_FORMATTER_DIM(4D)
-GENERATE_FORMATTER_DIM(5D)
+#define GENERATE_FORMATTER_ARR(ARR) \
+   GENERATE_FORMATTER_DIM(ARR, 1D)  \
+   GENERATE_FORMATTER_DIM(ARR, 2D)  \
+   GENERATE_FORMATTER_DIM(ARR, 3D)  \
+   GENERATE_FORMATTER_DIM(ARR, 4D)  \
+   GENERATE_FORMATTER_DIM(ARR, 5D)
 
+GENERATE_FORMATTER_ARR(HostArray)
+
+#ifdef OMEGA_TARGET_DEVICE
+GENERATE_FORMATTER_ARR(Array)
+#endif
+
+#undef GENERATE_FORMATTER_ARR
 #undef GENERATE_FORMATTER_DIM
 #undef GENERATE_FORMATTER
 

--- a/components/omega/test/infra/LoggingTest.cpp
+++ b/components/omega/test/infra/LoggingTest.cpp
@@ -141,8 +141,8 @@ int testKokkosDataTypes(bool LogEnabled) {
 
    Kokkos::initialize();
    {
-      HostArray1DReal test1d("test1d", d1);
-      HostArray2DReal test2d("test2d", d1, d2);
+      Array1DReal test1d("test1dD", d1);
+      Array2DReal test2d("test2dD", d1, d2);
 
       TestRun = true;
 
@@ -164,7 +164,7 @@ int testKokkosDataTypes(bool LogEnabled) {
 
       // check if HostArray1DReal is detected
       if (LogEnabled && TestRun)
-         RetVal += outputTestResult("Kokkos data type 1", "test1d", Contains);
+         RetVal += outputTestResult("Kokkos data type 1", "test1dD", Contains);
 
       TestRun = true;
 
@@ -186,7 +186,52 @@ int testKokkosDataTypes(bool LogEnabled) {
 
       // check if HostArray2DReal is detected
       if (LogEnabled && TestRun)
-         RetVal += outputTestResult("Kokkos data type 2", "test2d", Contains);
+         RetVal += outputTestResult("Kokkos data type 2", "test2dD", Contains);
+
+      HostArray1DReal test1dH("test1dH", d1);
+      HostArray2DReal test2dH("test2dH", d1, d2);
+
+      if (OMEGA_LOG_LEVEL == 0) {
+         LOG_INFO("1d var {}", test1dH);
+      } else if (OMEGA_LOG_LEVEL == 1) {
+         LOG_DEBUG("1d var {}", test1dH);
+      } else if (OMEGA_LOG_LEVEL == 2) {
+         LOG_INFO("1d var {}", test1dH);
+      } else if (OMEGA_LOG_LEVEL == 3) {
+         LOG_WARN("1d var {}", test1dH);
+      } else if (OMEGA_LOG_LEVEL == 4) {
+         LOG_ERROR("1d var {}", test1dH);
+      } else if (OMEGA_LOG_LEVEL == 5) {
+         LOG_CRITICAL("1d var {}", test1dH);
+      } else {
+         TestRun = false; // off
+      }
+
+      // check if HostArray1DReal is detected
+      if (LogEnabled && TestRun)
+         RetVal += outputTestResult("Kokkos data type 1", "test1dH", Contains);
+
+      TestRun = true;
+
+      if (OMEGA_LOG_LEVEL == 0) {
+         LOG_INFO("2d var {}", test2dH);
+      } else if (OMEGA_LOG_LEVEL == 1) {
+         LOG_DEBUG("2d var {}", test2dH);
+      } else if (OMEGA_LOG_LEVEL == 2) {
+         LOG_INFO("2d var {}", test2dH);
+      } else if (OMEGA_LOG_LEVEL == 3) {
+         LOG_WARN("2d var {}", test2dH);
+      } else if (OMEGA_LOG_LEVEL == 4) {
+         LOG_ERROR("2d var {}", test2dH);
+      } else if (OMEGA_LOG_LEVEL == 5) {
+         LOG_CRITICAL("2d var {}", test2dH);
+      } else {
+         TestRun = false; // off
+      }
+
+      // check if HostArray2DReal is detected
+      if (LogEnabled && TestRun)
+         RetVal += outputTestResult("Kokkos data type 2", "test2dH", Contains);
    }
    Kokkos::finalize();
 


### PR DESCRIPTION
A bug fix to resolve the issue #143 related to logging for Kokkos data types.

Tested and passed on Chrysalis, pm-cpu, pm-gpu, and Frontier.

* [X] Testing
  * [X] CTest unit tests for new features have been added per the approved design. 



