### PR TITLE
Omega/state time level change

### DIFF
--- a/components/omega/doc/devGuide/OceanState.md
+++ b/components/omega/doc/devGuide/OceanState.md
@@ -40,22 +40,48 @@ For now, member variables that are host arrays have variable names are appended 
 `H`.  Array variable names not ending in `H` are device arrays.  For a given time level,
 host to device array is performed via:
 ```c++
-State->copyToDevice(TimeLevel);
+Err = State->copyToDevice(TimeLevel);
 ```
 and a copy from device to host is performed by:
 ```c++
-State->copyToHost(TimeLevel);
+Err = State->copyToHost(TimeLevel);
 ```
 Eventually, the host arrays will be eliminated when `IO` and `Halo` are extended to
 handle host <-> device transfers.
 
 A time level update to advance the solution at the end of a model timestep is done by:
 ```c++
-State->updateTimeLevels();
+Err = State->updateTimeLevels();
 ```
-This shifts the time levels to the previous index with the last index being shifted to the
-highest index to be overwritten in the next timestep. A halo exchange is also performed on
-these arrays and the IOFields data pointer is attached to the current time level.
+This shifts the time level indices within the `State` instance. A halo exchange is
+also performed on these arrays and the IOFields data pointer is attached
+to the current time level.
+
+The arrays associated with a given time level can be accessed with the functions:
+```c++
+Array2DReal LayerThick;
+Err = State->getLayerThickness(LayerThick, TimeLevel);
+Array2DReal NormVel;
+Err = State->getNormalVelocity(NormVel, TimeLevel);
+```
+for the device arrays and
+```c++
+HostArray2DReal LayerThickH;
+Err = State->getLayerThicknessH(LayerThickH, TimeLevel);
+HostArray2DReal NormVelH;
+Err = State->getNormalVelocityH(NormVelH, TimeLevel);
+```
+for the host arrays. The time level convention is:
+| time level | `TimeLevel` |
+|------------|-------------|
+| New | 1 |
+| Current | 0 |
+| Previous | -1 |
+| Two time levels ago | -2 |
+| etc. | etc. |
+
+For a `State` with `NTimeLevels = 1`, only the current time level, `TimeLevel=0` is
+availiable.
 
 The state arrays are deallocated by the `OceanState::clear()` method, which is
 necessary before calling `Kokkos::finalize`.

--- a/components/omega/doc/userGuide/OceanState.md
+++ b/components/omega/doc/userGuide/OceanState.md
@@ -5,4 +5,4 @@
 The `OceanState` class provides a container for the non-tracer prognostic variables in Omega, namely `normalVelocity` and `layerThickness`.
 Upon creation of a `OceanState` instance, these variables are allocated and registered with the IO infrastructure.
 The class contains a method to update the time levels for the state variables between timesteps.
-This involves a halo update, pointer swap, and updating the `IOFields` data references.
+This involves a halo update, time level index update, and updating the `IOFields` data references.

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -52,8 +52,10 @@ AuxiliaryState::~AuxiliaryState() {
 // Compute the auxiliary variables needed for momentum equation
 void AuxiliaryState::computeMomAux(const OceanState *State, int ThickTimeLevel,
                                    int VelTimeLevel) const {
-   const Array2DReal &LayerThickCell = State->LayerThickness[ThickTimeLevel];
-   const Array2DReal &NormalVelEdge  = State->NormalVelocity[VelTimeLevel];
+   Array2DReal LayerThickCell;
+   Array2DReal NormalVelEdge;
+   State->getLayerThickness(LayerThickCell, ThickTimeLevel);
+   State->getNormalVelocity(NormalVelEdge, VelTimeLevel);
 
    const int NVertLevels = LayerThickCell.extent_int(1);
    const int NChunks     = NVertLevels / VecLength;
@@ -113,8 +115,10 @@ void AuxiliaryState::computeMomAux(const OceanState *State, int ThickTimeLevel,
 void AuxiliaryState::computeAll(const OceanState *State,
                                 const Array3DReal &TracerArray,
                                 int ThickTimeLevel, int VelTimeLevel) const {
-   const Array2DReal &LayerThickCell = State->LayerThickness[ThickTimeLevel];
-   const Array2DReal &NormalVelEdge  = State->NormalVelocity[VelTimeLevel];
+   Array2DReal LayerThickCell;
+   Array2DReal NormalVelEdge;
+   State->getLayerThickness(LayerThickCell, ThickTimeLevel);
+   State->getNormalVelocity(NormalVelEdge, VelTimeLevel);
 
    const int NVertLevels = LayerThickCell.extent_int(1);
    const int NChunks     = NVertLevels / VecLength;

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -91,7 +91,6 @@ OceanState::OceanState(
    LayerThicknessH.resize(NTimeLevels);
    NormalVelocityH.resize(NTimeLevels);
 
-
    for (int I = 0; I < NTimeLevels; I++) {
       LayerThicknessH[I] = HostArray2DReal("LayerThickness" + std::to_string(I),
                                            NCellsSize, NVertLevels);
@@ -381,7 +380,8 @@ void OceanState::read(int StateFileID, I4 CellDecompR8, I4 EdgeDecompR8) {
 
 //------------------------------------------------------------------------------
 // Get layer thickness device array
-I4 OceanState::getLayerThickness(Array2DReal &LayerThick, const I4 TimeLevel) const {
+I4 OceanState::getLayerThickness(Array2DReal &LayerThick,
+                                 const I4 TimeLevel) const {
    I4 Err = 0;
 
    I4 TimeIndex = getTimeIndex(TimeLevel);
@@ -404,7 +404,8 @@ I4 OceanState::getLayerThicknessH(HostArray2DReal &LayerThickH,
 
 //------------------------------------------------------------------------------
 // Get normal velocity device array
-I4 OceanState::getNormalVelocity(Array2DReal &NormVel, const I4 TimeLevel) const {
+I4 OceanState::getNormalVelocity(Array2DReal &NormVel,
+                                 const I4 TimeLevel) const {
 
    I4 Err = 0;
 
@@ -459,8 +460,7 @@ I4 OceanState::exchangeHalo(const I4 TimeLevel) {
 
    copyToHost(TimeLevel);
 
-
-   I4 TimeIndex = getTimeIndex(TimeLevel); 
+   I4 TimeIndex = getTimeIndex(TimeLevel);
 
    MeshHalo->exchangeFullArrayHalo(LayerThicknessH[TimeIndex], OnCell);
    MeshHalo->exchangeFullArrayHalo(NormalVelocityH[TimeIndex], OnEdge);
@@ -534,7 +534,8 @@ I4 OceanState::getTimeIndex(const I4 TimeLevel) const {
 
    // Check if time level is valid
    if (TimeLevel > 1 || (TimeLevel + NTimeLevels) <= 1) {
-      LOG_ERROR("OceanState: Time level {} is out of range {}", TimeLevel, NTimeLevels);
+      LOG_ERROR("OceanState: Time level {} is out of range {}", TimeLevel,
+                NTimeLevels);
       return -1;
    }
 

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -542,22 +542,14 @@ OceanState *OceanState::get(const std::string Name ///< [in] Name of state
 // TimeLevel == [1:new, 0:current, -1:previous, -2:two times ago, ...]
 I4 OceanState::getTimeIndex(I4 &TimeIndex, const I4 TimeLevel) const {
 
-   // Handle single time level case (no new time level)
-   I4 TimeLevelAdj;
-   if (NTimeLevels == 1) {
-      TimeLevelAdj = TimeLevel;
-   } else {
-      TimeLevelAdj = TimeLevel - 1;
-   }
-
    // Check if time level is valid
-   if (TimeLevelAdj > 0 || (TimeLevelAdj + NTimeLevels) <= 0) {
+   if (NTimeLevels > 1 && (TimeLevel > 1 || (TimeLevel + NTimeLevels) <= 1)) {
       LOG_ERROR("OceanState: Time level {} is out of range for NTimeLevels {}",
                 TimeLevel, NTimeLevels);
       return -1;
    }
 
-   TimeIndex = (TimeLevelAdj + CurTimeIndex + NTimeLevels) % NTimeLevels;
+   TimeIndex = (TimeLevel + CurTimeIndex + NTimeLevels) % NTimeLevels;
 
    return 0;
 

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -44,6 +44,11 @@ int OceanState::init() {
    }
    int NTimeLevels = DefTimeStepper->getNTimeLevels();
 
+   if (NTimeLevels < 2) {
+      LOG_ERROR("OceanState: the number of time level is lower than 2");
+      return -2;
+   }
+
    // Create the default state and set pointer to it
    OceanState::DefaultOceanState =
        create("Default", DefHorzMesh, DefHalo, NVertLevels, NTimeLevels);
@@ -75,14 +80,18 @@ OceanState::OceanState(
 
    NVertLevels = NVertLevels_;
    NTimeLevels = NTimeLevels_;
-   CurLevel    = std::max(0, NTimeLevels - 2);
-   NewLevel    = NTimeLevels - 1;
 
    MeshHalo = MeshHalo_;
 
    Name = Name_;
 
+   CurTimeIndex = 0;
+
    // Allocate state host arrays
+   LayerThicknessH.resize(NTimeLevels);
+   NormalVelocityH.resize(NTimeLevels);
+
+
    for (int I = 0; I < NTimeLevels; I++) {
       LayerThicknessH[I] = HostArray2DReal("LayerThickness" + std::to_string(I),
                                            NCellsSize, NVertLevels);
@@ -90,10 +99,16 @@ OceanState::OceanState(
                                            NEdgesSize, NVertLevels);
    }
 
+   // Allocate state device arrays
+   LayerThickness.resize(NTimeLevels);
+   NormalVelocity.resize(NTimeLevels);
+
    // Create device arrays and copy host data
    for (int I = 0; I < NTimeLevels; I++) {
-      LayerThickness[I] = createDeviceMirrorCopy(LayerThicknessH[I]);
-      NormalVelocity[I] = createDeviceMirrorCopy(NormalVelocityH[I]);
+      LayerThickness[I] = Array2DR8("LayerThickness" + std::to_string(I),
+                                    NCellsSize, NVertLevels);
+      NormalVelocity[I] = Array2DR8("NormalVelocity" + std::to_string(I),
+                                    NEdgesSize, NVertLevels);
    }
 
    // Register fields and metadata for IO
@@ -192,7 +207,8 @@ void OceanState::loadStateFromFile(const std::string &StateFileName,
    finalizeParallelIO(CellDecompR8, EdgeDecompR8);
 
    // Sync with device
-   copyToDevice(CurLevel);
+   copyToDevice(0);
+
 } // end loadStateFromFile
 
 //------------------------------------------------------------------------------
@@ -296,11 +312,14 @@ void OceanState::defineFields() {
                 StateGroupName);
 
    // Associate Field with data
-   Err = NormalVelocityField->attachData<Array2DReal>(NormalVelocity[CurLevel]);
+   I4 TimeIndex = getTimeIndex(0);
+   Err = NormalVelocityField->attachData<Array2DReal>(
+       NormalVelocity[TimeIndex]);
    if (Err != 0)
       LOG_ERROR("Error attaching data array to field {}",
                 NormalVelocityFldName);
-   Err = LayerThicknessField->attachData<Array2DReal>(LayerThickness[CurLevel]);
+   Err = LayerThicknessField->attachData<Array2DReal>(
+       LayerThickness[TimeIndex]);
    if (Err != 0)
       LOG_ERROR("Error attaching data array to field {}",
                 LayerThicknessFldName);
@@ -330,6 +349,7 @@ void OceanState::finalizeParallelIO(I4 CellDecompR8, I4 EdgeDecompR8) {
 void OceanState::read(int StateFileID, I4 CellDecompR8, I4 EdgeDecompR8) {
 
    I4 Err;
+   I4 TimeIndex = getTimeIndex(0);
 
    // Read LayerThickness into a temporary double-precision array
    int LayerThicknessID;
@@ -342,7 +362,7 @@ void OceanState::read(int StateFileID, I4 CellDecompR8, I4 EdgeDecompR8) {
 
    // Copy the thickness data into the final state array of user-specified
    // precision
-   deepCopy(LayerThicknessH[CurLevel], TmpLayerThicknessR8);
+   deepCopy(LayerThicknessH[TimeIndex], TmpLayerThicknessR8);
 
    // Read NormalVelocity  into a temporary double-precision array
    int NormalVelocityID;
@@ -355,62 +375,126 @@ void OceanState::read(int StateFileID, I4 CellDecompR8, I4 EdgeDecompR8) {
 
    // Copy the velocity data into the final state array of user-specified
    // precision
-   deepCopy(NormalVelocityH[CurLevel], TmpNormalVelocityR8);
+   deepCopy(NormalVelocityH[TimeIndex], TmpNormalVelocityR8);
 
 } // end read
 
 //------------------------------------------------------------------------------
+// Get layer thickness device array
+I4 OceanState::getLayerThickness(Array2DReal &LayerThick, const I4 TimeLevel) const {
+   I4 Err = 0;
+
+   I4 TimeIndex = getTimeIndex(TimeLevel);
+   LayerThick   = LayerThickness[TimeIndex];
+
+   return Err;
+}
+
+//------------------------------------------------------------------------------
+// Get layer thickness host array
+I4 OceanState::getLayerThicknessH(HostArray2DReal &LayerThickH,
+                                  const I4 TimeLevel) const {
+   I4 Err = 0;
+
+   I4 TimeIndex = getTimeIndex(TimeLevel);
+   LayerThickH  = LayerThicknessH[TimeIndex];
+
+   return Err;
+}
+
+//------------------------------------------------------------------------------
+// Get normal velocity device array
+I4 OceanState::getNormalVelocity(Array2DReal &NormVel, const I4 TimeLevel) const {
+
+   I4 Err = 0;
+
+   I4 TimeIndex = getTimeIndex(TimeLevel);
+   NormVel      = NormalVelocity[TimeIndex];
+
+   return Err;
+}
+
+//------------------------------------------------------------------------------
+// Get normal velocity host array
+I4 OceanState::getNormalVelocityH(HostArray2DReal &NormVelH,
+                                  const I4 TimeLevel) const {
+   I4 Err = 0;
+
+   I4 TimeIndex = getTimeIndex(TimeLevel);
+   NormVelH     = NormalVelocityH[TimeIndex];
+
+   return Err;
+}
+
+//------------------------------------------------------------------------------
 // Perform copy to device for state variables
-void OceanState::copyToDevice(int TimeLevel) {
+// TimeLevel == [1:new, 0:current, -1:previous, -2:two times ago, ...]
+I4 OceanState::copyToDevice(const I4 TimeLevel) {
 
-   deepCopy(LayerThickness[TimeLevel], LayerThicknessH[TimeLevel]);
-   deepCopy(NormalVelocity[TimeLevel], NormalVelocityH[TimeLevel]);
+   I4 TimeIndex = getTimeIndex(TimeLevel);
 
+   deepCopy(LayerThickness[TimeIndex], LayerThicknessH[TimeIndex]);
+   deepCopy(NormalVelocity[TimeIndex], NormalVelocityH[TimeIndex]);
+
+   return 0;
 } // end copyToDevice
 
 //------------------------------------------------------------------------------
 // Perform copy to host for state variables
-void OceanState::copyToHost(int TimeLevel) {
+// TimeLevel == [1: new, 0:current, -1:previous, -2:two times ago, ...]
+I4 OceanState::copyToHost(const I4 TimeLevel) {
 
-   deepCopy(LayerThicknessH[TimeLevel], LayerThickness[TimeLevel]);
-   deepCopy(NormalVelocityH[TimeLevel], NormalVelocity[TimeLevel]);
+   I4 TimeIndex = getTimeIndex(TimeLevel);
 
+   deepCopy(LayerThicknessH[TimeIndex], LayerThickness[TimeIndex]);
+   deepCopy(NormalVelocityH[TimeIndex], NormalVelocity[TimeIndex]);
+
+   return 0;
 } // end copyToHost
 
 //------------------------------------------------------------------------------
 // Perform state halo exchange
-void OceanState::exchangeHalo(int TimeLevel) {
+// TimeLevel == [1:new, 0:current, -1:previous, -2:two times ago, ...]
+I4 OceanState::exchangeHalo(const I4 TimeLevel) {
+
    copyToHost(TimeLevel);
-   MeshHalo->exchangeFullArrayHalo(LayerThicknessH[TimeLevel], OnCell);
-   MeshHalo->exchangeFullArrayHalo(NormalVelocityH[TimeLevel], OnEdge);
+
+
+   I4 TimeIndex = getTimeIndex(TimeLevel); 
+
+   MeshHalo->exchangeFullArrayHalo(LayerThicknessH[TimeIndex], OnCell);
+   MeshHalo->exchangeFullArrayHalo(NormalVelocityH[TimeIndex], OnEdge);
+
    copyToDevice(TimeLevel);
+
+   return 0;
+
 } // end exchangeHalo
 
 //------------------------------------------------------------------------------
 // Perform time level update
-void OceanState::updateTimeLevels() {
+I4 OceanState::updateTimeLevels() {
 
-   int NewLevel = NTimeLevels - 1;
-
-   // Exchange halo
-   exchangeHalo(NewLevel);
-
-   // Update time levels for layer thickness and normal velocity
-   for (int Level = 0; Level < NTimeLevels - 1; Level++) {
-      std::swap(LayerThickness[Level + 1], LayerThickness[Level]);
-      std::swap(LayerThicknessH[Level + 1], LayerThicknessH[Level]);
-
-      std::swap(NormalVelocity[Level + 1], NormalVelocity[Level]);
-      std::swap(NormalVelocityH[Level + 1], NormalVelocityH[Level]);
+   if (NTimeLevels == 1) {
+      LOG_ERROR("OceanState: can't update time levels for NTimeLevels == 1");
+      return -1;
    }
 
-   // Update IOField data associations
-   int Err = 0;
+   // Exchange halo
+   exchangeHalo(1);
 
+   // Update current time index for layer thickness and normal velocity
+   CurTimeIndex = (CurTimeIndex + 1) % NTimeLevels;
+
+   I4 Err = 0;
+
+   // Update IOField data associations
    Err = Field::attachFieldData<Array2DReal>(NormalVelocityFldName,
-                                             NormalVelocity[CurLevel]);
-   Err = Field::attachFieldData<Array2DReal>(LayerThicknessFldName,
-                                             LayerThickness[CurLevel]);
+                                           NormalVelocity[CurTimeIndex]);
+   Err = Field::attachFieldData<Array2DReeal>(LayerThicknessFldName,
+                                           LayerThickness[CurTimeIndex]);
+
+   return 0;
 
 } // end updateTimeLevels
 
@@ -437,6 +521,28 @@ OceanState *OceanState::get(const std::string Name ///< [in] Name of state
       return nullptr;
    }
 } // end get state
+
+//------------------------------------------------------------------------------
+// Get time index from time level
+// TimeLevel == [1:new, 0:current, -1:previous, -2:two times ago, ...]
+I4 OceanState::getTimeIndex(const I4 TimeLevel) const {
+
+   if (NTimeLevels == 1) {
+      I4 TimeIndex = 0;
+      return TimeIndex;
+   }
+
+   // Check if time level is valid
+   if (TimeLevel > 1 || (TimeLevel + NTimeLevels) <= 1) {
+      LOG_ERROR("OceanState: Time level {} is out of range {}", TimeLevel, NTimeLevels);
+      return -1;
+   }
+
+   I4 TimeIndex = (TimeLevel + CurTimeIndex + NTimeLevels) % NTimeLevels;
+
+   return TimeIndex;
+
+} // end get time index
 
 } // end namespace OMEGA
 

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -104,10 +104,10 @@ OceanState::OceanState(
 
    // Create device arrays and copy host data
    for (int I = 0; I < NTimeLevels; I++) {
-      LayerThickness[I] = Array2DR8("LayerThickness" + std::to_string(I),
-                                    NCellsSize, NVertLevels);
-      NormalVelocity[I] = Array2DR8("NormalVelocity" + std::to_string(I),
-                                    NEdgesSize, NVertLevels);
+      LayerThickness[I] = Array2DReal("LayerThickness" + std::to_string(I),
+                                      NCellsSize, NVertLevels);
+      NormalVelocity[I] = Array2DReal("NormalVelocity" + std::to_string(I),
+                                      NEdgesSize, NVertLevels);
    }
 
    // Register fields and metadata for IO
@@ -314,13 +314,13 @@ void OceanState::defineFields() {
    I4 TimeIndex;
    Err = getTimeIndex(TimeIndex, 0);
 
-   Err = NormalVelocityField->attachData<Array2DReal>(
-       NormalVelocity[TimeIndex]);
+   Err =
+       NormalVelocityField->attachData<Array2DReal>(NormalVelocity[TimeIndex]);
    if (Err != 0)
       LOG_ERROR("Error attaching data array to field {}",
                 NormalVelocityFldName);
-   Err = LayerThicknessField->attachData<Array2DReal>(
-       LayerThickness[TimeIndex]);
+   Err =
+       LayerThicknessField->attachData<Array2DReal>(LayerThickness[TimeIndex]);
    if (Err != 0)
       LOG_ERROR("Error attaching data array to field {}",
                 LayerThicknessFldName);
@@ -350,6 +350,7 @@ void OceanState::finalizeParallelIO(I4 CellDecompR8, I4 EdgeDecompR8) {
 void OceanState::read(int StateFileID, I4 CellDecompR8, I4 EdgeDecompR8) {
 
    I4 Err;
+   I4 TimeIndex;
 
    Err = getTimeIndex(TimeIndex, 0);
 
@@ -505,9 +506,9 @@ I4 OceanState::updateTimeLevels() {
 
    // Update IOField data associations
    Err = Field::attachFieldData<Array2DReal>(NormalVelocityFldName,
-                                           NormalVelocity[CurTimeIndex]);
-   Err = Field::attachFieldData<Array2DReeal>(LayerThicknessFldName,
-                                           LayerThickness[CurTimeIndex]);
+                                             NormalVelocity[CurTimeIndex]);
+   Err = Field::attachFieldData<Array2DReal>(LayerThicknessFldName,
+                                             LayerThickness[CurTimeIndex]);
 
    return 0;
 

--- a/components/omega/src/ocn/OceanState.h
+++ b/components/omega/src/ocn/OceanState.h
@@ -122,7 +122,8 @@ class OceanState {
    I4 getLayerThickness(Array2DReal &LayerThick, const I4 TimeLevel) const;
 
    /// Get layer thickness host array at given time level
-   I4 getLayerThicknessH(HostArray2DReal &LayerThickH, const I4 TimeLevel) const;
+   I4 getLayerThicknessH(HostArray2DReal &LayerThickH,
+                         const I4 TimeLevel) const;
 
    /// Get normal velocity device array at given time level
    I4 getNormalVelocity(Array2DReal &NormVel, const I4 TimeLevel) const;

--- a/components/omega/src/ocn/OceanState.h
+++ b/components/omega/src/ocn/OceanState.h
@@ -54,6 +54,14 @@ class OceanState {
    OceanState(const OceanState &) = delete;
    OceanState(OceanState &&)      = delete;
 
+   // Current time index
+   // this index is circular so that it returns to index 0
+   // if it is over max index
+   I4 CurTimeIndex; ///< Time dimension array index for current level
+
+   /// Get the current time level index associated with a time level
+   I4 getTimeIndex(const I4 TimeLevel) const;
+
  public:
    // Variables
    // Since these are used frequently, we make them public to reduce the
@@ -78,20 +86,13 @@ class OceanState {
    I4 NTimeLevels; ///< Number of time levels in state variable arrays
    I4 NVertLevels; ///< Number of vertical levels in state variable arrays
 
-   I4 CurLevel; ///< Time dimension index for current level
-   I4 NewLevel; ///< Time dimension index for new level
-
    // Prognostic variables
 
-   Kokkos::Array<Array2DReal, MaxTimeLevels>
-       LayerThickness; ///< Device LayerThickness array
-   Kokkos::Array<HostArray2DReal, MaxTimeLevels>
-       LayerThicknessH; ///< Host LayerThickness array
+   std::vector<Array2DReal> LayerThickness; ///< Device LayerThickness array
+   std::vector<HostArray2DReal> LayerThicknessH; ///< Host LayerThickness array
 
-   Kokkos::Array<Array2DReal, MaxTimeLevels>
-       NormalVelocity; ///< Device NormalVelocity array
-   Kokkos::Array<HostArray2DReal, MaxTimeLevels>
-       NormalVelocityH; ///< Host NormalVelocity array
+   std::vector<Array2DReal> NormalVelocity; ///< Device NormalVelocity array
+   std::vector<HostArray2DReal> NormalVelocityH; ///< Host NormalVelocity array
 
    // Field names
    // These are appended with the State name for non-Default state instances
@@ -117,17 +118,29 @@ class OceanState {
    /// load state from file
    void loadStateFromFile(const std::string &StateFileName, Decomp *MeshDecomp);
 
+   /// Get layer thickness device array at given time level
+   I4 getLayerThickness(Array2DReal &LayerThick, const I4 TimeLevel) const;
+
+   /// Get layer thickness host array at given time level
+   I4 getLayerThicknessH(HostArray2DReal &LayerThickH, const I4 TimeLevel) const;
+
+   /// Get normal velocity device array at given time level
+   I4 getNormalVelocity(Array2DReal &NormVel, const I4 TimeLevel) const;
+
+   /// Get normal velocity host array at given time level
+   I4 getNormalVelocityH(HostArray2DReal &NormVelH, const I4 TimeLevel) const;
+
    /// Exchange halo
-   void exchangeHalo(int TimeLevel);
+   I4 exchangeHalo(const I4 TimeLevel);
 
    /// Swap time levels to update state arrays
-   void updateTimeLevels();
+   I4 updateTimeLevels();
 
    /// Copy state variables from host to device
-   void copyToDevice(int TimeLevel);
+   I4 copyToDevice(const I4 TimeLevel);
 
    /// Copy state variables from device to host
-   void copyToHost(int TimeLevel);
+   I4 copyToHost(const I4 TimeLevel);
 
    /// Destructor - deallocates all memory and deletes an OceanState
    ~OceanState();

--- a/components/omega/src/ocn/OceanState.h
+++ b/components/omega/src/ocn/OceanState.h
@@ -60,7 +60,7 @@ class OceanState {
    I4 CurTimeIndex; ///< Time dimension array index for current level
 
    /// Get the current time level index associated with a time level
-   I4 getTimeIndex(const I4 TimeLevel) const;
+   I4 getTimeIndex(I4 &TimeIndex, const I4 TimeLevel) const;
 
  public:
    // Variables

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -252,7 +252,8 @@ void Tendencies::computeThicknessTendenciesOnly(
 
    OMEGA_SCOPE(LocLayerThicknessTend, LayerThicknessTend);
    OMEGA_SCOPE(LocThicknessFluxDiv, ThicknessFluxDiv);
-   const Array2DReal &NormalVelEdge = State->NormalVelocity[VelTimeLevel];
+   Array2DReal NormalVelEdge;
+   State->getNormalVelocity(NormalVelEdge, VelTimeLevel);
 
    deepCopy(LocLayerThicknessTend, 0);
 
@@ -299,7 +300,8 @@ void Tendencies::computeVelocityTendenciesOnly(
        AuxState->LayerThicknessAux.FluxLayerThickEdge;
    const Array2DReal &NormRVortEdge = AuxState->VorticityAux.NormRelVortEdge;
    const Array2DReal &NormFEdge     = AuxState->VorticityAux.NormPlanetVortEdge;
-   const Array2DReal &NormVelEdge   = State->NormalVelocity[VelTimeLevel];
+   Array2DReal NormVelEdge;
+   State->getNormalVelocity(NormVelEdge, VelTimeLevel);
    if (LocPotientialVortHAdv.Enabled) {
       parallelFor(
           {NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
@@ -417,9 +419,13 @@ void Tendencies::computeThicknessTendencies(
     TimeInstant Time                ///< [in] Time
 ) {
    // only need LayerThicknessAux on edge
+   Array2DReal LayerThick;
+   Array2DReal NormVel;
+   State->getLayerThickness(LayerThick, ThickTimeLevel);
+   State->getNormalVelocity(NormVel, VelTimeLevel);
    OMEGA_SCOPE(LayerThicknessAux, AuxState->LayerThicknessAux);
-   OMEGA_SCOPE(LayerThickCell, State->LayerThickness[ThickTimeLevel]);
-   OMEGA_SCOPE(NormalVelEdge, State->NormalVelocity[VelTimeLevel]);
+   OMEGA_SCOPE(LayerThickCell, LayerThick);
+   OMEGA_SCOPE(NormalVelEdge, NormVel);
 
    parallelFor(
        "computeLayerThickAux", {NEdgesAll, NChunks},

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -499,7 +499,7 @@ I4 Tracers::updateTimeLevels() {
 }
 
 //---------------------------------------------------------------------------
-// get index for time level 
+// get index for time level
 // TimeLevel == [1:new, 0:current, -1:previous, -2:two times ago, ...]
 //---------------------------------------------------------------------------
 I4 Tracers::getTimeIndex(const I4 TimeLevel) {

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -529,7 +529,6 @@ I4 Tracers::getTimeIndex(I4 &TimeIndex, const I4 TimeLevel) {
       TimeLevelAdj = TimeLevel - 1;
    }
 
-
    // Check if time level is valid
    if (TimeLevelAdj > 0 || (TimeLevelAdj + NTimeLevels) <= 0) {
       LOG_ERROR("Tracers: Time level {} is out of range for NTimeLevels {}",

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -492,7 +492,7 @@ I4 Tracers::updateTimeLevels() {
    }
 
    // Exchange halo
-   exchangeHalo(0);
+   exchangeHalo(1);
 
    CurTimeIndex = (CurTimeIndex + 1) % NTimeLevels;
 
@@ -521,22 +521,14 @@ I4 Tracers::updateTimeLevels() {
 //---------------------------------------------------------------------------
 I4 Tracers::getTimeIndex(I4 &TimeIndex, const I4 TimeLevel) {
 
-   // Handle single time level case (no new time level)
-   I4 TimeLevelAdj;
-   if (NTimeLevels == 1) {
-      TimeLevelAdj = TimeIndex;
-   } else {
-      TimeLevelAdj = TimeLevel - 1;
-   }
-
    // Check if time level is valid
-   if (TimeLevelAdj > 0 || (TimeLevelAdj + NTimeLevels) <= 0) {
+   if (NTimeLevels > 1 && (TimeLevel > 1 || (TimeLevel + NTimeLevels) <= 1)) {
       LOG_ERROR("Tracers: Time level {} is out of range for NTimeLevels {}",
                 TimeLevel, NTimeLevels);
       return -1;
    }
 
-   TimeIndex = (TimeLevelAdj + CurTimeIndex + NTimeLevels) % NTimeLevels;
+   TimeIndex = (TimeLevel + CurTimeIndex + NTimeLevels) % NTimeLevels;
 
    return 0;
 }

--- a/components/omega/src/ocn/Tracers.h
+++ b/components/omega/src/ocn/Tracers.h
@@ -62,6 +62,9 @@ class Tracers {
    // if it is over max index
    static I4 CurTimeIndex; ///< Time dimension array index for current level
 
+   // get the time level index
+   static I4 getTimeIndex(const I4 TimeLevel);
+
    // locally defines all tracers but do not allocates memory
    static I4
    define(const std::string &Name,        ///< [in] Name of tracer

--- a/components/omega/src/ocn/Tracers.h
+++ b/components/omega/src/ocn/Tracers.h
@@ -63,7 +63,7 @@ class Tracers {
    static I4 CurTimeIndex; ///< Time dimension array index for current level
 
    // get the time level index
-   static I4 getTimeIndex(const I4 TimeLevel);
+   static I4 getTimeIndex(I4 &TimeIndex, const I4 TimeLevel);
 
    // locally defines all tracers but do not allocates memory
    static I4

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -18,13 +18,10 @@ void ForwardBackwardStepper::doStep(OceanState *State, TimeInstant Time) const {
 
    const int CurLevel  = 0;
    const int NextLevel = 1;
-   // TODO: resolve time level indexing
-   const int TrCurLevel  = -1;
-   const int TrNextLevel = 0;
 
    Array3DReal CurTracerArray, NextTracerArray;
-   Err = Tracers::getAll(CurTracerArray, TrCurLevel);
-   Err = Tracers::getAll(NextTracerArray, TrNextLevel);
+   Err = Tracers::getAll(CurTracerArray, CurLevel);
+   Err = Tracers::getAll(NextTracerArray, NextLevel);
 
    // R_h^{n} = RHS_h(u^{n}, h^{n}, t^{n})
    Tend->computeThicknessTendencies(State, AuxState, CurLevel, CurLevel, Time);

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -18,13 +18,10 @@ void RungeKutta2Stepper::doStep(OceanState *State, TimeInstant Time) const {
 
    const int CurLevel  = 0;
    const int NextLevel = 1;
-   // TODO: resolve time level indexing
-   const int TrCurLevel  = -1;
-   const int TrNextLevel = 0;
 
    Array3DReal CurTracerArray, NextTracerArray;
-   Err = Tracers::getAll(CurTracerArray, TrCurLevel);
-   Err = Tracers::getAll(NextTracerArray, TrNextLevel);
+   Err = Tracers::getAll(CurTracerArray, CurLevel);
+   Err = Tracers::getAll(NextTracerArray, NextLevel);
 
    // q = (h,u,phi)
    // R_q^{n} = RHS_q(u^{n}, h^{n}, phi^{n}, t^{n})

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -47,13 +47,10 @@ void RungeKutta4Stepper::doStep(OceanState *State, TimeInstant Time) const {
 
    const int CurLevel  = 0;
    const int NextLevel = 1;
-   // TODO: resolve time level indexing
-   const int TrCurLevel  = -1;
-   const int TrNextLevel = 0;
 
    Array3DReal NextTracerArray, CurTracerArray;
-   Err = Tracers::getAll(CurTracerArray, TrCurLevel);
-   Err = Tracers::getAll(NextTracerArray, TrNextLevel);
+   Err = Tracers::getAll(CurTracerArray, CurLevel);
+   Err = Tracers::getAll(NextTracerArray, NextLevel);
 
    for (int Stage = 0; Stage < NStages; ++Stage) {
       const TimeInstant StageTime = Time + RKC[Stage] * TimeStep;

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -186,8 +186,11 @@ void TimeStepper::updateThicknessByTend(OceanState *State1, int TimeLevel1,
                                         OceanState *State2, int TimeLevel2,
                                         TimeInterval Coeff) const {
 
-   const auto &LayerThick1    = State1->LayerThickness[TimeLevel1];
-   const auto &LayerThick2    = State2->LayerThickness[TimeLevel2];
+   Array2DReal LayerThick1;
+   Array2DReal LayerThick2;
+   I4 Err;
+   Err = State1->getLayerThickness(LayerThick1, TimeLevel1);
+   Err = State2->getLayerThickness(LayerThick2, TimeLevel2);
    const auto &LayerThickTend = Tend->LayerThicknessTend;
    const int NVertLevels      = LayerThickTend.extent_int(1);
 
@@ -208,8 +211,11 @@ void TimeStepper::updateVelocityByTend(OceanState *State1, int TimeLevel1,
                                        OceanState *State2, int TimeLevel2,
                                        TimeInterval Coeff) const {
 
-   const auto &NormalVel1    = State1->NormalVelocity[TimeLevel1];
-   const auto &NormalVel2    = State2->NormalVelocity[TimeLevel2];
+   Array2DReal NormalVel1;
+   Array2DReal NormalVel2;
+   I4 Err;
+   Err = State1->getNormalVelocity(NormalVel1, TimeLevel1);
+   Err = State2->getNormalVelocity(NormalVel2, TimeLevel2);
    const auto &NormalVelTend = Tend->NormalVelocityTend;
    const int NVertLevels     = NormalVelTend.extent_int(1);
 

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -51,8 +51,10 @@ int initState() {
    auto *Mesh  = HorzMesh::getDefault();
    auto *State = OceanState::getDefault();
 
-   const auto &LayerThickCell = State->LayerThickness[0];
-   const auto &NormalVelEdge  = State->NormalVelocity[0];
+   Array2DReal LayerThickCell;
+   Array2DReal NormalVelEdge;
+   Err = State->getLayerThickness(LayerThickCell, 0);
+   Err += State->getNormalVelocity(NormalVelEdge, 0);
    Array3DReal TracerArray;
    Err += Tracers::getAll(TracerArray, 0);
 

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -118,11 +118,8 @@ int main(int argc, char *argv[]) {
 
       for (int NTimeLevels = 2; NTimeLevels < 4; NTimeLevels++) {
 
-         int CurLevel = NTimeLevels - 2;
-         int NewLevel = CurLevel - 1;
-         if (NewLevel < 0) {
-            NewLevel = NTimeLevels - 1;
-         }
+         int CurLevel = -1;
+         int NewLevel = 0;
 
          // Create "default" state
          if (NTimeLevels == 2) {
@@ -162,11 +159,13 @@ int main(int argc, char *argv[]) {
          TestState->loadStateFromFile(DefHorzMesh->MeshFileName, DefDecomp);
 
          // Test that reasonable values have been read in for LayerThickness
+         OMEGA::HostArray2DReal LayerThickH;
+         DefState->getLayerThicknessH(LayerThickH, CurLevel);
          int count = 0;
          for (int Cell = 0; Cell < DefState->NCellsAll; Cell++) {
             int colCount = 0;
             for (int Level = 0; Level < DefState->NVertLevels; Level++) {
-               OMEGA::R8 val = DefState->LayerThicknessH[CurLevel](Cell, Level);
+               OMEGA::R8 val = LayerThickH(Cell, Level);
                if (val > 0.0 && val < 300.0) {
                   colCount++;
                }
@@ -184,18 +183,24 @@ int main(int argc, char *argv[]) {
          }
 
          // Initialize NormalVelocity values
+         OMEGA::HostArray2DReal NormalVelocityHDef;
+         OMEGA::HostArray2DReal NormalVelocityHTest;
+         DefState->getNormalVelocityH(NormalVelocityHDef, CurLevel);
+         TestState->getNormalVelocityH(NormalVelocityHTest, CurLevel);
          for (int Edge = 0; Edge < DefState->NEdgesAll; Edge++) {
             for (int Level = 0; Level < DefState->NVertLevels; Level++) {
-               DefState->NormalVelocityH[CurLevel](Edge, Level)  = Edge;
-               TestState->NormalVelocityH[CurLevel](Edge, Level) = Edge;
+               NormalVelocityHDef(Edge, Level)  = Edge;
+               NormalVelocityHTest(Edge, Level) = Edge;
             }
          }
 
          // Test that initally the 0 time levels of the
          // Def and Test state arrays match
-         count                     = 0;
-         auto LayerThicknessH_def  = DefState->LayerThicknessH[CurLevel];
-         auto LayerThicknessH_test = TestState->LayerThicknessH[CurLevel];
+         count = 0;
+         OMEGA::HostArray2DReal LayerThicknessH_def;
+         OMEGA::HostArray2DReal LayerThicknessH_test;
+         DefState->getLayerThicknessH(LayerThicknessH_def, CurLevel);
+         TestState->getLayerThicknessH(LayerThicknessH_test, CurLevel);
          for (int Cell = 0; Cell < DefState->NCellsAll; Cell++) {
             for (int Level = 0; Level < DefState->NVertLevels; Level++) {
                if (LayerThicknessH_def(Cell, Level) !=
@@ -205,8 +210,10 @@ int main(int argc, char *argv[]) {
             }
          }
 
-         auto NormalVelocityH_def  = DefState->NormalVelocityH[CurLevel];
-         auto NormalVelocityH_test = TestState->NormalVelocityH[CurLevel];
+         OMEGA::HostArray2DReal NormalVelocityH_def;
+         OMEGA::HostArray2DReal NormalVelocityH_test;
+         DefState->getNormalVelocityH(NormalVelocityH_def, CurLevel);
+         TestState->getNormalVelocityH(NormalVelocityH_test, CurLevel);
          for (int Edge = 0; Edge < DefState->NEdgesAll; Edge++) {
             for (int Level = 0; Level < DefState->NVertLevels; Level++) {
                if (NormalVelocityH_def(Edge, Level) !=
@@ -227,9 +234,9 @@ int main(int argc, char *argv[]) {
          DefState->updateTimeLevels();
 
          // Test that the time level update is correct.
-         count                = 0;
-         LayerThicknessH_def  = DefState->LayerThicknessH[NewLevel];
-         LayerThicknessH_test = TestState->LayerThicknessH[CurLevel];
+         count = 0;
+         DefState->getLayerThicknessH(LayerThicknessH_def, NewLevel);
+         TestState->getLayerThicknessH(LayerThicknessH_test, CurLevel);
          for (int Cell = 0; Cell < DefState->NCellsAll; Cell++) {
             for (int Level = 0; Level < DefState->NVertLevels; Level++) {
                if (LayerThicknessH_def(Cell, Level) !=
@@ -239,8 +246,8 @@ int main(int argc, char *argv[]) {
             }
          }
 
-         LayerThicknessH_def  = DefState->LayerThicknessH[CurLevel];
-         LayerThicknessH_test = TestState->LayerThicknessH[NewLevel];
+         DefState->getLayerThicknessH(LayerThicknessH_def, CurLevel);
+         TestState->getLayerThicknessH(LayerThicknessH_test, NewLevel);
          for (int Cell = 0; Cell < DefState->NCellsAll; Cell++) {
             for (int Level = 0; Level < DefState->NVertLevels; Level++) {
                if (LayerThicknessH_def(Cell, Level) !=
@@ -250,8 +257,8 @@ int main(int argc, char *argv[]) {
             }
          }
 
-         NormalVelocityH_def  = DefState->NormalVelocityH[NewLevel];
-         NormalVelocityH_test = TestState->NormalVelocityH[CurLevel];
+         DefState->getNormalVelocityH(NormalVelocityH_def, NewLevel);
+         TestState->getNormalVelocityH(NormalVelocityH_test, CurLevel);
          for (int Edge = 0; Edge < DefState->NEdgesAll; Edge++) {
             for (int Level = 0; Level < DefState->NVertLevels; Level++) {
                if (NormalVelocityH_def(Edge, Level) !=
@@ -261,8 +268,8 @@ int main(int argc, char *argv[]) {
             }
          }
 
-         NormalVelocityH_def  = DefState->NormalVelocityH[CurLevel];
-         NormalVelocityH_test = TestState->NormalVelocityH[NewLevel];
+         DefState->getNormalVelocityH(NormalVelocityH_def, CurLevel);
+         TestState->getNormalVelocityH(NormalVelocityH_test, NewLevel);
          for (int Edge = 0; Edge < DefState->NEdgesAll; Edge++) {
             for (int Level = 0; Level < DefState->NVertLevels; Level++) {
                if (NormalVelocityH_def(Edge, Level) !=
@@ -281,8 +288,10 @@ int main(int argc, char *argv[]) {
 
          // Test time level update on device
          int count1;
-         auto LayerThickness_def  = DefState->LayerThickness[NewLevel];
-         auto LayerThickness_test = TestState->LayerThickness[CurLevel];
+         OMEGA::Array2DReal LayerThickness_def;
+         OMEGA::Array2DReal LayerThickness_test;
+         DefState->getLayerThickness(LayerThickness_def, NewLevel);
+         TestState->getLayerThickness(LayerThickness_test, CurLevel);
          OMEGA::parallelReduce(
              "reduce", {DefState->NCellsAll, DefState->NVertLevels},
              KOKKOS_LAMBDA(int Cell, int Level, int &Accum) {
@@ -294,8 +303,8 @@ int main(int argc, char *argv[]) {
              count1);
 
          int count2;
-         LayerThickness_def  = DefState->LayerThickness[CurLevel];
-         LayerThickness_test = TestState->LayerThickness[NewLevel];
+         DefState->getLayerThickness(LayerThickness_def, CurLevel);
+         TestState->getLayerThickness(LayerThickness_test, NewLevel);
          OMEGA::parallelReduce(
              "reduce", {DefState->NCellsAll, DefState->NVertLevels},
              KOKKOS_LAMBDA(int Cell, int Level, int &Accum) {
@@ -307,8 +316,10 @@ int main(int argc, char *argv[]) {
              count2);
 
          int count3;
-         auto NormalVelocity_def  = DefState->NormalVelocity[CurLevel];
-         auto NormalVelocity_test = TestState->NormalVelocity[NewLevel];
+         OMEGA::Array2DReal NormalVelocity_def;
+         OMEGA::Array2DReal NormalVelocity_test;
+         DefState->getNormalVelocity(NormalVelocity_def, CurLevel);
+         TestState->getNormalVelocity(NormalVelocity_test, NewLevel);
          OMEGA::parallelReduce(
              "reduce", {DefState->NEdgesAll, DefState->NVertLevels},
              KOKKOS_LAMBDA(int Edge, int Level, int &Accum) {
@@ -320,8 +331,8 @@ int main(int argc, char *argv[]) {
              count3);
 
          int count4;
-         NormalVelocity_def  = DefState->NormalVelocity[NewLevel];
-         NormalVelocity_test = TestState->NormalVelocity[CurLevel];
+         DefState->getNormalVelocity(NormalVelocity_def, NewLevel);
+         TestState->getNormalVelocity(NormalVelocity_test, CurLevel);
          OMEGA::parallelReduce(
              "reduce", {DefState->NEdgesAll, DefState->NVertLevels},
              KOKKOS_LAMBDA(int Edge, int Level, int &Accum) {

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -80,7 +80,8 @@ int initStateTest() {
 }
 
 // Check for differences between layer thickness and normal velocity host arrays
-int checkHost(OMEGA::OceanState* DefState, OMEGA::OceanState* TestState, int DefLevel, int TestLevel) {
+int checkHost(OMEGA::OceanState *DefState, OMEGA::OceanState *TestState,
+              int DefLevel, int TestLevel) {
 
    int count = 0;
    OMEGA::HostArray2DReal LayerThicknessH_def;
@@ -112,8 +113,10 @@ int checkHost(OMEGA::OceanState* DefState, OMEGA::OceanState* TestState, int Def
    return count;
 }
 
-// Check for differences between layer thickness and normal velocity device arrays
-int checkDevice(OMEGA::OceanState* DefState, OMEGA::OceanState* TestState, int DefLevel, int TestLevel) {
+// Check for differences between layer thickness and normal velocity device
+// arrays
+int checkDevice(OMEGA::OceanState *DefState, OMEGA::OceanState *TestState,
+                int DefLevel, int TestLevel) {
 
    int count1;
    OMEGA::Array2DReal LayerThickness_def;
@@ -205,10 +208,12 @@ int main(int argc, char *argv[]) {
          // Test retrieval of the default state
          OMEGA::OceanState *DefState = OMEGA::OceanState::get("Default");
          if (DefState) { // true if non-null ptr
-            LOG_INFO("State: Default state retrieval (NTimeLevels={}) PASS", NTimeLevels);
+            LOG_INFO("State: Default state retrieval (NTimeLevels={}) PASS",
+                     NTimeLevels);
          } else {
             RetVal += 1;
-            LOG_INFO("State: Default state retrieval (NTimeLevels={}) FAIL", NTimeLevels);
+            LOG_INFO("State: Default state retrieval (NTimeLevels={}) FAIL",
+                     NTimeLevels);
          }
 
          // Create "test" state
@@ -218,10 +223,12 @@ int main(int argc, char *argv[]) {
          OMEGA::OceanState *TestState = OMEGA::OceanState::get("Test");
 
          if (TestState) { // true if non-null ptr
-            LOG_INFO("State: Test state retrieval (NTimeLevels={}) PASS", NTimeLevels);
+            LOG_INFO("State: Test state retrieval (NTimeLevels={}) PASS",
+                     NTimeLevels);
          } else {
             RetVal += 1;
-            LOG_INFO("State: Test state retrieval (NTimeLevels={}) FAIL", NTimeLevels);
+            LOG_INFO("State: Test state retrieval (NTimeLevels={}) FAIL",
+                     NTimeLevels);
          }
 
          // Initially fill test state with the same values as the default state
@@ -273,10 +280,14 @@ int main(int argc, char *argv[]) {
          int count2 = checkDevice(DefState, TestState, CurLevel, CurLevel);
 
          if (count1 + count2 == 0) {
-            LOG_INFO("State: Default test state comparison (NTimeLevels={}) PASS", NTimeLevels);
+            LOG_INFO(
+                "State: Default test state comparison (NTimeLevels={}) PASS",
+                NTimeLevels);
          } else {
             RetVal += 1;
-            LOG_INFO("State: Default test state comparison (NTimeLevels={}) FAIL", NTimeLevels);
+            LOG_INFO(
+                "State: Default test state comparison (NTimeLevels={}) FAIL",
+                NTimeLevels);
          }
 
          // Perform time level update.
@@ -288,14 +299,18 @@ int main(int argc, char *argv[]) {
          count2 = checkDevice(DefState, TestState, CurLevel, CurLevel);
 
          if (count1 + count2 != 0) {
-            LOG_INFO("State: time levels different after single update (NTimeLevels={}) PASS", NTimeLevels);
+            LOG_INFO("State: time levels different after single update "
+                     "(NTimeLevels={}) PASS",
+                     NTimeLevels);
          } else {
             RetVal += 1;
-            LOG_INFO("State: time levels different after single update (NTimeLevels={}) FAIL", NTimeLevels);
+            LOG_INFO("State: time levels different after single update "
+                     "(NTimeLevels={}) FAIL",
+                     NTimeLevels);
          }
 
          // Perform time level updates to cycle back to inital index
-         for (int i = 0; i < NTimeLevels-1; i++) {
+         for (int i = 0; i < NTimeLevels - 1; i++) {
             DefState->updateTimeLevels();
          }
 
@@ -305,12 +320,13 @@ int main(int argc, char *argv[]) {
          count2 = checkDevice(DefState, TestState, CurLevel, CurLevel);
 
          if (count1 + count2 == 0) {
-            LOG_INFO("State: time level update (NTimeLevels={}) PASS", NTimeLevels);
+            LOG_INFO("State: time level update (NTimeLevels={}) PASS",
+                     NTimeLevels);
          } else {
             RetVal += 1;
-            LOG_INFO("State: time level update (NTimeLevels={}) FAIL", NTimeLevels);
+            LOG_INFO("State: time level update (NTimeLevels={}) FAIL",
+                     NTimeLevels);
          }
-
 
          OMEGA::OceanState::clear();
       }

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -51,8 +51,10 @@ int initState() {
    auto *Mesh  = HorzMesh::getDefault();
    auto *State = OceanState::getDefault();
 
-   const auto &LayerThickCell = State->LayerThickness[0];
-   const auto &NormalVelEdge  = State->NormalVelocity[0];
+   Array2DReal LayerThickCell;
+   Array2DReal NormalVelEdge;
+   Err += State->getLayerThickness(LayerThickCell, 0);
+   Err += State->getNormalVelocity(NormalVelEdge, 0);
 
    Array3DReal TracersArray;
    Err += Tracers::getAll(TracersArray, 0);

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -252,7 +252,7 @@ int main(int argc, char *argv[]) {
           HostArray3DReal("RefHostArray", NTracers, NCellsSize, NVertLevels);
 
       // intialize tracer elements of all time levels
-      for (I4 TimeLevel = 0; TimeLevel + NTimeLevels > 0; --TimeLevel) {
+      for (I4 TimeLevel = 1; TimeLevel + NTimeLevels > 1; --TimeLevel) {
          HostArray3DReal TempHostArray;
          Err = Tracers::getAllHost(TempHostArray, TimeLevel);
          if (Err != 0) {
@@ -267,7 +267,7 @@ int main(int argc, char *argv[]) {
                for (I4 Vert = 0; Vert < NVertLevels; Vert++) {
                   TempHostArray(Tracer, Cell, Vert) =
                       RefReal + Tracer + Cell + Vert + TimeLevel;
-                  if (TimeLevel == 0)
+                  if (TimeLevel == 1)
                      RefHostArray(Tracer, Cell, Vert) =
                          TempHostArray(Tracer, Cell, Vert);
                }
@@ -276,13 +276,13 @@ int main(int argc, char *argv[]) {
          Tracers::copyToDevice(TimeLevel);
       }
 
-      // Reference device array of current time level
+      // Reference device array of new time level
       Array3DReal RefArray =
           Array3DReal("RefArray", NTracers, NCellsSize, NVertLevels);
 
-      Err = Tracers::getAll(RefArray, 0);
+      Err = Tracers::getAll(RefArray, 1);
       if (Err != 0) {
-         LOG_ERROR("getAll(RefArray, -1) returns non-zero code: {}", Err);
+         LOG_ERROR("getAll(RefArray, 1) returns non-zero code: {}", Err);
          RetVal += 1;
       }
 
@@ -300,11 +300,11 @@ int main(int argc, char *argv[]) {
       // update time levels
       Tracers::updateTimeLevels();
 
-      // getAll of previous time level(-1) should return the same to RefArray
+      // getAll of current time level(0) should return the same to RefArray
       Array3DReal PrevArray;
-      Err = Tracers::getAll(PrevArray, -1);
+      Err = Tracers::getAll(PrevArray, 0);
       if (Err != 0) {
-         LOG_ERROR("getAll(PrevArray, -1) returns non-zero code: {}", Err);
+         LOG_ERROR("getAll(PrevArray, 0) returns non-zero code: {}", Err);
          RetVal += 1;
       }
 
@@ -336,9 +336,9 @@ int main(int argc, char *argv[]) {
          Tracers::getName(TracerName, Tracer);
 
          Array2DReal PrevTracer;
-         Err = Tracers::getByName(PrevTracer, -1, TracerName);
+         Err = Tracers::getByName(PrevTracer, 1, TracerName);
          if (Err != 0) {
-            LOG_ERROR("getByName(PrevTracer, -1, TracerName) returns non-zero "
+            LOG_ERROR("getByName(PrevTracer, 1, TracerName) returns non-zero "
                       "code: {}",
                       Err);
             RetVal += 1;
@@ -436,10 +436,10 @@ int main(int argc, char *argv[]) {
       count = 0;
 
       Array2DReal SaltTracerByName;
-      Err = Tracers::getByName(SaltTracerByName, 0, "Salt");
+      Err = Tracers::getByName(SaltTracerByName, 1, "Salt");
 
       Array2DReal SaltTracerByIndexVar;
-      Err = Tracers::getByIndex(SaltTracerByIndexVar, 0, Tracers::IndxSalt);
+      Err = Tracers::getByIndex(SaltTracerByIndexVar, 1, Tracers::IndxSalt);
 
       count = -1;
 
@@ -470,7 +470,7 @@ int main(int argc, char *argv[]) {
          Tracers::getName(TracerName, Tracer);
 
          HostArray2DReal TestHostArray;
-         Err = Tracers::getHostByName(TestHostArray, 0, TracerName);
+         Err = Tracers::getHostByName(TestHostArray, 1, TracerName);
          if (Err != 0) {
             LOG_ERROR("getHostByName(TestHostArray, 0, TracerName) returns "
                       "non-zero code: {}",

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -58,7 +58,8 @@ struct DecayVelocityTendency {
 
       auto *Mesh                = HorzMesh::getDefault();
       auto NVertLevels          = NormalVelTend.extent_int(1);
-      const auto &NormalVelEdge = State->NormalVelocity[VelTimeLevel];
+      Array2DReal NormalVelEdge;
+      State->getNormalVelocity(NormalVelEdge, VelTimeLevel);
 
       OMEGA_SCOPE(LocCoeff, Coeff);
 
@@ -77,8 +78,10 @@ int initState() {
    Array3DReal TracerArray;
    Err = Tracers::getAll(TracerArray, 0);
 
-   const auto &LayerThickCell = State->LayerThickness[0];
-   const auto &NormalVelEdge  = State->NormalVelocity[0];
+   Array2DReal LayerThickCell;
+   Array2DReal NormalVelEdge;
+   State->getLayerThickness(LayerThickCell, 0);
+   State->getNormalVelocity(NormalVelEdge, 0);
 
    // Initially set thickness and velocity and tracers to 1
    deepCopy(LayerThickCell, 1);
@@ -99,8 +102,10 @@ int createExactSolution(Real TimeEnd) {
    auto *ExactState =
        OceanState::create("Exact", DefMesh, DefHalo, NVertLevels, 1);
 
-   const auto &LayerThickCell = ExactState->LayerThickness[0];
-   const auto &NormalVelEdge  = ExactState->NormalVelocity[0];
+   Array2DReal LayerThickCell;
+   Array2DReal NormalVelEdge;
+   ExactState->getLayerThickness(LayerThickCell, 0);
+   ExactState->getNormalVelocity(NormalVelEdge, 0);
 
    // There are no thickness tendencies in this test, so exact thickness ==
    // initial thickness
@@ -119,8 +124,10 @@ ErrorMeasures computeErrors() {
    const auto *State      = OceanState::get("TestState");
    const auto *ExactState = OceanState::get("Exact");
 
-   const auto &NormalVelEdge      = State->NormalVelocity[0];
-   const auto &ExactNormalVelEdge = ExactState->NormalVelocity[0];
+   Array2DReal NormalVelEdge;
+   Array2DReal ExactNormalVelEdge;
+   State->getNormalVelocity(NormalVelEdge, 0);
+   ExactState->getNormalVelocity(ExactNormalVelEdge, 0);
 
    // Only velocity errors matters, because thickness remains constant
    ErrorMeasures VelErrors;

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -56,8 +56,8 @@ struct DecayVelocityTendency {
                    const AuxiliaryState *AuxState, int ThickTimeLevel,
                    int VelTimeLevel, TimeInstant Time) const {
 
-      auto *Mesh                = HorzMesh::getDefault();
-      auto NVertLevels          = NormalVelTend.extent_int(1);
+      auto *Mesh       = HorzMesh::getDefault();
+      auto NVertLevels = NormalVelTend.extent_int(1);
       Array2DReal NormalVelEdge;
       State->getNormalVelocity(NormalVelEdge, VelTimeLevel);
 


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
This PR changes the time level interface in the State class to be consistent with what has been implemented in Tracers.
The new functions `getLayerThickness` and `getNormalVelocity` retrieve the device array corresponding to a given `TimeLevel`. `getLayerThicknessH` and `getNormalVelocityH` provide the same functionality for the host arrays. All time index calculations for a given `TimeLevel` are done in the function `getTimeIndex`. A `getTimeIndex` function has been added to the Tracers class as well.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Design document has been generated and added to the docs
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.


<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
