### PR TITLE
Add time-stacked output streams in IOStreams

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -93,6 +93,8 @@ Omega:
       Precision: single
       Freq: 10
       FreqUnits: days
+      FileFreq: 1
+      FileFreqUnits: months
       UseStartEnd: true
       StartTime: 0001-06-01_00:00:00
       EndTime: 0001-06-30_00:00:00

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -77,7 +77,11 @@ Omega:
       IfExists: replace
       Precision: double
       Freq: 1
-      FreqUnits: months
+      FreqUnits: months,OnStartup
+      # If FileFreq and FileFreqUnits are commented out,
+      # the output file frequency will default to the IO frequency.
+      FileFreq: 1
+      FileFreqUnits: years
       UseStartEnd: false
       Contents:
         - Tracers

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -483,10 +483,10 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
    NewStream->OnShutdown = false;
 
    TimeInterval AlarmInt;
-   for ( int i = 0; i < IOFreqUnitsSplit.size(); i++ ) {
+   for (int i = 0; i < IOFreqUnitsSplit.size(); i++) {
       if (IOFreqUnitsSplit[i] == "years") {
 
-         Err = AlarmInt.set(IOFreq, TimeUnits::Years);
+         Err                       = AlarmInt.set(IOFreq, TimeUnits::Years);
          NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
@@ -494,7 +494,7 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
 
       } else if (IOFreqUnitsSplit[i] == "months") {
 
-         Err = AlarmInt.set(IOFreq, TimeUnits::Months);
+         Err                       = AlarmInt.set(IOFreq, TimeUnits::Months);
          NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
@@ -502,7 +502,7 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
 
       } else if (IOFreqUnitsSplit[i] == "days") {
 
-         Err = AlarmInt.set(IOFreq, TimeUnits::Days);
+         Err                       = AlarmInt.set(IOFreq, TimeUnits::Days);
          NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
@@ -510,7 +510,7 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
 
       } else if (IOFreqUnitsSplit[i] == "hours") {
 
-         Err = AlarmInt.set(IOFreq, TimeUnits::Hours);
+         Err                       = AlarmInt.set(IOFreq, TimeUnits::Hours);
          NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
@@ -518,7 +518,7 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
 
       } else if (IOFreqUnitsSplit[i] == "minutes") {
 
-         Err = AlarmInt.set(IOFreq, TimeUnits::Minutes);
+         Err                       = AlarmInt.set(IOFreq, TimeUnits::Minutes);
          NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
@@ -526,7 +526,7 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
 
       } else if (IOFreqUnitsSplit[i] == "seconds") {
 
-         Err = AlarmInt.set(IOFreq, TimeUnits::Seconds);
+         Err                       = AlarmInt.set(IOFreq, TimeUnits::Seconds);
          NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
          NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
@@ -540,12 +540,14 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
 
          NewStream->OnShutdown = true;
 
-      } else if (IOFreqUnitsSplit[i] == "attime" or IOFreqUnitsSplit[i] == "ontime" or
-                 IOFreqUnitsSplit[i] == "time"   or IOFreqUnitsSplit[i] == "timeinstant") {
+      } else if (IOFreqUnitsSplit[i] == "attime" or
+                 IOFreqUnitsSplit[i] == "ontime" or
+                 IOFreqUnitsSplit[i] == "time" or
+                 IOFreqUnitsSplit[i] == "timeinstant") {
 
          // A one-time event for this stream - use the StartTime string
          // as the time instant to use
-         if (HasAlarm or NewStream->OnStartup or NewStream->OnShutdown ) {
+         if (HasAlarm or NewStream->OnStartup or NewStream->OnShutdown) {
             LOG_ERROR("Stream {} requests a one-time read/write but another"
                       "frequency is specified.",
                       StreamName);
@@ -584,10 +586,10 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
       }
    } // end for IOFreqUnitsSplit
 
-
    // Set File IO frequency for time-stacked output streams
-   // If 'FileFreq' does not exist in omega.yml for the stream, the file frequency
-   // is defined the same as the IO frequency without stacking over time.
+   // If 'FileFreq' does not exist in omega.yml for the stream, the file
+   // frequency is defined the same as the IO frequency without stacking over
+   // time.
    TimeInterval FileAlarmInt;
 
    if (StreamConfig.existsVar("FileFreq")) {
@@ -597,7 +599,7 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
       // Get FileFreq & FreqUnits from Config
       Err = StreamConfig.get("FileFreq", IOFileFreq);
       Err = StreamConfig.get("FileFreqUnits", IOFileFreqUnits);
-      if ( Err != 0) {
+      if (Err != 0) {
          LOG_ERROR("FileFreq of Stream {} is specified, but FileFreqUnits"
                    "is not provided",
                    StreamName);
@@ -629,20 +631,24 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
 
       } else {
          if (!NewStream->OnStartup and !NewStream->OnShutdown) {
-            LOG_ERROR("Unknown IOFileFreqUnits option for stream {}", StreamName);
+            LOG_ERROR("Unknown IOFileFreqUnits option for stream {}",
+                      StreamName);
             Err = 4;
             return Err;
          }
       }
 
-      if ( ClockStart+AlarmInt > ClockStart+FileAlarmInt ) {
-         LOG_ERROR("AlarmInt is longer than FileAlarmInt for stream {}", StreamName);
+      if (ClockStart + AlarmInt > ClockStart + FileAlarmInt) {
+         LOG_ERROR("AlarmInt is longer than FileAlarmInt for stream {}",
+                   StreamName);
          Err = 4;
          return Err;
       } else {
 
-         NewStream->MyFileAlarm = Alarm(AlarmName, FileAlarmInt, ClockStart-FileAlarmInt);
-         NewStream->MyFileEndAlarm = Alarm(AlarmName, FileAlarmInt,ClockStart-AlarmInt);
+         NewStream->MyFileAlarm =
+             Alarm(AlarmName, FileAlarmInt, ClockStart - FileAlarmInt);
+         NewStream->MyFileEndAlarm =
+             Alarm(AlarmName, FileAlarmInt, ClockStart - AlarmInt);
       }
 
    } else {
@@ -654,9 +660,11 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
    } // end if StreamConfig.existsVar("FileFreq")
 
    // Reset Alarm for OnStartup
-   if ( HasAlarm and NewStream->OnStartup ) {
-      NewStream->MyFileAlarm    = Alarm(AlarmName, FileAlarmInt, ClockStart-FileAlarmInt);
-      NewStream->MyFileEndAlarm = Alarm(AlarmName, FileAlarmInt, ClockStart-AlarmInt);
+   if (HasAlarm and NewStream->OnStartup) {
+      NewStream->MyFileAlarm =
+          Alarm(AlarmName, FileAlarmInt, ClockStart - FileAlarmInt);
+      NewStream->MyFileEndAlarm =
+          Alarm(AlarmName, FileAlarmInt, ClockStart - AlarmInt);
       NewStream->MyFileAlarm.updateStatus(ClockStart);
       NewStream->MyFileEndAlarm.updateStatus(ClockStart);
    }
@@ -698,15 +706,17 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
       }
       TimeInstant Start(CalendarPtr, StartTimeStr);
       TimeInstant End(CalendarPtr, EndTimeStr);
-      std::string StartName     = StreamName + "Start";
-      std::string EndName       = StreamName + "End";
-      NewStream->StartAlarm     = Alarm(StartName, Start);
-      NewStream->EndAlarm       = Alarm(EndName, End);
+      std::string StartName = StreamName + "Start";
+      std::string EndName   = StreamName + "End";
+      NewStream->StartAlarm = Alarm(StartName, Start);
+      NewStream->EndAlarm   = Alarm(EndName, End);
       if (StreamConfig.existsVar("FileFreq")) {
-         NewStream->MyFileAlarm    = Alarm(AlarmName, FileAlarmInt, Start-FileAlarmInt);
-         NewStream->MyFileEndAlarm = Alarm(AlarmName, FileAlarmInt, Start-AlarmInt);
+         NewStream->MyFileAlarm =
+             Alarm(AlarmName, FileAlarmInt, Start - FileAlarmInt);
+         NewStream->MyFileEndAlarm =
+             Alarm(AlarmName, FileAlarmInt, Start - AlarmInt);
       }
-      Err                   = ModelClock.attachAlarm(&(NewStream->StartAlarm));
+      Err = ModelClock.attachAlarm(&(NewStream->StartAlarm));
       if (Err != 0) {
          LOG_ERROR("Error attaching start alarm to model clock for stream {}",
                    StreamName);
@@ -803,7 +813,7 @@ int IOStream::defineAllDims(
       // For output files, we need to define the dimension
       if (Mode == IO::ModeWrite) {
 
-         if ( DimName == "Time" ) {
+         if (DimName == "Time") {
             // UNLIMITED length for time dimension to allow stacking over time
             Err = IO::defineDim(FileID, DimName, PIO_UNLIMITED, DimID);
          } else {
@@ -1065,8 +1075,8 @@ int IOStream::writeFieldData(
    // dimension is 'Time' and NDims is 1.
    // TODO: Future work is required for this section, as it currently assumes
    //       that the time dimension has a size of 1.
-   if ( DimNames[0] == "Time" and NDims > 1) {
-      NDims = NDims-1;
+   if (DimNames[0] == "Time" and NDims > 1) {
+      NDims = NDims - 1;
    }
 
    // Create the decomposition needed for parallel I/O
@@ -1758,8 +1768,8 @@ int IOStream::readFieldData(
    // dimension is 'Time' and NDims is 1.
    // TODO: Future work is required for this section, as it currently assumes
    //       that the time dimension has a size of 1.
-   if ( DimNames[0] == "Time" and NDims > 1) {
-      NDims = NDims-1;
+   if (DimNames[0] == "Time" and NDims > 1) {
+      NDims = NDims - 1;
    }
 
    // Compute the parallel decomposition
@@ -2575,7 +2585,7 @@ int IOStream::writeStream(
 
    // Open a new file if MyFileAlarm is ringing
    std::shared_ptr<Field> SimField = Field::get(SimMeta);
-   if ( MyFileAlarm.isRinging()) {
+   if (MyFileAlarm.isRinging()) {
 
       // Create filename
       if (FilenameIsTemplate) {
@@ -2643,7 +2653,8 @@ int IOStream::writeStream(
          FieldDims.resize(NDims);
          Err = ThisField->getDimNames(DimNames);
          if (Err != 0) {
-            LOG_ERROR("Error retrieving dimension names for Field {}", FieldName);
+            LOG_ERROR("Error retrieving dimension names for Field {}",
+                      FieldName);
             return Err;
          }
          for (int IDim = 0; IDim < NDims; ++IDim) {
@@ -2657,8 +2668,8 @@ int IOStream::writeStream(
 
          // Define the field and assign a FieldID
          int FieldID;
-         Err = defineVar(OutFileID, FieldName, MyIOType, NDims, FieldDims.data(),
-                         FieldID);
+         Err = defineVar(OutFileID, FieldName, MyIOType, NDims,
+                         FieldDims.data(), FieldID);
          if (Err != 0) {
             LOG_ERROR("Error defining field {} in stream {}", FieldName, Name);
             return Err;
@@ -2686,8 +2697,8 @@ int IOStream::writeStream(
    // re-add the current time
    // TODO: The time string metadata will be deleted when the IOStreams
    //       are adjusted in conjunction with the OceanDriver.
-   std::string TimeIndexStr = std::to_string(TimeIndex);
-   std::string SimTimeString = "SimulationTime"+TimeIndexStr;
+   std::string TimeIndexStr  = std::to_string(TimeIndex);
+   std::string SimTimeString = "SimulationTime" + TimeIndexStr;
    if (SimField->hasMetadata(SimTimeString))
       Err = SimField->removeMetadata(SimTimeString);
    Err = SimField->addMetadata(SimTimeString, SimTimeStr);

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1759,7 +1759,6 @@ int IOStream::readFieldData(
    // TODO: Future work is required for this section, as it currently assumes
    //       that the time dimension has a size of 1.
    if ( DimNames[0] == "Time" and NDims > 1) {
-      LOG_INFO("TimeTime");
       NDims = NDims-1;
    }
 

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1744,6 +1744,25 @@ int IOStream::readFieldData(
       return Err;
    }
 
+   // Retrieve dimension names
+   std::vector<std::string> DimNames(NDims);
+   Err = FieldPtr->getDimNames(DimNames);
+   if (Err != 0) {
+      LOG_ERROR("Error retrieving dimension names for Field {}", FieldName);
+      return Err;
+   }
+
+   // If the first dimension is 'Time', reduce the number of dimensions by one,
+   // as the field array to be written is declared without the 'Time' dimension.
+   // Additionally, the field array is assumed to be a time series if the first
+   // dimension is 'Time' and NDims is 1.
+   // TODO: Future work is required for this section, as it currently assumes
+   //       that the time dimension has a size of 1.
+   if ( DimNames[0] == "Time" and NDims > 1) {
+      LOG_INFO("TimeTime");
+      NDims = NDims-1;
+   }
+
    // Compute the parallel decomposition
    int DecompID;
    int LocSize;

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1051,6 +1051,24 @@ int IOStream::writeFieldData(
       return Err;
    }
 
+   // Retrieve dimension names
+   std::vector<std::string> DimNames(NDims);
+   Err = FieldPtr->getDimNames(DimNames);
+   if (Err != 0) {
+      LOG_ERROR("Error retrieving dimension names for Field {}", FieldName);
+      return Err;
+   }
+
+   // If the first dimension is 'Time', reduce the number of dimensions by one,
+   // as the field array to be written is declared without the 'Time' dimension.
+   // Additionally, the field array is assumed to be a time series if the first
+   // dimension is 'Time' and NDims is 1.
+   // TODO: Future work is required for this section, as it currently assumes
+   //       that the time dimension has a size of 1.
+   if ( DimNames[0] == "Time" and NDims > 1) {
+      NDims = NDims-1;
+   }
+
    // Create the decomposition needed for parallel I/O
    int MyDecompID;
    int LocSize;

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1764,16 +1764,6 @@ int IOStream::readFieldData(
       return Err;
    }
 
-   // If the first dimension is 'Time', reduce the number of dimensions by one,
-   // as the field array to be written is declared without the 'Time' dimension.
-   // Additionally, the field array is assumed to be a time series if the first
-   // dimension is 'Time' and NDims is 1.
-   // TODO: Future work is required for this section, as it currently assumes
-   //       that the time dimension has a size of 1.
-   if (DimNames[0] == "Time" and NDims > 1) {
-      NDims = NDims - 1;
-   }
-
    // Compute the parallel decomposition
    int DecompID;
    int LocSize;
@@ -1782,6 +1772,18 @@ int IOStream::readFieldData(
    if (Err != 0) {
       LOG_ERROR("Error computing decomposition for Field {}", FieldName);
       return Err;
+   }
+
+   // If the first dimension is 'Time', reduce the number of dimensions by one,
+   // as the field array to be written is declared without the 'Time' dimension.
+   // Additionally, the field array is assumed to be a time series if the first
+   // dimension is 'Time' and NDims is 1.
+   // TODO: Additional work is required for this section if variables are
+   //       declared in the Time dimension.
+   LOG_INFO("Ndims {}", NDims);
+   if (DimNames[0] == "Time" and NDims > 1) {
+      NDims = NDims - 1;
+      DimLengths.erase(DimLengths.begin());
    }
 
    // The IO routines require a pointer to a contiguous memory on the host

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1069,16 +1069,6 @@ int IOStream::writeFieldData(
       return Err;
    }
 
-   // If the first dimension is 'Time', reduce the number of dimensions by one,
-   // as the field array to be written is declared without the 'Time' dimension.
-   // Additionally, the field array is assumed to be a time series if the first
-   // dimension is 'Time' and NDims is 1.
-   // TODO: Future work is required for this section, as it currently assumes
-   //       that the time dimension has a size of 1.
-   if (DimNames[0] == "Time" and NDims > 1) {
-      NDims = NDims - 1;
-   }
-
    // Create the decomposition needed for parallel I/O
    int MyDecompID;
    int LocSize;
@@ -1087,6 +1077,18 @@ int IOStream::writeFieldData(
    if (Err != 0) {
       LOG_ERROR("Error computing decomposition for Field {}", FieldName);
       return Err;
+   }
+
+   // If the first dimension is 'Time', reduce the number of dimensions by one,
+   // as the field array to be written is declared without the 'Time' dimension.
+   // Additionally, the field array is assumed to be a time series if the first
+   // dimension is 'Time' and NDims is 1.
+   // TODO: Additional work is required for this section if variables are
+   //       declared in the Time dimension.
+   LOG_INFO("Ndims {}", NDims);
+   if (DimNames[0] == "Time" and NDims > 1) {
+      NDims = NDims - 1;
+      DimLengths.erase(DimLengths.begin());
    }
 
    // Extract and write the array of data based on the type, dimension and

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -2568,12 +2568,6 @@ int IOStream::writeStream(
          LOG_ERROR("Error writing Code Metadata to file {}", OutFileName);
          return Err;
       }
-      // Add the simulation time - if it was added previously, remove and
-      // re-add the current time
-
-      //if (SimField->hasMetadata("SimulationTime"))
-      //   Err = SimField->removeMetadata("SimulationTime");
-      //Err = SimField->addMetadata("SimulationTime", SimTimeStr);
 
       if (Err != 0) {
          LOG_ERROR("Error adding current sim time to output {}", OutFileName);
@@ -2652,6 +2646,18 @@ int IOStream::writeStream(
       }
    } // end if MyFileAlarm.isRinging
 
+   // Add the simulation time - if it was added previously, remove and
+   // re-add the current time
+   // TODO: The time string metadata will be deleted when the IOStreams
+   //       are adjusted in conjunction with the OceanDriver.
+   std::string TimeIndexStr = std::to_string(TimeIndex);
+   std::string SimTimeString = "SimulationTime"+TimeIndexStr;
+   if (SimField->hasMetadata(SimTimeString))
+      Err = SimField->removeMetadata(SimTimeString);
+   Err = SimField->addMetadata(SimTimeString, SimTimeStr);
+   Err = writeFieldMeta(SimMeta, OutFileID, IO::GlobalID);
+   Err = SimField->removeMetadata(SimTimeString);
+
    // Now write data arrays for all fields in contents
    for (auto IFld = Contents.begin(); IFld != Contents.end(); ++IFld) {
 
@@ -2671,17 +2677,6 @@ int IOStream::writeStream(
          return Err;
       }
    }
-
-   // Write metadata for simulating time (delete - add - write - delete)
-   // TODO: The time string metadata will be deleted when the IOStreams
-   //       are adjusted in conjunction with the OceanDriver.
-   std::string TimeIndexStr = std::to_string(TimeIndex);
-   std::string SimTimeString = "SimulationTime"+TimeIndexStr;
-   if (SimField->hasMetadata(SimTimeString))
-      Err = SimField->removeMetadata(SimTimeString);
-   Err = SimField->addMetadata(SimTimeString, SimTimeStr);
-   Err = writeFieldMeta(SimMeta, OutFileID, IO::GlobalID);
-   Err = SimField->removeMetadata(SimTimeString);
 
    // Increase time frame index
    TimeIndex++;

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -356,6 +356,9 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
    auto NewStream  = std::make_shared<IOStream>();
    NewStream->Name = StreamName;
 
+   // Initialize time frame index
+   NewStream->TimeIndex = 0;
+
    // Set file mode (Read/Write)
    std::string StreamMode;
    Err             = StreamConfig.get("Mode", StreamMode);
@@ -462,90 +465,207 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
    std::transform(IOFreqUnits.begin(), IOFreqUnits.end(), IOFreqUnits.begin(),
                   [](unsigned char C) { return std::tolower(C); });
 
+   // A stringstream object with IOFreqUnits
+   std::stringstream ss(IOFreqUnits);
+
+   // Split IOFreqUnits string based on a delimiter ','
+   std::string token;
+   std::vector<std::string> IOFreqUnitsSplit;
+   char delimiter = ',';
+
+   while (getline(ss, token, delimiter)) {
+      IOFreqUnitsSplit.push_back(token);
+   }
+
    // Based on input frequency and units, create the alarm or set flags
    bool HasAlarm         = false;
    NewStream->OnStartup  = false;
    NewStream->OnShutdown = false;
 
-   if (IOFreqUnits == "years") {
+   TimeInterval AlarmInt;
+   for ( int i = 0; i < IOFreqUnitsSplit.size(); i++ ) {
+      if (IOFreqUnitsSplit[i] == "years") {
 
-      TimeInterval AlarmInt(IOFreq, TimeUnits::Years);
-      NewStream->MyAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
-      HasAlarm           = true;
+         Err = AlarmInt.set(IOFreq, TimeUnits::Years);
+         NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
+         HasAlarm                  = true;
 
-   } else if (IOFreqUnits == "months") {
+      } else if (IOFreqUnitsSplit[i] == "months") {
 
-      TimeInterval AlarmInt(IOFreq, TimeUnits::Months);
-      NewStream->MyAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
-      HasAlarm           = true;
+         Err = AlarmInt.set(IOFreq, TimeUnits::Months);
+         NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
+         HasAlarm                  = true;
 
-   } else if (IOFreqUnits == "days") {
+      } else if (IOFreqUnitsSplit[i] == "days") {
 
-      TimeInterval AlarmInt(IOFreq, TimeUnits::Days);
-      NewStream->MyAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
-      HasAlarm           = true;
+         Err = AlarmInt.set(IOFreq, TimeUnits::Days);
+         NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
+         HasAlarm                  = true;
 
-   } else if (IOFreqUnits == "hours") {
+      } else if (IOFreqUnitsSplit[i] == "hours") {
 
-      TimeInterval AlarmInt(IOFreq, TimeUnits::Hours);
-      NewStream->MyAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
-      HasAlarm           = true;
+         Err = AlarmInt.set(IOFreq, TimeUnits::Hours);
+         NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
+         HasAlarm                  = true;
 
-   } else if (IOFreqUnits == "minutes") {
+      } else if (IOFreqUnitsSplit[i] == "minutes") {
 
-      TimeInterval AlarmInt(IOFreq, TimeUnits::Minutes);
-      NewStream->MyAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
-      HasAlarm           = true;
+         Err = AlarmInt.set(IOFreq, TimeUnits::Minutes);
+         NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
+         HasAlarm                  = true;
 
-   } else if (IOFreqUnits == "seconds") {
+      } else if (IOFreqUnitsSplit[i] == "seconds") {
 
-      TimeInterval AlarmInt(IOFreq, TimeUnits::Seconds);
-      NewStream->MyAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
-      HasAlarm           = true;
+         Err = AlarmInt.set(IOFreq, TimeUnits::Seconds);
+         NewStream->MyAlarm        = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmInt, ClockStart);
+         NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmInt, ClockStart);
+         HasAlarm                  = true;
 
-   } else if (IOFreqUnits == "onstartup") {
+      } else if (IOFreqUnitsSplit[i] == "onstartup") {
 
-      NewStream->OnStartup = true;
+         NewStream->OnStartup = true;
 
-   } else if (IOFreqUnits == "onshutdown") {
-      NewStream->OnShutdown = true;
+      } else if (IOFreqUnitsSplit[i] == "onshutdown") {
 
-   } else if (IOFreqUnits == "attime" or IOFreqUnits == "ontime" or
-              IOFreqUnits == "time" or IOFreqUnits == "timeinstant") {
+         NewStream->OnShutdown = true;
 
-      // A one-time event for this stream - use the StartTime string
-      // as the time instant to use
-      std::string StrtTime;
-      Err = StreamConfig.get("StartTime", StrtTime);
-      if (Err == 0) {
-         TimeInstant AlarmTime(CalendarPtr, StrtTime);
-         NewStream->MyAlarm = Alarm(AlarmName, AlarmTime);
-         HasAlarm           = true;
-      } else {
-         LOG_ERROR("Stream {} requests a one-time read/write but StartTime"
-                   "not provided",
-                   StreamName);
+      } else if (IOFreqUnitsSplit[i] == "attime" or IOFreqUnitsSplit[i] == "ontime" or
+                 IOFreqUnitsSplit[i] == "time"   or IOFreqUnitsSplit[i] == "timeinstant") {
+
+         // A one-time event for this stream - use the StartTime string
+         // as the time instant to use
+         if (HasAlarm or NewStream->OnStartup or NewStream->OnShutdown ) {
+            LOG_ERROR("Stream {} requests a one-time read/write but another"
+                      "frequency is specified.",
+                      StreamName);
+            return Err;
+         }
+
+         std::string StrtTime;
+         Err = StreamConfig.get("StartTime", StrtTime);
+         if (Err == 0) {
+            TimeInstant AlarmTime(CalendarPtr, StrtTime);
+            NewStream->MyAlarm        = Alarm(AlarmName, AlarmTime);
+            NewStream->MyFileAlarm    = Alarm(AlarmName, AlarmTime);
+            NewStream->MyFileEndAlarm = Alarm(AlarmName, AlarmTime);
+            HasAlarm                  = true;
+         } else {
+            LOG_ERROR("Stream {} requests a one-time read/write but StartTime"
+                      "not provided",
+                      StreamName);
+            return Err;
+         }
+
+      } else if (IOFreqUnitsSplit[i] == "never") {
+
+         LOG_WARN("Stream {} has IO frequency of never and will be skipped",
+                  StreamName);
+         Err = 0;
          return Err;
+
+      } else {
+
+         if (!NewStream->OnStartup and !NewStream->OnShutdown) {
+            LOG_ERROR("Unknown IOFreqUnits option for stream {}", StreamName);
+            Err = 4;
+            return Err;
+         }
+      }
+   } // end for IOFreqUnitsSplit
+
+
+   // Set File IO frequency for time-stacked output streams
+   // If 'FileFreq' does not exist in omega.yml for the stream, the file frequency
+   // is defined the same as the IO frequency without stacking over time.
+   TimeInterval FileAlarmInt;
+
+   if (StreamConfig.existsVar("FileFreq")) {
+      int IOFileFreq;
+      std::string IOFileFreqUnits;
+
+      // Get FileFreq & FreqUnits from Config
+      Err = StreamConfig.get("FileFreq", IOFileFreq);
+      Err = StreamConfig.get("FileFreqUnits", IOFileFreqUnits);
+      if ( Err != 0) {
+         LOG_ERROR("FileFreq of Stream {} is specified, but FileFreqUnits"
+                   "is not provided",
+                   StreamName);
       }
 
-   } else if (IOFreqUnits == "never") {
+      if (IOFileFreqUnits == "years") {
 
-      LOG_WARN("Stream {} has IO frequency of never and will be skipped",
-               StreamName);
-      Err = 0;
-      return Err;
+         Err = FileAlarmInt.set(IOFileFreq, TimeUnits::Years);
+
+      } else if (IOFileFreqUnits == "months") {
+
+         Err = FileAlarmInt.set(IOFileFreq, TimeUnits::Months);
+
+      } else if (IOFileFreqUnits == "days") {
+
+         Err = FileAlarmInt.set(IOFileFreq, TimeUnits::Days);
+
+      } else if (IOFileFreqUnits == "hours") {
+
+         Err = FileAlarmInt.set(IOFileFreq, TimeUnits::Hours);
+
+      } else if (IOFileFreqUnits == "minutes") {
+
+         Err = FileAlarmInt.set(IOFileFreq, TimeUnits::Minutes);
+
+      } else if (IOFileFreqUnits == "seconds") {
+
+         Err = FileAlarmInt.set(IOFileFreq, TimeUnits::Seconds);
+
+      } else {
+         if (!NewStream->OnStartup and !NewStream->OnShutdown) {
+            LOG_ERROR("Unknown IOFileFreqUnits option for stream {}", StreamName);
+            Err = 4;
+            return Err;
+         }
+      }
+
+      if ( ClockStart+AlarmInt > ClockStart+FileAlarmInt ) {
+         LOG_ERROR("AlarmInt is longer than FileAlarmInt for stream {}", StreamName);
+         Err = 4;
+         return Err;
+      } else {
+
+         NewStream->MyFileAlarm = Alarm(AlarmName, FileAlarmInt, ClockStart-FileAlarmInt);
+         NewStream->MyFileEndAlarm = Alarm(AlarmName, FileAlarmInt,ClockStart-AlarmInt);
+      }
 
    } else {
 
-      if (!NewStream->OnStartup and !NewStream->OnShutdown) {
-         LOG_ERROR("Unknown IOFreqUnits option for stream {}", StreamName);
-         Err = 4;
-         return Err;
-      }
+      // Set the same output file interval as the output interval
+      // unless FileFreq and FileFreqUnits are provided.
+      FileAlarmInt = AlarmInt;
+
+   } // end if StreamConfig.existsVar("FileFreq")
+
+   // Reset Alarm for OnStartup
+   if ( HasAlarm and NewStream->OnStartup ) {
+      NewStream->MyFileAlarm    = Alarm(AlarmName, FileAlarmInt, ClockStart-FileAlarmInt);
+      NewStream->MyFileEndAlarm = Alarm(AlarmName, FileAlarmInt, ClockStart-AlarmInt);
+      NewStream->MyFileAlarm.updateStatus(ClockStart);
+      NewStream->MyFileEndAlarm.updateStatus(ClockStart);
    }
+
    // If an alarm is set, attach it to the model clock
    if (HasAlarm) {
       Err = ModelClock.attachAlarm(&(NewStream->MyAlarm));
+      Err = ModelClock.attachAlarm(&(NewStream->MyFileAlarm));
+      Err = ModelClock.attachAlarm(&(NewStream->MyFileEndAlarm));
       if (Err != 0) {
          LOG_ERROR("Error attaching alarm to model clock for stream {}",
                    StreamName);
@@ -578,10 +698,10 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
       }
       TimeInstant Start(CalendarPtr, StartTimeStr);
       TimeInstant End(CalendarPtr, EndTimeStr);
-      std::string StartName = StreamName + "Start";
-      std::string EndName   = StreamName + "End";
-      NewStream->StartAlarm = Alarm(StartName, Start);
-      NewStream->EndAlarm   = Alarm(EndName, End);
+      std::string StartName     = StreamName + "Start";
+      std::string EndName       = StreamName + "End";
+      NewStream->StartAlarm     = Alarm(StartName, Start);
+      NewStream->EndAlarm       = Alarm(EndName, End+AlarmInt);
       Err                   = ModelClock.attachAlarm(&(NewStream->StartAlarm));
       if (Err != 0) {
          LOG_ERROR("Error attaching start alarm to model clock for stream {}",
@@ -679,12 +799,18 @@ int IOStream::defineAllDims(
       // For output files, we need to define the dimension
       if (Mode == IO::ModeWrite) {
 
-         Err = IO::defineDim(FileID, DimName, Length, DimID);
+         if ( DimName == "Time" ) {
+            // UNLIMITED length for time dimension to allow stacking over time
+            Err = IO::defineDim(FileID, DimName, PIO_UNLIMITED, DimID);
+         } else {
+            Err = IO::defineDim(FileID, DimName, Length, DimID);
+         }
          if (Err != 0) {
             LOG_ERROR("Error defining dimension {} for output stream {}",
                       DimName, Name);
             return Err;
          }
+
       } // end write case
 
       // Add the DimID to map for later use
@@ -2407,115 +2533,120 @@ int IOStream::writeStream(
    if (MyAlarm.isRinging())
       MyAlarm.reset(SimTime);
 
-   // Create filename
-   std::string OutFileName;
-   if (FilenameIsTemplate) {
-      // create file name from template
-      OutFileName = buildFilename(Filename, ModelClock);
-   } else {
-      OutFileName = Filename;
-   }
-
-   // Open output file
-   int OutFileID;
-   Err = OMEGA::IO::openFile(OutFileID, OutFileName, Mode, IO::FmtDefault,
-                             ExistAction);
-   if (Err != 0) {
-      LOG_ERROR("IOStream::write: error opening file {} for output",
-                OutFileName);
-      return Err;
-   }
-
-   // Write Metadata for global metadata (Code and Simulation)
-   // Always add current simulation time to Simulation metadata
-   Err = writeFieldMeta(CodeMeta, OutFileID, IO::GlobalID);
-   if (Err != 0) {
-      LOG_ERROR("Error writing Code Metadata to file {}", OutFileName);
-      return Err;
-   }
+   // Open a new file if MyFileAlarm is ringing
    std::shared_ptr<Field> SimField = Field::get(SimMeta);
-   // Add the simulation time - if it was added previously, remove and
-   // re-add the current time
-   if (SimField->hasMetadata("SimulationTime"))
-      Err = SimField->removeMetadata("SimulationTime");
-   Err = SimField->addMetadata("SimulationTime", SimTimeStr);
-   if (Err != 0) {
-      LOG_ERROR("Error adding current sim time to output {}", OutFileName);
-      return Err;
-   }
-   Err = writeFieldMeta(SimMeta, OutFileID, IO::GlobalID);
-   if (Err != 0) {
-      LOG_ERROR("Error writing Simulation Metadata to file {}", OutFileName);
-      return Err;
-   }
+   if ( MyFileAlarm.isRinging()) {
 
-   // Assign dimension IDs for all defined dimensions
-   std::map<std::string, int> AllDimIDs;
-   Err = defineAllDims(OutFileID, AllDimIDs);
-   if (Err != 0) {
-      LOG_ERROR("Error defined dimensions for file {}", OutFileName);
-      return Err;
-   }
-
-   // Define each field and write field metadata
-   std::map<std::string, int> FieldIDs;
-   I4 NDims;
-   std::vector<std::string> DimNames;
-   std::vector<int> FieldDims;
-   for (auto IFld = Contents.begin(); IFld != Contents.end(); ++IFld) {
-
-      // Retrieve the field pointer
-      std::string FieldName            = *IFld;
-      std::shared_ptr<Field> ThisField = Field::get(FieldName);
-
-      // Retrieve the dimensions for this field and determine dim IDs
-      NDims = ThisField->getNumDims();
-      if (NDims < 1) {
-         LOG_ERROR("Invalid number of dimensions for Field {}", FieldName);
-         Err = 2;
-         return Err;
+      // Create filename
+      if (FilenameIsTemplate) {
+         // create file name from template
+         OutFileName = buildFilename(Filename, ModelClock);
+      } else {
+         OutFileName = Filename;
       }
-      DimNames.resize(NDims);
-      FieldDims.resize(NDims);
-      Err = ThisField->getDimNames(DimNames);
+
+      // Reset file alarms
+      MyFileAlarm.reset(SimTime);
+
+      // Open output file
+      Err = OMEGA::IO::openFile(OutFileID, OutFileName, Mode, IO::FmtDefault,
+                                ExistAction);
       if (Err != 0) {
-         LOG_ERROR("Error retrieving dimension names for Field {}", FieldName);
+         LOG_ERROR("IOStream::write: error opening file {} for output",
+                   OutFileName);
          return Err;
       }
-      for (int IDim = 0; IDim < NDims; ++IDim) {
-         std::string DimName = DimNames[IDim];
-         FieldDims[IDim]     = AllDimIDs[DimName];
-      }
 
-      // Determine the data type and convert to IODataType
-      // Reduce floating point precision if requested
-      IO::IODataType MyIOType = getFieldIOType(ThisField);
-
-      // Define the field and assign a FieldID
-      int FieldID;
-      Err = defineVar(OutFileID, FieldName, MyIOType, NDims, FieldDims.data(),
-                      FieldID);
+      // Write Metadata for global metadata (Code and Simulation)
+      // Always add current simulation time to Simulation metadata
+      Err = writeFieldMeta(CodeMeta, OutFileID, IO::GlobalID);
       if (Err != 0) {
-         LOG_ERROR("Error defining field {} in stream {}", FieldName, Name);
+         LOG_ERROR("Error writing Code Metadata to file {}", OutFileName);
          return Err;
       }
-      FieldIDs[FieldName] = FieldID;
+      // Add the simulation time - if it was added previously, remove and
+      // re-add the current time
 
-      // Now we can write the field metadata
-      Err = writeFieldMeta(FieldName, OutFileID, FieldID);
+      //if (SimField->hasMetadata("SimulationTime"))
+      //   Err = SimField->removeMetadata("SimulationTime");
+      //Err = SimField->addMetadata("SimulationTime", SimTimeStr);
+
       if (Err != 0) {
-         LOG_ERROR("Error writing field metadata for field {} in stream {}",
-                   FieldName, Name);
+         LOG_ERROR("Error adding current sim time to output {}", OutFileName);
          return Err;
       }
-   }
+      Err = writeFieldMeta(SimMeta, OutFileID, IO::GlobalID);
+      if (Err != 0) {
+         LOG_ERROR("Error writing Simulation Metadata to file {}", OutFileName);
+         return Err;
+      }
 
-   // End define mode
-   Err = IO::endDefinePhase(OutFileID);
-   if (Err != 0) {
-      LOG_ERROR("Error ending define phase for stream {}", Name);
-      return Err;
-   }
+      // Assign dimension IDs for all defined dimensions
+      Err = defineAllDims(OutFileID, AllDimIDs);
+      if (Err != 0) {
+         LOG_ERROR("Error defined dimensions for file {}", OutFileName);
+         return Err;
+      }
+
+      // Define each field and write field metadata
+      I4 NDims;
+      std::vector<std::string> DimNames;
+      std::vector<int> FieldDims;
+      for (auto IFld = Contents.begin(); IFld != Contents.end(); ++IFld) {
+
+         // Retrieve the field pointer
+         std::string FieldName            = *IFld;
+         std::shared_ptr<Field> ThisField = Field::get(FieldName);
+
+         // Retrieve the dimensions for this field and determine dim IDs
+         NDims = ThisField->getNumDims();
+         if (NDims < 1) {
+            LOG_ERROR("Invalid number of dimensions for Field {}", FieldName);
+            Err = 2;
+            return Err;
+         }
+         DimNames.resize(NDims);
+         FieldDims.resize(NDims);
+         Err = ThisField->getDimNames(DimNames);
+         if (Err != 0) {
+            LOG_ERROR("Error retrieving dimension names for Field {}", FieldName);
+            return Err;
+         }
+         for (int IDim = 0; IDim < NDims; ++IDim) {
+            std::string DimName = DimNames[IDim];
+            FieldDims[IDim]     = AllDimIDs[DimName];
+         }
+
+         // Determine the data type and convert to IODataType
+         // Reduce floating point precision if requested
+         IO::IODataType MyIOType = getFieldIOType(ThisField);
+
+         // Define the field and assign a FieldID
+         int FieldID;
+         Err = defineVar(OutFileID, FieldName, MyIOType, NDims, FieldDims.data(),
+                         FieldID);
+         if (Err != 0) {
+            LOG_ERROR("Error defining field {} in stream {}", FieldName, Name);
+            return Err;
+         }
+         FieldIDs[FieldName] = FieldID;
+
+         // Now we can write the field metadata
+         Err = writeFieldMeta(FieldName, OutFileID, FieldID);
+         if (Err != 0) {
+            LOG_ERROR("Error writing field metadata for field {} in stream {}",
+                      FieldName, Name);
+            return Err;
+         }
+      }
+
+      // End define mode
+      Err = IO::endDefinePhase(OutFileID);
+      if (Err != 0) {
+         LOG_ERROR("Error ending define phase for stream {}", Name);
+         return Err;
+      }
+   } // end if MyFileAlarm.isRinging
 
    // Now write data arrays for all fields in contents
    for (auto IFld = Contents.begin(); IFld != Contents.end(); ++IFld) {
@@ -2524,6 +2655,9 @@ int IOStream::writeStream(
       std::string FieldName            = *IFld;
       std::shared_ptr<Field> ThisField = Field::get(FieldName);
       int FieldID                      = FieldIDs[FieldName];
+
+      // PIO set a time frame with the time index to stack over time
+      PIOc_setframe(OutFileID, FieldID, TimeIndex);
 
       // Extract and write the data array
       Err = this->writeFieldData(ThisField, OutFileID, FieldID, AllDimIDs);
@@ -2534,11 +2668,32 @@ int IOStream::writeStream(
       }
    }
 
+   // Write metadata for simulating time (delete - add - write - delete)
+   // TODO: The time string metadata will be deleted when the IOStreams
+   //       are adjusted in conjunction with the OceanDriver.
+   std::string TimeIndexStr = std::to_string(TimeIndex);
+   std::string SimTimeString = "SimulationTime"+TimeIndexStr;
+   if (SimField->hasMetadata(SimTimeString))
+      Err = SimField->removeMetadata(SimTimeString);
+   Err = SimField->addMetadata(SimTimeString, SimTimeStr);
+   Err = writeFieldMeta(SimMeta, OutFileID, IO::GlobalID);
+   Err = SimField->removeMetadata(SimTimeString);
+
+   // Increase time frame index
+   TimeIndex++;
+
    // Close output file
-   Err = IO::closeFile(OutFileID);
-   if (Err != 0) {
-      LOG_ERROR("Error closing output file {}", OutFileName);
-      return Err;
+   if (MyFileEndAlarm.isRinging() or FinalCall) {
+
+      // Reset time frame index for a new file
+      TimeIndex = 0;
+
+      MyFileEndAlarm.reset(SimTime);
+      Err = IO::closeFile(OutFileID);
+      if (Err != 0) {
+         LOG_ERROR("Error closing output file {}", OutFileName);
+         return Err;
+      }
    }
 
    // If using pointer files for this stream, write the filename to the pointer

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -701,7 +701,11 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
       std::string StartName     = StreamName + "Start";
       std::string EndName       = StreamName + "End";
       NewStream->StartAlarm     = Alarm(StartName, Start);
-      NewStream->EndAlarm       = Alarm(EndName, End+AlarmInt);
+      NewStream->EndAlarm       = Alarm(EndName, End);
+      if (StreamConfig.existsVar("FileFreq")) {
+         NewStream->MyFileAlarm    = Alarm(AlarmName, FileAlarmInt, Start-FileAlarmInt);
+         NewStream->MyFileEndAlarm = Alarm(AlarmName, FileAlarmInt, Start-AlarmInt);
+      }
       Err                   = ModelClock.attachAlarm(&(NewStream->StartAlarm));
       if (Err != 0) {
          LOG_ERROR("Error attaching start alarm to model clock for stream {}",

--- a/components/omega/src/infra/IOStream.h
+++ b/components/omega/src/infra/IOStream.h
@@ -42,8 +42,18 @@ class IOStream {
    IO::Mode Mode;        ///< mode (read or write)
    bool ReducePrecision; ///< flag to use 32-bit precision for 64-bit floats
    Alarm MyAlarm;        ///< time mgr alarm for read/write
+   Alarm MyFileAlarm;    ///< time mgr alarm for creating new output file
+   Alarm MyFileEndAlarm; ///< time mgr alarm for closing output file
    bool OnStartup;       ///< flag to read/write on model startup
    bool OnShutdown;      ///< flag to read/write on model shutdown
+
+   int OutFileID;                        ///< ID assigned to the output file
+   std::map<std::string, int> FieldIDs;  ///< ID assigned to fields
+   std::map<std::string, int> AllDimIDs; ///< ID assigned to dimensions
+
+   std::string OutFileName; ///< name of output file
+
+   int TimeIndex; ///< Index for the stacked time frame
 
    /// A pointer file is used if we wish OMEGA to read the name of the file
    /// from another file. This is useful for writing the name of a restart

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -98,6 +98,9 @@ int initIOStreamTest(std::shared_ptr<Clock> &ModelClock, // Model clock
    HorzMesh *DefMesh = HorzMesh::getDefault();
    I4 NCellsSize     = DefMesh->NCellsSize;
 
+   // Create the time dimension
+   std::shared_ptr<Dimension> TimeDim = Dimension::create("Time", 1);
+
    // Set vertical levels and time levels
    I4 NVertLevels = 60;
    std::shared_ptr<Dimension> VertDim =
@@ -135,21 +138,23 @@ int initIOStreamTest(std::shared_ptr<Clock> &ModelClock, // Model clock
    // Define temperature and salinity tracer fields and create a tracer
    // group
 
-   std::vector<std::string> DimNames(2);
-   DimNames[0] = "NCells";
-   DimNames[1] = "NVertLevels";
+   std::vector<std::string> DimNames(3);
+   DimNames[0] = "Time";
+   DimNames[1] = "NCells";
+   DimNames[2] = "NVertLevels";
 
    // 2D Fields on device
 
-   DimNames[0]    = "NCells";
-   DimNames[1]    = "NVertLevels";
+   DimNames[0]    = "Time";
+   DimNames[1]    = "NCells";
+   DimNames[2]    = "NVertLevels";
    Real FillValue = -1.2345e-30;
    auto TempField = Field::create(
        "Temperature", "Potential temperature at cell centers", "deg C",
-       "sea_water_pot_tem", -3.0, 100.0, FillValue, 2, DimNames);
+       "sea_water_pot_tem", -3.0, 100.0, FillValue, 3, DimNames);
    auto SaltField =
        Field::create("Salinity", "Salinity at cell centers", "",
-                     "sea_water_salinity", 0.0, 100.0, FillValue, 2, DimNames);
+                     "sea_water_salinity", 0.0, 100.0, FillValue, 3, DimNames);
 
    // Create Tracer group
    auto TracerGroup = FieldGroup::create("Tracers");
@@ -239,6 +244,9 @@ int main(int argc, char **argv) {
       Alarm StopAlarm("Stop Time", StopTime);
       Err1 = ModelClock->attachAlarm(&StopAlarm);
       TestEval("Attach stop alarm", Err1, ErrRef, Err);
+
+      // Try to write for 'OnStartup' before time integration
+      Err1 = IOStream::writeAll(*ModelClock);
 
       // Overwrite
       // Step forward in time and write files if it is time

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -143,7 +143,7 @@ int initIOStreamTest(std::shared_ptr<Clock> &ModelClock, // Model clock
    DimNames[1] = "NCells";
    DimNames[2] = "NVertLevels";
 
-   // 2D Fields on device
+   // 3D Fields on device
 
    DimNames[0]    = "Time";
    DimNames[1]    = "NCells";


### PR DESCRIPTION
This update is a subsequent PR for IOStreams.
- This update introduces time-stacked output streams in IOStreams by incorporating the `FileFreq` and `FileFreqUnits` options in the `omega.yml` file.
- Additionally, this update allows multiple IO `FreqUnits` to be used with `OnStartup` option, separated by a comma ',' (e.g., `FreqUnits = months,OnStartup`).

Unit tests passed on Frontier CPU and GPU after applying @grnydawn 's hot fix for Frontier's core module updates as of Oct 15: https://acmeclimate.slack.com/archives/C010KQD6S5T/p1728920431549039 (download `config_machines.xml` and replace it with `Omega/cime_config/machines/config_machines.xml`)

Checklist
* [x] Testing
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
