### PR TITLE
allow only one calendar instance for a simulation

### DIFF
--- a/components/omega/doc/devGuide/TimeMgr.md
+++ b/components/omega/doc/devGuide/TimeMgr.md
@@ -39,24 +39,46 @@ enum CalendarKind {
    CalendarUnknown        ///< uninitialized or invalid
 };
 ```
+During a simulation, only one calendar can be defined and is set with the call:
+```c++
+Calendar::init("CalendarName");
+```
+that must be set early in the model initialization before other time quantities
+are defined. CalendarName is a string associated with the defined calendars
+above and found in the list CalendarKindName in ``TimeMgr.h``. Typically, they
+are the same as the kinds above with a space for multi-word names
+(eg "No Leap"). If a custom calendar is desired rather than the supported
+calendars, a custom calendar can be defined with a different init
+interface in which all the relevant quantities are provided:
+```c++
+Calendar::init(
+   std::vector<I4> &InDaysPerMonth, ///< [in] array of days per month
+   I4 InSecondsPerDay,              ///< [in] seconds per day
+   I4 InSecondsPerYear,             ///< [in] seconds per year
+   I4 InDaysPerYear                 ///< [in] days per year (dpy)
+);
+```
 Time is generally tracked as the amount of time elapsed from a reference date
-for a given calendar.
+for a given calendar. A number of public functions exist to retrieve Calendar
+information, convert between dates and elapsed time, check for leap years and
+other checks. However, these are typically used by other TimeMgr classes and
+not directly by the developer. Examples of their use can be found in the
+TimeMgr unit test.
 
 ### 3. TimeInstant
 
-The TimeInstant class represents a moment in time for a particular calendar. It
-consists of a TimeFrac and a pointer to the Calendar in which the time is based.
+The TimeInstant class represents a moment in time with the particular calendar
+that has been defined for the simulation. It consists of a TimeFrac that
+represents the time since a reference time associated with the defined calendar.
 There are three constructors for initializing a TimeInstant. One method is with
-a pointer to an initialized Calendar object, five 8-byte integers, and an 8-byte
-real value:
+five 8-byte integers, and an 8-byte real value:
 ```c++
-OMEGA::TimeInstant TI1(&CalGreg, Year, Month, Day, Hour, Minute, RealSecond);
+OMEGA::TimeInstant TI1(Year, Month, Day, Hour, Minute, RealSecond);
 ```
-Alternatively, the TimeInstant can be initialized with a Calendar pointer and
-eight 8-byte integers, with the seconds value represented by three 8-byte
-integers:
+Alternatively, the TimeInstant can be initialized with eight 8-byte integers,
+with the seconds value represented by three 8-byte integers:
 ```c++
-OMEGA::TimeInstant TI2(&CalGreg, Y, M, D, H, M, Whole, Numer, Denom);
+OMEGA::TimeInstant TI2(Y, M, D, H, M, Whole, Numer, Denom);
 ```
 A final constructor creates a time instant based on a time string that
 conforms roughly to the ISO standard `"YYYYYY-MM-DD_HH:MM:SS.SSSS"` though
@@ -64,7 +86,7 @@ the constructor allows for any single-character non-numeric separator between
 each of the numeric fields and the width of the YY and SS fields can be up
 to the 8-byte standards for integer and floats, respectively.
 ```c++
-OMEGA::TimeInstant TI3(&CalGreg, TimeString);
+OMEGA::TimeInstant TI3(TimeString);
 ```
 
 Among the methods defined in the TimeInstant class is `getString` which will
@@ -107,6 +129,10 @@ enum class TimeUnits {
    Months,   ///< time units in months
    Years,    ///< time units in years
 };
+```
+Finally, a time interval can be defined as the time between two time instants:
+```c++
+OMEGA::TimeInterval MyDeltaTime = MyTimeInstant2 - MyTimeInstant1;
 ```
 
 ### 5. Alarm

--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -23,11 +23,10 @@ int main(int argc, char **argv) {
    Kokkos::initialize();   // initialize Kokkos
 
    // Time management objects
-   OMEGA::Calendar OmegaCal;
    OMEGA::TimeInstant CurrTime;
    OMEGA::Alarm EndAlarm;
 
-   ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD, OmegaCal, CurrTime, EndAlarm);
+   ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD, CurrTime, EndAlarm);
    if (ErrCurr != 0)
       LOG_ERROR("Error initializing OMEGA");
 

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -431,13 +431,6 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
 
    // For alarms, need to retrieve clock start time
    TimeInstant ClockStart = ModelClock.getStartTime();
-   Calendar *CalendarPtr;
-   Err = ClockStart.get(CalendarPtr);
-   if (Err != 0) {
-      LOG_ERROR("Unable to retrieve clock info while constructing stream {}",
-                StreamName);
-      return Err;
-   }
 
    // Read frequency of input/output
    int IOFreq;
@@ -518,7 +511,7 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
       std::string StrtTime;
       Err = StreamConfig.get("StartTime", StrtTime);
       if (Err == 0) {
-         TimeInstant AlarmTime(CalendarPtr, StrtTime);
+         TimeInstant AlarmTime(StrtTime);
          NewStream->MyAlarm = Alarm(AlarmName, AlarmTime);
          HasAlarm           = true;
       } else {
@@ -576,8 +569,8 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
                    StreamName);
          return Err;
       }
-      TimeInstant Start(CalendarPtr, StartTimeStr);
-      TimeInstant End(CalendarPtr, EndTimeStr);
+      TimeInstant Start(StartTimeStr);
+      TimeInstant End(EndTimeStr);
       std::string StartName = StreamName + "Start";
       std::string EndName   = StreamName + "End";
       NewStream->StartAlarm = Alarm(StartName, Start);

--- a/components/omega/src/infra/TimeMgr.cpp
+++ b/components/omega/src/infra/TimeMgr.cpp
@@ -30,10 +30,12 @@
 #include "TimeMgr.h"
 #include "Logging.h"
 
+#include <algorithm>
 #include <cfloat>
 #include <climits>
 #include <cmath>
 #include <cstdlib>
+#include <memory>
 
 // max/min macros if they don't already exist
 #ifndef MAX
@@ -1086,118 +1088,159 @@ I4 TimeFrac::simplify(void) {
 // Calendar definitions
 //------------------------------------------------------------------------------
 
-// initialize static calendar instance counter
-I4 Calendar::NumCalendars = 0;
+// initialize static calendar instance
+std::unique_ptr<Calendar> Calendar::OmegaCal = nullptr;
 
 // Calendar accessors
 //------------------------------------------------------------------------------
-// Calendar::rename - Resets a calendar's name
-// Resets the name of a calendar. This is the only variable that
-// should be changed outside the constructor.
-
-I4 Calendar::rename(const std::string InName) { // input - name of calendar
-
-   // set error code
-   I4 Err = 0;
-
-   // set calendar name
-   Name = InName;
-
-   // Return error code
-   return Err;
-
-} // end Calendar::rename
 
 //-------------------------------------------------------------------------
-// Calendar::get - retrieves calendar properties
-// Retrieves selected components of a Calendar
+// Calendar::get - retrieves pointer to model calendar
+Calendar::Calendar *Calendar::get() {
+   if (isDefined()) {
+      return Calendar::OmegaCal.get();
+   } else {
+      LOG_CRITICAL("Attempt to retrieve undefined calendar");
+   }
+} // end retrieve calendar pointer
 
-I4 Calendar::get(I4 *OutID,             // [out] assigned id
-                 std::string *OutName,  // [out] calendar name
-                 CalendarKind *OutKind, // [out] calendar type
-                 I4 *OutDaysPerMonth,   // [out] array of days/month
-                 I4 *OutMonthsPerYear,  // [out] months per year
-                 I4 *OutSecondsPerDay,  // [out] seconds per day
-                 I4 *OutSecondsPerYear, // [out] seconds per normal year
-                 I4 *OutDaysPerYear     // [out] days per normal year
-) const {
+//------------------------------------------------------------------------------
+// Calendar::get - retrievals for each calendar property
 
-   // initial error code
-   I4 Err = 0;
+CalendarKind Calendar::getKind() {
 
-   // check for valid calendar
-   if (this->CalKind == CalendarUnknown) {
-      Err = 1;
-      LOG_ERROR("TimeMgr: Calendar::get unknown calendar");
-      return Err;
+   CalendarKind OutKind = CalendarUnknown;
+   // check if calendar defined
+   if (isDefined()) {
+
+      // get calendar type and check for valid value
+      OutKind = Calendar::OmegaCal->CalKind;
+      if (OutKind == CalendarUnknown)
+         LOG_CRITICAL("Cannot retrieve calendar kind"
+                      " - Calendar undefined or not initialized");
+
+   } else {
+      LOG_CRITICAL("Cannot retrieve calendar kind - Calendar not initialized");
    }
 
-   // if id requested, return id
-   if (OutID != NULL)
-      *OutID = this->ID;
+   return OutKind;
+}
 
-   // if name requested, return calendar name
-   if (OutName != NULL)
-      *OutName = this->Name;
+std::vector<I4> Calendar::getDaysPerMonth() {
 
-   // if calendar type requested, return calendar type
-   if (OutKind != NULL)
-      *OutKind = this->CalKind;
-
-   // if days per month requested, return days per month
-   if (OutDaysPerMonth != NULL) {
-      for (I4 I = 0; I < this->MonthsPerYear; I++) {
-         OutDaysPerMonth[I] = this->DaysPerMonth[I];
+   // check if calendar defined
+   if (isDefined) {
+      // also check for valid vector
+      if (Calendar::OmegaCal->DaysPerMonth.size() > 0) {
+         return Calendar::OmegaCal->DaysPerMonth;
+      } else {
+         LOG_CRITICAL("Invalid DaysPerMonth vector");
       }
+   } else {
+      LOG_CRITICAL("Cannot retrieve calendar props - Calendar not initialized");
    }
+}
 
-   // if months per year requested, return months per year
-   if (OutMonthsPerYear != NULL)
-      *OutMonthsPerYear = this->MonthsPerYear;
+I4 Calendar::getMonthsPerYear() {
 
-   // if seconds per day requested, return seconds per day
-   if (OutSecondsPerDay != NULL)
-      *OutSecondsPerDay = this->SecondsPerDay;
+   // check if calendar defined
+   if (isDefined()) {
+      return Calendar::OmegaCal->MonthsPerYear;
+   } else {
+      LOG_CRITICAL("Cannot retrieve MonthsPerYear - Calendar not initialized");
+      return 0;
+   }
+}
 
-   // if seconds per year requested, return seconds per year
-   if (OutSecondsPerYear != NULL)
-      *OutSecondsPerYear = this->SecondsPerYear;
+I4 Calendar::getSecondsPerDay() {
 
-   // if days per year requested, return seconds per year
-   if (OutDaysPerYear != NULL)
-      *OutDaysPerYear = this->DaysPerYear;
+   // check if calendar defined
+   if (isDefined()) {
+      return Calendar::OmegaCal->SecondsPerDay;
+   } else {
+      LOG_CRITICAL("Cannot retrieve SecondsPerDay - Calendar not initialized");
+      return 0;
+   }
+}
 
-   // all done, return
-   return Err;
+I4 Calendar::getSecondsPerYear() {
 
-} // end Calendar::get
+   // check if calendar defined
+   if (isDefined()) {
+      return Calendar::OmegaCal->SecondsPerYear;
+   } else {
+      LOG_CRITICAL("Cannot retrieve SecondsPerYear - Calendar not initialized");
+      return 0;
+   }
+}
+
+I4 Calendar::getDaysPerYear() {
+   // check if calendar defined
+   if (isDefined()) {
+      return Calendar::OmegaCal->DaysPerYear;
+   } else {
+      LOG_CRITICAL("Cannot retrieve DaysPerYear - Calendar not initialized");
+      return 0;
+   }
+}
 
 // Calendar constructors/destructors
 //------------------------------------------------------------------------------
-// Calendar::Calendar - default constructor creates no calendar option
-// This constructor routine creates a calendar that uses no calendar,
-// meaning the time variable stays in seconds with no notion of days
-// or years. Construction by calendar kind is the most preferred
-// option for construction, so this version should not be used often.
+// Calendar::init - creates the calendar from a supported calendar option
+void Calendar::init(
+    std::string CalendarKindStr // [in] string name for calendar type
+) {
 
-Calendar::Calendar(void) {
+   // If calendar has already been set, throw a critical error
+   if (isDefined()) {
+      LOG_CRITICAL("Omega calendar already set, can not be changed");
+      return;
+   }
 
-   // set default name and id
-   Name = ' ';
-   ID   = ++NumCalendars;
+   // Convert string name for type of calendar to a supported kind
+   CalendarKind CalKindLoc = CalendarUnknown;
+   for (int I = 0; I < NUM_SUPPORTED_CALENDARS; ++I) {
+      if (CalendarKindStr == CalendarKindName[I]) {
+         CalKindLoc = (CalendarKind)(I);
+         break;
+      }
+   }
 
-   // define calendar as using no calendar
-   CalKind     = CalendarNoCalendar;
-   CalKindName = CalendarKindName[CalKind - 1];
+   // Call constructor and assign the calendar if it is valid
+   if (CalKindLoc == CalendarUnknown) {
+      LOG_CRITICAL("Attempt to create calendar of unknown name: {}",
+                   CalendarKindStr);
+      Calendar::OmegaCal = nullptr;
+   } else {
+      Calendar::OmegaCal = std::unique_ptr<Calendar>(new Calendar(CalKindLoc));
+   }
 
-   MonthsPerYear = MONTHS_PER_YEAR;
-   for (I4 I = 0; I < MonthsPerYear; I++)
-      DaysPerMonth[I] = 0;
-   SecondsPerDay  = 0;
-   SecondsPerYear = 0;
-   DaysPerYear    = 0;
+   LOG_INFO("Omega using calendar type: {}", CalendarKindStr);
+}
 
-} // end Calendar::Calendar default constructor
+//------------------------------------------------------------------------------
+// Calendar::init - creates the calendar from a custom calendar
+
+void Calendar::init(std::vector<I4> &InDaysPerMonth, // [in] vector days/month
+                    int InSecondsPerDay,             // [in] seconds per day
+                    int InSecondsPerYear,            // [in] seconds per year
+                    int InDaysPerYear                // [in] days per year
+) {
+
+   // If calendar has already been set, throw a critical error
+   if (isDefined()) {
+      LOG_CRITICAL("Omega calendar already set, can not be changed");
+      return;
+   }
+
+   // Call constructor and assign the single instance
+   // instance = std::unique_ptr<Singleton>(new Singleton());
+   Calendar::OmegaCal = std::unique_ptr<Calendar>(new Calendar(
+       InDaysPerMonth, InSecondsPerDay, InSecondsPerYear, InDaysPerYear));
+
+   LOG_INFO("Omega using a custom calendar");
+
+} // end custom calendar create
 
 //------------------------------------------------------------------------------
 // Calendar::Calendar - constructor creates standard calendar by kind
@@ -1205,21 +1248,17 @@ Calendar::Calendar(void) {
 // standard supported calendars (e.g. Gregorian, Julian, no-leap).
 // It is the preferred method for creating a calendar.
 
-Calendar::Calendar(std::string InName,       // [in] name for calendar
-                   CalendarKind InCalKind) { // [in] calendar type
-
-   // set calendar name and id
-   Name = InName;
-   ID   = ++NumCalendars;
+Calendar::Calendar(CalendarKind InCalKind) { // [in] calendar type
 
    // set calendar kind
    CalKind     = InCalKind;
-   CalKindName = CalendarKindName[CalKind - 1];
+   CalKindName = CalendarKindName[CalKind];
 
    // months per year fixed
    MonthsPerYear = MONTHS_PER_YEAR;
 
    // set remaining variables based on type (kind) of calendar
+   DaysPerMonth.resize(MonthsPerYear);
    switch (CalKind) {
    // All these cases have similar months, days per month
    case CalendarGregorian:
@@ -1282,52 +1321,33 @@ Calendar::Calendar(std::string InName,       // [in] name for calendar
    default:
       // unknown calendar kind, invalidate and return with error
       CalKind     = CalendarUnknown;
-      CalKindName = CalendarKindName[CalKind - 1];
-      LOG_ERROR("TimeMgr: Calendar constructor unknown calendar kind");
+      CalKindName = CalendarKindName[CalKind];
+      LOG_ERROR("Attempt to create a calendar of unknown kind");
       break;
 
    } // end switch on CalKind
 
 } // end Calendar::Calendar standard constructor
 
-//-----------------------------------------------------------------------------
-// Calendar::Calendar - constructor that creates by copying another
-// This calendar constructor creates a new calendar by copying from
-// an existing calendar.
-
-Calendar::Calendar(const Calendar &InCalendar) { // in - calendar to copy
-
-   // copy from the input calendar
-   *this = InCalendar;
-
-   // but give it a new id
-   ID = ++NumCalendars;
-
-} // end Calendar::Calendar copy constructor
-
 //------------------------------------------------------------------------------
 // Calendar::Calendar - constructs a custom calendar
 // In some cases, the standard calendars are inappropriate, so this
 // custom constructor permits users to define their own calendar.
 
-Calendar::Calendar(const std::string InName, // [in] name for calendar
-                   int *InDaysPerMonth,      // [in] array of days/month
-                   int InSecondsPerDay,      // [in] seconds per day
-                   int InSecondsPerYear,     // [in] seconds per year
-                   int InDaysPerYear) {      // [in] days per year
-
-   // set name and id
-   Name = InName;
-   ID   = ++NumCalendars;
+Calendar::Calendar(std::vector<I4> &InDaysPerMonth, // [in] array of days/month
+                   int InSecondsPerDay,             // [in] seconds per day
+                   int InSecondsPerYear,            // [in] seconds per year
+                   int InDaysPerYear) {             // [in] days per year
 
    // define calendar as custom
    CalKind     = CalendarCustom;
-   CalKindName = CalendarKindName[CalKind - 1];
+   CalKindName = CalendarKindName[CalKind];
 
    // months per year is fixed
    MonthsPerYear = MONTHS_PER_YEAR;
 
    // set remaining calendar vars from input values
+   DaysPerMonth.resize(MonthsPerYear);
    for (I4 I = 0; I < MonthsPerYear; I++)
       DaysPerMonth[I] = InDaysPerMonth[I];
    SecondsPerDay  = InSecondsPerDay;
@@ -1339,79 +1359,31 @@ Calendar::Calendar(const std::string InName, // [in] name for calendar
 //------------------------------------------------------------------------------
 // Calendar::~Calendar - destructor for calendar
 
-Calendar::~Calendar(void) {
+Calendar::~Calendar(void) {}
 
-   // decrement counter
-   --NumCalendars;
+//------------------------------------------------------------------------------
+// Calendar::reset - Destroys the single instance
+// This should only be used during testing as it will invalidate most
+// time instants and other time manager functions
+void Calendar::reset() {
 
-} // end ~Calendar
+   LOG_WARN("Removing Omega calendar");
+   LOG_WARN("This invalidates all prior time manager values"
+            "and should only be used in testing");
+   Calendar::OmegaCal.reset(); // Resets the calendar pointer
+}
 
 // Calendar operators
 //------------------------------------------------------------------------------
-// Calendar(==) - Calendar equality comparison
-// The equivalence operator to determine whether two calendars are the
-// same. For most, it is sufficient to compare the calendar type, but
-// for custom calendars, must check equivalence of each component.
-
-bool Calendar::operator==(const Calendar &Cal) const {
-
-   // if custom calendars, must check all properties for equality;
-   // return false as soon as inequality is known, otherwise return true
-   if (CalKind == CalendarCustom && Cal.CalKind == CalendarCustom) {
-      if (MonthsPerYear != Cal.MonthsPerYear)
-         return false;
-      for (I4 I = 0; I < MonthsPerYear; I++) {
-         if (DaysPerMonth[I] != Cal.DaysPerMonth[I])
-            return false;
-      }
-      if (SecondsPerDay != Cal.SecondsPerDay)
-         return false;
-      if (SecondsPerYear != Cal.SecondsPerYear)
-         return false;
-      if (DaysPerYear != Cal.DaysPerYear)
-         return false;
-      return true; // custom calendars are equal
+// Calendar::isDefined - checks whether a calendar has been initialized
+bool Calendar::isDefined() {
+   if (Calendar::OmegaCal) {
+      return true;
    } else {
-      // for all other calendars, sufficient to just check kind
-      return CalKind == Cal.CalKind;
+      return false;
    }
-   return true;
+}
 
-} // end Calendar::operator==
-
-//------------------------------------------------------------------------------
-// Calendar(!=) - Calendar inequality comparison
-// Compare two calendars for inequality. For most calendars, sufficient
-// to check calendar kind, but custom calendars must compare all
-// properties.
-
-bool Calendar::operator!=(const Calendar &Cal) const {
-
-   // if custom calendars, must check all properties for inequality
-   // can return true as soon as any inequality is known
-   if (CalKind == CalendarCustom && Cal.CalKind == CalendarCustom) {
-      if (MonthsPerYear != Cal.MonthsPerYear)
-         return true;
-      if (SecondsPerDay != Cal.SecondsPerDay)
-         return true;
-      if (SecondsPerYear != Cal.SecondsPerYear)
-         return true;
-      if (DaysPerYear != Cal.DaysPerYear)
-         return true;
-      for (I4 I = 0; I < MonthsPerYear; I++) {
-         if (DaysPerMonth[I] != Cal.DaysPerMonth[I])
-            return true;
-      }
-      return false; // custom calendars are equal
-   }
-
-   // for all other calendars, just check calendar kind
-   else
-      return CalKind != Cal.CalKind;
-
-} // end Calendar::operator!=
-
-// Calendar methods
 //------------------------------------------------------------------------------
 // Calendar::validate - validate Calendar state
 // Validates the Calendar state, checking for improper values.
@@ -1488,14 +1460,17 @@ I4 Calendar::validate() const {
 // Calendar::isLeapYear - Determine if given year is a leap year
 // Logical function that returns true if input year is a leap year.
 
-bool Calendar::isLeapYear(I8 Year,         // [in] a calendar year
-                          I4 &Err) const { // [out] error return code
+bool Calendar::isLeapYear(I8 Year // [in] a calendar year
+) {
 
-   // initialize error code
-   Err = 0;
+   // Check calendar existence
+   if (!isDefined()) {
+      LOG_CRITICAL("Attempt to check leap year - calendar not defined");
+      return false;
+   }
 
    // now check for leap year depending on calendar kind
-   switch (CalKind) {
+   switch (Calendar::OmegaCal->CalKind) {
    case CalendarGregorian:
       // leap year is divisible by 400 or divisible by 4 and not 100.
       return (Year % 400 == 0) || ((Year % 4 == 0) && (Year % 100 != 0));
@@ -1529,7 +1504,7 @@ TimeFrac Calendar::getElapsedTime(
     const I8 Whole,  ///< [in] time of day-whole seconds
     const I8 Numer,  ///< [in] time of day-frac secs (numerator)
     const I8 Denom   ///< [in] time of day-frac secs (denom)
-) const {
+) {
 
    // initialize error code, the basetime result, and common temps
    I4 Err{0};
@@ -1540,8 +1515,14 @@ TimeFrac Calendar::getElapsedTime(
    I8 HourTmp{0};     // For half-day JD conversions
    I4 FebDays{0};     // For tracking leap days
 
+   // Check that calendar has been defined
+   if (!isDefined()) {
+      LOG_CRITICAL("Cannot get elapsed time - calendar not defined");
+      return Result;
+   }
+
    // Branch on calendar type for actual calculation
-   switch (CalKind) {
+   switch (Calendar::OmegaCal->CalKind) {
 
    // convert Gregorian Date to time since reference of noon 3/1/-4800
    case CalendarGregorian: {
@@ -1559,7 +1540,7 @@ TimeFrac Calendar::getElapsedTime(
          break;
       }
       // check day of the month for any month except February
-      if (Month != 2 && Day > DaysPerMonth[Month - 1]) {
+      if (Month != 2 && Day > Calendar::OmegaCal->DaysPerMonth[Month - 1]) {
          Err = 1;
          LOG_ERROR("TimeMgr: Calendar::getElapsedTime invalid day of month for "
                    "Gregorian calendar");
@@ -1568,8 +1549,8 @@ TimeFrac Calendar::getElapsedTime(
       // if February, take leap year into account before checking
       //   day of the month
       if (Month == 2) {
-         FebDays = DaysPerMonth[1];
-         if (isLeapYear(Year, Err))
+         FebDays = Calendar::OmegaCal->DaysPerMonth[1];
+         if (isLeapYear(Year))
             FebDays += 1;
          if (Day > FebDays) {
             Err = 1;
@@ -1602,8 +1583,9 @@ TimeFrac Calendar::getElapsedTime(
       }
 
       // Finally, convert JD to seconds and add hours, minutes, secs
-      ResultWhole = JD * SecondsPerDay + HourTmp * SECONDS_PER_HOUR +
-                    Minute * SECONDS_PER_MINUTE + Whole;
+      ResultWhole = JD * Calendar::OmegaCal->SecondsPerDay +
+                    HourTmp * SECONDS_PER_HOUR + Minute * SECONDS_PER_MINUTE +
+                    Whole;
       Err = Result.set(ResultWhole, Numer, Denom);
       if (Err != 0)
          LOG_ERROR("TimeMgr: Calendar::getElapsedTime Gregorian - error "
@@ -1627,7 +1609,7 @@ TimeFrac Calendar::getElapsedTime(
          break;
       }
       // check day of the month for any month except February
-      if (Month != 2 && Day > DaysPerMonth[Month - 1]) {
+      if (Month != 2 && Day > Calendar::OmegaCal->DaysPerMonth[Month - 1]) {
          Err = 1;
          LOG_ERROR("TimeMgr: Calendar::getElapsedTime invalid day of month for "
                    "Julian calendar");
@@ -1636,8 +1618,8 @@ TimeFrac Calendar::getElapsedTime(
       // if February, take leap year into account before checking
       //   day of the month
       if (Month == 2) {
-         FebDays = DaysPerMonth[1];
-         if (isLeapYear(Year, Err))
+         FebDays = Calendar::OmegaCal->DaysPerMonth[1];
+         if (isLeapYear(Year))
             FebDays += 1;
          if (Day > FebDays) {
             Err = 1;
@@ -1670,8 +1652,9 @@ TimeFrac Calendar::getElapsedTime(
       }
 
       // Finally, conver JD to seconds and add hours, minutes, secs
-      ResultWhole = JD * SecondsPerDay + HourTmp * SECONDS_PER_HOUR +
-                    Minute * SECONDS_PER_MINUTE + Whole;
+      ResultWhole = JD * Calendar::OmegaCal->SecondsPerDay +
+                    HourTmp * SECONDS_PER_HOUR + Minute * SECONDS_PER_MINUTE +
+                    Whole;
       Err = Result.set(ResultWhole, Numer, Denom);
       if (Err != 0)
          LOG_ERROR("TimeMgr: Calendar::getElapsedTime Julian - error setting "
@@ -1700,8 +1683,9 @@ TimeFrac Calendar::getElapsedTime(
       // For regular Julian Day, the start of the day is at noon on
       // other calendars - does not matter for internal calendar
       // operations, so no correction and just noted here
-      ResultWhole = (Day - 1) * SecondsPerDay + Hour * SECONDS_PER_HOUR +
-                    Minute * SECONDS_PER_MINUTE + Whole;
+      ResultWhole = (Day - 1) * Calendar::OmegaCal->SecondsPerDay +
+                    Hour * SECONDS_PER_HOUR + Minute * SECONDS_PER_MINUTE +
+                    Whole;
       // Now set final result and add fractional second
       Err = Result.set(ResultWhole, Numer, Denom);
       if (Err != 0)
@@ -1714,14 +1698,15 @@ TimeFrac Calendar::getElapsedTime(
    case Calendar360Day:
    case CalendarCustom: {
       // Validate inputs
-      if (Year < 0 || Month < 1 || Month > MonthsPerYear || Day < 1) {
+      if (Year < 0 || Month < 1 || Month > Calendar::OmegaCal->MonthsPerYear ||
+          Day < 1) {
          Err = 1;
          LOG_ERROR("TimeMgr: Calendar::getElapsedTime invalid date for "
                    "fixed-length calendars");
          break;
       }
       // check day of the month for any month except February
-      if (Day > DaysPerMonth[Month - 1]) {
+      if (Day > Calendar::OmegaCal->DaysPerMonth[Month - 1]) {
          Err = 1;
          LOG_ERROR("TimeMgr: Calendar::getElapsedTime invalid date of month "
                    "for fixed-length calendars");
@@ -1737,10 +1722,11 @@ TimeFrac Calendar::getElapsedTime(
       }
 
       // Conversion straightforward for fixed-length calendars
-      ResultWhole = Year * SecondsPerYear; // secs at beg of year
+      ResultWhole = Year * Calendar::OmegaCal->SecondsPerYear; // at beg of year
       for (I4 Imonth = 0; Imonth < Month - 1; Imonth++)
-         ResultWhole += DaysPerMonth[Imonth] * SecondsPerDay; // add months
-      ResultWhole += (Day - 1) * SecondsPerDay;               // add days
+         ResultWhole += Calendar::OmegaCal->DaysPerMonth[Imonth] *
+                        Calendar::OmegaCal->SecondsPerDay; // add months
+      ResultWhole += (Day - 1) * Calendar::OmegaCal->SecondsPerDay; // add days
       ResultWhole +=
           Hour * SECONDS_PER_HOUR + Minute * SECONDS_PER_MINUTE + Whole;
       // Now set final result and add fractional second
@@ -1793,11 +1779,18 @@ I4 Calendar::getDateTime(
     I8 &Whole,                  //< [out] time of day-whole seconds
     I8 &Numer,                  //< [out] time of day-frac secs (numerator)
     I8 &Denom                   //< [out] time of day-frac secs (denom)
-) const {
+) {
 
    // initialize error code to success and make sure input elapsed
    // time is reduced to its simplest form
    I4 Error{0};
+
+   // Check existence of calendar
+   if (!isDefined()) {
+      LOG_CRITICAL("Attempt to getDateTime on non-existent calendar");
+      return 1;
+   }
+
    TimeFrac RevisedTime = ElapsedTime;
    Error                = RevisedTime.simplify();
    if (Error != 0) {
@@ -1821,13 +1814,13 @@ I4 Calendar::getDateTime(
    I8 JD{0};
 
    // branch to appropriate calculation based on calendar type
-   switch (CalKind) {
+   switch (OmegaCal->CalKind) {
    case CalendarGregorian: {
       // Reference time same as Julian Days
       // Convert whole seconds to Julian Day (number of days)
       // and remove that from elapsed seconds
-      JD = Whole / SecondsPerDay;
-      Whole -= (JD * SecondsPerDay);
+      JD = Whole / Calendar::OmegaCal->SecondsPerDay;
+      Whole -= (JD * Calendar::OmegaCal->SecondsPerDay);
 
       // Now convert the remaining seconds to hour, minute, seconds
       Hour = Whole / SECONDS_PER_HOUR;
@@ -1868,8 +1861,8 @@ I4 Calendar::getDateTime(
       // Reference time same as Julian Days
       // Convert whole seconds to Julian Day (number of days)
       // and remove that from elapsed seconds
-      JD = Whole / SecondsPerDay;
-      Whole -= JD * SecondsPerDay;
+      JD = Whole / Calendar::OmegaCal->SecondsPerDay;
+      Whole -= JD * Calendar::OmegaCal->SecondsPerDay;
 
       // Now convert the remaining seconds to hour, minute, seconds
       Hour = Whole / SECONDS_PER_HOUR;
@@ -1900,8 +1893,8 @@ I4 Calendar::getDateTime(
       // year and month not defined
       // Convert whole seconds to Julian Day (number of days)
       // and remove that from elapsed seconds
-      JD = Whole / SecondsPerDay;
-      Whole -= JD * SecondsPerDay;
+      JD = Whole / Calendar::OmegaCal->SecondsPerDay;
+      Whole -= JD * Calendar::OmegaCal->SecondsPerDay;
       Year  = 0;
       Month = 0;
       Day   = JD + 1; // correct for 1-based counting
@@ -1920,22 +1913,22 @@ I4 Calendar::getDateTime(
    case CalendarNoLeap:
    case Calendar360Day:
    case CalendarCustom: {
-      Year = Whole / SecondsPerYear;      // determine year
-      Whole -= SecondsPerYear * Year;     // modify Whole to hold remainder
-      DayInYear = Whole / SecondsPerDay;  // determine day in current year
-      Whole -= SecondsPerDay * DayInYear; // modify Whole to hold remainder
-      DayInYear += 1;                     // correct for 1-based counting
+      Year = Whole / Calendar::OmegaCal->SecondsPerYear;      // determine year
+      Whole -= Calendar::OmegaCal->SecondsPerYear * Year;     // holds remainder
+      DayInYear = Whole / Calendar::OmegaCal->SecondsPerDay;  // day in year
+      Whole -= Calendar::OmegaCal->SecondsPerDay * DayInYear; // holds remainder
+      DayInYear += 1; // correct for 1-based counting
       // find month, day
       CountDays = 0;
       PrevDays  = 0;
-      for (I4 I = 0; I < MonthsPerYear; I++) {
-         CountDays += DaysPerMonth[I];
+      for (I4 I = 0; I < Calendar::OmegaCal->MonthsPerYear; I++) {
+         CountDays += Calendar::OmegaCal->DaysPerMonth[I];
          if (DayInYear <= CountDays) { // day is in this month
             Month = I + 1;
             Day   = DayInYear - PrevDays;
             break;
          }
-         PrevDays += DaysPerMonth[I];
+         PrevDays += Calendar::OmegaCal->DaysPerMonth[I];
       }
       // keep peeling off for hour, minute
       Hour = Whole / SECONDS_PER_HOUR;
@@ -1979,24 +1972,30 @@ I4 Calendar::incrementDate(
     I8 &Year,              //< [in,out] calendar year for time to be advanced
     I8 &Month,             //< [in,out] calendar month for time to be advanced
     I8 &Day                //< [in,out] calendar day for time to be advanced
-) const {
+) {
 
    // initialize error code
    I4 Err{0};
+
+   // Check calendar exists
+   if (!isDefined()) {
+      LOG_CRITICAL("Attempt to increment non-existent calendar");
+      return 1;
+   }
 
    // Increment date based on supported interval types
    switch (Units) {
    // For year intervals, mostly just increment/decrement the year
    // while keeping all other units fixed, though check for leap day error
    case TimeUnits::Years: {
-      switch (CalKind) {
+      switch (Calendar::OmegaCal->CalKind) {
       case CalendarGregorian:
       case CalendarNoLeap:
       case CalendarJulian:
       case Calendar360Day:
       case CalendarCustom: {
          Year += Interval;
-         if (!(this->isLeapYear(Year, Err)) && Month == 2 && Day == 29) {
+         if (!(isLeapYear(Year)) && Month == 2 && Day == 29) {
             Err = 1;
             LOG_ERROR("TimeMgr: Calendar::incrementDate day out of range for "
                       "new year increment");
@@ -2020,7 +2019,7 @@ I4 Calendar::incrementDate(
 
    // For monthly intervals, check for year rollovers
    case TimeUnits::Months: {
-      switch (CalKind) {
+      switch (Calendar::OmegaCal->CalKind) {
       // For most calendars, add the monthly interval and adjust year
       // and day accordingly.
       case CalendarGregorian:
@@ -2031,19 +2030,19 @@ I4 Calendar::incrementDate(
          I8 TmpMonth = Month + Interval;
          // correct the year if the interval pushes beyond the end of year
          // use a while loop in case interval extends across multiple years
-         while (TmpMonth > MonthsPerYear) {
+         while (TmpMonth > Calendar::OmegaCal->MonthsPerYear) {
             Year += 1;
-            TmpMonth -= MonthsPerYear;
+            TmpMonth -= Calendar::OmegaCal->MonthsPerYear;
          }
          // For negative intervals, check the opposite direction
          while (TmpMonth < 1) {
             Year -= 1;
-            TmpMonth += MonthsPerYear;
+            TmpMonth += Calendar::OmegaCal->MonthsPerYear;
          }
          // Set month and check that the day of the month is valid
          Month      = TmpMonth;
-         I8 MaxDays = DaysPerMonth[Month - 1];
-         if (this->isLeapYear(Year, Err) && Month == 2)
+         I8 MaxDays = Calendar::OmegaCal->DaysPerMonth[Month - 1];
+         if (isLeapYear(Year) && Month == 2)
             MaxDays += 1;
          if (Day < 1 || Day > MaxDays) {
             Err = 1;
@@ -2069,27 +2068,28 @@ I4 Calendar::incrementDate(
 
    // For day intervals, increment days and adjust year, month
    case TimeUnits::Days: {
-      switch (CalKind) {
+      switch (Calendar::OmegaCal->CalKind) {
       case CalendarGregorian:
       case CalendarNoLeap:
       case CalendarJulian:
       case Calendar360Day:
       case CalendarCustom: {
          if (Interval > 0) { // positive interval - step forward
-            I4 DayMax = DaysPerMonth[Month - 1];
-            if (Month == 2 && this->isLeapYear(Year, Err))
+            I4 DayMax = Calendar::OmegaCal->DaysPerMonth[Month - 1];
+            if (Month == 2 && isLeapYear(Year))
                DayMax += 1;
             for (I4 I = 1; I <= Interval; ++I) {
                Day += 1;
                if (Day > DayMax) { // rollover month boundary
                   Day = 1;
                   Month += 1;
-                  if (Month > MonthsPerYear) { // rollover year boundary
+                  // rollover year boundary
+                  if (Month > Calendar::OmegaCal->MonthsPerYear) {
                      Month = 1;
                      Year += 1;
                   }
-                  DayMax = DaysPerMonth[Month - 1];
-                  if (Month == 2 && this->isLeapYear(Year, Err))
+                  DayMax = Calendar::OmegaCal->DaysPerMonth[Month - 1];
+                  if (Month == 2 && isLeapYear(Year))
                      DayMax += 1;
                }
             }
@@ -2099,11 +2099,11 @@ I4 Calendar::incrementDate(
                if (Day < 1) {
                   Month -= 1;
                   if (Month < 1) {
-                     Month = MonthsPerYear;
+                     Month = Calendar::OmegaCal->MonthsPerYear;
                      Year -= 1;
                   }
-                  Day = DaysPerMonth[Month - 1];
-                  if (Month == 2 && this->isLeapYear(Year, Err))
+                  Day = Calendar::OmegaCal->DaysPerMonth[Month - 1];
+                  if (Month == 2 && isLeapYear(Year))
                      Day += 1;
                }
             }
@@ -3343,28 +3343,6 @@ bool TimeInterval::isPositive(void) {
 // TimeInstant accessors
 // Define first so constructors can use set methods
 //------------------------------------------------------------------------------
-// TimeInstant::set (calendar)
-// Sets the calendar to be used for a time instant
-
-I4 TimeInstant::set(Calendar *Cal) {
-
-   I4 Err{0};
-
-   // Check to see whether pointer is valid and if so, set the pointer
-   if (Cal != nullptr) {
-      CalPtr = Cal;
-   } else {
-      // Otherwise return an error
-      Err = 1;
-      LOG_ERROR("TimeMgr: TimeInstant::set(calendar) Calendar not defined "
-                "(null ptr)");
-   }
-
-   return Err;
-
-} // end TimeInstant::set (calendar)
-
-//------------------------------------------------------------------------------
 // TimeInstant::set (date and time, real seconds)
 // Sets a time instant from a date and time, where the seconds is supplied as
 // a real number. The calendar must already be set in order to correctly use
@@ -3388,16 +3366,9 @@ I4 TimeInstant::set(const I8 Year,   //< [in] year
    I8 Denom{0};
    Err = TmpSeconds.get(Whole, Numer, Denom);
 
-   // Check that calendar has already been defined
-   if (CalPtr == nullptr) {
-      Err = 1;
-      LOG_ERROR("TimeMgr: TimeInstant::set(date and time, real seconds) "
-                "calendar must be defined to set by date");
-   } else {
-      // Call Calendar function to determine elapsed time since reference time
-      ElapsedTime = CalPtr->getElapsedTime(Year, Month, Day, Hour, Minute,
-                                           Whole, Numer, Denom);
-   }
+   // Call Calendar function to determine elapsed time since reference time
+   ElapsedTime = Calendar::getElapsedTime(Year, Month, Day, Hour, Minute, Whole,
+                                          Numer, Denom);
 
    return Err;
 
@@ -3422,45 +3393,13 @@ int TimeInstant::set(const I8 Year,   //< [in] year
    // Initialize error code
    I4 Err{0};
 
-   // Check that calendar has already been defined
-   if (CalPtr == nullptr) {
-      LOG_ERROR("TimeMgr: TimeInstant::set(date and time, frac int seconds)",
-                "calendar must be defined to set by date");
-   } else {
-      // Call Calendar function to determine elapsed time since reference time
-      ElapsedTime = CalPtr->getElapsedTime(Year, Month, Day, Hour, Minute,
-                                           Whole, Numer, Denom);
-   }
+   // Call Calendar function to determine elapsed time since reference time
+   ElapsedTime = Calendar::getElapsedTime(Year, Month, Day, Hour, Minute, Whole,
+                                          Numer, Denom);
 
    return Err;
 
 } // end TimeInstant::set (date and time, fractional integer seconds)
-
-//------------------------------------------------------------------------------
-// TimeInstant::get (calendar)
-// Retrieve the associated calendar from a time instant.
-
-I4 TimeInstant::get(Calendar *&Cal //< [out] Calendar in which instant defined
-) const {
-
-   // Initialize error code
-   I4 Err{0};
-
-   // If the calendar has been defined, return the calendar pointer
-   if (CalPtr != nullptr) {
-      Cal = CalPtr;
-   } else {
-      // Otherwise, set a null pointer print an error message
-      Cal = nullptr;
-      Err = 0;
-      LOG_ERROR("TimeMgr: TimeInstant::get(date and time, frac int seconds) ",
-                "attempt to retrieve a Calendar that is not defined");
-   }
-
-   // return the error code
-   return Err;
-
-} // end TimeInstant::get (calendar)
 
 //------------------------------------------------------------------------------
 // TimeInstant::get (date and time, real seconds)
@@ -3480,29 +3419,21 @@ I4 TimeInstant::get(I8 &Year,   //< [out] year   of this time instant
 
    Second = 0.0;
 
-   // If the calendar has been defined, call the calendar function to
-   // convert the time to a date and time appropriate for that calendar
-   if (CalPtr != nullptr) {
-      I8 Whole{0};
-      I8 Numer{0};
-      I8 Denom{0};
-      Err = CalPtr->getDateTime(ElapsedTime, Year, Month, Day, Hour, Minute,
-                                Whole, Numer, Denom);
-      if (Err != 0) {
-         LOG_ERROR("TimeMgr: TimeInstant::get(date and time, real seconds) "
-                   "error converting base time to date/time");
-      } else {
-         // Convert retrieved seconds in TimeFrac and then
-         // to real seconds for return
-         TimeFrac TmpSeconds(Whole, Numer, Denom);
-         Second = TmpSeconds.getSeconds();
-      }
-
+   // Call the calendar function to convert the time to a date and time
+   // appropriate for the calendar
+   I8 Whole{0};
+   I8 Numer{0};
+   I8 Denom{0};
+   Err = Calendar::getDateTime(ElapsedTime, Year, Month, Day, Hour, Minute,
+                               Whole, Numer, Denom);
+   if (Err != 0) {
+      LOG_ERROR("TimeMgr: TimeInstant::get(date and time, real seconds) "
+                "error converting base time to date/time");
    } else {
-      // Otherwise, print an error message
-      Err = 1;
-      LOG_ERROR("TimeMgr: TimeInstant::get(date and time, real seconds) ",
-                "calendar not defined.");
+      // Convert retrieved seconds in TimeFrac and then
+      // to real seconds for return
+      TimeFrac TmpSeconds(Whole, Numer, Denom);
+      Second = TmpSeconds.getSeconds();
    }
 
    // return the error code
@@ -3528,19 +3459,13 @@ I4 TimeInstant::get(I8 &Year,   //< [out] year   of this time instant
    // Initialize error code
    I4 Err{0};
 
-   // If the calendar has been defined, call the calendar function to
-   // convert the time to a date and time appropriate for that calendar
-   if (CalPtr != nullptr) {
-      Err = CalPtr->getDateTime(ElapsedTime, Year, Month, Day, Hour, Minute,
-                                Whole, Numer, Denom);
-      if (Err != 0)
-         LOG_ERROR("TimeMgr: TimeInstant::get(date and time, frac int seconds) "
-                   "error converting base time to date/time");
-   } else {
-      // Otherwise, print an error message
+   // Call the calendar function to convert the time to a date and time
+   // appropriate for that calendar
+   Err = Calendar::getDateTime(ElapsedTime, Year, Month, Day, Hour, Minute,
+                               Whole, Numer, Denom);
+   if (Err != 0)
       LOG_ERROR("TimeMgr: TimeInstant::get(date and time, frac int seconds) "
-                "calendar not defined.");
-   }
+                "error converting base time to date/time");
 
    // return the error code
    return Err;
@@ -3553,7 +3478,7 @@ I4 TimeInstant::get(I8 &Year,   //< [out] year   of this time instant
 // This is a default constructor that creates an empty time instant with zero
 // values and a null calendar.
 
-TimeInstant::TimeInstant(void) : ElapsedTime(0, 0, 1), CalPtr(nullptr) {
+TimeInstant::TimeInstant(void) : ElapsedTime(0, 0, 1) {
    // Everything taken care of in initialization list above
 } // end TimeInstant::TimeInstant
 
@@ -3562,17 +3487,13 @@ TimeInstant::TimeInstant(void) : ElapsedTime(0, 0, 1), CalPtr(nullptr) {
 // Constructs a time instant from a date, time, calendar, where the seconds
 // part of time is supplied as a real number.
 
-TimeInstant::TimeInstant(Calendar *Cal,   //< [in] Calendar to use
-                         const I8 Year,   //< [in] year
+TimeInstant::TimeInstant(const I8 Year,   //< [in] year
                          const I8 Month,  //< [in] month
                          const I8 Day,    //< [in] day
                          const I8 Hour,   //< [in] hour
                          const I8 Minute, //< [in] minute
                          const R8 RSecond //< [in] second (real)
 ) {
-
-   // Set the calendar
-   CalPtr = Cal;
 
    // Reuse the set function to define the time component
    I4 Err = this->set(Year, Month, Day, Hour, Minute, RSecond);
@@ -3588,8 +3509,7 @@ TimeInstant::TimeInstant(Calendar *Cal,   //< [in] Calendar to use
 // Constructs a time instant from a calendar, date and time, where the seconds
 // is supplied as an integer fraction (whole + numrator/denominator)
 
-TimeInstant::TimeInstant(Calendar *Cal,   //< [in] Calendar to use
-                         const I8 Year,   //< [in] year
+TimeInstant::TimeInstant(const I8 Year,   //< [in] year
                          const I8 Month,  //< [in] month
                          const I8 Day,    //< [in] day
                          const I8 Hour,   //< [in] hour
@@ -3598,9 +3518,6 @@ TimeInstant::TimeInstant(Calendar *Cal,   //< [in] Calendar to use
                          const I8 Numer,  //< [in] second (fraction numerator)
                          const I8 Denom   //< [in] second (fraction denominator)
 ) {
-
-   // Set the calendar
-   CalPtr = Cal;
 
    // Reuse the set function to define the time component
    I4 Err = this->set(Year, Month, Day, Hour, Minute, Whole, Numer, Denom);
@@ -3617,12 +3534,8 @@ TimeInstant::TimeInstant(Calendar *Cal,   //< [in] Calendar to use
 // YYYYY-MM-DD_HH:MM:SS.SSS where the width of the YY and SS fields can
 // be of arbitrary width and the separators can be any non-numeric character
 
-TimeInstant::TimeInstant(Calendar *Cal,          //< [in] Calendar to use
-                         std::string &TimeString //< [in] string with date/time
+TimeInstant::TimeInstant(std::string &TimeString //< [in] string with date/time
 ) {
-
-   // Set the calendar
-   CalPtr = Cal;
 
    // Extract variables from string
    I8 Year    = 0;
@@ -3668,8 +3581,7 @@ bool TimeInstant::operator==(
    // Note that the calendars do not need to be the same calendar,
    //   simply equivalent calendars
 
-   if ((*(this->CalPtr) == *(Instant.CalPtr)) &&
-       (this->ElapsedTime == Instant.ElapsedTime))
+   if (this->ElapsedTime == Instant.ElapsedTime)
       return true;
    else
       return false;
@@ -3698,14 +3610,6 @@ bool TimeInstant::operator!=(
 bool TimeInstant::operator<(
     const TimeInstant &Instant) const { // [in] - instant to compare
 
-   // check that calendars are equivalent
-   if (*(this->CalPtr) != *(Instant.CalPtr)) {
-      LOG_ERROR("TimeMgr: TimeInstant::operator< cannot compare time instants "
-                "on different calendars");
-      return false;
-   }
-
-   // If on the same calendar, just a matter of comparing ElapsedTimes
    return (this->ElapsedTime < Instant.ElapsedTime);
 
 } // end TimeInstant::operator<
@@ -3718,14 +3622,6 @@ bool TimeInstant::operator<(
 bool TimeInstant::operator>(
     const TimeInstant &Instant) const { // [in] - instant to compare
 
-   // check that calendars are equivalent
-   if (*(this->CalPtr) != *(Instant.CalPtr)) {
-      LOG_ERROR("TimeMgr: TimeInstant::operator> cannot compare time instants "
-                "on different calendars");
-      return false;
-   }
-
-   // If on the same calendar, just a matter of comparing ElapsedTimes
    return (this->ElapsedTime > Instant.ElapsedTime);
 
 } // end TimeInstant::operator>
@@ -3738,14 +3634,6 @@ bool TimeInstant::operator>(
 bool TimeInstant::operator<=(
     const TimeInstant &Instant) const { // [in] - instant to compare
 
-   // check that calendars are equivalent
-   if (*(this->CalPtr) != *(Instant.CalPtr)) {
-      LOG_ERROR("TimeMgr: TimeInstant::operator<= cannot compare time instants "
-                "on different calendars");
-      return false;
-   }
-
-   // If on the same calendar, just a matter of comparing ElapsedTimes
    return (this->ElapsedTime <= Instant.ElapsedTime);
 
 } // end TimeInstant::operator<=
@@ -3758,14 +3646,6 @@ bool TimeInstant::operator<=(
 bool TimeInstant::operator>=(
     const TimeInstant &Instant) const { // [in] - instant to compare
 
-   // check that calendars are equivalent
-   if (*(this->CalPtr) != *(Instant.CalPtr)) {
-      LOG_ERROR("TimeMgr: TimeInstant::operator>= cannot compare time instants "
-                "on different calendars");
-      return false;
-   }
-
-   // If on the same calendar, just a matter of comparing ElapsedTimes
    return (this->ElapsedTime >= Instant.ElapsedTime);
 
 } // end TimeInstant::operator>=
@@ -3797,14 +3677,14 @@ TimeInstant TimeInstant::operator+(
       I8 Whole{0};
       I8 Numer{0};
       I8 Denom{1};
-      Err = CalPtr->getDateTime(ElapsedTime, Year, Month, Day, Hour, Minute,
-                                Whole, Numer, Denom);
+      Err = Calendar::getDateTime(ElapsedTime, Year, Month, Day, Hour, Minute,
+                                  Whole, Numer, Denom);
       if (Err != 0)
          LOG_ERROR("TimeMgr: TimeInstant::operator+ error converting instant "
                    "to date/time");
       // use calendar function to increment date based on calendar kind
-      Err = CalPtr->incrementDate(Interval.CalInterval, Interval.Units, Year,
-                                  Month, Day);
+      Err = Calendar::incrementDate(Interval.CalInterval, Interval.Units, Year,
+                                    Month, Day);
       if (Err != 0)
          LOG_ERROR("TimeMgr: TimeInstant::operator+ error advancing calendar "
                    "date/time");
@@ -3850,15 +3730,15 @@ TimeInstant TimeInstant::operator-(
       I8 Whole{0};
       I8 Numer{0};
       I8 Denom{1};
-      Err = CalPtr->getDateTime(ElapsedTime, Year, Month, Day, Hour, Minute,
-                                Whole, Numer, Denom);
+      Err = Calendar::getDateTime(ElapsedTime, Year, Month, Day, Hour, Minute,
+                                  Whole, Numer, Denom);
       if (Err != 0)
          LOG_ERROR("TimeMgr: TimeInstant::operator- error converting instant "
                    "to date/time");
       // use calendar function to decrement date based on calendar kind
       I8 TmpInterval = -(Interval.CalInterval);
-      Err =
-          CalPtr->incrementDate(TmpInterval, Interval.Units, Year, Month, Day);
+      Err = Calendar::incrementDate(TmpInterval, Interval.Units, Year, Month,
+                                    Day);
       if (Err != 0)
          LOG_ERROR("TimeMgr: TimeInstant::operator- error reversing calendar "
                    "date/time");
@@ -3887,13 +3767,6 @@ TimeInterval TimeInstant::operator-(const TimeInstant &Instant) const {
    I8 Numer{0};
    I8 Denom{1};
    TimeInterval Result(Whole, Numer, Denom); // zero interval as default
-
-   // check that calendars are equivalent
-   if (*(this->CalPtr) != *(Instant.CalPtr)) {
-      LOG_ERROR("TimeMgr: TimeInstant::operator- (interval) cannot subtract "
-                "time instants on different calendars");
-      return Result;
-   }
 
    // subtract the ElapsedTime components of time instants
    TimeFrac Timediff = ElapsedTime - Instant.ElapsedTime;
@@ -4100,7 +3973,7 @@ Alarm::~Alarm(void) { // Nothing to be done
 
 bool Alarm::isRinging(void) { return Ringing; }
 
-// end TimeInstant::isRinging
+// end Alarm::isRinging
 
 //------------------------------------------------------------------------------
 // Alarm::updateStatus - Changes the alarm status based on current time

--- a/components/omega/src/infra/TimeMgr.cpp
+++ b/components/omega/src/infra/TimeMgr.cpp
@@ -1096,7 +1096,7 @@ std::unique_ptr<Calendar> Calendar::OmegaCal = nullptr;
 
 //-------------------------------------------------------------------------
 // Calendar::get - retrieves pointer to model calendar
-Calendar::Calendar *Calendar::get() {
+Calendar *Calendar::get() {
    if (isDefined()) {
       return Calendar::OmegaCal.get();
    } else {

--- a/components/omega/src/ocn/OceanDriver.h
+++ b/components/omega/src/ocn/OceanDriver.h
@@ -20,8 +20,7 @@ namespace OMEGA {
 
 /// Read the config file and call all the inidividual initialization routines
 /// for each Omega module
-int ocnInit(MPI_Comm Comm, Calendar &OmegaCal, TimeInstant &StartTime,
-            Alarm &EndAlarm);
+int ocnInit(MPI_Comm Comm, TimeInstant &StartTime, Alarm &EndAlarm);
 
 /// Advance the model from starting from CurrTime until EndAlarm rings
 int ocnRun(TimeInstant &CurrTime, Alarm &EndAlarm);
@@ -30,8 +29,8 @@ int ocnRun(TimeInstant &CurrTime, Alarm &EndAlarm);
 int ocnFinalize(const TimeInstant &CurrTime);
 
 /// Extract time management options from Config
-int initTimeManagement(Calendar &OmegaCal, TimeInstant &StartTime,
-                       Alarm &EndAlarm, Config *OmegaConfig);
+int initTimeManagement(TimeInstant &StartTime, Alarm &EndAlarm,
+                       Config *OmegaConfig);
 
 /// Initialize Omega modules needed to run ocean model
 int initOmegaModules(MPI_Comm Comm);

--- a/components/omega/test/drivers/StandaloneDriverTest.cpp
+++ b/components/omega/test/drivers/StandaloneDriverTest.cpp
@@ -30,11 +30,10 @@ int main(int argc, char *argv[]) {
    Kokkos::initialize();   // initialize Kokkos
 
    // Time management objects
-   OMEGA::Calendar OmegaCal;
    OMEGA::TimeInstant CurrTime;
    OMEGA::Alarm EndAlarm;
 
-   ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD, OmegaCal, CurrTime, EndAlarm);
+   ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD, CurrTime, EndAlarm);
    if (ErrCurr == 0) {
       LOG_INFO("DriverTest: Omega initialize PASS");
    } else {

--- a/components/omega/test/infra/TimeMgrTest.cpp
+++ b/components/omega/test/infra/TimeMgrTest.cpp
@@ -17,6 +17,8 @@
 #include "MachEnv.h"
 #include "mpi.h"
 
+using namespace OMEGA;
+
 //------------------------------------------------------------------------------
 // TimeFrac test
 
@@ -25,26 +27,26 @@ int testTimeFrac(void) {
    LOG_INFO("TimeMgrTest: TimeFrac tests ------------------------------------");
 
    // Initialize error codes
-   OMEGA::I4 Err1{0};
-   OMEGA::I4 Err2{0};
-   OMEGA::I4 ErrAll{0};
+   I4 Err1{0};
+   I4 Err2{0};
+   I4 ErrAll{0};
 
    // Initialize some reference values for the fractional
    // representation of 2 1/3 seconds.
-   OMEGA::I8 WRef{2};
-   OMEGA::I8 NRef{1};
-   OMEGA::I8 DRef{3};
-   OMEGA::R8 RRef{2.3333333333333333};
+   I8 WRef{2};
+   I8 NRef{1};
+   I8 DRef{3};
+   R8 RRef{2.3333333333333333};
 
-   OMEGA::I8 WTst{2};
-   OMEGA::I8 NTst{1};
-   OMEGA::I8 DTst{3};
-   OMEGA::R8 RTst{2.3333333333333333};
+   I8 WTst{2};
+   I8 NTst{1};
+   I8 DTst{3};
+   R8 RTst{2.3333333333333333};
 
    // Test default constructor to create a reference fraction
    // Also implicitly tests one form of the get routine.
 
-   OMEGA::TimeFrac RefTF;
+   TimeFrac RefTF;
 
    Err1 = RefTF.get(WTst, NTst, DTst);
 
@@ -100,7 +102,7 @@ int testTimeFrac(void) {
 
    // Test component constructor
 
-   OMEGA::TimeFrac Tst1TF(WRef, NRef, DRef);
+   TimeFrac Tst1TF(WRef, NRef, DRef);
 
    Err1 = Tst1TF.get(WTst, NTst, DTst);
 
@@ -202,7 +204,7 @@ int testTimeFrac(void) {
 
    // Test copy constuctor
 
-   OMEGA::TimeFrac Tst2TF(RefTF);
+   TimeFrac Tst2TF(RefTF);
 
    if (Tst2TF == RefTF) {
       LOG_INFO("TimeMgrTest/TimeFrac: copy constructor: PASS");
@@ -216,7 +218,7 @@ int testTimeFrac(void) {
    Tst1TF.set(2, 2, 3);
    Tst2TF.set(1, 1, 5);
 
-   OMEGA::TimeFrac Tst3TF;
+   TimeFrac Tst3TF;
    Tst3TF = Tst1TF + Tst2TF;
 
    Err1 = Tst3TF.get(WTst, NTst, DTst);
@@ -281,8 +283,8 @@ int testTimeFrac(void) {
    // Test multiply by int functions
 
    Tst1TF.set(2, 2, 3);
-   Tst3TF         = Tst1TF;
-   OMEGA::I4 ITst = 5;
+   Tst3TF  = Tst1TF;
+   I4 ITst = 5;
 
    Tst2TF = Tst1TF * ITst;
    Tst3TF *= ITst;
@@ -393,12 +395,12 @@ int testTimeFrac(void) {
 
    // Test get/set for integer hour, minute, second interfaces
 
-   OMEGA::I4 HRef{13};
-   OMEGA::I4 MRef{87};
-   OMEGA::I4 SRef{36};
-   OMEGA::I4 HTst{0};
-   OMEGA::I4 MTst{0};
-   OMEGA::I4 STst{0};
+   I4 HRef{13};
+   I4 MRef{87};
+   I4 SRef{36};
+   I4 HTst{0};
+   I4 MTst{0};
+   I4 STst{0};
 
    Err1 = Tst1TF.setHMS(HRef, MRef, SRef);
    Err2 = Tst1TF.getHMS(HTst, MTst, STst);
@@ -430,7 +432,7 @@ int testTimeFrac(void) {
 
    // Test the related constructor from real seconds.
 
-   OMEGA::TimeFrac Tst4TF(RRef);
+   TimeFrac Tst4TF(RRef);
 
    if (Tst4TF == Tst1TF) {
       LOG_INFO("TimeMgrTest/TimeFrac: real seconds constructor: PASS");
@@ -513,121 +515,72 @@ int testCalendar(void) {
    LOG_INFO("TimeMgrTest: Calendar tests ------------------------------------");
 
    // Initialize error codes
-   OMEGA::I4 Err1{0};
-   OMEGA::I4 Err2{0};
-   OMEGA::I4 ErrAll{0};
+   I4 Err1{0};
+   I4 Err2{0};
+   I4 ErrAll{0};
 
-   // Test default constructor.
+   // Test custom calendar
    // Also tests the get routine.
 
-   OMEGA::Calendar CalEmpty;
+   CalendarKind Kind0 = CalendarCustom;
+   I4 MonthsPerYear0  = 12;
+   std::vector<I4> DaysPerMonth0(MonthsPerYear0, 0);
+   DaysPerMonth0[0]   = 10;
+   DaysPerMonth0[1]   = 10;
+   DaysPerMonth0[2]   = 10;
+   DaysPerMonth0[3]   = 10;
+   DaysPerMonth0[4]   = 10;
+   DaysPerMonth0[5]   = 10;
+   DaysPerMonth0[6]   = 10;
+   DaysPerMonth0[7]   = 10;
+   DaysPerMonth0[8]   = 10;
+   DaysPerMonth0[9]   = 10;
+   DaysPerMonth0[10]  = 10;
+   DaysPerMonth0[11]  = 14;
+   I4 SecondsPerDay0  = 100;
+   I4 SecondsPerYear0 = 12400;
+   I4 DaysPerYear0    = 124;
 
-   OMEGA::CalendarKind Kind0 = OMEGA::CalendarNoCalendar;
-   OMEGA::I4 ID0             = 1;
-   std::string Name0(" ");
-   OMEGA::I4 DaysPerMonth0[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-   OMEGA::I4 MonthsPerYear0  = 12;
-   OMEGA::I4 SecondsPerDay0  = 0;
-   OMEGA::I4 SecondsPerYear0 = 0;
-   OMEGA::I4 DaysPerYear0    = 0;
+   CalendarKind Kind1 = CalendarCustom;
+   I4 MonthsPerYear1  = 12;
+   std::vector<I4> DaysPerMonth1(MonthsPerYear1, 0);
+   DaysPerMonth1[0]   = 99;
+   DaysPerMonth1[1]   = 99;
+   DaysPerMonth1[2]   = 99;
+   DaysPerMonth1[3]   = 99;
+   DaysPerMonth1[4]   = 99;
+   DaysPerMonth1[5]   = 99;
+   DaysPerMonth1[6]   = 99;
+   DaysPerMonth1[7]   = 99;
+   DaysPerMonth1[8]   = 99;
+   DaysPerMonth1[9]   = 99;
+   DaysPerMonth1[10]  = 99;
+   DaysPerMonth1[11]  = 99;
+   I4 SecondsPerDay1  = 999;
+   I4 SecondsPerYear1 = 999;
+   I4 DaysPerYear1    = 999;
 
-   OMEGA::CalendarKind Kind1 = OMEGA::CalendarGregorian;
-   OMEGA::I4 ID1             = 1;
-   std::string Name1("junk");
-   OMEGA::I4 DaysPerMonth1[] = {99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99};
-   OMEGA::I4 MonthsPerYear1  = 999;
-   OMEGA::I4 SecondsPerDay1  = 999;
-   OMEGA::I4 SecondsPerYear1 = 999;
-   OMEGA::I4 DaysPerYear1    = 999;
+   Calendar::init(DaysPerMonth0, SecondsPerDay0, SecondsPerYear0, DaysPerYear0);
 
-   Err1 = CalEmpty.get(&ID1, &Name1, &Kind1, DaysPerMonth1, &MonthsPerYear1,
-                       &SecondsPerDay1, &SecondsPerYear1, &DaysPerYear1);
+   Calendar *CalCustom = Calendar::get();
+   Kind1               = Calendar::getKind();
+   DaysPerMonth1       = Calendar::getDaysPerMonth();
+   MonthsPerYear1      = Calendar::getMonthsPerYear();
+   SecondsPerDay1      = Calendar::getSecondsPerDay();
+   SecondsPerYear1     = Calendar::getSecondsPerYear();
+   DaysPerYear1        = Calendar::getDaysPerYear();
 
-   if (Err1 != 0 || Kind1 != Kind0 || ID1 != ID0 || Name1 != Name0 ||
-       MonthsPerYear1 != MonthsPerYear0 || SecondsPerDay1 != SecondsPerDay0 ||
-       SecondsPerYear1 != SecondsPerYear0 || DaysPerYear1 != DaysPerYear0)
+   if (Err1 != 0 || Kind1 != Kind0 || MonthsPerYear1 != MonthsPerYear0 ||
+       SecondsPerDay1 != SecondsPerDay0 || SecondsPerYear1 != SecondsPerYear0 ||
+       DaysPerYear1 != DaysPerYear0) {
       Err2 = 1;
+   } else {
+      Err2 = 0;
+   }
 
    for (int I = 0; I < MonthsPerYear0; I++) {
       if (DaysPerMonth0[I] != DaysPerMonth1[I])
          Err2 = 1;
-   }
-
-   if (Err2 == 0) {
-      LOG_INFO("TimeMgrTest/Calendar: default constructor and get: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: default constructor or get: FAIL");
-   }
-
-   // Test rename function
-   Err1  = CalEmpty.rename("junk");
-   Name1 = "junk";
-
-   Err2 = CalEmpty.get(nullptr, &Name0, nullptr, nullptr, nullptr, nullptr,
-                       nullptr, nullptr);
-
-   if (Err1 == 0 && Err2 == 0 && Name1 == Name0) {
-      LOG_INFO("TimeMgrTest/Calendar: rename: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: rename: FAIL");
-   }
-
-   // Test custom calendar
-
-   Kind0             = OMEGA::CalendarCustom;
-   ID0               = 2;
-   Name0             = "Custom";
-   DaysPerMonth0[0]  = 10;
-   DaysPerMonth0[1]  = 10;
-   DaysPerMonth0[2]  = 10;
-   DaysPerMonth0[3]  = 10;
-   DaysPerMonth0[4]  = 10;
-   DaysPerMonth0[5]  = 10;
-   DaysPerMonth0[6]  = 10;
-   DaysPerMonth0[7]  = 10;
-   DaysPerMonth0[8]  = 10;
-   DaysPerMonth0[9]  = 10;
-   DaysPerMonth0[10] = 10;
-   DaysPerMonth0[11] = 14;
-   MonthsPerYear0    = 12;
-   SecondsPerDay0    = 100;
-   SecondsPerYear0   = 12400;
-   DaysPerYear0      = 124;
-
-   Kind1             = OMEGA::CalendarCustom;
-   ID1               = 0;
-   Name1             = "junk";
-   DaysPerMonth1[0]  = 99;
-   DaysPerMonth1[1]  = 99;
-   DaysPerMonth1[2]  = 99;
-   DaysPerMonth1[3]  = 99;
-   DaysPerMonth1[4]  = 99;
-   DaysPerMonth1[5]  = 99;
-   DaysPerMonth1[6]  = 99;
-   DaysPerMonth1[7]  = 99;
-   DaysPerMonth1[8]  = 99;
-   DaysPerMonth1[9]  = 99;
-   DaysPerMonth1[10] = 99;
-   DaysPerMonth1[11] = 99;
-   MonthsPerYear1    = 999;
-   SecondsPerDay1    = 999;
-   SecondsPerYear1   = 999;
-   DaysPerYear1      = 999;
-
-   OMEGA::Calendar CalCustom(Name0, DaysPerMonth0, SecondsPerDay0,
-                             SecondsPerYear0, DaysPerYear0);
-
-   Err1 = CalCustom.get(&ID1, &Name1, &Kind1, DaysPerMonth1, &MonthsPerYear1,
-                        &SecondsPerDay1, &SecondsPerYear1, &DaysPerYear1);
-
-   if (Err1 != 0 || Kind1 != Kind0 || ID1 != ID0 || Name1 != Name0 ||
-       MonthsPerYear1 != MonthsPerYear0 || SecondsPerDay1 != SecondsPerDay0 ||
-       SecondsPerYear1 != SecondsPerYear0 || DaysPerYear1 != DaysPerYear0) {
-      Err2 = 1;
-   } else {
-      Err2 = 0;
    }
 
    if (Err2 == 0) {
@@ -637,50 +590,71 @@ int testCalendar(void) {
       LOG_ERROR("TimeMgrTest/Calendar: custom constructor: FAIL");
    }
 
-   // Test copy constructor
+   // Test a date in custom calendar (1957-10-4, 00:01:24.25)
+   I8 TmpSeconds = (1957 * (I8)12400) + (9 * 10 + 4 - 1) * 100 + 60 + 24;
+   TimeFrac TstTime(TmpSeconds, 1, 4);
+   I8 TstYear    = 1957;
+   I8 TstMonth   = 10;
+   I8 TstDay     = 4;
+   I8 TstHour    = 0;
+   I8 TstMinute  = 1;
+   I8 TstSecondW = 24;
+   I8 TstSecondN = 1;
+   I8 TstSecondD = 4;
 
-   ID0 = 3;
+   TimeFrac ChkTime(0, 0, 1);
+   I8 ChkYear    = 0;
+   I8 ChkMonth   = 0;
+   I8 ChkDay     = 0;
+   I8 ChkHour    = 0;
+   I8 ChkMinute  = 0;
+   I8 ChkSecondW = 0;
+   I8 ChkSecondN = 0;
+   I8 ChkSecondD = 1;
 
-   OMEGA::Calendar CalCopy(CalCustom);
-
-   Err1 = CalCopy.get(&ID1, &Name1, &Kind1, DaysPerMonth1, &MonthsPerYear1,
-                      &SecondsPerDay1, &SecondsPerYear1, &DaysPerYear1);
-
-   if (Err1 != 0 || Kind1 != Kind0 || ID1 != ID0 || Name1 != Name0 ||
-       MonthsPerYear1 != MonthsPerYear0 || SecondsPerDay1 != SecondsPerDay0 ||
-       SecondsPerYear1 != SecondsPerYear0 || DaysPerYear1 != DaysPerYear0)
-      Err2 = 1;
-   else
-      Err2 = 0;
-
-   if (Err2 == 0) {
-      LOG_INFO("TimeMgrTest/Calendar: copy constructor: PASS");
+   ChkTime =
+       Calendar::getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
+                                TstSecondW, TstSecondN, TstSecondD);
+   if (ChkTime == TstTime) {
+      LOG_INFO("TimeMgrTest/Calendar: convert custom date to "
+               "elapsed time: PASS");
    } else {
       ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: copy constructor: FAIL");
+      LOG_ERROR("TimeMgrTest/Calendar: convert custom date to "
+                "elapsed time: FAIL");
    }
 
-   // Test equivalence and non-equivalence
+   Err1 = Calendar::getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
+                                ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
+   if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
+       ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
+       ChkSecondW == TstSecondW && ChkSecondN == TstSecondN &&
+       ChkSecondD == TstSecondD) {
+      LOG_INFO("TimeMgrTest/Calendar: convert elapsed time to "
+               "Custom date: PASS");
 
-   if (CalCustom == CalCopy) {
-      LOG_INFO("TimeMgrTest/Calendar: operator(==): PASS");
    } else {
       ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: operator(==): FAIL");
+      LOG_ERROR("TimeMgrTest/Calendar: convert elapsed time to "
+                "Custom date: FAIL");
    }
 
-   if (CalCustom != CalEmpty) {
-      LOG_INFO("TimeMgrTest/Calendar: operator(!=): PASS");
+   // Test validate
+
+   Err1 = CalCustom->validate();
+
+   if (Err1 == 0) {
+      LOG_INFO("TimeMgrTest/Calendar: validate: PASS");
    } else {
       ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: operator(!=): FAIL");
+      LOG_ERROR("TimeMgrTest/Calendar: validate: FAIL");
    }
 
-   // Test calendar construction for Gregorian
+   //------------------------
+   // Test Gregorian calendar
 
-   Kind0             = OMEGA::CalendarGregorian;
-   ID0               = 4;
-   Name0             = "Gregorian";
+   Calendar::reset(); // reset calendar
+   Kind0             = CalendarGregorian;
    DaysPerMonth0[0]  = 31;
    DaysPerMonth0[1]  = 28;
    DaysPerMonth0[2]  = 31;
@@ -698,9 +672,7 @@ int testCalendar(void) {
    SecondsPerYear0   = 31536000;
    DaysPerYear0      = 365;
 
-   Kind1             = OMEGA::CalendarNoCalendar;
-   ID1               = 0;
-   Name1             = "junk";
+   Kind1             = CalendarNoCalendar;
    DaysPerMonth1[0]  = 99;
    DaysPerMonth1[1]  = 99;
    DaysPerMonth1[2]  = 99;
@@ -718,14 +690,19 @@ int testCalendar(void) {
    SecondsPerYear1   = 999;
    DaysPerYear1      = 999;
 
-   OMEGA::Calendar CalGreg("Gregorian", OMEGA::CalendarGregorian);
+   Calendar::init("Gregorian");
+   Calendar *CalGreg = Calendar::get();
 
-   Err1 = CalGreg.get(&ID1, &Name1, &Kind1, DaysPerMonth1, &MonthsPerYear1,
-                      &SecondsPerDay1, &SecondsPerYear1, &DaysPerYear1);
+   Kind1           = Calendar::getKind();
+   DaysPerMonth1   = Calendar::getDaysPerMonth();
+   MonthsPerYear1  = Calendar::getMonthsPerYear();
+   SecondsPerDay1  = Calendar::getSecondsPerDay();
+   SecondsPerYear1 = Calendar::getSecondsPerYear();
+   DaysPerYear1    = Calendar::getDaysPerYear();
 
-   if (Kind1 != Kind0 || ID1 != ID0 || Name1 != Name0 ||
-       MonthsPerYear1 != MonthsPerYear0 || SecondsPerDay1 != SecondsPerDay0 ||
-       SecondsPerYear1 != SecondsPerYear0 || DaysPerYear1 != DaysPerYear0)
+   if (Kind1 != Kind0 || MonthsPerYear1 != MonthsPerYear0 ||
+       SecondsPerDay1 != SecondsPerDay0 || SecondsPerYear1 != SecondsPerYear0 ||
+       DaysPerYear1 != DaysPerYear0)
       Err1 = 1;
 
    if (Err1 == 0) {
@@ -735,273 +712,9 @@ int testCalendar(void) {
       LOG_ERROR("TimeMgrTest/Calendar: Gregorian constructor: FAIL");
    }
 
-   // No leap calendar is identical
-
-   Kind1             = OMEGA::CalendarNoCalendar;
-   ID1               = 0;
-   Name1             = "junk";
-   DaysPerMonth1[0]  = 99;
-   DaysPerMonth1[1]  = 99;
-   DaysPerMonth1[2]  = 99;
-   DaysPerMonth1[3]  = 99;
-   DaysPerMonth1[4]  = 99;
-   DaysPerMonth1[5]  = 99;
-   DaysPerMonth1[6]  = 99;
-   DaysPerMonth1[7]  = 99;
-   DaysPerMonth1[8]  = 99;
-   DaysPerMonth1[9]  = 99;
-   DaysPerMonth1[10] = 99;
-   DaysPerMonth1[11] = 99;
-   MonthsPerYear1    = 999;
-   SecondsPerDay1    = 999;
-   SecondsPerYear1   = 999;
-   DaysPerYear1      = 999;
-
-   ID0   = 5;
-   Kind0 = OMEGA::CalendarNoLeap;
-   Name0 = "Noleap";
-
-   OMEGA::Calendar CalNoLeap("Noleap", OMEGA::CalendarNoLeap);
-
-   Err1 = CalNoLeap.get(&ID1, &Name1, &Kind1, DaysPerMonth1, &MonthsPerYear1,
-                        &SecondsPerDay1, &SecondsPerYear1, &DaysPerYear1);
-
-   if (Kind1 != Kind0 || ID1 != ID0 || Name1 != Name0 ||
-       MonthsPerYear1 != MonthsPerYear0 || SecondsPerDay1 != SecondsPerDay0 ||
-       SecondsPerYear1 != SecondsPerYear0 || DaysPerYear1 != DaysPerYear0)
-      Err1 = 1;
-
-   if (Err1 == 0) {
-      LOG_INFO("TimeMgrTest/Calendar: No leap constructor: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: No leap constructor: FAIL");
-   }
-
-   // Straight Julian calendar the same
-
-   Kind1             = OMEGA::CalendarNoCalendar;
-   ID1               = 0;
-   Name1             = "junk";
-   DaysPerMonth1[0]  = 99;
-   DaysPerMonth1[1]  = 99;
-   DaysPerMonth1[2]  = 99;
-   DaysPerMonth1[3]  = 99;
-   DaysPerMonth1[4]  = 99;
-   DaysPerMonth1[5]  = 99;
-   DaysPerMonth1[6]  = 99;
-   DaysPerMonth1[7]  = 99;
-   DaysPerMonth1[8]  = 99;
-   DaysPerMonth1[9]  = 99;
-   DaysPerMonth1[10] = 99;
-   DaysPerMonth1[11] = 99;
-   MonthsPerYear1    = 999;
-   SecondsPerDay1    = 999;
-   SecondsPerYear1   = 999;
-   DaysPerYear1      = 999;
-
-   ID0   = 6;
-   Kind0 = OMEGA::CalendarJulian;
-   Name0 = "Julian";
-
-   OMEGA::Calendar CalJulian("Julian", OMEGA::CalendarJulian);
-
-   Err1 = CalJulian.get(&ID1, &Name1, &Kind1, DaysPerMonth1, &MonthsPerYear1,
-                        &SecondsPerDay1, &SecondsPerYear1, &DaysPerYear1);
-
-   if (Kind1 != Kind0 || ID1 != ID0 || Name1 != Name0 ||
-       MonthsPerYear1 != MonthsPerYear0 || SecondsPerDay1 != SecondsPerDay0 ||
-       SecondsPerYear1 != SecondsPerYear0 || DaysPerYear1 != DaysPerYear0)
-      Err1 = 1;
-
-   if (Err1 == 0) {
-      LOG_INFO("TimeMgrTest/Calendar: Julian constructor: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: Julian constructor: FAIL");
-   }
-
-   // Test calendar construction for 360 day
-
-   Kind0             = OMEGA::Calendar360Day;
-   ID0               = 7;
-   Name0             = "360Day";
-   DaysPerMonth0[0]  = 30;
-   DaysPerMonth0[1]  = 30;
-   DaysPerMonth0[2]  = 30;
-   DaysPerMonth0[3]  = 30;
-   DaysPerMonth0[4]  = 30;
-   DaysPerMonth0[5]  = 30;
-   DaysPerMonth0[6]  = 30;
-   DaysPerMonth0[7]  = 30;
-   DaysPerMonth0[8]  = 30;
-   DaysPerMonth0[9]  = 30;
-   DaysPerMonth0[10] = 30;
-   DaysPerMonth0[11] = 30;
-   MonthsPerYear0    = 12;
-   SecondsPerDay0    = 86400;
-   SecondsPerYear0   = 31104000;
-   DaysPerYear0      = 360;
-
-   Kind1             = OMEGA::CalendarNoCalendar;
-   ID1               = 0;
-   Name1             = "junk";
-   DaysPerMonth1[0]  = 99;
-   DaysPerMonth1[1]  = 99;
-   DaysPerMonth1[2]  = 99;
-   DaysPerMonth1[3]  = 99;
-   DaysPerMonth1[4]  = 99;
-   DaysPerMonth1[5]  = 99;
-   DaysPerMonth1[6]  = 99;
-   DaysPerMonth1[7]  = 99;
-   DaysPerMonth1[8]  = 99;
-   DaysPerMonth1[9]  = 99;
-   DaysPerMonth1[10] = 99;
-   DaysPerMonth1[11] = 99;
-   MonthsPerYear1    = 999;
-   SecondsPerDay1    = 999;
-   SecondsPerYear1   = 999;
-   DaysPerYear1      = 999;
-
-   OMEGA::Calendar Cal360Day("360Day", OMEGA::Calendar360Day);
-
-   Err1 = Cal360Day.get(&ID1, &Name1, &Kind1, DaysPerMonth1, &MonthsPerYear1,
-                        &SecondsPerDay1, &SecondsPerYear1, &DaysPerYear1);
-
-   if (Kind1 != Kind0 || ID1 != ID0 || Name1 != Name0 ||
-       MonthsPerYear1 != MonthsPerYear0 || SecondsPerDay1 != SecondsPerDay0 ||
-       SecondsPerYear1 != SecondsPerYear0 || DaysPerYear1 != DaysPerYear0)
-      Err1 = 1;
-
-   if (Err1 == 0) {
-      LOG_INFO("TimeMgrTest/Calendar: 360 Day constructor: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: 360 Day constructor: FAIL");
-   }
-
-   // Test calendar construction for Julian day
-
-   Kind0             = OMEGA::CalendarJulianDay;
-   ID0               = 8;
-   Name0             = "JulianDay";
-   DaysPerMonth0[0]  = 0;
-   DaysPerMonth0[1]  = 0;
-   DaysPerMonth0[2]  = 0;
-   DaysPerMonth0[3]  = 0;
-   DaysPerMonth0[4]  = 0;
-   DaysPerMonth0[5]  = 0;
-   DaysPerMonth0[6]  = 0;
-   DaysPerMonth0[7]  = 0;
-   DaysPerMonth0[8]  = 0;
-   DaysPerMonth0[9]  = 0;
-   DaysPerMonth0[10] = 0;
-   DaysPerMonth0[11] = 0;
-   MonthsPerYear0    = 12;
-   SecondsPerDay0    = 86400;
-   SecondsPerYear0   = 0;
-   DaysPerYear0      = 0;
-
-   Kind1             = OMEGA::CalendarNoCalendar;
-   ID1               = 0;
-   Name1             = "junk";
-   DaysPerMonth1[0]  = 99;
-   DaysPerMonth1[1]  = 99;
-   DaysPerMonth1[2]  = 99;
-   DaysPerMonth1[3]  = 99;
-   DaysPerMonth1[4]  = 99;
-   DaysPerMonth1[5]  = 99;
-   DaysPerMonth1[6]  = 99;
-   DaysPerMonth1[7]  = 99;
-   DaysPerMonth1[8]  = 99;
-   DaysPerMonth1[9]  = 99;
-   DaysPerMonth1[10] = 99;
-   DaysPerMonth1[11] = 99;
-   MonthsPerYear1    = 999;
-   SecondsPerDay1    = 999;
-   SecondsPerYear1   = 999;
-   DaysPerYear1      = 999;
-
-   OMEGA::Calendar CalJulianDay("JulianDay", OMEGA::CalendarJulianDay);
-
-   Err1 = CalJulianDay.get(&ID1, &Name1, &Kind1, DaysPerMonth1, &MonthsPerYear1,
-                           &SecondsPerDay1, &SecondsPerYear1, &DaysPerYear1);
-
-   if (Kind1 != Kind0 || ID1 != ID0 || Name1 != Name0 ||
-       MonthsPerYear1 != MonthsPerYear0 || SecondsPerDay1 != SecondsPerDay0 ||
-       SecondsPerYear1 != SecondsPerYear0 || DaysPerYear1 != DaysPerYear0)
-      Err1 = 1;
-
-   if (Err1 == 0) {
-      LOG_INFO("TimeMgrTest/Calendar: Julian Day constructor: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: Julian Day constructor: FAIL");
-   }
-
-   // Modified Julian day identical
-
-   Kind0 = OMEGA::CalendarModJulianDay;
-   ID0   = 9;
-   Name0 = "ModJulianDay";
-
-   Kind1             = OMEGA::CalendarNoCalendar;
-   ID1               = 0;
-   Name1             = "junk";
-   DaysPerMonth1[0]  = 99;
-   DaysPerMonth1[1]  = 99;
-   DaysPerMonth1[2]  = 99;
-   DaysPerMonth1[3]  = 99;
-   DaysPerMonth1[4]  = 99;
-   DaysPerMonth1[5]  = 99;
-   DaysPerMonth1[6]  = 99;
-   DaysPerMonth1[7]  = 99;
-   DaysPerMonth1[8]  = 99;
-   DaysPerMonth1[9]  = 99;
-   DaysPerMonth1[10] = 99;
-   DaysPerMonth1[11] = 99;
-   MonthsPerYear1    = 999;
-   SecondsPerDay1    = 999;
-   SecondsPerYear1   = 999;
-   DaysPerYear1      = 999;
-
-   OMEGA::Calendar CalModJulianDay("ModJulianDay", OMEGA::CalendarModJulianDay);
-
-   Err1 =
-       CalModJulianDay.get(&ID1, &Name1, &Kind1, DaysPerMonth1, &MonthsPerYear1,
-                           &SecondsPerDay1, &SecondsPerYear1, &DaysPerYear1);
-
-   if (Kind1 != Kind0 || ID1 != ID0 || Name1 != Name0 ||
-       MonthsPerYear1 != MonthsPerYear0 || SecondsPerDay1 != SecondsPerDay0 ||
-       SecondsPerYear1 != SecondsPerYear0 || DaysPerYear1 != DaysPerYear0)
-      Err1 = 1;
-
-   if (Err1 == 0) {
-      LOG_INFO("TimeMgrTest/Calendar: Modified Julian Day constructor: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: Modified Julian Day constructor: FAIL");
-   }
-
-   // Test leap year functions for different calendars
-
-   OMEGA::I8 TstYear = 1981;
-
-   // Calendar with no leap year
-   if (!CalJulianDay.isLeapYear(TstYear, Err1)) {
-      if (Err1 == 0) {
-         LOG_INFO("TimeMgrTest/Calendar: non-leap year JulianDay: PASS");
-      } else {
-         ++ErrAll;
-         LOG_ERROR("TimeMgrTest/Calendar: non-leap year JulianDay: FAIL");
-      }
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: non-leap year JulianDay: FAIL");
-   }
-
-   // Leap year calendar but not a leap year
-   if (!CalGreg.isLeapYear(TstYear, Err1)) {
+   // Test leap year with a non-leap year
+   TstYear = 1981;
+   if (!Calendar::isLeapYear(TstYear)) {
       if (Err1 == 0) {
          LOG_INFO("TimeMgrTest/Calendar: non-leap year Gregorian: PASS");
       } else {
@@ -1012,10 +725,9 @@ int testCalendar(void) {
       ++ErrAll;
       LOG_ERROR("TimeMgrTest/Calendar: non-leap year Gregorian: FAIL");
    }
-
-   // Leap year calendar normal leap years
+   // Test leap year with a leap year
    TstYear = 1984;
-   if (CalGreg.isLeapYear(TstYear, Err1)) {
+   if (Calendar::isLeapYear(TstYear)) {
       if (Err1 == 0) {
          LOG_INFO("TimeMgrTest/Calendar: 1984 leap year Gregorian: PASS");
       } else {
@@ -1026,32 +738,9 @@ int testCalendar(void) {
       ++ErrAll;
       LOG_ERROR("TimeMgrTest/Calendar: 1984 leap year Gregorian: FAIL");
    }
-   if (CalJulian.isLeapYear(TstYear, Err1)) {
-      if (Err1 == 0) {
-         LOG_INFO("TimeMgrTest/Calendar: 1984 leap year Julian: PASS");
-      } else {
-         ++ErrAll;
-         LOG_ERROR("TimeMgrTest/Calendar: 1984 leap year Julian: FAIL");
-      }
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: 1984 leap year Julian: FAIL");
-   }
-   if (!CalNoLeap.isLeapYear(TstYear, Err1)) {
-      if (Err1 == 0) {
-         LOG_INFO("TimeMgrTest/Calendar: 1984 leap year NoLeap: PASS");
-      } else {
-         ++ErrAll;
-         LOG_ERROR("TimeMgrTest/Calendar: 1984 leap year NoLeap: FAIL");
-      }
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: 1984 leap year NoLeap: FAIL");
-   }
-
-   // Special Gregorian leap year exceptions
+   // Test special Gregorian leap year exceptions
    TstYear = 1900;
-   if (!CalGreg.isLeapYear(TstYear, Err1)) {
+   if (!Calendar::isLeapYear(TstYear)) {
       if (Err1 == 0) {
          LOG_INFO("TimeMgrTest/Calendar: leap year exception "
                   "100 Gregorian: PASS");
@@ -1066,7 +755,7 @@ int testCalendar(void) {
                 "100 Gregorian: FAIL");
    }
    TstYear = 2000;
-   if (CalGreg.isLeapYear(TstYear, Err1)) {
+   if (Calendar::isLeapYear(TstYear)) {
       if (Err1 == 0) {
          LOG_INFO("TimeMgrTest/Calendar: leap year exception "
                   "400 Gregorian: PASS");
@@ -1087,29 +776,29 @@ int testCalendar(void) {
 
    // For Gregorian, check that Oct 4.81 1957 converts to the
    // Julian Day of 2436116.31 * SECONDS_PER_DAY for elapsed time
-   OMEGA::TimeFrac TstTime(210480449184, 1, 4);
-   TstYear = 1957;
-   OMEGA::I8 TstMonth{10};
-   OMEGA::I8 TstDay{4};
-   OMEGA::I8 TstHour{19};
-   OMEGA::I8 TstMinute{26};
-   OMEGA::I8 TstSecondW{24};
-   OMEGA::I8 TstSecondN{1};
-   OMEGA::I8 TstSecondD{4};
+   Err1       = TstTime.set(210480449184, 1, 4);
+   TstYear    = 1957;
+   TstMonth   = 10;
+   TstDay     = 4;
+   TstHour    = 19;
+   TstMinute  = 26;
+   TstSecondW = 24;
+   TstSecondN = 1;
+   TstSecondD = 4;
 
-   OMEGA::TimeFrac ChkTime(0, 0, 1);
-   OMEGA::I8 ChkYear{0};
-   OMEGA::I8 ChkMonth{0};
-   OMEGA::I8 ChkDay{0};
-   OMEGA::I8 ChkHour{0};
-   OMEGA::I8 ChkMinute{0};
-   OMEGA::I8 ChkSecondW{0};
-   OMEGA::I8 ChkSecondN{0};
-   OMEGA::I8 ChkSecondD{1};
+   Err1       = ChkTime.set(0, 0, 1);
+   ChkYear    = 0;
+   ChkMonth   = 0;
+   ChkDay     = 0;
+   ChkHour    = 0;
+   ChkMinute  = 0;
+   ChkSecondW = 0;
+   ChkSecondN = 0;
+   ChkSecondD = 1;
 
    ChkTime =
-       CalGreg.getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
-                              TstSecondW, TstSecondN, TstSecondD);
+       Calendar::getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
+                                TstSecondW, TstSecondN, TstSecondD);
 
    if (ChkTime == TstTime) {
       LOG_INFO("TimeMgrTest/Calendar: convert Gregorian date to "
@@ -1120,8 +809,8 @@ int testCalendar(void) {
                 "elapsed time: FAIL");
    }
 
-   Err1 = CalGreg.getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
-                              ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
+   Err1 = Calendar::getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
+                                ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
    if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
        ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
        ChkSecondW == TstSecondW && ChkSecondN == TstSecondN &&
@@ -1135,10 +824,248 @@ int testCalendar(void) {
                 "Gregorian date: FAIL");
    }
 
-   // Use same date for no leap calendar
-   OMEGA::I8 TmpSeconds =
-       (1957 * (OMEGA::I8)86400 * 365) +
-       (31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 4 - 1) * (OMEGA::I8)86400 +
+   // Test calendar date increment function
+   // Check normal year increment/decrement
+
+   TstYear  = 1983;
+   TstMonth = 6;
+   TstDay   = 15;
+   ChkYear  = 1985;
+   ChkMonth = 6;
+   ChkDay   = 15;
+
+   Err1 =
+       CalGreg->incrementDate(2, TimeUnits::Years, TstYear, TstMonth, TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: increment Gregorian date by year: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: increment Gregorian date by year: FAIL");
+   }
+
+   // Check normal month increment/decrement
+   TstYear  = 1984;
+   TstMonth = 6;
+   TstDay   = 15;
+   ChkYear  = 1984;
+   ChkMonth = 8;
+   ChkDay   = 15;
+
+   Err1 =
+       CalGreg->incrementDate(2, TimeUnits::Months, TstYear, TstMonth, TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: increment Gregorian date by month: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: increment Gregorian date "
+                "by month: FAIL");
+   }
+
+   // Check year rollover for longer month intervals
+
+   TstYear  = 1984;
+   TstMonth = 10;
+   TstDay   = 15;
+   ChkYear  = 1986;
+   ChkMonth = 4;
+   ChkDay   = 15;
+
+   Err1 =
+       CalGreg->incrementDate(18, TimeUnits::Months, TstYear, TstMonth, TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: increment Gregorian date by "
+               "18 months: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: increment Gregorian date by "
+                "18 months: FAIL");
+   }
+
+   TstYear  = 1984;
+   TstMonth = 10;
+   TstDay   = 15;
+   ChkYear  = 1983;
+   ChkMonth = 4;
+   ChkDay   = 15;
+
+   Err1 = CalGreg->incrementDate(-18, TimeUnits::Months, TstYear, TstMonth,
+                                 TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: decrement Gregorian date by "
+               "18 months: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: decrement Gregorian date by "
+                "18 months: FAIL");
+   }
+
+   // Check error case when day exceeds max day of new month
+
+   TstYear  = 1984;
+   TstMonth = 8;
+   TstDay   = 31;
+
+   Err1 =
+       CalGreg->incrementDate(1, TimeUnits::Months, TstYear, TstMonth, TstDay);
+   if (Err1 != 0) {
+      LOG_INFO("TimeMgrTest/Calendar: increment catch bad day range: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: increment catch bad day range: FAIL");
+   }
+
+   // Test normal daily increments/decrements including a leap day
+
+   TstYear  = 1984;
+   TstMonth = 2;
+   TstDay   = 25;
+   ChkYear  = 1984;
+   ChkMonth = 3;
+   ChkDay   = 6;
+
+   Err1 =
+       CalGreg->incrementDate(10, TimeUnits::Days, TstYear, TstMonth, TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: increment Gregorian date by "
+               "10 days: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: increment Gregorian date by "
+                "10 days: FAIL");
+   }
+
+   TstYear  = 1984;
+   TstMonth = 3;
+   TstDay   = 6;
+   ChkYear  = 1984;
+   ChkMonth = 2;
+   ChkDay   = 25;
+
+   Err1 =
+       CalGreg->incrementDate(-10, TimeUnits::Days, TstYear, TstMonth, TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: decrement Gregorian date by "
+               "10 days: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: decrement Gregorian date by "
+                "10 days: FAIL");
+   }
+
+   // Test longer daily intervals
+
+   TstYear  = 1984;
+   TstMonth = 2;
+   TstDay   = 25;
+   ChkYear  = 1985;
+   ChkMonth = 3;
+   ChkDay   = 31;
+
+   Err1 =
+       CalGreg->incrementDate(400, TimeUnits::Days, TstYear, TstMonth, TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: increment Gregorian date by "
+               "400 days: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: increment Gregorian date by "
+                "400 days: FAIL");
+   }
+
+   TstYear  = 1985;
+   TstMonth = 3;
+   TstDay   = 31;
+   ChkYear  = 1984;
+   ChkMonth = 2;
+   ChkDay   = 25;
+
+   Err1 =
+       CalGreg->incrementDate(-400, TimeUnits::Days, TstYear, TstMonth, TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: decrement Gregorian date by "
+               "400 days: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: decrement Gregorian date by "
+                "400 days: FAIL");
+   }
+
+   //------------------------
+   // Test No Leap calendar
+
+   Calendar::reset(); // reset calendar
+   Calendar::init("No Leap");
+   Calendar *CalNoLeap = Calendar::get();
+
+   Kind0 = CalendarNoLeap;
+   // Other quantities identical to Gregorian above
+
+   Kind1             = CalendarNoCalendar;
+   DaysPerMonth1[0]  = 99;
+   DaysPerMonth1[1]  = 99;
+   DaysPerMonth1[2]  = 99;
+   DaysPerMonth1[3]  = 99;
+   DaysPerMonth1[4]  = 99;
+   DaysPerMonth1[5]  = 99;
+   DaysPerMonth1[6]  = 99;
+   DaysPerMonth1[7]  = 99;
+   DaysPerMonth1[8]  = 99;
+   DaysPerMonth1[9]  = 99;
+   DaysPerMonth1[10] = 99;
+   DaysPerMonth1[11] = 99;
+   MonthsPerYear1    = 999;
+   SecondsPerDay1    = 999;
+   SecondsPerYear1   = 999;
+   DaysPerYear1      = 999;
+
+   Kind1           = Calendar::getKind();
+   DaysPerMonth1   = Calendar::getDaysPerMonth();
+   MonthsPerYear1  = Calendar::getMonthsPerYear();
+   SecondsPerDay1  = Calendar::getSecondsPerDay();
+   SecondsPerYear1 = Calendar::getSecondsPerYear();
+   DaysPerYear1    = Calendar::getDaysPerYear();
+
+   if (Kind1 != Kind0 || MonthsPerYear1 != MonthsPerYear0 ||
+       SecondsPerDay1 != SecondsPerDay0 || SecondsPerYear1 != SecondsPerYear0 ||
+       DaysPerYear1 != DaysPerYear0)
+      Err1 = 1;
+
+   if (Err1 == 0) {
+      LOG_INFO("TimeMgrTest/Calendar: No leap constructor: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: No leap constructor: FAIL");
+   }
+
+   // Verify the calendar does not have a leap year
+   TstYear = 1984;
+   if (!Calendar::isLeapYear(TstYear)) {
+      if (Err1 == 0) {
+         LOG_INFO("TimeMgrTest/Calendar: 1984 leap year NoLeap: PASS");
+      } else {
+         ++ErrAll;
+         LOG_ERROR("TimeMgrTest/Calendar: 1984 leap year NoLeap: FAIL");
+      }
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: 1984 leap year NoLeap: FAIL");
+   }
+
+   // Test calendar date to/from elapsed time conversion
+   // This is not an exhaustive test - just testing a single time
+   // and for internal consistency
+
+   TmpSeconds =
+       (1957 * (I8)86400 * 365) +
+       (31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 4 - 1) * (I8)86400 +
        19 * 3600 + 26 * 60 + 24;
    Err1       = TstTime.set(TmpSeconds, 1, 4);
    TstYear    = 1957;
@@ -1161,7 +1088,7 @@ int testCalendar(void) {
    ChkSecondD = 1;
 
    ChkTime =
-       CalNoLeap.getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
+       Calendar::getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
                                 TstSecondW, TstSecondN, TstSecondD);
    if (ChkTime == TstTime) {
       LOG_INFO("TimeMgrTest/Calendar: convert NoLeap date to "
@@ -1172,7 +1099,7 @@ int testCalendar(void) {
                 "elapsed time: FAIL");
    }
 
-   Err1 = CalNoLeap.getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
+   Err1 = Calendar::getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
                                 ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
    if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
        ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
@@ -1187,205 +1114,202 @@ int testCalendar(void) {
                 "NoLeap date: FAIL");
    }
 
-   // Use same date for 360-day
-   TmpSeconds = (1957 * (OMEGA::I8)86400 * 360) +
-                (9 * 30 + 4 - 1) * (OMEGA::I8)86400 + 19 * 3600 + 26 * 60 + 24;
-   Err1       = TstTime.set(TmpSeconds, 1, 4);
-   TstYear    = 1957;
-   TstMonth   = 10;
-   TstDay     = 4;
-   TstHour    = 19;
-   TstMinute  = 26;
-   TstSecondW = 24;
-   TstSecondN = 1;
-   TstSecondD = 4;
-
-   Err1       = ChkTime.set(0, 0, 1);
-   ChkYear    = 0;
-   ChkMonth   = 0;
-   ChkDay     = 0;
-   ChkHour    = 0;
-   ChkMinute  = 0;
-   ChkSecondW = 0;
-   ChkSecondN = 0;
-   ChkSecondD = 1;
-
-   ChkTime =
-       Cal360Day.getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
-                                TstSecondW, TstSecondN, TstSecondD);
-   if (ChkTime == TstTime) {
-      LOG_INFO("TimeMgrTest/Calendar: convert 360-day date to "
-               "elapsed time: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: convert 360-day date to "
-                "elapsed time: FAIL");
-   }
-
-   Err1 = Cal360Day.getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
-                                ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
-   if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
-       ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
-       ChkSecondW == TstSecondW && ChkSecondN == TstSecondN &&
-       ChkSecondD == TstSecondD) {
-      LOG_INFO("TimeMgrTest/Calendar: convert elapsed time to "
-               "360-day date: PASS");
-
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: convert elapsed time to "
-                "360-day date: FAIL");
-   }
-
-   // Modify same date to fit in custom calendar (1957-10-4, 00:01:24.25)
-   TmpSeconds = (1957 * (OMEGA::I8)12400) + (9 * 10 + 4 - 1) * 100 + 60 + 24;
-   Err1       = TstTime.set(TmpSeconds, 1, 4);
-   TstYear    = 1957;
-   TstMonth   = 10;
-   TstDay     = 4;
-   TstHour    = 0;
-   TstMinute  = 1;
-   TstSecondW = 24;
-   TstSecondN = 1;
-   TstSecondD = 4;
-
-   Err1       = ChkTime.set(0, 0, 1);
-   ChkYear    = 0;
-   ChkMonth   = 0;
-   ChkDay     = 0;
-   ChkHour    = 0;
-   ChkMinute  = 0;
-   ChkSecondW = 0;
-   ChkSecondN = 0;
-   ChkSecondD = 1;
-
-   ChkTime =
-       CalCustom.getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
-                                TstSecondW, TstSecondN, TstSecondD);
-   if (ChkTime == TstTime) {
-      LOG_INFO("TimeMgrTest/Calendar: convert custom date to "
-               "elapsed time: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: convert custom date to "
-                "elapsed time: FAIL");
-   }
-
-   Err1 = CalCustom.getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
-                                ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
-   if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
-       ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
-       ChkSecondW == TstSecondW && ChkSecondN == TstSecondN &&
-       ChkSecondD == TstSecondD) {
-      LOG_INFO("TimeMgrTest/Calendar: convert elapsed time to "
-               "Custom date: PASS");
-
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: convert elapsed time to "
-                "Custom date: FAIL");
-   }
-
-   // Julian Day - test Julian Day of 2436116.31 (plus 1/4 second)
-   TmpSeconds = (2436116 - 1) * (OMEGA::I8)86400 + 7 * 3600 + 26 * 60 + 24;
-   Err1       = TstTime.set(TmpSeconds, 1, 4);
-   TstYear    = 0;
-   TstMonth   = 0;
-   TstDay     = 2436116;
-   TstHour    = 7;
-   TstMinute  = 26;
-   TstSecondW = 24;
-   TstSecondN = 1;
-   TstSecondD = 4;
-
-   Err1       = ChkTime.set(0, 0, 1);
-   ChkYear    = 0;
-   ChkMonth   = 0;
-   ChkDay     = 0;
-   ChkHour    = 0;
-   ChkMinute  = 0;
-   ChkSecondW = 0;
-   ChkSecondN = 0;
-   ChkSecondD = 1;
-
-   ChkTime = CalJulianDay.getElapsedTime(TstYear, TstMonth, TstDay, TstHour,
-                                         TstMinute, TstSecondW, TstSecondN,
-                                         TstSecondD);
-   if (ChkTime == TstTime) {
-      LOG_INFO("TimeMgrTest/Calendar: convert Julian day to "
-               "elapsed time: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: convert Julian day to "
-                "elapsed time: FAIL");
-   }
+   // Test calendar date increment function
+   // Check normal year increment/decrement
+   TstYear  = 1983;
+   TstMonth = 6;
+   TstDay   = 15;
+   ChkYear  = 1985;
+   ChkMonth = 6;
+   ChkDay   = 15;
 
    Err1 =
-       CalJulianDay.getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
-                                ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
-   if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
-       ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
-       ChkSecondW == TstSecondW && ChkSecondN == TstSecondN &&
-       ChkSecondD == TstSecondD) {
-      LOG_INFO("TimeMgrTest/Calendar: convert elapsed time to "
-               "Julian day: PASS");
-
+       CalNoLeap->incrementDate(2, TimeUnits::Years, TstYear, TstMonth, TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: increment NoLeap date by year: PASS");
    } else {
       ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: convert elapsed time to "
-                "Julian day: FAIL");
+      LOG_ERROR("TimeMgrTest/Calendar: increment NoLeap date by year: FAIL");
    }
 
-   // Mod Julian Day - test Mod Julian Day of 2436116.31 (plus 1/4 second)
-   TmpSeconds = (2436116 - 1) * (OMEGA::I8)86400 + 7 * 3600 + 26 * 60 + 24;
-   Err1       = TstTime.set(TmpSeconds, 1, 4);
-   TstYear    = 0;
-   TstMonth   = 0;
-   TstDay     = 2436116;
-   TstHour    = 7;
-   TstMinute  = 26;
-   TstSecondW = 24;
-   TstSecondN = 1;
-   TstSecondD = 4;
-
-   Err1       = ChkTime.set(0, 0, 1);
-   ChkYear    = 0;
-   ChkMonth   = 0;
-   ChkDay     = 0;
-   ChkHour    = 0;
-   ChkMinute  = 0;
-   ChkSecondW = 0;
-   ChkSecondN = 0;
-   ChkSecondD = 1;
-
-   ChkTime = CalModJulianDay.getElapsedTime(TstYear, TstMonth, TstDay, TstHour,
-                                            TstMinute, TstSecondW, TstSecondN,
-                                            TstSecondD);
-   if (ChkTime == TstTime) {
-      LOG_INFO("TimeMgrTest/Calendar: convert Mod Julian day to "
-               "elapsed time: PASS");
+   TstYear = 1983;
+   ChkYear = 1981;
+   Err1    = CalNoLeap->incrementDate(-2, TimeUnits::Years, TstYear, TstMonth,
+                                      TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: decrement NoLeap date by year: PASS");
    } else {
       ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: convert Mod Julian day to "
-                "elapsed time: FAIL");
+      LOG_ERROR("TimeMgrTest/Calendar: decrement NoLeap date by year: FAIL");
    }
 
-   Err1 = CalModJulianDay.getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay,
-                                      ChkHour, ChkMinute, ChkSecondW,
-                                      ChkSecondN, ChkSecondD);
-   if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
-       ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
-       ChkSecondW == TstSecondW && ChkSecondN == TstSecondN &&
-       ChkSecondD == TstSecondD) {
-      LOG_INFO("TimeMgrTest/Calendar: convert elapsed time to "
-               "Mod Julian day: PASS");
+   // Check normal month increment/decrement
+   TstYear  = 1984;
+   TstMonth = 6;
+   TstDay   = 15;
+   ChkYear  = 1984;
+   ChkMonth = 8;
+   ChkDay   = 15;
 
+   TstMonth = 6;
+   Err1     = CalNoLeap->incrementDate(2, TimeUnits::Months, TstYear, TstMonth,
+                                       TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: increment NoLeap date by month: PASS");
    } else {
       ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: convert elapsed time to "
-                "Mod Julian day: FAIL");
+      LOG_ERROR("TimeMgrTest/Calendar: increment NoLeap date by month: FAIL");
    }
 
+   TstMonth = 6;
+   ChkMonth = 4;
+   Err1     = CalNoLeap->incrementDate(-2, TimeUnits::Months, TstYear, TstMonth,
+                                       TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: decrement NoLeap date by month: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: decrement NoLeap date by month: FAIL");
+   }
+
+   // Test normal daily increments/decrements
+
+   TstYear  = 1984;
+   TstMonth = 2;
+   TstDay   = 25;
+   ChkYear  = 1984;
+   ChkMonth = 3;
+   ChkDay   = 7;
+
+   Err1 =
+       CalNoLeap->incrementDate(10, TimeUnits::Days, TstYear, TstMonth, TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: increment NoLeap date by 10 days: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: increment NoLeap date by 10 days: FAIL");
+   }
+
+   TstYear  = 1984;
+   TstMonth = 3;
+   TstDay   = 7;
+   ChkYear  = 1984;
+   ChkMonth = 2;
+   ChkDay   = 25;
+
+   Err1 = CalNoLeap->incrementDate(-10, TimeUnits::Days, TstYear, TstMonth,
+                                   TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: decrement NoLeap date by 10 days: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: decrement NoLeap date by 10 days: FAIL");
+   }
+
+   // Test longer daily intervals
+
+   TstYear  = 1984;
+   TstMonth = 2;
+   TstDay   = 25;
+   ChkYear  = 1985;
+   ChkMonth = 4;
+   ChkDay   = 1;
+
+   Err1 = CalNoLeap->incrementDate(400, TimeUnits::Days, TstYear, TstMonth,
+                                   TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: increment NoLeap date by 400 days: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: increment NoLeap date by "
+                "400 days: FAIL");
+   }
+
+   TstYear  = 1985;
+   TstMonth = 4;
+   TstDay   = 1;
+   ChkYear  = 1984;
+   ChkMonth = 2;
+   ChkDay   = 25;
+
+   Err1 = CalNoLeap->incrementDate(-400, TimeUnits::Days, TstYear, TstMonth,
+                                   TstDay);
+   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
+       TstDay == ChkDay) {
+      LOG_INFO("TimeMgrTest/Calendar: decrement NoLeap date by 400 days: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: decrement NoLeap date by "
+                "400 days: FAIL");
+   }
+
+   //------------------------
+   // Straight Julian calendar the same
+   Calendar::reset(); // reset calendar
+   Calendar::init("Julian");
+   Calendar *CalJulian = Calendar::get();
+
+   Kind1             = CalendarNoCalendar;
+   DaysPerMonth1[0]  = 99;
+   DaysPerMonth1[1]  = 99;
+   DaysPerMonth1[2]  = 99;
+   DaysPerMonth1[3]  = 99;
+   DaysPerMonth1[4]  = 99;
+   DaysPerMonth1[5]  = 99;
+   DaysPerMonth1[6]  = 99;
+   DaysPerMonth1[7]  = 99;
+   DaysPerMonth1[8]  = 99;
+   DaysPerMonth1[9]  = 99;
+   DaysPerMonth1[10] = 99;
+   DaysPerMonth1[11] = 99;
+   MonthsPerYear1    = 999;
+   SecondsPerDay1    = 999;
+   SecondsPerYear1   = 999;
+   DaysPerYear1      = 999;
+
+   Kind0 = CalendarJulian;
+
+   Kind1           = Calendar::getKind();
+   DaysPerMonth1   = Calendar::getDaysPerMonth();
+   MonthsPerYear1  = Calendar::getMonthsPerYear();
+   SecondsPerDay1  = Calendar::getSecondsPerDay();
+   SecondsPerYear1 = Calendar::getSecondsPerYear();
+   DaysPerYear1    = Calendar::getDaysPerYear();
+
+   if (Kind1 != Kind0 || MonthsPerYear1 != MonthsPerYear0 ||
+       SecondsPerDay1 != SecondsPerDay0 || SecondsPerYear1 != SecondsPerYear0 ||
+       DaysPerYear1 != DaysPerYear0)
+      Err1 = 1;
+
+   if (Err1 == 0) {
+      LOG_INFO("TimeMgrTest/Calendar: Julian constructor: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: Julian constructor: FAIL");
+   }
+
+   // Leap year calendar normal leap years
+   TstYear = 1984;
+   if (Calendar::isLeapYear(TstYear)) {
+      if (Err1 == 0) {
+         LOG_INFO("TimeMgrTest/Calendar: 1984 leap year Julian: PASS");
+      } else {
+         ++ErrAll;
+         LOG_ERROR("TimeMgrTest/Calendar: 1984 leap year Julian: FAIL");
+      }
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: 1984 leap year Julian: FAIL");
+   }
+
+   // Test calendar date to/from elapsed time conversion
    // For Julian calendar, don't have a good reference date
    // so just check internal consistency
    TstYear    = 1957;
@@ -1408,10 +1332,10 @@ int testCalendar(void) {
    ChkSecondD = 1;
 
    ChkTime =
-       CalJulian.getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
+       Calendar::getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
                                 TstSecondW, TstSecondN, TstSecondD);
 
-   Err1 = CalJulian.getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
+   Err1 = Calendar::getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
                                 ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
    if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
        ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
@@ -1426,308 +1350,347 @@ int testCalendar(void) {
                 "Julian date: FAIL");
    }
 
-   // Test calendar date increment function
+   //------------------------
+   // Test calendar construction for 360 day
+   Calendar::reset(); // reset calendar
+   Calendar::init("360 Day");
+   Calendar *Cal360Day = Calendar::get();
 
-   // Check normal year increment/decrement
+   Kind0             = Calendar360Day;
+   DaysPerMonth0[0]  = 30;
+   DaysPerMonth0[1]  = 30;
+   DaysPerMonth0[2]  = 30;
+   DaysPerMonth0[3]  = 30;
+   DaysPerMonth0[4]  = 30;
+   DaysPerMonth0[5]  = 30;
+   DaysPerMonth0[6]  = 30;
+   DaysPerMonth0[7]  = 30;
+   DaysPerMonth0[8]  = 30;
+   DaysPerMonth0[9]  = 30;
+   DaysPerMonth0[10] = 30;
+   DaysPerMonth0[11] = 30;
+   MonthsPerYear0    = 12;
+   SecondsPerDay0    = 86400;
+   SecondsPerYear0   = 31104000;
+   DaysPerYear0      = 360;
 
-   TstYear  = 1983;
-   TstMonth = 6;
-   TstDay   = 15;
-   ChkYear  = 1985;
-   ChkMonth = 6;
-   ChkDay   = 15;
+   Kind1             = CalendarNoCalendar;
+   DaysPerMonth1[0]  = 99;
+   DaysPerMonth1[1]  = 99;
+   DaysPerMonth1[2]  = 99;
+   DaysPerMonth1[3]  = 99;
+   DaysPerMonth1[4]  = 99;
+   DaysPerMonth1[5]  = 99;
+   DaysPerMonth1[6]  = 99;
+   DaysPerMonth1[7]  = 99;
+   DaysPerMonth1[8]  = 99;
+   DaysPerMonth1[9]  = 99;
+   DaysPerMonth1[10] = 99;
+   DaysPerMonth1[11] = 99;
+   MonthsPerYear1    = 999;
+   SecondsPerDay1    = 999;
+   SecondsPerYear1   = 999;
+   DaysPerYear1      = 999;
 
-   Err1 = CalGreg.incrementDate(2, OMEGA::TimeUnits::Years, TstYear, TstMonth,
-                                TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: increment Gregorian date by year: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: increment Gregorian date by year: FAIL");
-   }
+   Kind1           = Calendar::getKind();
+   DaysPerMonth1   = Calendar::getDaysPerMonth();
+   MonthsPerYear1  = Calendar::getMonthsPerYear();
+   SecondsPerDay1  = Calendar::getSecondsPerDay();
+   SecondsPerYear1 = Calendar::getSecondsPerYear();
+   DaysPerYear1    = Calendar::getDaysPerYear();
 
-   TstYear = 1983;
-   Err1 = CalNoLeap.incrementDate(2, OMEGA::TimeUnits::Years, TstYear, TstMonth,
-                                  TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: increment NoLeap date by year: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: increment NoLeap date by year: FAIL");
-   }
-
-   TstYear = 1983;
-   ChkYear = 1981;
-   Err1    = CalNoLeap.incrementDate(-2, OMEGA::TimeUnits::Years, TstYear,
-                                     TstMonth, TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: decrement NoLeap date by year: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: decrement NoLeap date by year: FAIL");
-   }
-
-   // Check normal month increment/decrement
-   TstYear  = 1984;
-   TstMonth = 6;
-   TstDay   = 15;
-   ChkYear  = 1984;
-   ChkMonth = 8;
-   ChkDay   = 15;
-
-   Err1 = CalGreg.incrementDate(2, OMEGA::TimeUnits::Months, TstYear, TstMonth,
-                                TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: increment Gregorian date by month: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: increment Gregorian date "
-                "by month: FAIL");
-   }
-
-   TstMonth = 6;
-   Err1     = CalNoLeap.incrementDate(2, OMEGA::TimeUnits::Months, TstYear,
-                                      TstMonth, TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: increment NoLeap date by month: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: increment NoLeap date by month: FAIL");
-   }
-
-   TstMonth = 6;
-   ChkMonth = 4;
-   Err1     = CalNoLeap.incrementDate(-2, OMEGA::TimeUnits::Months, TstYear,
-                                      TstMonth, TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: decrement NoLeap date by month: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: decrement NoLeap date by month: FAIL");
-   }
-
-   // Check year rollover for longer month intervals
-
-   TstYear  = 1984;
-   TstMonth = 10;
-   TstDay   = 15;
-   ChkYear  = 1986;
-   ChkMonth = 4;
-   ChkDay   = 15;
-
-   Err1 = CalGreg.incrementDate(18, OMEGA::TimeUnits::Months, TstYear, TstMonth,
-                                TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: increment Gregorian date by "
-               "18 months: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: increment Gregorian date by "
-                "18 months: FAIL");
-   }
-
-   TstYear  = 1984;
-   TstMonth = 10;
-   TstDay   = 15;
-   ChkYear  = 1983;
-   ChkMonth = 4;
-   ChkDay   = 15;
-
-   Err1 = CalGreg.incrementDate(-18, OMEGA::TimeUnits::Months, TstYear,
-                                TstMonth, TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: decrement Gregorian date by "
-               "18 months: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: decrement Gregorian date by "
-                "18 months: FAIL");
-   }
-
-   // Check error case when day exceeds max day of new month
-
-   TstYear  = 1984;
-   TstMonth = 8;
-   TstDay   = 31;
-
-   Err1 = CalGreg.incrementDate(1, OMEGA::TimeUnits::Months, TstYear, TstMonth,
-                                TstDay);
-   if (Err1 != 0) {
-      LOG_INFO("TimeMgrTest/Calendar: increment catch bad day range: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: increment catch bad day range: FAIL");
-   }
-
-   // Test normal daily increments/decrements (include a leap day for Gregorian)
-
-   TstYear  = 1984;
-   TstMonth = 2;
-   TstDay   = 25;
-   ChkYear  = 1984;
-   ChkMonth = 3;
-   ChkDay   = 6;
-
-   Err1 = CalGreg.incrementDate(10, OMEGA::TimeUnits::Days, TstYear, TstMonth,
-                                TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: increment Gregorian date by "
-               "10 days: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: increment Gregorian date by "
-                "10 days: FAIL");
-   }
-
-   TstYear  = 1984;
-   TstMonth = 2;
-   TstDay   = 25;
-   ChkYear  = 1984;
-   ChkMonth = 3;
-   ChkDay   = 7;
-
-   Err1 = CalNoLeap.incrementDate(10, OMEGA::TimeUnits::Days, TstYear, TstMonth,
-                                  TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: increment NoLeap date by 10 days: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: increment NoLeap date by 10 days: FAIL");
-   }
-
-   TstYear  = 1984;
-   TstMonth = 3;
-   TstDay   = 6;
-   ChkYear  = 1984;
-   ChkMonth = 2;
-   ChkDay   = 25;
-
-   Err1 = CalGreg.incrementDate(-10, OMEGA::TimeUnits::Days, TstYear, TstMonth,
-                                TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: decrement Gregorian date by "
-               "10 days: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: decrement Gregorian date by "
-                "10 days: FAIL");
-   }
-
-   TstYear  = 1984;
-   TstMonth = 3;
-   TstDay   = 7;
-   ChkYear  = 1984;
-   ChkMonth = 2;
-   ChkDay   = 25;
-
-   Err1 = CalNoLeap.incrementDate(-10, OMEGA::TimeUnits::Days, TstYear,
-                                  TstMonth, TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: decrement NoLeap date by 10 days: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: decrement NoLeap date by 10 days: FAIL");
-   }
-
-   // Test longer daily intervals
-
-   TstYear  = 1984;
-   TstMonth = 2;
-   TstDay   = 25;
-   ChkYear  = 1985;
-   ChkMonth = 3;
-   ChkDay   = 31;
-
-   Err1 = CalGreg.incrementDate(400, OMEGA::TimeUnits::Days, TstYear, TstMonth,
-                                TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: increment Gregorian date by "
-               "400 days: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: increment Gregorian date by "
-                "400 days: FAIL");
-   }
-
-   TstYear  = 1984;
-   TstMonth = 2;
-   TstDay   = 25;
-   ChkYear  = 1985;
-   ChkMonth = 4;
-   ChkDay   = 1;
-
-   Err1 = CalNoLeap.incrementDate(400, OMEGA::TimeUnits::Days, TstYear,
-                                  TstMonth, TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: increment NoLeap date by 400 days: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: increment NoLeap date by "
-                "400 days: FAIL");
-   }
-
-   TstYear  = 1985;
-   TstMonth = 3;
-   TstDay   = 31;
-   ChkYear  = 1984;
-   ChkMonth = 2;
-   ChkDay   = 25;
-
-   Err1 = CalGreg.incrementDate(-400, OMEGA::TimeUnits::Days, TstYear, TstMonth,
-                                TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: decrement Gregorian date by "
-               "400 days: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: decrement Gregorian date by "
-                "400 days: FAIL");
-   }
-
-   TstYear  = 1985;
-   TstMonth = 4;
-   TstDay   = 1;
-   ChkYear  = 1984;
-   ChkMonth = 2;
-   ChkDay   = 25;
-
-   Err1 = CalNoLeap.incrementDate(-400, OMEGA::TimeUnits::Days, TstYear,
-                                  TstMonth, TstDay);
-   if (Err1 == 0 && TstYear == ChkYear && TstMonth == ChkMonth &&
-       TstDay == ChkDay) {
-      LOG_INFO("TimeMgrTest/Calendar: decrement NoLeap date by 400 days: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: decrement NoLeap date by "
-                "400 days: FAIL");
-   }
-
-   // Test validate
-
-   Err1 = CalCustom.validate();
+   if (Kind1 != Kind0 || MonthsPerYear1 != MonthsPerYear0 ||
+       SecondsPerDay1 != SecondsPerDay0 || SecondsPerYear1 != SecondsPerYear0 ||
+       DaysPerYear1 != DaysPerYear0)
+      Err1 = 1;
 
    if (Err1 == 0) {
-      LOG_INFO("TimeMgrTest/Calendar: validate: PASS");
+      LOG_INFO("TimeMgrTest/Calendar: 360 Day constructor: PASS");
    } else {
       ++ErrAll;
-      LOG_ERROR("TimeMgrTest/Calendar: validate: FAIL");
+      LOG_ERROR("TimeMgrTest/Calendar: 360 Day constructor: FAIL");
    }
 
+   // Test calendar date to/from elapsed time conversion
+   // This is not an exhaustive test - just testing a single time
+   // and for internal consistency
+
+   TmpSeconds = (1957 * (I8)86400 * 360) + (9 * 30 + 4 - 1) * (I8)86400 +
+                19 * 3600 + 26 * 60 + 24;
+   Err1       = TstTime.set(TmpSeconds, 1, 4);
+   TstYear    = 1957;
+   TstMonth   = 10;
+   TstDay     = 4;
+   TstHour    = 19;
+   TstMinute  = 26;
+   TstSecondW = 24;
+   TstSecondN = 1;
+   TstSecondD = 4;
+
+   Err1       = ChkTime.set(0, 0, 1);
+   ChkYear    = 0;
+   ChkMonth   = 0;
+   ChkDay     = 0;
+   ChkHour    = 0;
+   ChkMinute  = 0;
+   ChkSecondW = 0;
+   ChkSecondN = 0;
+   ChkSecondD = 1;
+
+   ChkTime =
+       Calendar::getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
+                                TstSecondW, TstSecondN, TstSecondD);
+   if (ChkTime == TstTime) {
+      LOG_INFO("TimeMgrTest/Calendar: convert 360-day date to "
+               "elapsed time: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: convert 360-day date to "
+                "elapsed time: FAIL");
+   }
+
+   Err1 = Calendar::getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
+                                ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
+   if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
+       ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
+       ChkSecondW == TstSecondW && ChkSecondN == TstSecondN &&
+       ChkSecondD == TstSecondD) {
+      LOG_INFO("TimeMgrTest/Calendar: convert elapsed time to "
+               "360-day date: PASS");
+
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: convert elapsed time to "
+                "360-day date: FAIL");
+   }
+
+   //------------------------
+   // Test calendar construction for Julian day
+   Calendar::reset(); // reset calendar
+   Calendar::init("Julian Day");
+   Calendar *CalJulianDay = Calendar::get();
+
+   Kind0             = CalendarJulianDay;
+   DaysPerMonth0[0]  = 0;
+   DaysPerMonth0[1]  = 0;
+   DaysPerMonth0[2]  = 0;
+   DaysPerMonth0[3]  = 0;
+   DaysPerMonth0[4]  = 0;
+   DaysPerMonth0[5]  = 0;
+   DaysPerMonth0[6]  = 0;
+   DaysPerMonth0[7]  = 0;
+   DaysPerMonth0[8]  = 0;
+   DaysPerMonth0[9]  = 0;
+   DaysPerMonth0[10] = 0;
+   DaysPerMonth0[11] = 0;
+   MonthsPerYear0    = 12;
+   SecondsPerDay0    = 86400;
+   SecondsPerYear0   = 0;
+   DaysPerYear0      = 0;
+
+   Kind1             = CalendarNoCalendar;
+   DaysPerMonth1[0]  = 99;
+   DaysPerMonth1[1]  = 99;
+   DaysPerMonth1[2]  = 99;
+   DaysPerMonth1[3]  = 99;
+   DaysPerMonth1[4]  = 99;
+   DaysPerMonth1[5]  = 99;
+   DaysPerMonth1[6]  = 99;
+   DaysPerMonth1[7]  = 99;
+   DaysPerMonth1[8]  = 99;
+   DaysPerMonth1[9]  = 99;
+   DaysPerMonth1[10] = 99;
+   DaysPerMonth1[11] = 99;
+   MonthsPerYear1    = 999;
+   SecondsPerDay1    = 999;
+   SecondsPerYear1   = 999;
+   DaysPerYear1      = 999;
+
+   Kind1           = Calendar::getKind();
+   DaysPerMonth1   = Calendar::getDaysPerMonth();
+   MonthsPerYear1  = Calendar::getMonthsPerYear();
+   SecondsPerDay1  = Calendar::getSecondsPerDay();
+   SecondsPerYear1 = Calendar::getSecondsPerYear();
+   DaysPerYear1    = Calendar::getDaysPerYear();
+
+   if (Kind1 != Kind0 || MonthsPerYear1 != MonthsPerYear0 ||
+       SecondsPerDay1 != SecondsPerDay0 || SecondsPerYear1 != SecondsPerYear0 ||
+       DaysPerYear1 != DaysPerYear0)
+      Err1 = 1;
+
+   if (Err1 == 0) {
+      LOG_INFO("TimeMgrTest/Calendar: Julian Day constructor: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: Julian Day constructor: FAIL");
+   }
+
+   // Calendar with no leap year
+   TstYear = 1981;
+   if (!Calendar::isLeapYear(TstYear)) {
+      if (Err1 == 0) {
+         LOG_INFO("TimeMgrTest/Calendar: non-leap year JulianDay: PASS");
+      } else {
+         ++ErrAll;
+         LOG_ERROR("TimeMgrTest/Calendar: non-leap year JulianDay: FAIL");
+      }
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: non-leap year JulianDay: FAIL");
+   }
+
+   // Test calendar date to/from elapsed time conversion
+   // This is not an exhaustive test - just testing a single time
+   // and for internal consistency
+   // Julian Day - test Julian Day of 2436116.31 (plus 1/4 second)
+   TmpSeconds = (2436116 - 1) * (I8)86400 + 7 * 3600 + 26 * 60 + 24;
+   Err1       = TstTime.set(TmpSeconds, 1, 4);
+   TstYear    = 0;
+   TstMonth   = 0;
+   TstDay     = 2436116;
+   TstHour    = 7;
+   TstMinute  = 26;
+   TstSecondW = 24;
+   TstSecondN = 1;
+   TstSecondD = 4;
+
+   Err1       = ChkTime.set(0, 0, 1);
+   ChkYear    = 0;
+   ChkMonth   = 0;
+   ChkDay     = 0;
+   ChkHour    = 0;
+   ChkMinute  = 0;
+   ChkSecondW = 0;
+   ChkSecondN = 0;
+   ChkSecondD = 1;
+
+   ChkTime =
+       Calendar::getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
+                                TstSecondW, TstSecondN, TstSecondD);
+   if (ChkTime == TstTime) {
+      LOG_INFO("TimeMgrTest/Calendar: convert Julian day to "
+               "elapsed time: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: convert Julian day to "
+                "elapsed time: FAIL");
+   }
+
+   Err1 = Calendar::getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
+                                ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
+   if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
+       ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
+       ChkSecondW == TstSecondW && ChkSecondN == TstSecondN &&
+       ChkSecondD == TstSecondD) {
+      LOG_INFO("TimeMgrTest/Calendar: convert elapsed time to "
+               "Julian day: PASS");
+
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: convert elapsed time to "
+                "Julian day: FAIL");
+   }
+
+   //------------------------
+   // Modified Julian day identical
+   Calendar::reset(); // reset calendar
+   Calendar::init("Modified Julian Day");
+   Calendar *CalModJulianDay = Calendar::get();
+
+   Kind0 = CalendarModJulianDay;
+
+   Kind1             = CalendarNoCalendar;
+   DaysPerMonth1[0]  = 99;
+   DaysPerMonth1[1]  = 99;
+   DaysPerMonth1[2]  = 99;
+   DaysPerMonth1[3]  = 99;
+   DaysPerMonth1[4]  = 99;
+   DaysPerMonth1[5]  = 99;
+   DaysPerMonth1[6]  = 99;
+   DaysPerMonth1[7]  = 99;
+   DaysPerMonth1[8]  = 99;
+   DaysPerMonth1[9]  = 99;
+   DaysPerMonth1[10] = 99;
+   DaysPerMonth1[11] = 99;
+   MonthsPerYear1    = 999;
+   SecondsPerDay1    = 999;
+   SecondsPerYear1   = 999;
+   DaysPerYear1      = 999;
+
+   Kind1           = Calendar::getKind();
+   DaysPerMonth1   = Calendar::getDaysPerMonth();
+   MonthsPerYear1  = Calendar::getMonthsPerYear();
+   SecondsPerDay1  = Calendar::getSecondsPerDay();
+   SecondsPerYear1 = Calendar::getSecondsPerYear();
+   DaysPerYear1    = Calendar::getDaysPerYear();
+
+   if (Kind1 != Kind0 || MonthsPerYear1 != MonthsPerYear0 ||
+       SecondsPerDay1 != SecondsPerDay0 || SecondsPerYear1 != SecondsPerYear0 ||
+       DaysPerYear1 != DaysPerYear0)
+      Err1 = 1;
+
+   if (Err1 == 0) {
+      LOG_INFO("TimeMgrTest/Calendar: Modified Julian Day constructor: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: Modified Julian Day constructor: FAIL");
+   }
+
+   // Test calendar date to/from elapsed time conversion
+   // This is not an exhaustive test - just testing a single time
+   // and for internal consistency
+   // Mod Julian Day - test Mod Julian Day of 2436116.31 (plus 1/4 second)
+   TmpSeconds = (2436116 - 1) * (I8)86400 + 7 * 3600 + 26 * 60 + 24;
+   Err1       = TstTime.set(TmpSeconds, 1, 4);
+   TstYear    = 0;
+   TstMonth   = 0;
+   TstDay     = 2436116;
+   TstHour    = 7;
+   TstMinute  = 26;
+   TstSecondW = 24;
+   TstSecondN = 1;
+   TstSecondD = 4;
+
+   Err1       = ChkTime.set(0, 0, 1);
+   ChkYear    = 0;
+   ChkMonth   = 0;
+   ChkDay     = 0;
+   ChkHour    = 0;
+   ChkMinute  = 0;
+   ChkSecondW = 0;
+   ChkSecondN = 0;
+   ChkSecondD = 1;
+
+   ChkTime =
+       Calendar::getElapsedTime(TstYear, TstMonth, TstDay, TstHour, TstMinute,
+                                TstSecondW, TstSecondN, TstSecondD);
+   if (ChkTime == TstTime) {
+      LOG_INFO("TimeMgrTest/Calendar: convert Mod Julian day to "
+               "elapsed time: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: convert Mod Julian day to "
+                "elapsed time: FAIL");
+   }
+
+   Err1 = Calendar::getDateTime(ChkTime, ChkYear, ChkMonth, ChkDay, ChkHour,
+                                ChkMinute, ChkSecondW, ChkSecondN, ChkSecondD);
+   if (Err1 == 0 && ChkYear == TstYear && ChkMonth == TstMonth &&
+       ChkDay == TstDay && ChkHour == TstHour && ChkMinute == TstMinute &&
+       ChkSecondW == TstSecondW && ChkSecondN == TstSecondN &&
+       ChkSecondD == TstSecondD) {
+      LOG_INFO("TimeMgrTest/Calendar: convert elapsed time to "
+               "Mod Julian day: PASS");
+
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Calendar: convert elapsed time to "
+                "Mod Julian day: FAIL");
+   }
+
+   // All done calendar tests - switch to Gregorian calendar before returning
+   Calendar::reset();
+   Calendar::init("Gregorian");
    return ErrAll;
 
 } // end testCalendar
@@ -1740,28 +1703,28 @@ int testTimeInterval(void) {
    LOG_INFO("TimeMgrTest: TimeInterval tests --------------------------------");
 
    // Initialize error codes
-   OMEGA::I4 Err1{0};
-   OMEGA::I4 Err2{0};
-   OMEGA::I4 ErrAll{0};
+   I4 Err1{0};
+   I4 Err2{0};
+   I4 ErrAll{0};
 
    // Initialize some reference values for the fractional
    // representation of a TimeInterval 5 3/8 seconds.
-   OMEGA::I8 WRef{5};
-   OMEGA::I8 NRef{3};
-   OMEGA::I8 DRef{8};
-   OMEGA::R8 RRef{5.375};
-   OMEGA::I8 IRef{WRef};
+   I8 WRef{5};
+   I8 NRef{3};
+   I8 DRef{8};
+   R8 RRef{5.375};
+   I8 IRef{WRef};
 
-   OMEGA::I8 WTst{5};
-   OMEGA::I8 NTst{3};
-   OMEGA::I8 DTst{8};
-   OMEGA::R8 RTst{5.375};
-   OMEGA::I8 ITst{WTst};
+   I8 WTst{5};
+   I8 NTst{3};
+   I8 DTst{8};
+   R8 RTst{5.375};
+   I8 ITst{WTst};
 
    // Test default constructor to create a reference fraction
    // Also implicitly tests one form of the get routine.
 
-   OMEGA::TimeInterval TiRef;
+   TimeInterval TiRef;
 
    // Test get function for a fractional second representation
    Err1 = TiRef.get(WTst, NTst, DTst);
@@ -1775,7 +1738,7 @@ int testTimeInterval(void) {
 
    // Test constructor from fractional seconds
 
-   OMEGA::TimeInterval TiTstFS(WRef, NRef, DRef);
+   TimeInterval TiTstFS(WRef, NRef, DRef);
 
    Err1 = TiTstFS.get(WTst, NTst, DTst);
 
@@ -1798,7 +1761,7 @@ int testTimeInterval(void) {
    }
 
    // Test time interval constructor from real seconds
-   OMEGA::TimeInterval TiTstRSec(RRef, OMEGA::TimeUnits::Seconds);
+   TimeInterval TiTstRSec(RRef, TimeUnits::Seconds);
 
    if (TiTstRSec == TiRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: real seconds constructor: PASS");
@@ -1808,8 +1771,7 @@ int testTimeInterval(void) {
    }
 
    // Test time interval constructor from real minutes
-   OMEGA::TimeInterval TiTstRMin((RRef / SECONDS_PER_MINUTE),
-                                 OMEGA::TimeUnits::Minutes);
+   TimeInterval TiTstRMin((RRef / SECONDS_PER_MINUTE), TimeUnits::Minutes);
    if (TiTstRMin == TiRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: real minutes constructor: PASS");
    } else {
@@ -1818,8 +1780,7 @@ int testTimeInterval(void) {
    }
 
    // Test time interval constructor from real hours
-   OMEGA::TimeInterval TiTstRHour((RRef / SECONDS_PER_HOUR),
-                                  OMEGA::TimeUnits::Hours);
+   TimeInterval TiTstRHour((RRef / SECONDS_PER_HOUR), TimeUnits::Hours);
    if (TiTstRHour == TiRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: real hours constructor: PASS");
    } else {
@@ -1828,9 +1789,9 @@ int testTimeInterval(void) {
    }
 
    // Test time interval constructor from real days
-   OMEGA::TimeInterval TiTstRDay(RRef, OMEGA::TimeUnits::Days);
+   TimeInterval TiTstRDay(RRef, TimeUnits::Days);
 
-   Err1 = TiTstRDay.get(RTst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstRDay.get(RTst, TimeUnits::Days);
    if (Err1 == 0 && RTst == 5.0) {
       LOG_INFO("TimeMgrTest/TimeInterval: real days constructor: PASS");
    } else {
@@ -1839,9 +1800,9 @@ int testTimeInterval(void) {
    }
 
    // Test time interval constructor from real months
-   OMEGA::TimeInterval TiTstRMonth(RRef, OMEGA::TimeUnits::Months);
+   TimeInterval TiTstRMonth(RRef, TimeUnits::Months);
 
-   Err1 = TiTstRMonth.get(RTst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstRMonth.get(RTst, TimeUnits::Months);
    if (Err1 == 0 && RTst == 5.0) {
       LOG_INFO("TimeMgrTest/TimeInterval: real months constructor: PASS");
    } else {
@@ -1850,9 +1811,9 @@ int testTimeInterval(void) {
    }
 
    // Test time interval constructor from real years
-   OMEGA::TimeInterval TiTstRYear(RRef, OMEGA::TimeUnits::Years);
+   TimeInterval TiTstRYear(RRef, TimeUnits::Years);
 
-   Err1 = TiTstRYear.get(RTst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstRYear.get(RTst, TimeUnits::Years);
    if (Err1 == 0 && RTst == 5.0) {
       LOG_INFO("TimeMgrTest/TimeInterval: real years constructor: PASS");
    } else {
@@ -1861,7 +1822,7 @@ int testTimeInterval(void) {
    }
 
    // Test time interval constructor from integer seconds
-   OMEGA::TimeInterval TiTstISec(IRef, OMEGA::TimeUnits::Seconds);
+   TimeInterval TiTstISec(IRef, TimeUnits::Seconds);
 
    Err1 = TiTstISec.get(WTst, NTst, DTst);
    if (Err1 == 0 && WTst == WRef && NTst == 0 && DTst == 1) {
@@ -1872,7 +1833,7 @@ int testTimeInterval(void) {
    }
 
    // Test time interval constructor from integer minutes
-   OMEGA::TimeInterval TiTstIMin(IRef, OMEGA::TimeUnits::Minutes);
+   TimeInterval TiTstIMin(IRef, TimeUnits::Minutes);
 
    Err1 = TiTstIMin.get(WTst, NTst, DTst);
    if (Err1 == 0 && WTst == WRef * SECONDS_PER_MINUTE && NTst == 0 &&
@@ -1893,7 +1854,7 @@ int testTimeInterval(void) {
    }
 
    // Test time interval constructor from integer hours
-   OMEGA::TimeInterval TiTstIHour(IRef, OMEGA::TimeUnits::Hours);
+   TimeInterval TiTstIHour(IRef, TimeUnits::Hours);
 
    Err1 = TiTstIHour.get(WTst, NTst, DTst);
    if (Err1 == 0 && WTst == WRef * SECONDS_PER_HOUR && NTst == 0 && DTst == 1) {
@@ -1904,9 +1865,9 @@ int testTimeInterval(void) {
    }
 
    // Test calendar-based time interval constructor in years
-   OMEGA::TimeInterval TiTstIYear(IRef, OMEGA::TimeUnits::Years);
+   TimeInterval TiTstIYear(IRef, TimeUnits::Years);
 
-   Err1 = TiTstIYear.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear.get(ITst, TimeUnits::Years);
 
    if (Err1 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: year constructor: PASS");
@@ -1916,9 +1877,9 @@ int testTimeInterval(void) {
    }
 
    // Test calendar-based time interval constructor in months
-   OMEGA::TimeInterval TiTstIMonth(IRef, OMEGA::TimeUnits::Months);
+   TimeInterval TiTstIMonth(IRef, TimeUnits::Months);
 
-   Err1 = TiTstIMonth.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth.get(ITst, TimeUnits::Months);
 
    if (Err1 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: month constructor: PASS");
@@ -1928,9 +1889,9 @@ int testTimeInterval(void) {
    }
 
    // Test calendar-based time interval constructor in days
-   OMEGA::TimeInterval TiTstIDay(IRef, OMEGA::TimeUnits::Days);
+   TimeInterval TiTstIDay(IRef, TimeUnits::Days);
 
-   Err1 = TiTstIDay.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay.get(ITst, TimeUnits::Days);
 
    if (Err1 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: day constructor: PASS");
@@ -1964,8 +1925,8 @@ int testTimeInterval(void) {
 
    // Test real seconds put/get
 
-   Err1 = TiTstRSec.set(RRef, OMEGA::TimeUnits::Seconds);
-   Err2 = TiTstRSec.get(RTst, OMEGA::TimeUnits::Seconds);
+   Err1 = TiTstRSec.set(RRef, TimeUnits::Seconds);
+   Err2 = TiTstRSec.get(RTst, TimeUnits::Seconds);
 
    if (Err1 == 0 && Err2 == 0 && RTst == RRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: real seconds put/get: PASS");
@@ -1976,8 +1937,8 @@ int testTimeInterval(void) {
 
    // Test integer seconds put/get
 
-   Err1 = TiTstISec.set(IRef, OMEGA::TimeUnits::Seconds);
-   Err2 = TiTstISec.get(ITst, OMEGA::TimeUnits::Seconds);
+   Err1 = TiTstISec.set(IRef, TimeUnits::Seconds);
+   Err2 = TiTstISec.get(ITst, TimeUnits::Seconds);
 
    if (Err1 == 0 && Err2 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: integer seconds put/get: PASS");
@@ -1988,8 +1949,8 @@ int testTimeInterval(void) {
 
    // Test real hours put/get
 
-   Err1 = TiTstRSec.set(RRef, OMEGA::TimeUnits::Hours);
-   Err2 = TiTstRSec.get(RTst, OMEGA::TimeUnits::Hours);
+   Err1 = TiTstRSec.set(RRef, TimeUnits::Hours);
+   Err2 = TiTstRSec.get(RTst, TimeUnits::Hours);
 
    if (Err1 == 0 && Err2 == 0 && RTst == RRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: real hours put/get: PASS");
@@ -2000,8 +1961,8 @@ int testTimeInterval(void) {
 
    // Test integer hours put/get
 
-   Err1 = TiTstISec.set(IRef, OMEGA::TimeUnits::Hours);
-   Err2 = TiTstISec.get(ITst, OMEGA::TimeUnits::Hours);
+   Err1 = TiTstISec.set(IRef, TimeUnits::Hours);
+   Err2 = TiTstISec.get(ITst, TimeUnits::Hours);
 
    if (Err1 == 0 && Err2 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: integer hours put/get: PASS");
@@ -2012,8 +1973,8 @@ int testTimeInterval(void) {
 
    // Test real minutes put/get
 
-   Err1 = TiTstRSec.set(RRef, OMEGA::TimeUnits::Minutes);
-   Err2 = TiTstRSec.get(RTst, OMEGA::TimeUnits::Minutes);
+   Err1 = TiTstRSec.set(RRef, TimeUnits::Minutes);
+   Err2 = TiTstRSec.get(RTst, TimeUnits::Minutes);
 
    if (Err1 == 0 && Err2 == 0 && RTst == RRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: real minutes put/get: PASS");
@@ -2024,8 +1985,8 @@ int testTimeInterval(void) {
 
    // Test integer minutes put/get
 
-   Err1 = TiTstISec.set(IRef, OMEGA::TimeUnits::Minutes);
-   Err2 = TiTstISec.get(ITst, OMEGA::TimeUnits::Minutes);
+   Err1 = TiTstISec.set(IRef, TimeUnits::Minutes);
+   Err2 = TiTstISec.get(ITst, TimeUnits::Minutes);
 
    if (Err1 == 0 && Err2 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: integer minutes put/get: PASS");
@@ -2036,8 +1997,8 @@ int testTimeInterval(void) {
 
    // Test integer years put/get
 
-   Err1 = TiTstISec.set(IRef + 1, OMEGA::TimeUnits::Years);
-   Err2 = TiTstISec.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstISec.set(IRef + 1, TimeUnits::Years);
+   Err2 = TiTstISec.get(ITst, TimeUnits::Years);
 
    if (Err1 == 0 && Err2 == 0 && ITst == IRef + 1) {
       LOG_INFO("TimeMgrTest/TimeInterval: integer years put/get: PASS");
@@ -2048,8 +2009,8 @@ int testTimeInterval(void) {
 
    // Test integer months put/get
 
-   Err1 = TiTstISec.set(IRef + 1, OMEGA::TimeUnits::Months);
-   Err2 = TiTstISec.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstISec.set(IRef + 1, TimeUnits::Months);
+   Err2 = TiTstISec.get(ITst, TimeUnits::Months);
 
    if (Err1 == 0 && Err2 == 0 && ITst == IRef + 1) {
       LOG_INFO("TimeMgrTest/TimeInterval: integer months put/get: PASS");
@@ -2060,8 +2021,8 @@ int testTimeInterval(void) {
 
    // Test integer days put/get
 
-   Err1 = TiTstISec.set(IRef + 1, OMEGA::TimeUnits::Days);
-   Err2 = TiTstISec.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstISec.set(IRef + 1, TimeUnits::Days);
+   Err2 = TiTstISec.get(ITst, TimeUnits::Days);
 
    if (Err1 == 0 && Err2 == 0 && ITst == IRef + 1) {
       LOG_INFO("TimeMgrTest/TimeInterval: integer days put/get: PASS");
@@ -2105,13 +2066,13 @@ int testTimeInterval(void) {
 
    // Test < operator (and < part of <= operator) for calendar intervals
 
-   Err1 = TiTstIYear.set(IRef, OMEGA::TimeUnits::Years);
-   Err1 = TiTstIMonth.set(IRef, OMEGA::TimeUnits::Months);
-   Err1 = TiTstIDay.set(IRef, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIYear.set(IRef, TimeUnits::Years);
+   Err1 = TiTstIMonth.set(IRef, TimeUnits::Months);
+   Err1 = TiTstIDay.set(IRef, TimeUnits::Days);
 
-   OMEGA::TimeInterval TiTstIYear2(IRef - 1, OMEGA::TimeUnits::Years);
-   OMEGA::TimeInterval TiTstIMonth2(IRef - 1, OMEGA::TimeUnits::Months);
-   OMEGA::TimeInterval TiTstIDay2(IRef - 1, OMEGA::TimeUnits::Days);
+   TimeInterval TiTstIYear2(IRef - 1, TimeUnits::Years);
+   TimeInterval TiTstIMonth2(IRef - 1, TimeUnits::Months);
+   TimeInterval TiTstIDay2(IRef - 1, TimeUnits::Days);
 
    if (TiTstIYear2 < TiTstIYear) {
       LOG_INFO("TimeMgrTest/TimeInterval: operator(<) years: PASS");
@@ -2395,7 +2356,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: addition: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == (IRef + IRef)) {
       LOG_INFO("TimeMgrTest/TimeInterval: addition years: PASS");
    } else {
@@ -2403,7 +2364,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: addition years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == (IRef + IRef)) {
       LOG_INFO("TimeMgrTest/TimeInterval: addition months: PASS");
    } else {
@@ -2411,7 +2372,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: addition months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == (IRef + IRef)) {
       LOG_INFO("TimeMgrTest/TimeInterval: addition days: PASS");
    } else {
@@ -2434,7 +2395,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: increment: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == (IRef + IRef + IRef)) {
       LOG_INFO("TimeMgrTest/TimeInterval: increment years: PASS");
    } else {
@@ -2442,7 +2403,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: increment years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == (IRef + IRef + IRef)) {
       LOG_INFO("TimeMgrTest/TimeInterval: increment months: PASS");
    } else {
@@ -2450,7 +2411,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: increment months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == (IRef + IRef + IRef)) {
       LOG_INFO("TimeMgrTest/TimeInterval: increment days: PASS");
    } else {
@@ -2473,7 +2434,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: subtraction: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == (IRef + IRef)) {
       LOG_INFO("TimeMgrTest/TimeInterval: subtraction years: PASS");
    } else {
@@ -2481,7 +2442,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: subtraction years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == (IRef + IRef)) {
       LOG_INFO("TimeMgrTest/TimeInterval: subtraction months: PASS");
    } else {
@@ -2489,7 +2450,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: subtraction months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == (IRef + IRef)) {
       LOG_INFO("TimeMgrTest/TimeInterval: subtraction days: PASS");
    } else {
@@ -2512,7 +2473,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: decrement: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: decrement years: PASS");
    } else {
@@ -2520,7 +2481,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: decrement years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: decrement months: PASS");
    } else {
@@ -2528,7 +2489,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: decrement months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: decrement days: PASS");
    } else {
@@ -2551,7 +2512,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int multiply: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == 3 * IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: int multiply years: PASS");
    } else {
@@ -2559,7 +2520,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int multiply years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == 3 * IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: int multiply months: PASS");
    } else {
@@ -2567,7 +2528,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int multiply months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == 3 * IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: int multiply days: PASS");
    } else {
@@ -2590,7 +2551,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: comm int multiply: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == 3 * IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: comm int multiply years: PASS");
    } else {
@@ -2598,7 +2559,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: comm int multiply years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == 3 * IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: comm int multiply months: PASS");
    } else {
@@ -2606,7 +2567,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: comm int multiply months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == 3 * IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: comm int multiply days: PASS");
    } else {
@@ -2629,7 +2590,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int multiply in place: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == 9 * IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: int multiply in place years: PASS");
    } else {
@@ -2637,7 +2598,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int multiply in place years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == 9 * IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: int multiply in place months: PASS");
    } else {
@@ -2645,7 +2606,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int multiply in place months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == 9 * IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: int multiply in place days: PASS");
    } else {
@@ -2668,7 +2629,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: real multiply: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == 16) {
       LOG_INFO("TimeMgrTest/TimeInterval: real multiply years: PASS");
    } else {
@@ -2676,7 +2637,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: real multiply years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == 16) {
       LOG_INFO("TimeMgrTest/TimeInterval: real multiply months: PASS");
    } else {
@@ -2684,7 +2645,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: real multiply months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == 16) {
       LOG_INFO("TimeMgrTest/TimeInterval: real multiply days: PASS");
    } else {
@@ -2707,7 +2668,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: comm real multiply: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == 16) {
       LOG_INFO("TimeMgrTest/TimeInterval: comm real multiply years: PASS");
    } else {
@@ -2715,7 +2676,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: comm real multiply years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == 16) {
       LOG_INFO("TimeMgrTest/TimeInterval: comm real multiply months: PASS");
    } else {
@@ -2723,7 +2684,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: comm real multiply months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == 16) {
       LOG_INFO("TimeMgrTest/TimeInterval: comm real multiply days: PASS");
    } else {
@@ -2746,7 +2707,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: real multiply in place: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == 52) {
       LOG_INFO("TimeMgrTest/TimeInterval: real multiply in place years: PASS");
    } else {
@@ -2754,7 +2715,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: real multiply in place years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == 52) {
       LOG_INFO("TimeMgrTest/TimeInterval: real multiply in place months: PASS");
    } else {
@@ -2763,7 +2724,7 @@ int testTimeInterval(void) {
                 "months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == 52) {
       LOG_INFO("TimeMgrTest/TimeInterval: real multiply in place days: PASS");
    } else {
@@ -2786,7 +2747,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int divide: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == 1) {
       LOG_INFO("TimeMgrTest/TimeInterval: int divide years: PASS");
    } else {
@@ -2794,7 +2755,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int divide years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == 1) {
       LOG_INFO("TimeMgrTest/TimeInterval: int divide months: PASS");
    } else {
@@ -2802,7 +2763,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int divide months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == 1) {
       LOG_INFO("TimeMgrTest/TimeInterval: int divide days: PASS");
    } else {
@@ -2825,7 +2786,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int divide in place: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == 0) {
       LOG_INFO("TimeMgrTest/TimeInterval: int divide in place years: PASS");
    } else {
@@ -2833,7 +2794,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int divide in place years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == 0) {
       LOG_INFO("TimeMgrTest/TimeInterval: int divide in place months: PASS");
    } else {
@@ -2841,7 +2802,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: int divide in place months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == 0) {
       LOG_INFO("TimeMgrTest/TimeInterval: int divide in place days: PASS");
    } else {
@@ -2851,10 +2812,10 @@ int testTimeInterval(void) {
 
    // Test negative absolute value first to change sign
 
-   TiTstFS      = OMEGA::TimeInterval::negAbsValue(TiRef);
-   TiTstIYear2  = OMEGA::TimeInterval::negAbsValue(TiTstIYear);
-   TiTstIMonth2 = OMEGA::TimeInterval::negAbsValue(TiTstIMonth);
-   TiTstIDay2   = OMEGA::TimeInterval::negAbsValue(TiTstIDay);
+   TiTstFS      = TimeInterval::negAbsValue(TiRef);
+   TiTstIYear2  = TimeInterval::negAbsValue(TiTstIYear);
+   TiTstIMonth2 = TimeInterval::negAbsValue(TiTstIMonth);
+   TiTstIDay2   = TimeInterval::negAbsValue(TiTstIDay);
 
    Err1 = TiTstFS.get(WTst, NTst, DTst);
    if (Err1 == 0 && WTst == -WRef && NTst == -NRef && DTst == DRef) {
@@ -2864,7 +2825,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: negAbsValue: FAIL");
    }
 
-   Err1 = TiTstIYear2.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear2.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == -IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: negAbsValue years: PASS");
    } else {
@@ -2872,7 +2833,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: negAbsValue years: FAIL");
    }
 
-   Err1 = TiTstIMonth2.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth2.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == -IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: negAbsValue months: PASS");
    } else {
@@ -2880,7 +2841,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: negAbsValue months: FAIL");
    }
 
-   Err1 = TiTstIDay2.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay2.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == -IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: negAbsValue days: PASS");
    } else {
@@ -2900,15 +2861,15 @@ int testTimeInterval(void) {
 
    // Test absolute value by changing the above to abs value
 
-   OMEGA::TimeInterval TiTst3;
-   OMEGA::TimeInterval TiTstIYear3;
-   OMEGA::TimeInterval TiTstIMonth3;
-   OMEGA::TimeInterval TiTstIDay3;
+   TimeInterval TiTst3;
+   TimeInterval TiTstIYear3;
+   TimeInterval TiTstIMonth3;
+   TimeInterval TiTstIDay3;
 
-   TiTst3       = OMEGA::TimeInterval::absValue(TiTstFS);
-   TiTstIYear3  = OMEGA::TimeInterval::absValue(TiTstIYear2);
-   TiTstIMonth3 = OMEGA::TimeInterval::absValue(TiTstIMonth2);
-   TiTstIDay3   = OMEGA::TimeInterval::absValue(TiTstIDay2);
+   TiTst3       = TimeInterval::absValue(TiTstFS);
+   TiTstIYear3  = TimeInterval::absValue(TiTstIYear2);
+   TiTstIMonth3 = TimeInterval::absValue(TiTstIMonth2);
+   TiTstIDay3   = TimeInterval::absValue(TiTstIDay2);
 
    Err1 = TiTst3.get(WTst, NTst, DTst);
    if (Err1 == 0 && WTst == WRef && NTst == NRef && DTst == DRef) {
@@ -2918,7 +2879,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: absValue: FAIL");
    }
 
-   Err1 = TiTstIYear3.get(ITst, OMEGA::TimeUnits::Years);
+   Err1 = TiTstIYear3.get(ITst, TimeUnits::Years);
    if (Err1 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: absValue years: PASS");
    } else {
@@ -2926,7 +2887,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: absValue years: FAIL");
    }
 
-   Err1 = TiTstIMonth3.get(ITst, OMEGA::TimeUnits::Months);
+   Err1 = TiTstIMonth3.get(ITst, TimeUnits::Months);
    if (Err1 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: absValue months: PASS");
    } else {
@@ -2934,7 +2895,7 @@ int testTimeInterval(void) {
       LOG_ERROR("TimeMgrTest/TimeInterval: absValue months: FAIL");
    }
 
-   Err1 = TiTstIDay3.get(ITst, OMEGA::TimeUnits::Days);
+   Err1 = TiTstIDay3.get(ITst, TimeUnits::Days);
    if (Err1 == 0 && ITst == IRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: absValue days: PASS");
    } else {
@@ -2954,9 +2915,9 @@ int testTimeInterval(void) {
 
    // Test time interval constructor from string
    std::string TiStr = "1001_11:23:45.375";
-   OMEGA::TimeInterval TiTstStr(TiStr);
+   TimeInterval TiTstStr(TiStr);
    RRef = 86527425.375;
-   Err1 = TiTstStr.get(RTst, OMEGA::TimeUnits::Seconds);
+   Err1 = TiTstStr.get(RTst, TimeUnits::Seconds);
 
    if (Err1 == 0 && RTst == RRef) {
       LOG_INFO("TimeMgrTest/TimeInterval: string constructor: PASS");
@@ -2977,58 +2938,43 @@ int testTimeInstant(void) {
    LOG_INFO("TimeMgrTest: TimeInstant tests ---------------------------------");
 
    // Initialize error codes
-   OMEGA::I4 Err1{0};
-   OMEGA::I4 Err2{0};
-   OMEGA::I4 Err3{0};
-   OMEGA::I4 ErrAll{0};
+   I4 Err1{0};
+   I4 Err2{0};
+   I4 Err3{0};
+   I4 ErrAll{0};
 
    // Use default constructor to create first (empty) instant
-   OMEGA::TimeInstant TiEmpty;
-
-   // Test put/get function for calendar
-   OMEGA::Calendar CalGreg("Gregorian", OMEGA::CalendarGregorian);
-   OMEGA::Calendar *CalCheckPtr;
-
-   Err1 = TiEmpty.set(&CalGreg);
-   Err2 = TiEmpty.get(CalCheckPtr);
-
-   if (Err1 == 0 && Err2 == 0 && CalGreg == *CalCheckPtr) {
-      LOG_INFO("TimeMgrTest/TimeInstant: calendar get/set: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: calendar get/set: FAIL");
-   }
+   TimeInstant TiEmpty;
 
    // Create some reference elapsed times based on 4 most likely calendars
    // (Gregorian, NoLeap, 360 day and no-calendar). And use reference date
    // of July 4, 2019 at 3:16:23.25.
 
-   OMEGA::Calendar CalNoLeap("NoLeap", OMEGA::CalendarNoLeap);
-   OMEGA::Calendar Cal360Day("360Day", OMEGA::Calendar360Day);
-   OMEGA::Calendar CalNone("No Calendar", OMEGA::CalendarNoCalendar);
+   I8 YearRef{2019};
+   I8 MonthRef{7};
+   I8 DayRef{4};
+   I8 HourRef{15};
+   I8 MinuteRef{16};
+   I8 WRef{23};
+   I8 NRef{1};
+   I8 DRef{4};
+   R8 RRef{23.25};
 
-   OMEGA::I8 YearRef{2019};
-   OMEGA::I8 MonthRef{7};
-   OMEGA::I8 DayRef{4};
-   OMEGA::I8 HourRef{15};
-   OMEGA::I8 MinuteRef{16};
-   OMEGA::I8 WRef{23};
-   OMEGA::I8 NRef{1};
-   OMEGA::I8 DRef{4};
-   OMEGA::R8 RRef{23.25};
-
+   //--- Gregorian calendar tests
    // Construct an instant for the most likely Gregorian use case
    // Then test using get functions
 
-   OMEGA::TimeInstant TiGreg(&CalGreg, YearRef, MonthRef, DayRef, HourRef,
-                             MinuteRef, RRef);
+   Calendar::reset(); // reset calendar
+   Calendar::init("Gregorian");
 
-   OMEGA::I8 YearChk    = 0;
-   OMEGA::I8 MonthChk   = 0;
-   OMEGA::I8 DayChk     = 0;
-   OMEGA::I8 HourChk    = 0;
-   OMEGA::I8 MinuteChk  = 0;
-   OMEGA::R8 RSecondChk = 0.0;
+   TimeInstant TiGreg(YearRef, MonthRef, DayRef, HourRef, MinuteRef, RRef);
+
+   I8 YearChk    = 0;
+   I8 MonthChk   = 0;
+   I8 DayChk     = 0;
+   I8 HourChk    = 0;
+   I8 MinuteChk  = 0;
+   R8 RSecondChk = 0.0;
 
    Err1 = TiGreg.get(YearChk, MonthChk, DayChk, HourChk, MinuteChk, RSecondChk);
    if (Err1 == 0 && YearChk == YearRef && MonthChk == MonthRef &&
@@ -3042,9 +2988,8 @@ int testTimeInstant(void) {
 
    // Now use set function to create an identical instant
 
-   OMEGA::TimeInstant TiGreg2;
-   Err1 = TiGreg2.set(&CalGreg);
-   Err2 = TiGreg2.set(YearRef, MonthRef, DayRef, HourRef, MinuteRef, RRef);
+   TimeInstant TiGreg2;
+   Err1 = TiGreg2.set(YearRef, MonthRef, DayRef, HourRef, MinuteRef, RRef);
 
    YearChk    = 0;
    MonthChk   = 0;
@@ -3053,11 +2998,11 @@ int testTimeInstant(void) {
    MinuteChk  = 0;
    RSecondChk = 0.0;
 
-   Err3 =
+   Err2 =
        TiGreg2.get(YearChk, MonthChk, DayChk, HourChk, MinuteChk, RSecondChk);
-   if (Err1 == 0 && Err2 == 0 && Err3 == 0 && YearChk == YearRef &&
-       MonthChk == MonthRef && DayChk == DayRef && HourChk == HourRef &&
-       MinuteChk == MinuteRef && abs(RSecondChk - RRef) < 1.e-15) {
+   if (Err1 == 0 && Err2 == 0 && YearChk == YearRef && MonthChk == MonthRef &&
+       DayChk == DayRef && HourChk == HourRef && MinuteChk == MinuteRef &&
+       abs(RSecondChk - RRef) < 1.e-15) {
       LOG_INFO("TimeMgrTest/TimeInstant: get/set YMDHMS(real): PASS");
    } else {
       ++ErrAll;
@@ -3087,186 +3032,22 @@ int testTimeInstant(void) {
       LOG_ERROR("TimeMgrTest/TimeInstant: operator(<=): FAIL");
    }
 
-   // Construct a no-leap instant using frac second interface
-   OMEGA::TimeInstant TiNoLeap(&CalNoLeap, YearRef, MonthRef, DayRef, HourRef,
-                               MinuteRef, WRef, NRef, DRef);
-
-   YearChk   = 0;
-   MonthChk  = 0;
-   DayChk    = 0;
-   HourChk   = 0;
-   MinuteChk = 0;
-   OMEGA::I8 WChk{0};
-   OMEGA::I8 NChk{0};
-   OMEGA::I8 DChk{0};
-
-   Err1 = TiNoLeap.get(YearChk, MonthChk, DayChk, HourChk, MinuteChk, WChk,
-                       NChk, DChk);
-   if (Err1 == 0 && YearChk == YearRef && MonthChk == MonthRef &&
-       DayChk == DayRef && HourChk == HourRef && MinuteChk == MinuteRef &&
-       WChk == WRef && NChk == NRef && DChk == DRef) {
-      LOG_INFO("TimeMgrTest/TimeInstant: constructor YMDHMS(frac): PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: constructor YMDHMS(frac): FAIL");
-   }
-
-   // Now use get/set interface to set a slightly earlier instant
-
-   OMEGA::TimeInstant TiNoLeap2;
-   Err1 = TiNoLeap2.set(&CalNoLeap);
-   Err2 = TiNoLeap2.set(YearRef, MonthRef, DayRef, HourRef, MinuteRef, WRef - 1,
-                        NRef, DRef);
-
-   YearChk   = 0;
-   MonthChk  = 0;
-   DayChk    = 0;
-   HourChk   = 0;
-   MinuteChk = 0;
-   WChk      = 0;
-   NChk      = 0;
-   DChk      = 0;
-   Err3 = TiNoLeap2.get(YearChk, MonthChk, DayChk, HourChk, MinuteChk, WChk,
-                        NChk, DChk);
-
-   if (Err1 == 0 && Err2 == 0 && Err3 == 0 && YearChk == YearRef &&
-       MonthChk == MonthRef && DayChk == DayRef && HourChk == HourRef &&
-       MinuteChk == MinuteRef && WChk == WRef - 1 && NChk == NRef &&
-       DChk == DRef) {
-      LOG_INFO("TimeMgrTest/TimeInstant: get/set by YMDHMS(frac): PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: get/set by YMDHMS(frac): FAIL");
-   }
-
-   // Can use these to test a few more operators like non-equivalence, <
-
-   // Non-equiv for different calendars
-   if (TiNoLeap != TiGreg) {
-      LOG_INFO("TimeMgrTest/TimeInstant: operator(!=) for "
-               "different calendars: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: operator(!=) for "
-                "different calendars: FAIL");
-   }
-
-   // Non-equiv for different time instant in same calendar
-   if (TiNoLeap != TiNoLeap2) {
-      LOG_INFO("TimeMgrTest/TimeInstant: operator(!=) for "
-               "different time instant: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: operator(!=) for "
-                "different time instant: FAIL");
-   }
-
-   // Test forms of > operator
-   if (TiNoLeap >= TiNoLeap2) {
-      LOG_INFO("TimeMgrTest/TimeInstant: operator(>=): PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: operator(>=): FAIL");
-   }
-
-   if (TiNoLeap > TiNoLeap2) {
-      LOG_INFO("TimeMgrTest/TimeInstant: operator(>): PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: operator(>): FAIL");
-   }
-
-   // Test forms of < operator
-   if (TiNoLeap2 <= TiNoLeap) {
-      LOG_INFO("TimeMgrTest/TimeInstant: operator(<=): PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: operator(<=): FAIL");
-   }
-
-   if (TiNoLeap2 < TiNoLeap) {
-      LOG_INFO("TimeMgrTest/TimeInstant: operator(<): PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: operator(<): FAIL");
-   }
-
-   // Construct a 360Day instant using frac second interface
-   OMEGA::TimeInstant Ti360Day(&Cal360Day, YearRef, MonthRef, DayRef, HourRef,
-                               MinuteRef, WRef, NRef, DRef);
-
-   YearChk   = 0;
-   MonthChk  = 0;
-   DayChk    = 0;
-   HourChk   = 0;
-   MinuteChk = 0;
-   WChk      = 0;
-   NChk      = 0;
-   DChk      = 0;
-   Err1      = Ti360Day.get(YearChk, MonthChk, DayChk, HourChk, MinuteChk, WChk,
-                            NChk, DChk);
-
-   if (Err1 == 0 && YearChk == YearRef && MonthChk == MonthRef &&
-       DayChk == DayRef && HourChk == HourRef && MinuteChk == MinuteRef &&
-       WChk == WRef && NChk == NRef && DChk == DRef) {
-      LOG_INFO("TimeMgrTest/TimeInstant: construct 360Day: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: construct 360Day: FAIL");
-   }
-
-   // Create 2 no-calendar time instants using different elapsed time
-   // constructors
-
-   YearChk   = 0;
-   MonthChk  = 0;
-   DayChk    = 0;
-   HourChk   = 0;
-   MinuteChk = 0;
-   OMEGA::TimeInstant TiNone(&CalNone, YearChk, MonthChk, DayChk, HourChk,
-                             MinuteChk, WRef, NRef, DRef);
-
-   OMEGA::TimeInstant TiNone2(&CalNone, YearChk, MonthChk, DayChk, HourChk,
-                              MinuteChk, RRef);
-
-   if (TiNone == TiNone2) {
-      LOG_INFO("TimeMgrTest/TimeInstant: No-calendar time constructors: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: No-calendar time constructors: FAIL");
-   }
-
    // Now must test remaining operators involving time intervals
 
-   // NoLeap and NoLeap2 above differ by one second, so create
-   // a 1-second interval and compare result with the difference
-   // between the two instants
+   // Test increment/decrement by time interval
+   TimeInterval IntervalSec(1, TimeUnits::Seconds);
 
-   OMEGA::TimeInterval IntervalSec(1, OMEGA::TimeUnits::Seconds);
-   OMEGA::TimeInterval IntervalSec2 = TiNoLeap - TiNoLeap2;
-
-   if (IntervalSec == IntervalSec2) {
-      LOG_INFO("TimeMgrTest/TimeInstant: create interval from "
-               "diff of instants: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: create interval from "
-                "diff of instants: FAIL");
-   }
-
-   // Now test addition, subtraction for seconds
-
-   TiGreg2                    = TiGreg + IntervalSec;
-   OMEGA::TimeInstant TiGreg3 = TiGreg2 - IntervalSec;
+   TiGreg2             = TiGreg + IntervalSec;
+   TimeInstant TiGreg3 = TiGreg2 - IntervalSec;
 
    YearChk   = 0;
    MonthChk  = 0;
    DayChk    = 0;
    HourChk   = 0;
    MinuteChk = 0;
-   WChk      = 0;
-   NChk      = 0;
-   DChk      = 0;
+   I8 WChk   = 0;
+   I8 NChk   = 0;
+   I8 DChk   = 0;
    Err1 = TiGreg2.get(YearChk, MonthChk, DayChk, HourChk, MinuteChk, WChk, NChk,
                       DChk);
 
@@ -3286,68 +3067,21 @@ int testTimeInstant(void) {
       LOG_ERROR("TimeMgrTest/TimeInstant: subtraction second interval: FAIL");
    }
 
-   // Test increment and decrement using the second interval and noLeap
-   OMEGA::TimeInstant TiNoLeap3 = TiNoLeap2;
+   // Test a 5-year integration in several units (year, month, day, hour,
+   // minute). Include a nominal leap year.
 
-   TiNoLeap2 += IntervalSec;
-   if (TiNoLeap2 == TiNoLeap) {
-      LOG_INFO("TimeMgrTest/TimeInstant: increment by second interval: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: increment by second interval: FAIL");
-   }
+   TimeInterval IntervalYear5(5, TimeUnits::Years);
+   TimeInterval IntervalYear(1, TimeUnits::Years);
+   TimeInterval IntervalMonth(2, TimeUnits::Months);
+   TimeInterval IntervalDay(1, TimeUnits::Days);
+   TimeInterval IntervalHour(2, TimeUnits::Hours);
+   TimeInterval IntervalMinute(20, TimeUnits::Minutes);
 
-   TiNoLeap2 -= IntervalSec;
-   if (TiNoLeap2 == TiNoLeap3) {
-      LOG_INFO("TimeMgrTest/TimeInstant: decrement by second interval: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: decrement by second interval: FAIL");
-   }
-
-   // Test time string generator and constructor from string
-
-   std::string StrDateRef = "2019-07-04_15:16:23.2500";
-   std::string StrDateChk = TiGreg.getString(4, 4, "_");
-
-   if (StrDateChk == StrDateRef) {
-      LOG_INFO("TimeMgrTest/TimeInstant: getString: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant: getString: FAIL");
-   }
-
-   OMEGA::TimeInstant TiFromString(&CalGreg, StrDateChk);
-   if (TiFromString == TiGreg) {
-      LOG_INFO("TimeMgrTest/TimeInstant from string: PASS");
-   } else {
-      ++ErrAll;
-      LOG_ERROR("TimeMgrTest/TimeInstant from string: FAIL");
-   }
-
-   // Finally, for each calendar, test a 5-year integration in several
-   // units (year, month, day, hour, minute). Include a nominal leap year to
-   // test Gregorian and noLeap calendars
-
-   OMEGA::TimeInterval IntervalYear5(5, OMEGA::TimeUnits::Years);
-   OMEGA::TimeInterval IntervalYear(1, OMEGA::TimeUnits::Years);
-   OMEGA::TimeInterval IntervalMonth(2, OMEGA::TimeUnits::Months);
-   OMEGA::TimeInterval IntervalDay(1, OMEGA::TimeUnits::Days);
-   OMEGA::TimeInterval IntervalHour(2, OMEGA::TimeUnits::Hours);
-   OMEGA::TimeInterval IntervalMinute(20, OMEGA::TimeUnits::Minutes);
-   // for the no-calendar case
-   OMEGA::TimeInterval IntervalSeconds5yr(86400 * 365 * 5,
-                                          OMEGA::TimeUnits::Seconds);
-
-   // Add the five year interval to create a final target for each calendar
-   OMEGA::TimeInstant Ti360Day2;
-   TiGreg2   = TiGreg + IntervalYear5;
-   TiNoLeap2 = TiNoLeap + IntervalYear5;
-   Ti360Day2 = Ti360Day + IntervalYear5;
-   TiNone2   = TiNone + IntervalSeconds5yr;
+   // Add the five year interval to create a final target date
+   TiGreg2 = TiGreg + IntervalYear5;
 
    // Test intervals for Gregorian calendars
-   OMEGA::TimeInstant TiFinal = TiGreg;
+   TimeInstant TiFinal = TiGreg;
    for (int N = 1; N <= 5; ++N) {
       TiFinal += IntervalYear;
    }
@@ -3402,10 +3136,174 @@ int testTimeInstant(void) {
       LOG_ERROR("TimeMgrTest/TimeInstant: Gregorian minute integration: FAIL");
    }
 
-   // Test intervals for NoLeap calendars
+   // Test time string generator and constructor from string
+
+   std::string StrDateRef = "2019-07-04_15:16:23.2500";
+   std::string StrDateChk = TiGreg.getString(4, 4, "_");
+
+   if (StrDateChk == StrDateRef) {
+      LOG_INFO("TimeMgrTest/TimeInstant: getString: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: getString: FAIL");
+   }
+
+   TimeInstant TiFromString(StrDateChk);
+   if (TiFromString == TiGreg) {
+      LOG_INFO("TimeMgrTest/TimeInstant from string: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant from string: FAIL");
+   }
+
+   //--- Test instants in no-leap calendar
+   Calendar::reset(); // reset calendar
+   Calendar::init("No Leap");
+
+   // Construct a no-leap instant using frac second interface
+   TimeInstant TiNoLeap(YearRef, MonthRef, DayRef, HourRef, MinuteRef, WRef,
+                        NRef, DRef);
+
+   YearChk   = 0;
+   MonthChk  = 0;
+   DayChk    = 0;
+   HourChk   = 0;
+   MinuteChk = 0;
+   WChk      = 0;
+   NChk      = 0;
+   DChk      = 0;
+
+   Err1 = TiNoLeap.get(YearChk, MonthChk, DayChk, HourChk, MinuteChk, WChk,
+                       NChk, DChk);
+   if (Err1 == 0 && YearChk == YearRef && MonthChk == MonthRef &&
+       DayChk == DayRef && HourChk == HourRef && MinuteChk == MinuteRef &&
+       WChk == WRef && NChk == NRef && DChk == DRef) {
+      LOG_INFO("TimeMgrTest/TimeInstant: constructor YMDHMS(frac): PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: constructor YMDHMS(frac): FAIL");
+   }
+
+   // Now use get/set interface to set a slightly earlier instant
+
+   TimeInstant TiNoLeap2;
+   Err2 = TiNoLeap2.set(YearRef, MonthRef, DayRef, HourRef, MinuteRef, WRef - 1,
+                        NRef, DRef);
+
+   YearChk   = 0;
+   MonthChk  = 0;
+   DayChk    = 0;
+   HourChk   = 0;
+   MinuteChk = 0;
+   WChk      = 0;
+   NChk      = 0;
+   DChk      = 0;
+   Err3 = TiNoLeap2.get(YearChk, MonthChk, DayChk, HourChk, MinuteChk, WChk,
+                        NChk, DChk);
+
+   if (Err2 == 0 && Err3 == 0 && YearChk == YearRef && MonthChk == MonthRef &&
+       DayChk == DayRef && HourChk == HourRef && MinuteChk == MinuteRef &&
+       WChk == WRef - 1 && NChk == NRef && DChk == DRef) {
+      LOG_INFO("TimeMgrTest/TimeInstant: get/set by YMDHMS(frac): PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: get/set by YMDHMS(frac): FAIL");
+   }
+
+   // Can use these to test a few more operators like non-equivalence, <
+
+   // Non-equiv for different time instant in same calendar
+   if (TiNoLeap != TiNoLeap2) {
+      LOG_INFO("TimeMgrTest/TimeInstant: operator(!=) for "
+               "different time instant: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: operator(!=) for "
+                "different time instant: FAIL");
+   }
+
+   // Test forms of > operator
+   if (TiNoLeap >= TiNoLeap2) {
+      LOG_INFO("TimeMgrTest/TimeInstant: operator(>=): PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: operator(>=): FAIL");
+   }
+
+   if (TiNoLeap > TiNoLeap2) {
+      LOG_INFO("TimeMgrTest/TimeInstant: operator(>): PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: operator(>): FAIL");
+   }
+
+   // Test forms of < operator
+   if (TiNoLeap2 <= TiNoLeap) {
+      LOG_INFO("TimeMgrTest/TimeInstant: operator(<=): PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: operator(<=): FAIL");
+   }
+
+   if (TiNoLeap2 < TiNoLeap) {
+      LOG_INFO("TimeMgrTest/TimeInstant: operator(<): PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: operator(<): FAIL");
+   }
+
+   // NoLeap and NoLeap2 above differ by one second, so create
+   // a 1-second interval using the difference between the two instants
+   // and check with the previously defined 1-second interval
+
+   TimeInterval IntervalSec2 = TiNoLeap - TiNoLeap2;
+
+   if (IntervalSec == IntervalSec2) {
+      LOG_INFO("TimeMgrTest/TimeInstant: create interval from "
+               "diff of instants: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: create interval from "
+                "diff of instants: FAIL");
+   }
+
+   // Now test addition, subtraction for seconds
+
+   // Test increment and decrement using the second interval and noLeap
+   TimeInstant TiNoLeap3 = TiNoLeap2;
+
+   TiNoLeap2 += IntervalSec;
+   if (TiNoLeap2 == TiNoLeap) {
+      LOG_INFO("TimeMgrTest/TimeInstant: increment by second interval: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: increment by second interval: FAIL");
+   }
+
+   TiNoLeap2 -= IntervalSec;
+   if (TiNoLeap2 == TiNoLeap3) {
+      LOG_INFO("TimeMgrTest/TimeInstant: decrement by second interval: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: decrement by second interval: FAIL");
+   }
+
+   // Test a 5-year integration in several units (year, month, day, hour,
+   // minute). Include a nominal leap year.
+
+   TimeInterval IntYear5NL(5, TimeUnits::Years);
+   TimeInterval IntYearNL(1, TimeUnits::Years);
+   TimeInterval IntMonthNL(2, TimeUnits::Months);
+   TimeInterval IntDayNL(1, TimeUnits::Days);
+   TimeInterval IntHourNL(2, TimeUnits::Hours);
+   TimeInterval IntMinuteNL(20, TimeUnits::Minutes);
+   // Add the five year interval to create a final target for each calendar
+   TiNoLeap2 = TiNoLeap + IntYear5NL;
+
+   // Test integration for each interval
    TiFinal = TiNoLeap;
    for (int N = 1; N <= 5; ++N) {
-      TiFinal += IntervalYear;
+      TiFinal += IntYearNL;
    }
    if (TiFinal == TiNoLeap2) {
       LOG_INFO("TimeMgrTest/TimeInstant: NoLeap annual integration: PASS");
@@ -3416,7 +3314,7 @@ int testTimeInstant(void) {
 
    TiFinal = TiNoLeap;
    for (int N = 1; N <= 30; ++N) {
-      TiFinal += IntervalMonth;
+      TiFinal += IntMonthNL;
    }
    if (TiFinal == TiNoLeap2) {
       LOG_INFO("TimeMgrTest/TimeInstant: NoLeap monthly integration: PASS");
@@ -3427,7 +3325,7 @@ int testTimeInstant(void) {
 
    TiFinal = TiNoLeap;
    for (int N = 1; N <= 365 * 5; ++N) {
-      TiFinal += IntervalDay;
+      TiFinal += IntDayNL;
    }
    if (TiFinal == TiNoLeap2) {
       LOG_INFO("TimeMgrTest/TimeInstant: NoLeap daily integration: PASS");
@@ -3438,7 +3336,7 @@ int testTimeInstant(void) {
 
    TiFinal = TiNoLeap;
    for (int N = 1; N <= 12 * 365 * 5; ++N) {
-      TiFinal += IntervalHour;
+      TiFinal += IntHourNL;
    }
    if (TiFinal == TiNoLeap2) {
       LOG_INFO("TimeMgrTest/TimeInstant: NoLeap hourly integration: PASS");
@@ -3449,7 +3347,7 @@ int testTimeInstant(void) {
 
    TiFinal = TiNoLeap;
    for (int N = 1; N <= (3 * 24) * (365 * 5); ++N) {
-      TiFinal += IntervalMinute;
+      TiFinal += IntMinuteNL;
    }
    if (TiFinal == TiNoLeap2) {
       LOG_INFO("TimeMgrTest/TimeInstant: NoLeap minute integration: PASS");
@@ -3458,10 +3356,50 @@ int testTimeInstant(void) {
       LOG_ERROR("TimeMgrTest/TimeInstant: NoLeap minute integration: FAIL");
    }
 
+   //--- Test instants in 360 day calendar
+   Calendar::reset(); // reset calendar
+   Calendar::init("360 Day");
+
+   // Construct a 360Day instant using frac second interface
+   TimeInstant Ti360Day(YearRef, MonthRef, DayRef, HourRef, MinuteRef, WRef,
+                        NRef, DRef);
+
+   YearChk   = 0;
+   MonthChk  = 0;
+   DayChk    = 0;
+   HourChk   = 0;
+   MinuteChk = 0;
+   WChk      = 0;
+   NChk      = 0;
+   DChk      = 0;
+   Err1      = Ti360Day.get(YearChk, MonthChk, DayChk, HourChk, MinuteChk, WChk,
+                            NChk, DChk);
+
+   if (Err1 == 0 && YearChk == YearRef && MonthChk == MonthRef &&
+       DayChk == DayRef && HourChk == HourRef && MinuteChk == MinuteRef &&
+       WChk == WRef && NChk == NRef && DChk == DRef) {
+      LOG_INFO("TimeMgrTest/TimeInstant: construct 360Day: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: construct 360Day: FAIL");
+   }
+
+   // Test a 5-year integration in several units (year, month, day, hour,
+   // minute).
+
+   TimeInterval IntYear5360(5, TimeUnits::Years);
+   TimeInterval IntYear360(1, TimeUnits::Years);
+   TimeInterval IntMonth360(2, TimeUnits::Months);
+   TimeInterval IntDay360(1, TimeUnits::Days);
+   TimeInterval IntHour360(2, TimeUnits::Hours);
+   TimeInterval IntMinute360(20, TimeUnits::Minutes);
+   // Add the five year interval to create a final target
+   TimeInstant Ti360Day2 = Ti360Day + IntYear5360;
+
    // Test intervals for 360Day calendars
    TiFinal = Ti360Day;
    for (int N = 1; N <= 5; ++N) {
-      TiFinal += IntervalYear;
+      TiFinal += IntYear360;
    }
    if (TiFinal == Ti360Day2) {
       LOG_INFO("TimeMgrTest/TimeInstant: 360Day annual integration: PASS");
@@ -3472,7 +3410,7 @@ int testTimeInstant(void) {
 
    TiFinal = Ti360Day;
    for (int N = 1; N <= 30; ++N) {
-      TiFinal += IntervalMonth;
+      TiFinal += IntMonth360;
    }
    if (TiFinal == Ti360Day2) {
       LOG_INFO("TimeMgrTest/TimeInstant: 360Day monthly integration: PASS");
@@ -3483,7 +3421,7 @@ int testTimeInstant(void) {
 
    TiFinal = Ti360Day;
    for (int N = 1; N <= 360 * 5; ++N) { // period includes 2 leap years
-      TiFinal += IntervalDay;
+      TiFinal += IntDay360;
    }
    if (TiFinal == Ti360Day2) {
       LOG_INFO("TimeMgrTest/TimeInstant: 360Day daily integration: PASS");
@@ -3494,7 +3432,7 @@ int testTimeInstant(void) {
 
    TiFinal = Ti360Day;
    for (int N = 1; N <= 12 * 360 * 5; ++N) {
-      TiFinal += IntervalHour;
+      TiFinal += IntHour360;
    }
    if (TiFinal == Ti360Day2) {
       LOG_INFO("TimeMgrTest/TimeInstant: 360Day hourly integration: PASS");
@@ -3505,7 +3443,7 @@ int testTimeInstant(void) {
 
    TiFinal = Ti360Day;
    for (int N = 1; N <= (3 * 24) * (360 * 5); ++N) {
-      TiFinal += IntervalMinute;
+      TiFinal += IntMinute360;
    }
    if (TiFinal == Ti360Day2) {
       LOG_INFO("TimeMgrTest/TimeInstant: 360Day minute integration: PASS");
@@ -3514,11 +3452,44 @@ int testTimeInstant(void) {
       LOG_ERROR("TimeMgrTest/TimeInstant: 360Day minute integration: FAIL");
    }
 
-   // Test intervals for no calendar times
+   //--- Test instants in no calendar option
+   Calendar::reset(); // reset calendar
+   Calendar::init("No Calendar");
+
+   // Create 2 no-calendar time instants using different elapsed time
+   // constructors
+
+   YearChk   = 0;
+   MonthChk  = 0;
+   DayChk    = 0;
+   HourChk   = 0;
+   MinuteChk = 0;
+   TimeInstant TiNone(YearChk, MonthChk, DayChk, HourChk, MinuteChk, WRef, NRef,
+                      DRef);
+
+   TimeInstant TiNone2(YearChk, MonthChk, DayChk, HourChk, MinuteChk, RRef);
+
+   if (TiNone == TiNone2) {
+      LOG_INFO("TimeMgrTest/TimeInstant: No-calendar time constructors: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/TimeInstant: No-calendar time constructors: FAIL");
+   }
+
+   // Test a five-year integration with only units that make sense when there
+   // is no calendar.
+
+   TimeInterval IntHourNone(2, TimeUnits::Hours);
+   TimeInterval IntMinuteNone(20, TimeUnits::Minutes);
+   TimeInterval IntSeconds5yr(86400 * 365 * 5, TimeUnits::Seconds);
+
+   // Step forward in time
    // In this case, annual, monthly or daily intervals are meaningless
    TiFinal = TiNone;
+   TiNone2 = TiNone + IntSeconds5yr;
+
    for (int N = 1; N <= 12 * 365 * 5; ++N) {
-      TiFinal += IntervalHour;
+      TiFinal += IntHourNone;
    }
    if (TiFinal == TiNone2) {
       LOG_INFO("TimeMgrTest/TimeInstant: No-calendar hourly integration: PASS");
@@ -3530,7 +3501,7 @@ int testTimeInstant(void) {
 
    TiFinal = TiNone;
    for (int N = 1; N <= (3 * 24) * (365 * 5); ++N) {
-      TiFinal += IntervalMinute;
+      TiFinal += IntMinuteNone;
    }
    if (TiFinal == TiNone2) {
       LOG_INFO("TimeMgrTest/TimeInstant: No-calendar minute integration: PASS");
@@ -3540,6 +3511,9 @@ int testTimeInstant(void) {
                 "minute integration: FAIL");
    }
 
+   //--- Finished time instant tests, switch back to Gregorian calendar
+   Calendar::reset(); // reset calendar
+   Calendar::init("Gregorian");
    return ErrAll;
 
 } // end testTimeInstant
@@ -3552,32 +3526,34 @@ int testAlarm(void) {
    LOG_INFO("TimeMgrTest: Alarm tests ---------------------------------------");
 
    // Initialize error codes
-   OMEGA::I4 Err1{0};
-   OMEGA::I4 Err2{0};
-   OMEGA::I4 Err3{0};
-   OMEGA::I4 ErrAll{0};
+   I4 Err1{0};
+   I4 Err2{0};
+   I4 Err3{0};
+   I4 ErrAll{0};
 
    // For various time intervals, we create alarms at relevant times
    // and step through time to trigger the alarm.
 
    // Do all testing in Gregorian calendar
-   OMEGA::Calendar CalGreg("Gregorian", OMEGA::CalendarGregorian);
+
+   Calendar::reset();
+   Calendar::init("Gregorian");
 
    // Create a zero start time and generic start time
-   OMEGA::TimeInstant Time0(&CalGreg, 2000, 1, 1, 0, 0, 0.0);
-   OMEGA::TimeInstant StartTime(&CalGreg, 2019, 8, 15, 14, 25, 23.25);
+   TimeInstant Time0(2000, 1, 1, 0, 0, 0.0);
+   TimeInstant StartTime(2019, 8, 15, 14, 25, 23.25);
 
    // Test a year-based alarm and periodic alarm using a start time and
    // monthly interval
 
-   OMEGA::TimeInstant TimeNewYear2020(&CalGreg, 2020, 1, 1, 0, 0, 0.0);
-   OMEGA::Alarm AlarmNewYear2020("New Year 2020", TimeNewYear2020);
+   TimeInstant TimeNewYear2020(2020, 1, 1, 0, 0, 0.0);
+   Alarm AlarmNewYear2020("New Year 2020", TimeNewYear2020);
 
-   OMEGA::TimeInterval IntervalAnnual(1, OMEGA::TimeUnits::Years);
-   OMEGA::TimeInterval IntervalMonthly(1, OMEGA::TimeUnits::Months);
-   OMEGA::Alarm AlarmEveryYear("Every Year", IntervalAnnual, Time0);
+   TimeInterval IntervalAnnual(1, TimeUnits::Years);
+   TimeInterval IntervalMonthly(1, TimeUnits::Months);
+   Alarm AlarmEveryYear("Every Year", IntervalAnnual, Time0);
 
-   OMEGA::TimeInstant CurTime = StartTime;
+   TimeInstant CurTime = StartTime;
 
    // quick test of update status function
    Err1 = AlarmNewYear2020.updateStatus(CurTime);
@@ -3661,11 +3637,11 @@ int testAlarm(void) {
    // Test a month-based alarm and periodic alarm using a start time and
    // daily interval (pick a leap year just to catch an edge case)
 
-   OMEGA::TimeInstant Time2020Mar1(&CalGreg, 2020, 3, 1, 0, 0, 0.0);
-   OMEGA::Alarm Alarm2020Mar1("2020-03-01", Time2020Mar1);
+   TimeInstant Time2020Mar1(2020, 3, 1, 0, 0, 0.0);
+   Alarm Alarm2020Mar1("2020-03-01", Time2020Mar1);
 
-   OMEGA::Alarm AlarmEveryMonth("Every Month", IntervalMonthly, Time0);
-   OMEGA::TimeInterval IntervalDaily(1, OMEGA::TimeUnits::Days);
+   Alarm AlarmEveryMonth("Every Month", IntervalMonthly, Time0);
+   TimeInterval IntervalDaily(1, TimeUnits::Days);
 
    CurTime = StartTime; // start time is 2019-08-15_14:25:23.25
    Err1    = AlarmEveryMonth.reset(CurTime); // ensure first alarm in future
@@ -3732,11 +3708,11 @@ int testAlarm(void) {
    // Test a day-based alarm and periodic alarm using a start time and
    // hourly interval
 
-   OMEGA::TimeInstant Time2019Aug20(&CalGreg, 2019, 8, 20, 0, 0, 0.0);
-   OMEGA::Alarm Alarm2019Aug20("2020-08-20", Time2019Aug20);
+   TimeInstant Time2019Aug20(2019, 8, 20, 0, 0, 0.0);
+   Alarm Alarm2019Aug20("2020-08-20", Time2019Aug20);
 
-   OMEGA::Alarm AlarmEveryDay("Every Day", IntervalDaily, Time0);
-   OMEGA::TimeInterval IntervalHourly(1, OMEGA::TimeUnits::Hours);
+   Alarm AlarmEveryDay("Every Day", IntervalDaily, Time0);
+   TimeInterval IntervalHourly(1, TimeUnits::Hours);
 
    CurTime = StartTime; // start time is 2019-08-15_14:25:23.25
    Err1    = AlarmEveryDay.reset(CurTime); // ensure first alarm in future
@@ -3803,11 +3779,11 @@ int testAlarm(void) {
    // Test an hour-based alarm and periodic alarm using a start time and
    // minute interval
 
-   OMEGA::TimeInstant Time9am(&CalGreg, 2019, 8, 16, 9, 0, 0.0);
-   OMEGA::Alarm Alarm9am("2019-08-16_0900", Time9am);
+   TimeInstant Time9am(2019, 8, 16, 9, 0, 0.0);
+   Alarm Alarm9am("2019-08-16_0900", Time9am);
 
-   OMEGA::Alarm AlarmEveryHour("Every Hour", IntervalHourly, Time0);
-   OMEGA::TimeInterval IntervalMinute(1, OMEGA::TimeUnits::Minutes);
+   Alarm AlarmEveryHour("Every Hour", IntervalHourly, Time0);
+   TimeInterval IntervalMinute(1, TimeUnits::Minutes);
 
    CurTime = StartTime; // start time is 2019-08-15_14:25:23.25
    Err1    = AlarmEveryHour.reset(CurTime); // ensure first alarm in future
@@ -3873,8 +3849,8 @@ int testAlarm(void) {
    // Test a 6-hour periodic alarm using a start time and
    // hourly interval to test a non-unit time interval
 
-   OMEGA::TimeInterval Interval6Hour(6, OMEGA::TimeUnits::Hours);
-   OMEGA::Alarm AlarmEvery6Hour("Every 6 Hours", Interval6Hour, Time0);
+   TimeInterval Interval6Hour(6, TimeUnits::Hours);
+   Alarm AlarmEvery6Hour("Every 6 Hours", Interval6Hour, Time0);
 
    CurTime = StartTime; // start time is 2019-08-15_14:25:23.25
    Err1    = AlarmEvery6Hour.reset(CurTime); // ensure first alarm in future
@@ -3918,12 +3894,12 @@ int testAlarm(void) {
    // Test a minute-based alarm and periodic 20-minute alarm using a start
    // time and second interval
 
-   OMEGA::TimeInstant Time30min(&CalGreg, 2019, 8, 15, 14, 55, 23.25);
-   OMEGA::Alarm Alarm30min("30min", Time30min);
+   TimeInstant Time30min(2019, 8, 15, 14, 55, 23.25);
+   Alarm Alarm30min("30min", Time30min);
 
-   OMEGA::TimeInterval Interval20min(20, OMEGA::TimeUnits::Minutes);
-   OMEGA::Alarm AlarmEvery20min("Every 20 minutes", Interval20min, Time0);
-   OMEGA::TimeInterval IntervalSecond(1, OMEGA::TimeUnits::Seconds);
+   TimeInterval Interval20min(20, TimeUnits::Minutes);
+   Alarm AlarmEvery20min("Every 20 minutes", Interval20min, Time0);
+   TimeInterval IntervalSecond(1, TimeUnits::Seconds);
 
    CurTime = StartTime; // start time is 2019-08-15_14:25:23.25
    Err1    = AlarmEvery20min.reset(CurTime); // ensure first alarm in future
@@ -3998,29 +3974,30 @@ int testClock(void) {
    LOG_INFO("TimeMgrTest: Clock tests ---------------------------------------");
 
    // Initialize error codes
-   OMEGA::I4 Err1{0};
-   OMEGA::I4 Err2{0};
-   OMEGA::I4 Err3{0};
-   OMEGA::I4 ErrAll{0};
+   I4 Err1{0};
+   I4 Err2{0};
+   I4 Err3{0};
+   I4 ErrAll{0};
 
    // For various time intervals, we create alarms at relevant times
    // and step through time to trigger the alarm.
 
    // Do all testing in Gregorian calendar
-   OMEGA::Calendar CalGreg("Gregorian", OMEGA::CalendarGregorian);
+   Calendar::reset();
+   Calendar::init("Gregorian");
 
    // Create an initial model clock with a 2000 start time and
    // one hour time step.
 
-   OMEGA::TimeInstant Time0(&CalGreg, 2000, 1, 1, 0, 0, 0.0);
-   OMEGA::TimeInterval TimeStep(1, OMEGA::TimeUnits::Hours);
+   TimeInstant Time0(2000, 1, 1, 0, 0, 0.0);
+   TimeInterval TimeStep(1, TimeUnits::Hours);
 
-   OMEGA::Clock ModelClock(Time0, TimeStep);
+   Clock ModelClock(Time0, TimeStep);
 
    // Test some basic retrieval functions
 
-   OMEGA::TimeInstant TimeCheck; // init to default values
-   OMEGA::TimeInterval StepCheck;
+   TimeInstant TimeCheck; // init to default values
+   TimeInterval StepCheck;
 
    TimeCheck = ModelClock.getStartTime();
    StepCheck = ModelClock.getTimeStep();
@@ -4041,27 +4018,27 @@ int testClock(void) {
 
    // Define a number of periodic and one-time alarms
 
-   OMEGA::TimeInstant TimeNewYear2020(&CalGreg, 2020, 1, 1, 0, 0, 0.0);
-   OMEGA::TimeInstant Time2020Mar1(&CalGreg, 2020, 3, 1, 0, 0, 0.0);
-   OMEGA::TimeInstant Time2019Aug20(&CalGreg, 2019, 8, 20, 0, 0, 0.0);
+   TimeInstant TimeNewYear2020(2020, 1, 1, 0, 0, 0.0);
+   TimeInstant Time2020Mar1(2020, 3, 1, 0, 0, 0.0);
+   TimeInstant Time2019Aug20(2019, 8, 20, 0, 0, 0.0);
 
-   OMEGA::Alarm AlarmNewYear2020("New Year 2020", TimeNewYear2020);
-   OMEGA::Alarm Alarm2020Mar1("2020-03-01", Time2020Mar1);
-   OMEGA::Alarm Alarm2019Aug20("2020-08-20", Time2019Aug20);
+   Alarm AlarmNewYear2020("New Year 2020", TimeNewYear2020);
+   Alarm Alarm2020Mar1("2020-03-01", Time2020Mar1);
+   Alarm Alarm2019Aug20("2020-08-20", Time2019Aug20);
 
-   OMEGA::TimeInterval IntervalAnnual(1, OMEGA::TimeUnits::Years);
-   OMEGA::TimeInterval IntervalMonthly(1, OMEGA::TimeUnits::Months);
-   OMEGA::TimeInterval IntervalDaily(1, OMEGA::TimeUnits::Days);
-   OMEGA::TimeInterval IntervalHourly(1, OMEGA::TimeUnits::Hours);
-   OMEGA::TimeInterval Interval6Hour(6, OMEGA::TimeUnits::Hours);
-   OMEGA::TimeInterval Interval20min(20, OMEGA::TimeUnits::Minutes);
+   TimeInterval IntervalAnnual(1, TimeUnits::Years);
+   TimeInterval IntervalMonthly(1, TimeUnits::Months);
+   TimeInterval IntervalDaily(1, TimeUnits::Days);
+   TimeInterval IntervalHourly(1, TimeUnits::Hours);
+   TimeInterval Interval6Hour(6, TimeUnits::Hours);
+   TimeInterval Interval20min(20, TimeUnits::Minutes);
 
-   OMEGA::Alarm AlarmEveryYear("Every Year", IntervalAnnual, Time0);
-   OMEGA::Alarm AlarmEveryMonth("Every Month", IntervalMonthly, Time0);
-   OMEGA::Alarm AlarmEveryDay("Every Day", IntervalDaily, Time0);
-   OMEGA::Alarm AlarmEveryHour("Every Hour", IntervalHourly, Time0);
-   OMEGA::Alarm AlarmEvery6Hour("Every 6 Hours", Interval6Hour, Time0);
-   OMEGA::Alarm AlarmEvery20min("Every 20 minutes", Interval20min, Time0);
+   Alarm AlarmEveryYear("Every Year", IntervalAnnual, Time0);
+   Alarm AlarmEveryMonth("Every Month", IntervalMonthly, Time0);
+   Alarm AlarmEveryDay("Every Day", IntervalDaily, Time0);
+   Alarm AlarmEveryHour("Every Hour", IntervalHourly, Time0);
+   Alarm AlarmEvery6Hour("Every 6 Hours", Interval6Hour, Time0);
+   Alarm AlarmEvery20min("Every 20 minutes", Interval20min, Time0);
 
    // Test adding alarms to clock
 
@@ -4113,9 +4090,9 @@ int testClock(void) {
    // Test setting new current time and retrieving current, previous,
    // and next times.
 
-   OMEGA::TimeInstant CurrTime(&CalGreg, 2019, 1, 1, 0, 0, 0.0);
-   OMEGA::TimeInstant PrevTime(&CalGreg, 2018, 12, 31, 23, 40, 0.0);
-   OMEGA::TimeInstant NextTime(&CalGreg, 2019, 1, 1, 0, 20, 0.0);
+   TimeInstant CurrTime(2019, 1, 1, 0, 0, 0.0);
+   TimeInstant PrevTime(2018, 12, 31, 23, 40, 0.0);
+   TimeInstant NextTime(2019, 1, 1, 0, 20, 0.0);
 
    Err1      = ModelClock.setCurrentTime(CurrTime);
    TimeCheck = ModelClock.getCurrentTime();
@@ -4156,15 +4133,15 @@ int testClock(void) {
    // in time and checking alarms. Integrate forward 2 years with a
    // 20 min timestep.
 
-   OMEGA::TimeInstant StopTime(&CalGreg, 2021, 1, 1, 0, 0, 0.0);
+   TimeInstant StopTime(2021, 1, 1, 0, 0, 0.0);
    bool FirstStep{true};
    bool RingCheck{false};
-   OMEGA::I8 Year{0};
-   OMEGA::I8 Month{0};
-   OMEGA::I8 Day{0};
-   OMEGA::I8 Hour{0};
-   OMEGA::I8 Minute{0};
-   OMEGA::R8 Second{0.0};
+   I8 Year{0};
+   I8 Month{0};
+   I8 Day{0};
+   I8 Hour{0};
+   I8 Minute{0};
+   R8 Second{0.0};
 
    while (CurrTime <= StopTime) {
 
@@ -4346,18 +4323,18 @@ int testClock(void) {
 
 int main(int argc, char *argv[]) {
 
-   OMEGA::I4 Err{0};
-   OMEGA::I4 TotErr{0};
+   I4 Err{0};
+   I4 TotErr{0};
 
    // Initialize the global MPI environment
    MPI_Init(&argc, &argv);
 
    // Initialize the Machine Environment and retrieve the default environment
-   OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
+   MachEnv::init(MPI_COMM_WORLD);
+   MachEnv *DefEnv = MachEnv::getDefault();
 
    // Initialize the Logging system
-   OMEGA::initLogging(DefEnv);
+   initLogging(DefEnv);
 
    Err = testTimeFrac();
    TotErr += Err;

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -292,7 +292,7 @@ int testTimeStepper(const std::string &Name, TimeStepperType Type,
    auto *TestAuxState   = AuxiliaryState::get("TestAuxState");
    auto *TestTendencies = Tendencies::get("TestTendencies");
 
-   Calendar TestCalendar("TestCalendar", CalendarNoCalendar);
+   Calendar::init("No Calendar");
 
    auto *TestTimeStepper = TimeStepper::create(
        "TestTimeStepper", Type, TestTendencies, TestAuxState, DefMesh, DefHalo);
@@ -306,7 +306,7 @@ int testTimeStepper(const std::string &Name, TimeStepperType Type,
    std::vector<ErrorMeasures> Errors(NRefinements);
 
    // Start time = 0
-   const TimeInstant TimeStart(&TestCalendar, 0, 0, 0, 0, 0, 0);
+   const TimeInstant TimeStart(0, 0, 0, 0, 0, 0);
 
    const Real TimeEnd = 1;
 


### PR DESCRIPTION
  - converts the calendar class to a singleton class
  - simplifies time instant interfaces (no longer requires a calendar ptr)
  - eliminates requirement to carry/pass a calendar instance everywhere
  - updates documentation and unit tests to reflect new interfaces and functions

Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.


