### PR TITLE
Add clock and time info to Omega TimeStepper

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -1,12 +1,11 @@
 Omega:
-  TimeManagement:
+  TimeIntegration:
+    CalendarType: No Leap
+    TimeStepper: Forward-Backward
+    TimeStep: 0000_00:10:00
     StartTime: 0001-01-01_00:00:00
     StopTime: 0001-01-01_02:00:00
     RunDuration: none
-    CalendarType: No Leap
-  TimeIntegration:
-    TimeStepper: Forward-Backward
-    TimeStep: 0000_00:10:00
   Dimension:
     NVertLevels: 60
   Decomp:

--- a/components/omega/doc/devGuide/TimeStepping.md
+++ b/components/omega/doc/devGuide/TimeStepping.md
@@ -18,7 +18,9 @@ enum class TimeStepperType { ForwardBackward, RungeKutta4, RungeKutta2 };
 
 ## TimeStepper base class
 The `TimeStepper` class is a base class for all Omega time steppers. It stores
-as members common data needed by every times stepper. Its `doStep` method
+as members common data needed by every time stepper. These include a name and
+time stepping method as well as some time tracking variables, including
+StartTime, StopTime, TimeStep, a Clock and an EndAlarm. Its `doStep` method
 defines the interface that every time stepper needs to implement. In addition to this
 method, it provides a number of other methods that can divided into two groups.
 The first group is for general time stepper management. The second group is
@@ -30,11 +32,13 @@ The `doStep` method is the main method of every time stepper class. It exists
 in the base class as a pure virtual method, meaning it defines an interface but
 has no implementation. Its signature is
 ```c++
-    void TimeStepper::doStep(OceanState *State, TimeInstant Time) const;
+    void TimeStepper::doStep(OceanState *State, TimeInstant &SimTime) const;
 ```
 It is meant to advance `State` by one time step, from `Time` to `Time +
 TimeStep`. Classes implementing concrete time stepping schemes need to provide
-implementations of this method.
+implementations of this method. As part of the time step, this routine advances
+the Clock associated with the time stepper and returns the current simulation
+time. For the default time stepper, this is advances the primary model clock.
 
 ### Time stepper management methods
 
@@ -45,9 +49,15 @@ Two static methods:
 TimeStepper::init1();
 TimeStepper::init2();
 ```
-initialize the default time stepper in two phases. The first phase must be called early in the
-initialization process, and the second phase is called after the default tendency, auxiliary state,
-horizontal mesh, and halo objects have been initialized. A pointer to it can be retrieved at any time using:
+initialize the default time stepper in two phases. The first phase must be
+called early in the initialization process. It creates and time stepper
+instance, fills it with various time quantities (StartTime, EndTime, TimeStep)
+and creates a Clock (the Model Clock for the simulation) and an EndAlarm to
+ring when this portion of the simulation should stop. The second phase is
+called after the default tendency, auxiliary state, horizontal mesh, and halo
+objects have been initialized. It attaches pointers to these objects for later
+use during the time stop phase. A pointer to the default time stepper can be
+retrieved at any time using:
 ```c++
 TimeStepper* DefTimeStepper = TimeStepper::getDefault();
 ```
@@ -55,10 +65,11 @@ TimeStepper* DefTimeStepper = TimeStepper::getDefault();
 #### Creation of non-default time steppers
 
 A non-default time stepper can be created from a string `Name`, time stepper
-type `Type`, tendencies `Tend`, auxiliary state `AuxState`, horizontal mesh
-`Mesh`, and halo layer `MyHalo`
+type `Type`, `TimeStep`, `StartTime`, `EndTime`, tendencies `Tend`,
+auxiliary state `AuxState`, horizontal mesh `Mesh`, and halo layer `MyHalo`
 ```c++
-TimeStepper*  NewTimeStepper = TimeStepper::create(Name, Type, Tend, AuxState, Mesh, MyHalo);
+TimeStepper*  NewTimeStepper = TimeStepper::create(Name, Type, StartTime,
+         EndTime, TimeStep, Tend, AuxState, Mesh, MyHalo);
 ```
 For convenience, this returns a pointer to the newly created time stepper.
 Given its name, a pointer to a named time stepper can be obtained at any time
@@ -67,24 +78,27 @@ by calling the static `get` method:
 TimeStepper* NewTimeStepper = TimeStepper::get(Name);
 ```
 
-#### Setting the time step
-After creating a time stepper, the time step can be set by
+#### Changing the time step
+The time step is set on creation, but if the time step must change, the
+function
 ```c++
-Stepper->setTimeStep(TimeStep);
+Stepper->changeTimeStep(TimeStep);
 ```
-where `TimeStep` is an instance of `TimeInterval` class.
+can be used where `TimeStep` is an instance of `TimeInterval` class.
 
 #### Getters
-Given a pointer to a `TimeStepper` you can obtain its type, name, number of time levels,
-or time step by calling
+Given a pointer to a `TimeStepper` you can obtain various class members.
+Pointers to the associated Clock and EndAlarm can also be retrieved.
 ```c++
 TimeStepperType Type = Stepper->getType();
 int NTimeLevels = Stepper->getNTimeLevels();
 std::string Name = Stepper->getName();
 TimeInterval TimeStep = Stepper->getTimeStep();
+TimeInstant StartTime = Stepper->getStartTime();
+TimeInstant StopTime = Stepper->getStopTime();
+Clock *ModelClock = Stepper->getClock();
+Alarm *EndAlarm = Stepper->getEndAlarm();
 ```
-respectively.
-
 
 #### Removal of time steppers
 To erase a specific named time stepper use `erase`
@@ -98,15 +112,16 @@ TimeStepper::clear();
 
 ### Utility methods
 
-In addition to the above management methods, the base class provides common functions that
-are useful in implementing different time steppers. Given two pointers to
-`OceanState` objects `State1` and `State2`, two integers representing two time
-levels `TimeLevel1` and `TimeLevel2`, and coefficient `Coeff` of type
-`TimeInterval` calling
+In addition to the above management methods, the base class provides common
+functions that are useful in implementing different time steppers. Given two
+pointers to `OceanState` objects `State1` and `State2`, two integers
+representing two time levels `TimeLevel1` and `TimeLevel2`, and coefficient
+`Coeff` of type `TimeInterval` calling
 ```c++
 updateStateByTend(State1, TimeLevel1, State2, TimeLevel2, Coeff);
 ```
-conceptually performs the following update `State1(TimeLevel1) = State2(TimeLevel2) + Coeff * Tend`
+conceptually performs the following update
+`State1(TimeLevel1) = State2(TimeLevel2) + Coeff * Tend`
 element-wise for every state variable. To perform this update only for
 layer thickness do
 ```c++

--- a/components/omega/doc/userGuide/TimeMgr.md
+++ b/components/omega/doc/userGuide/TimeMgr.md
@@ -2,8 +2,26 @@
 
 # Time Manager (TimeMgr)
 
-Users will ultimately utilize the Time Manager to control run duration,
-output variables and frequency, forcing data input, etc. via parameters
-defined in YAML configuration files. Details for this are to be determined,
-see the [Time Manager developer's guide](#omega-dev-time-manager) for a more
-comprehensive description of the Time Manager in the meantime.
+The time manager manages various time quantities during a simulation, including
+time steps, time instants, the calendar, clocks and alarms. The user can
+specify a few options through the ``TimeIntegration`` portion of the Omega
+configuration file. In particular, the user can specify the Calendar used
+for tracking simulation time. Supported calendars include:
+ - Gregorian: typical western calendar with leap years/days
+ - No Leap: a Gregorian calendar without leap days
+ - Julian: earlier calendar still used by Eastern Orthodox traditions
+ - Julian Day: a calendar that simply tracks the number of days since
+   a reference day
+ - Modified Julian Day: a modified version of Julian Day that changes the
+   reference time
+ - 360 Day: An artificial calendar with equal 30-day months
+ - Custom: A calendar in which a developer can specify the number of
+   days per month and days per year. This currently cannot be configured
+   entirely via the configuration and would require additional code to
+   specify those variables.
+ - No Calendar: This is supplied for test cases in which the calendar
+   is meaningless and time is simply tracked from time zero.
+
+A number of other time quantities are specified in the ``TimeIntegration``
+section (eg time step, start time) and are described in the
+[TimeStepping](#omega-user-time-stepping) section.

--- a/components/omega/doc/userGuide/TimeStepping.md
+++ b/components/omega/doc/userGuide/TimeStepping.md
@@ -1,17 +1,53 @@
 (omega-user-time-stepping)=
 
 # Time stepping
-Time stepper refers to the numerical scheme used to advance the model in time.
-Omega implements a couple of time-stepping schemes. The user can select the
-scheme they want in the configuration file.
+Time stepper refers to the means by which a simulation is advanced in time.
+The configuration of a simulation is set by the ``TimeIntegration`` section
+of the Omega configuration file:
 ```yaml
-    TimeStepping:
-       TimeStepperType: 'Forward-Backward'
+  TimeIntegration:
+    CalendarType: No Leap
+    TimeStepper: Forward-Backward
+    TimeStep: 0000_00:10:00
+    StartTime: 0001-01-01_00:00:00
+    StopTime: 0001-01-01_02:00:00
+    RunDuration: none
 ```
+This configuration refers to the default time stepping used for the model
+dynamics (momentum and continuity equations). Additional time steppers can
+be used for other portions of the model (eg the barotropic mode or tracer
+transport) that may have different time steps and use different algorithms.
 
+The Calendar choice is describe in the
+[Time Management](#omega-user-time-manager) section.
+
+The TimeStepper option refers to the numerical scheme used to advance the
+model in time. Omega implements a number of time-stepping schemes. The user
+can select the scheme they want in the configuration file.
 The following time steppers are currently available:
 | Config option name | Scheme |
 | ------------------- | ------- |
 | Forward-Backward | forward-backward |
 | RungeKutta2 | second-order two-stage midpoint Runge Kutta method |
 | RungeKutta4 | classic fourth-order four-stage Runge Kutta method |
+
+The time step refers to the main model time step used to advance the solution
+forward. The format is in ``dddd_hh:mm:ss`` for days, hours, minutes and
+seconds.
+
+The StartTime refers to the starting time for the simulation. It is in the
+format ``yyyy-mm-day_hh:mm:ss`` for year, month, day, hour, minute, second.
+This refers to the initial start time; for a longer simulation, the current
+time will be modified by the restart file to update to the present time for
+the current segment of the simulation.
+
+The simulation will be stopped either at a fixed StopTime if provided or
+by the RunDuration. For shorter simulations, the StopTime can be used to
+specify a specific time to stop. For longer simulations with multiple
+segments that are restarted, the RunDuration should used and should be set
+to fit within the queue time. The format for StopTime is the same as StartTime.
+The format for RunDuration is the same as the TimeStep.
+
+Only one of the StopTime or RunDuration should be specified with the other
+set to either an empty string or "none". If both are specified, the
+RunDuration is used instead of the StopTime.

--- a/components/omega/src/ocn/OceanDriver.h
+++ b/components/omega/src/ocn/OceanDriver.h
@@ -20,17 +20,13 @@ namespace OMEGA {
 
 /// Read the config file and call all the inidividual initialization routines
 /// for each Omega module
-int ocnInit(MPI_Comm Comm, TimeInstant &StartTime, Alarm &EndAlarm);
+int ocnInit(MPI_Comm Comm);
 
 /// Advance the model from starting from CurrTime until EndAlarm rings
-int ocnRun(TimeInstant &CurrTime, Alarm &EndAlarm);
+int ocnRun(TimeInstant &CurrTime);
 
 /// Clean up all Omega objects
 int ocnFinalize(const TimeInstant &CurrTime);
-
-/// Extract time management options from Config
-int initTimeManagement(TimeInstant &StartTime, Alarm &EndAlarm,
-                       Config *OmegaConfig);
 
 /// Initialize Omega modules needed to run ocean model
 int initOmegaModules(MPI_Comm Comm);

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -1,18 +1,32 @@
+//===-- ForwardBackwardStepper.cpp - forward-backward methods --*- C++ -*--===//
+//
+// Contains methods for the Forward-Backward time stepper
+//
+//===----------------------------------------------------------------------===//
+
 #include "ForwardBackwardStepper.h"
 
 namespace OMEGA {
 
-// Constructor. Construct a forward-backward stepper from
-// name, tendencies, auxiliary state, mesh, and halo
-ForwardBackwardStepper::ForwardBackwardStepper(const std::string &Name,
-                                               Tendencies *Tend,
-                                               AuxiliaryState *AuxState,
-                                               HorzMesh *Mesh, Halo *MeshHalo)
-    : TimeStepper(Name, TimeStepperType::ForwardBackward, 2, Tend, AuxState,
-                  Mesh, MeshHalo) {}
+//------------------------------------------------------------------------------
+// Constructor creates an instance of a forward-backward stepper and
+// fills with some time information. Data pointers are added later.
+// Mostly passes relevant info to the base constructor.
+ForwardBackwardStepper::ForwardBackwardStepper(
+    const std::string &InName,      ///< [in] name of time stepper
+    const TimeInstant &InStartTime, ///< [in] start time for time stepping
+    const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
+    const TimeInterval &InTimeStep  ///< [in] time step
+    )
+    : TimeStepper(InName, TimeStepperType::ForwardBackward, 2, InStartTime,
+                  InStopTime, InTimeStep) {}
 
+//------------------------------------------------------------------------------
 // Advance the state by one step of the forward-backward scheme
-void ForwardBackwardStepper::doStep(OceanState *State, TimeInstant Time) const {
+void ForwardBackwardStepper::doStep(
+    OceanState *State,   // input model state
+    TimeInstant &SimTime // current simulation time
+) const {
 
    int Err = 0;
 
@@ -26,15 +40,21 @@ void ForwardBackwardStepper::doStep(OceanState *State, TimeInstant Time) const {
    Err = Tracers::getAll(CurTracerArray, TrCurLevel);
    Err = Tracers::getAll(NextTracerArray, TrNextLevel);
 
+   if (State == nullptr)
+      LOG_CRITICAL("Invalid State");
+   if (AuxState == nullptr)
+      LOG_CRITICAL("Invalid AuxState");
+
    // R_h^{n} = RHS_h(u^{n}, h^{n}, t^{n})
-   Tend->computeThicknessTendencies(State, AuxState, CurLevel, CurLevel, Time);
+   Tend->computeThicknessTendencies(State, AuxState, CurLevel, CurLevel,
+                                    SimTime);
 
    // h^{n+1} = h^{n} + R_h^{n}
    updateThicknessByTend(State, NextLevel, State, CurLevel, TimeStep);
 
    // R_phi^{n} = RHS_phi(u^{n}, h^{n}, phi^{n}, t^{n})
    Tend->computeTracerTendencies(State, AuxState, CurTracerArray, CurLevel,
-                                 CurLevel, Time);
+                                 CurLevel, SimTime);
 
    // phi^{n+1} = (phi^{n} * h^{n} + R_phi^{n}) / h^{n+1}
    updateTracersByTend(NextTracerArray, CurTracerArray, State, NextLevel, State,
@@ -42,7 +62,7 @@ void ForwardBackwardStepper::doStep(OceanState *State, TimeInstant Time) const {
 
    // R_u^{n+1} = RHS_u(u^{n}, h^{n+1}, t^{n+1})
    Tend->computeVelocityTendencies(State, AuxState, NextLevel, CurLevel,
-                                   Time + TimeStep);
+                                   SimTime + TimeStep);
 
    // u^{n+1} = u^{n} + R_u^{n+1}
    updateVelocityByTend(State, NextLevel, State, CurLevel, TimeStep);
@@ -51,6 +71,10 @@ void ForwardBackwardStepper::doStep(OceanState *State, TimeInstant Time) const {
    // exchanges
    State->updateTimeLevels();
    Tracers::updateTimeLevels();
+
+   // Advance the clock and update the simulation time
+   Err     = StepClock->advance();
+   SimTime = StepClock->getCurrentTime();
 }
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.h
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.h
@@ -1,8 +1,6 @@
 #ifndef OMEGA_TSFB_H
 #define OMEGA_TSFB_H
-//===-- timeStepping/ForwardBackwardStepper.h - forward-backward time stepper
-//--------------------*- C++
-//-*-===//
+//===-- ForwardBackwardStepper.h - forward-backward time step --*- C++ -*--===//
 //
 /// \file
 /// \brief Contains the class for forward-backward time stepping scheme
@@ -14,14 +12,19 @@ namespace OMEGA {
 
 class ForwardBackwardStepper : public TimeStepper {
  public:
-   // Constructor. Construct a forward-backward stepper from
-   // name, tendencies, auxiliary state, mesh, and halo
-   ForwardBackwardStepper(const std::string &Name, Tendencies *Tend,
-                          AuxiliaryState *AuxState, HorzMesh *Mesh,
-                          Halo *MeshHalo);
+   /// Constructor creates an instance of a forward-backward stepper and
+   /// fills with some time information. Data pointers are added later.
+   ForwardBackwardStepper(
+       const std::string &InName,      ///< [in] name of time stepper
+       const TimeInstant &InStartTime, ///< [in] start time for time stepping
+       const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
+       const TimeInterval &InTimeStep  ///< [in] time step
+   );
 
-   // Advance the state by one step of the forward-backward scheme
-   void doStep(OceanState *State, TimeInstant Time) const override;
+   /// Advance the state by one step of the forward-backward scheme
+   void doStep(OceanState *State,   ///< [inout] model state
+               TimeInstant &SimTime ///< [inout] current simulation time
+   ) const override;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -1,18 +1,31 @@
+//===-- RungeKutta2Stepper.cpp - 2nd-order Runge Kutta methods --*- C++ -*-===//
+//
+// Contains methods for the midpoint Runge-Kutta time stepping scheme
+//
+//===----------------------------------------------------------------------===//
+
 #include "RungeKutta2Stepper.h"
 
 namespace OMEGA {
 
-// Constructor. Construct a midpoint Runge Kutta stepper from
-// name, tendencies, auxiliary state, mesh, and halo
-RungeKutta2Stepper::RungeKutta2Stepper(const std::string &Name,
-                                       Tendencies *Tend,
-                                       AuxiliaryState *AuxState, HorzMesh *Mesh,
-                                       Halo *MeshHalo)
-    : TimeStepper(Name, TimeStepperType::RungeKutta2, 2, Tend, AuxState, Mesh,
-                  MeshHalo) {}
+//------------------------------------------------------------------------------
+// Constructor creates an instance of a midpoint Runge Kutta stepper and
+// fills with some time information. Data pointers are added later.
+// Mostly just passes info to the base constructor.
+RungeKutta2Stepper::RungeKutta2Stepper(
+    const std::string &InName,      ///< [in] name of time stepper
+    const TimeInstant &InStartTime, ///< [in] start time for time stepping
+    const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
+    const TimeInterval &InTimeStep  ///< [in] time step
+    )
+    : TimeStepper(InName, TimeStepperType::RungeKutta2, 2, InStartTime,
+                  InStopTime, InTimeStep) {}
 
+//------------------------------------------------------------------------------
 // Advance the state by one step of the midpoint Runge Kutta scheme
-void RungeKutta2Stepper::doStep(OceanState *State, TimeInstant Time) const {
+void RungeKutta2Stepper::doStep(OceanState *State,   // model state
+                                TimeInstant &SimTime // current simulation time
+) const {
 
    int Err = 0;
 
@@ -29,7 +42,7 @@ void RungeKutta2Stepper::doStep(OceanState *State, TimeInstant Time) const {
    // q = (h,u,phi)
    // R_q^{n} = RHS_q(u^{n}, h^{n}, phi^{n}, t^{n})
    Tend->computeAllTendencies(State, AuxState, CurTracerArray, CurLevel,
-                              CurLevel, Time);
+                              CurLevel, SimTime);
 
    // q^{n+0.5} = q^{n} + 0.5*dt*R_q^{n}
    updateStateByTend(State, NextLevel, State, CurLevel, 0.5 * TimeStep);
@@ -38,7 +51,7 @@ void RungeKutta2Stepper::doStep(OceanState *State, TimeInstant Time) const {
 
    // R_q^{n+0.5} = RHS_q(u^{n+0.5}, h^{n+0.5}, phi^{n+0.5}, t^{n+0.5})
    Tend->computeAllTendencies(State, AuxState, NextTracerArray, NextLevel,
-                              NextLevel, Time + 0.5 * TimeStep);
+                              NextLevel, SimTime + 0.5 * TimeStep);
 
    // q^{n+1} = q^{n} + dt*R_q^{n+0.5}
    updateStateByTend(State, NextLevel, State, CurLevel, TimeStep);
@@ -49,6 +62,10 @@ void RungeKutta2Stepper::doStep(OceanState *State, TimeInstant Time) const {
    // exchanges
    State->updateTimeLevels();
    Tracers::updateTimeLevels();
+
+   // Advance the clock and update the simulation time
+   Err     = StepClock->advance();
+   SimTime = StepClock->getCurrentTime();
 }
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.h
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.h
@@ -1,11 +1,10 @@
 #ifndef OMEGA_TSRK2_H
 #define OMEGA_TSRK2_H
-//===-- timeStepping/RungeKutta2Stepper.h - second-order Runge Kutta time
-// stepper --------------------*- C++
-//-*-===//
+//===-- RungeKutta2Stepper.h - 2nd-order Runge Kutta time step --*- C++ -*-===//
 //
 /// \file
 /// \brief Contains the class for the midpoint Runge Kutta scheme
+//
 //===----------------------------------------------------------------------===//
 
 #include "TimeStepper.h"
@@ -14,13 +13,20 @@ namespace OMEGA {
 
 class RungeKutta2Stepper : public TimeStepper {
  public:
-   // Constructor. Construct a midpoint Runge Kutta stepper from
    // name, tendencies, auxiliary state, mesh, and halo
-   RungeKutta2Stepper(const std::string &Name, Tendencies *Tend,
-                      AuxiliaryState *AuxState, HorzMesh *Mesh, Halo *MeshHalo);
+   /// Constructor creates an instance of a midpoint Runge Kutta stepper and
+   /// fills with some time information. Data pointers are added later.
+   RungeKutta2Stepper(
+       const std::string &InName,      ///< [in] name of time stepper
+       const TimeInstant &InStartTime, ///< [in] start time for time stepping
+       const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
+       const TimeInterval &InTimeStep  ///< [in] time step
+   );
 
-   // Advance the state by one step of the midpoint Runge Kutta scheme
-   void doStep(OceanState *State, TimeInstant Time) const override;
+   /// Advance the state by one step of the midpoint Runge Kutta scheme
+   void doStep(OceanState *State,   ///< [inout] model state
+               TimeInstant &SimTime ///< [inout] current simulation time
+   ) const override;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -1,18 +1,25 @@
+//===-- RungeKutta4Stepper.cpp - 4th-order Runge Kutta methods --*- C++ -*-===//
+//
+// Methods for the fourth-order Runge-Kutta time stepping scheme
+//
+//===----------------------------------------------------------------------===//
+
 #include "RungeKutta4Stepper.h"
 
 namespace OMEGA {
 
-// Constructor. Construct a fourth order Runge Kutta stepper from
-// name, tendencies, auxiliary state, mesh, and halo
-RungeKutta4Stepper::RungeKutta4Stepper(const std::string &Name,
-                                       Tendencies *Tend,
-                                       AuxiliaryState *AuxState, HorzMesh *Mesh,
-                                       Halo *MeshHalo)
-    : TimeStepper(Name, TimeStepperType::RungeKutta4, 2, Tend, AuxState, Mesh,
-                  MeshHalo) {
-
-   if (Tend)
-      finalizeInit();
+//------------------------------------------------------------------------------
+// Constructor creates an instance of a fourth order Runge Kutta stepper and
+// fills with some time information. Data pointers are added later.
+// Uses the base constructor and adds some coefficients.
+RungeKutta4Stepper::RungeKutta4Stepper(
+    const std::string &InName,      ///< [in] name of time stepper
+    const TimeInstant &InStartTime, ///< [in] start time for time stepping
+    const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
+    const TimeInterval &InTimeStep  ///< [in] time step
+    )
+    : TimeStepper(InName, TimeStepperType::RungeKutta4, 2, InStartTime,
+                  InStopTime, InTimeStep) {
 
    RKA[0] = 0;
    RKA[1] = 1. / 2;
@@ -30,18 +37,36 @@ RungeKutta4Stepper::RungeKutta4Stepper(const std::string &Name,
    RKC[3] = 1;
 }
 
+//------------------------------------------------------------------------------
+// Performs some additional initialization for provisional fields
 void RungeKutta4Stepper::finalizeInit() {
 
-   auto NVertLevels = Tend->LayerThicknessTend.extent_int(1);
-   auto NTracers    = Tracers::getNumTracers();
+   if (!Tend)
+      LOG_CRITICAL("Tendency not initialized");
+   if (!Mesh)
+      LOG_CRITICAL("Invalid mesh");
+   if (!MeshHalo)
+      LOG_CRITICAL("Invalid MeshHalo");
 
-   ProvisState = OceanState::create("Provis", Mesh, MeshHalo, NVertLevels, 1);
+   int NVertLevels = Tend->LayerThicknessTend.extent_int(1);
+   int NTracers    = Tracers::getNumTracers();
+   int NCellsSize  = Mesh->NCellsSize;
+   int NTimeLevels = 1; // for provisional tracer
+
+   ProvisState =
+       OceanState::create("Provis", Mesh, MeshHalo, NVertLevels, NTimeLevels);
+   if (!ProvisState)
+      LOG_CRITICAL("Error creating Provis state");
+
    ProvisTracers =
-       Array3DReal("ProvisTracers", NTracers, Mesh->NCellsSize, NVertLevels);
+       Array3DReal("ProvisTracers", NTracers, NCellsSize, NVertLevels);
 }
 
+//------------------------------------------------------------------------------
 // Advance the state by one step of the fourth-order Runge Kutta scheme
-void RungeKutta4Stepper::doStep(OceanState *State, TimeInstant Time) const {
+void RungeKutta4Stepper::doStep(OceanState *State,   // model state
+                                TimeInstant &SimTime // current simulation time
+) const {
 
    int Err = 0;
 
@@ -56,7 +81,7 @@ void RungeKutta4Stepper::doStep(OceanState *State, TimeInstant Time) const {
    Err = Tracers::getAll(NextTracerArray, TrNextLevel);
 
    for (int Stage = 0; Stage < NStages; ++Stage) {
-      const TimeInstant StageTime = Time + RKC[Stage] * TimeStep;
+      const TimeInstant StageTime = SimTime + RKC[Stage] * TimeStep;
       // first stage does:
       // R^{(0)} = RHS(q^{n}, t^{n})
       // q^{n+1} = q^{n} + dt * RKB[0] * R^{(0)}
@@ -99,6 +124,10 @@ void RungeKutta4Stepper::doStep(OceanState *State, TimeInstant Time) const {
    // exchanges
    State->updateTimeLevels();
    Tracers::updateTimeLevels();
+
+   // Advance the clock and update the simulation time
+   Err     = StepClock->advance();
+   SimTime = StepClock->getCurrentTime();
 }
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.h
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.h
@@ -1,11 +1,10 @@
 #ifndef OMEGA_TSRK4_H
 #define OMEGA_TSRK4_H
-//===-- timeStepping/RungeKutta4Stepper.h - fourth-order Runge Kutta time
-// stepper --------------------*- C++
-//-*-===//
+//===-- RungeKutta4Stepper.h - 4th-order Runge Kutta time step --*- C++ -*-===//
 //
 /// \file
 /// \brief Contains the class for the classic fourth order Runge Kutta scheme
+//
 //===----------------------------------------------------------------------===//
 
 #include "TimeStepper.h"
@@ -14,28 +13,35 @@ namespace OMEGA {
 
 class RungeKutta4Stepper : public TimeStepper {
  public:
-   // Constructor. Construct a fourth order Runge Kutta stepper from
-   // name, tendencies, auxiliary state, mesh, and halo
-   RungeKutta4Stepper(const std::string &Name, Tendencies *Tend,
-                      AuxiliaryState *AuxState, HorzMesh *Mesh, Halo *MeshHalo);
+   /// Constructor creates an instance of a fourth order Runge Kutta stepper and
+   /// fills with some time information. Data pointers are added later.
+   RungeKutta4Stepper(
+       const std::string &InName,      ///< [in] name of time stepper
+       const TimeInstant &InStartTime, ///< [in] start time for time stepping
+       const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
+       const TimeInterval &InTimeStep  ///< [in] time step
+   );
 
-   // Advance the state by one step of the fourth-order Runge Kutta scheme
-   void doStep(OceanState *State, TimeInstant Time) const override;
+   /// Advance the state by one step of the fourth-order Runge Kutta scheme
+   void doStep(OceanState *State,   ///< [inout] model state
+               TimeInstant &SimTime ///< [inout] current simulation time
+   ) const override;
 
  protected:
+   /// Performs some additional initialization for provisional fields
    void finalizeInit() override;
 
  private:
-   // Number of stages
+   /// Number of stages
    static constexpr int NStages = 4;
 
-   // Provisional state
+   /// Provisional state
    OceanState *ProvisState;
 
-   // Provisional tracers
+   /// Provisional tracers
    Array3DReal ProvisTracers;
 
-   // Runge-Kutta coefficients
+   /// Runge-Kutta coefficients
    Real RKA[NStages];
    Real RKB[NStages];
    Real RKC[NStages];

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -1,5 +1,8 @@
-//===-- timeStepping/TimeStepper.cpp - time stepper methods -------------*- C++
-//-*-===//
+//===--- TimeStepper.cpp - time stepper methods -------------*- C++ -*-----===//
+//
+// The TimeStepper defines how a solution advances forward in time.
+//
+//===----------------------------------------------------------------------===//
 
 #include "TimeStepper.h"
 #include "Config.h"
@@ -9,11 +12,16 @@
 
 namespace OMEGA {
 
+//------------------------------------------------------------------------------
 // create the static class members
+// Default model time stepper
 TimeStepper *TimeStepper::DefaultTimeStepper = nullptr;
+// All defined time steppers
 std::map<std::string, std::unique_ptr<TimeStepper>>
     TimeStepper::AllTimeSteppers;
 
+//------------------------------------------------------------------------------
+// utility functions
 // convert string into TimeStepperType enum
 TimeStepperType getTimeStepperFromStr(const std::string &InString) {
 
@@ -35,101 +43,297 @@ TimeStepperType getTimeStepperFromStr(const std::string &InString) {
    return TimeStepperChoice;
 }
 
-// Constructor. Construct a time stepper from name, type, tendencies, auxiliary
-// state, mesh and halo
-TimeStepper::TimeStepper(const std::string &Name, TimeStepperType Type,
-                         int NTimeLevels, Tendencies *Tend,
-                         AuxiliaryState *AuxState, HorzMesh *Mesh,
-                         Halo *MeshHalo)
-    : Name(Name), Type(Type), NTimeLevels(NTimeLevels), Tend(Tend),
-      AuxState(AuxState), Mesh(Mesh), MeshHalo(MeshHalo) {}
+//------------------------------------------------------------------------------
+// Constructors and creation methods.
 
-// Create a time stepper from name, type, tendencies, auxiliary state, mesh and
-// halo
-TimeStepper *TimeStepper::create(const std::string &Name, TimeStepperType Type,
-                                 Tendencies *Tend, AuxiliaryState *AuxState,
-                                 HorzMesh *Mesh, Halo *MeshHalo) {
+// Constructor creates a new instance and fills in the time
+// related data. attachData function is used to add the data pointers
+TimeStepper::TimeStepper(
+    const std::string &InName,      // [in] name of time stepper
+    TimeStepperType InType,         // [in] type (time stepping method)
+    I4 InNTimeLevels,               // [in] num time levels needed by method
+    const TimeInstant &InStartTime, // [in] start time for time stepping
+    const TimeInstant &InStopTime,  // [in] stop  time for time stepping
+    const TimeInterval &InTimeStep  // [in] time step
+    )
+    : Name(InName), Type(InType), NTimeLevels(InNTimeLevels),
+      StartTime(InStartTime), StopTime(InStopTime), TimeStep(InTimeStep) {
+   // Most variables initialized via initializer list
 
-   if (AllTimeSteppers.find(Name) != AllTimeSteppers.end()) {
+   // Set up clock associated with this time stepper
+   StepClock = std::make_unique<Clock>(Clock(InStartTime, InTimeStep));
+
+   // Create an EndAlarm associated with the StopTime
+   std::string AlarmName = "EndAlarm";
+   if (InName != "Default")
+      AlarmName += InName;
+   EndAlarm = std::make_unique<Alarm>(Alarm(AlarmName, InStopTime));
+   int Err  = StepClock->attachAlarm(EndAlarm.get());
+   if (Err != 0)
+      LOG_CRITICAL("Error attaching EndAlarm to TimeStep Clock");
+}
+
+//------------------------------------------------------------------------------
+// Create a time stepper when all components are known
+TimeStepper *TimeStepper::create(
+    const std::string &InName,      ///< [in] name of time stepper
+    TimeStepperType InType,         ///< [in] type (time stepping method)
+    const TimeInstant &InStartTime, ///< [in] start time for time stepping
+    const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
+    const TimeInterval &InTimeStep, ///< [in] time step
+    Tendencies *InTend,             ///< [in] ptr to tendencies
+    AuxiliaryState *InAuxState,     ///< [in] ptr to aux state variables
+    HorzMesh *InMesh,               ///< [in] ptr to mesh information
+    Halo *InMeshHalo                ///< [in] ptr to halos
+) {
+
+   // Check for duplicates
+   if (AllTimeSteppers.find(InName) != AllTimeSteppers.end()) {
       LOG_ERROR("Attempted to create a new TimeStepper with name {} but it "
                 "already exists",
-                Name);
+                InName);
       return nullptr;
    }
 
    TimeStepper *NewTimeStepper;
 
-   switch (Type) {
+   // Call specific constructor with time info
+   // These constructors mostly just call the constructor above with some
+   // additional info (NTimeLevels)
+   switch (InType) {
    case TimeStepperType::ForwardBackward:
-      NewTimeStepper =
-          new ForwardBackwardStepper(Name, Tend, AuxState, Mesh, MeshHalo);
+      NewTimeStepper = new ForwardBackwardStepper(InName, InStartTime,
+                                                  InStopTime, InTimeStep);
       break;
    case TimeStepperType::RungeKutta4:
       NewTimeStepper =
-          new RungeKutta4Stepper(Name, Tend, AuxState, Mesh, MeshHalo);
+          new RungeKutta4Stepper(InName, InStartTime, InStopTime, InTimeStep);
       break;
    case TimeStepperType::RungeKutta2:
       NewTimeStepper =
-          new RungeKutta2Stepper(Name, Tend, AuxState, Mesh, MeshHalo);
+          new RungeKutta2Stepper(InName, InStartTime, InStopTime, InTimeStep);
       break;
    }
 
-   AllTimeSteppers.emplace(Name, NewTimeStepper);
+   // Attach data pointers
+   NewTimeStepper->attachData(InTend, InAuxState, InMesh, InMeshHalo);
+
+   // Store instance
+   AllTimeSteppers.emplace(InName, NewTimeStepper);
 
    return NewTimeStepper;
 }
 
-// Begin initialization of the default time stepper
+//------------------------------------------------------------------------------
+// Create a time stepper when time information is needed before state
+// and tendencies are defined. It creates an instance and only fills
+// the time information. Data pointers are attached later.
+TimeStepper *TimeStepper::create(
+    const std::string &InName, // [in] name of time stepper
+    TimeStepperType InType,    // [in] type (time stepping method)
+    TimeInstant &InStartTime,  // [in] start time for time stepping
+    TimeInstant &InStopTime,   // [in] stop  time for time stepping
+    TimeInterval &InTimeStep   // [in] time step
+) {
+
+   // Check for duplicates
+   if (AllTimeSteppers.find(InName) != AllTimeSteppers.end()) {
+      LOG_ERROR("Attempted to create a new TimeStepper with name {} but it "
+                "already exists",
+                InName);
+      return nullptr;
+   }
+
+   TimeStepper *NewTimeStepper;
+
+   // Call specific constructor with time info
+   switch (InType) {
+   case TimeStepperType::ForwardBackward:
+      NewTimeStepper = new ForwardBackwardStepper(InName, InStartTime,
+                                                  InStopTime, InTimeStep);
+      break;
+   case TimeStepperType::RungeKutta4:
+      NewTimeStepper =
+          new RungeKutta4Stepper(InName, InStartTime, InStopTime, InTimeStep);
+      break;
+   case TimeStepperType::RungeKutta2:
+      NewTimeStepper =
+          new RungeKutta2Stepper(InName, InStartTime, InStopTime, InTimeStep);
+      break;
+   }
+
+   // Store instance
+   AllTimeSteppers.emplace(InName, NewTimeStepper);
+
+   return NewTimeStepper;
+}
+
+//------------------------------------------------------------------------------
+// For 2-step creation, this attaches all the data pointers to an instance
+// once the data and tendencies have been created.
+void TimeStepper::attachData(
+    Tendencies *InTend,         // [in] ptr to tendencies (right hand side)
+    AuxiliaryState *InAuxState, // [in] ptr to needed aux state variables
+    HorzMesh *InMesh,           // [in] ptr to mesh information
+    Halo *InMeshHalo            // [in] ptr to halos
+) {
+
+   if (!InTend)
+      LOG_CRITICAL("Tend pointer not defined");
+   if (!InAuxState)
+      LOG_CRITICAL("AuxState pointer not defined");
+   if (!InMesh)
+      LOG_CRITICAL("HorzMesh pointer not defined");
+   if (!InMeshHalo)
+      LOG_CRITICAL("MeshHalo pointer not defined");
+
+   Tend     = InTend;
+   AuxState = InAuxState;
+   Mesh     = InMesh;
+   MeshHalo = InMeshHalo;
+
+   // Some time steppers have additional tasks to finalize
+   finalizeInit();
+}
+
+//------------------------------------------------------------------------------
+// Destructors or delete functions
+
+// Remove time stepper by name
+void TimeStepper::erase(const std::string &Name) {
+   AllTimeSteppers.erase(Name);
+}
+
+// Remove all time steppers
+void TimeStepper::clear() { AllTimeSteppers.clear(); }
+
+//------------------------------------------------------------------------------
+// Initialize the default time stepper in two phases
+
+// Begin initialization of the default time stepper (phase 1)
+// This is primarily the time information.
 int TimeStepper::init1() {
    int Err = 0;
-
-   TimeInterval TimeStep;
-   TimeStepperType TimeStepperChoice;
 
    // Retrieve TimeStepper options from Config if available
    Config *OmegaConfig = Config::getOmegaConfig();
    Config TimeIntConfig("TimeIntegration");
    Err = OmegaConfig->get(TimeIntConfig);
    if (Err != 0) {
-      LOG_CRITICAL("TimeStepper: TimeIntegration group not found in Config");
+      LOG_CRITICAL("TimeIntegration group not found in Config");
       return Err;
    }
-   std::string TimeStepStr;
-   Err = TimeIntConfig.get("TimeStep", TimeStepStr);
-   if (Err != 0) {
-      LOG_CRITICAL("TimeStepper: TimeStep not found in TimeIntConfig");
-      return Err;
-   }
-   TimeStep = TimeInterval(TimeStepStr);
 
+   // Must initialize the calendar first
+   std::string CalendarStr;
+   Err = TimeIntConfig.get("CalendarType", CalendarStr);
+   if (Err != 0) {
+      LOG_CRITICAL("CalendarType not found in TimeIntegration Config");
+      return Err;
+   }
+   Calendar::init(CalendarStr);
+
+   // Initialize choice of time stepper
    std::string TimeStepperStr;
    Err = TimeIntConfig.get("TimeStepper", TimeStepperStr);
    if (Err != 0) {
-      LOG_CRITICAL("TimeStepper: TimeStepper not found in TimeIntConfig");
+      LOG_CRITICAL("TimeStepper not found in TimeIntegration Config");
       return Err;
    }
-   TimeStepperChoice = getTimeStepperFromStr(TimeStepperStr);
+   TimeStepperType TimeStepperChoice = getTimeStepperFromStr(TimeStepperStr);
 
+   // Initialize time step
+   std::string TimeStepStr;
+   Err = TimeIntConfig.get("TimeStep", TimeStepStr);
+   if (Err != 0) {
+      LOG_CRITICAL("TimeStep not found in TimeIntegration Config");
+      return Err;
+   }
+   TimeInterval TimeStep(TimeStepStr);
+
+   // Initialize start time
+   std::string StartTimeStr;
+   Err = TimeIntConfig.get("StartTime", StartTimeStr);
+   if (Err != 0) {
+      LOG_CRITICAL("StartTime not found in TimeIntConfig");
+      return Err;
+   }
+   TimeInstant StartTime(StartTimeStr);
+
+   // Either the StopTime or RunDuration will be used to set the StopTime
+   int Err1 = 0;
+   std::string StopTimeStr;
+   std::string DurationStr;
+   Err  = TimeIntConfig.get("StopTime", StopTimeStr);
+   Err1 = TimeIntConfig.get("RunDuration", DurationStr);
+
+   // Check for empty or none strings for either choice
+   if (Err == 0) {
+      if (StopTimeStr == "" or StopTimeStr == " " or StopTimeStr == "none" or
+          StopTimeStr == "None")
+         Err = 1;
+   }
+   if (Err1 == 0) {
+      if (DurationStr == "" or DurationStr == " " or DurationStr == "none" or
+          DurationStr == "None")
+         Err1 = 1;
+   }
+   if (Err != 0 and Err1 != 0) {
+      LOG_CRITICAL("Either StopTime or RunDuration must be supplied in"
+                   "TimeIntegration Config");
+      return Err + Err1;
+   }
+
+   // Set stop time if a valid value is present. If both are present and
+   // valid, we use the RunDuration, so compute stop time based on that first
+   TimeInstant StopTime;
+   if (Err1 == 0) { // valid RunDuration supplied
+      TimeInterval Duration(DurationStr);
+      StopTime = StartTime + Duration;
+   }
+   if (Err == 0 and Err1 != 0) { // only valid StopTime supplied
+      TimeInstant StopTime2(StopTimeStr);
+      StopTime = StopTime2;
+   }
+   Err = 0; // reset return code
+
+   // Now that all the inputs are defined, create the default time stepper
+   // Use the partial creation function for only the time info. Data
+   // pointers will be attached in phase 2 initialization
    TimeStepper::DefaultTimeStepper =
-       create("Default", TimeStepperChoice, nullptr, nullptr, nullptr, nullptr);
-   DefaultTimeStepper->setTimeStep(TimeStep);
+       create("Default", TimeStepperChoice, StartTime, StopTime, TimeStep);
 
    return Err;
 }
 
-// Finish initialization of the default time stepper
+//------------------------------------------------------------------------------
+// Finish initialization of the default time stepper (phase 2)
 int TimeStepper::init2() {
    int Err = 0;
 
-   DefaultTimeStepper->Mesh     = HorzMesh::getDefault();
-   DefaultTimeStepper->MeshHalo = Halo::getDefault();
-   DefaultTimeStepper->AuxState = AuxiliaryState::getDefault();
-   DefaultTimeStepper->Tend     = Tendencies::getDefault();
+   // Get default pointers
+   HorzMesh *DefMesh        = HorzMesh::getDefault();
+   Halo *DefHalo            = Halo::getDefault();
+   Tendencies *DefTend      = Tendencies::getDefault();
+   AuxiliaryState *AuxState = AuxiliaryState::getDefault();
 
-   DefaultTimeStepper->finalizeInit();
+   // Attach data pointers
+   DefaultTimeStepper->attachData(DefTend, AuxState, DefMesh, DefHalo);
 
    return Err;
 }
+
+//------------------------------------------------------------------------------
+// Change time step
+void TimeStepper::changeTimeStep(const TimeInterval &TimeStepIn) {
+   TimeStep = TimeStepIn;
+   int Err  = StepClock->changeTimeStep(TimeStepIn);
+   if (Err != 0)
+      LOG_CRITICAL("Error changing clock time step");
+}
+
+//------------------------------------------------------------------------------
+// Retrieval functions
 
 // Get the default time stepper
 TimeStepper *TimeStepper::getDefault() {
@@ -154,23 +358,6 @@ TimeStepper *TimeStepper::get(const std::string &Name) {
    }
 }
 
-// Remove time stepper by name
-void TimeStepper::erase(const std::string &Name) {
-   AllTimeSteppers.erase(Name);
-}
-
-// Remove all time steppers
-void TimeStepper::clear() { AllTimeSteppers.clear(); }
-
-// Get time step
-TimeInterval TimeStepper::getTimeStep() const { return TimeStep; }
-
-//
-// Set time step
-void TimeStepper::setTimeStep(const TimeInterval &TimeStepIn) {
-   TimeStep = TimeStepIn;
-}
-
 // Get time stepper name
 std::string TimeStepper::getName() const { return Name; }
 
@@ -180,8 +367,28 @@ TimeStepperType TimeStepper::getType() const { return Type; }
 // Get number of time level
 int TimeStepper::getNTimeLevels() const { return NTimeLevels; }
 
-// LayerThickness1(TimeLevel1) = LayerThickness2(TimeLevel2) + Coeff *
-// LayerThicknessTend
+// Get time step
+TimeInterval TimeStepper::getTimeStep() const { return TimeStep; }
+
+// Get start time
+TimeInstant TimeStepper::getStartTime() const { return StartTime; }
+
+// Get stop time from instance
+TimeInstant TimeStepper::getStopTime() const { return StopTime; }
+
+// Get clock (ptr) from instance
+Clock *TimeStepper::getClock() { return StepClock.get(); }
+
+// Get end alarm (ptr) from instance
+Alarm *TimeStepper::getEndAlarm() { return EndAlarm.get(); }
+
+//------------------------------------------------------------------------------
+// Update functions
+
+//------------------------------------------------------------------------------
+// Updates layer thickness using tendency terms
+// LayerThickness1(TimeLevel1) = LayerThickness2(TimeLevel2) +
+//                               Coeff * LayerThicknessTend
 void TimeStepper::updateThicknessByTend(OceanState *State1, int TimeLevel1,
                                         OceanState *State2, int TimeLevel2,
                                         TimeInterval Coeff) const {
@@ -202,8 +409,10 @@ void TimeStepper::updateThicknessByTend(OceanState *State1, int TimeLevel1,
        });
 }
 
-// NormalVelocity1(TimeLevel1) = NormalVelocity2(TimeLevel2) + Coeff *
-// NormalVelocityTend
+//------------------------------------------------------------------------------
+// Updates velocity using tendency terms
+// NormalVelocity1(TimeLevel1) = NormalVelocity2(TimeLevel2) +
+//                               Coeff * NormalVelocityTend
 void TimeStepper::updateVelocityByTend(OceanState *State1, int TimeLevel1,
                                        OceanState *State2, int TimeLevel2,
                                        TimeInterval Coeff) const {
@@ -224,6 +433,8 @@ void TimeStepper::updateVelocityByTend(OceanState *State1, int TimeLevel1,
        });
 }
 
+//------------------------------------------------------------------------------
+// Updates full non-tracer state
 // State1(TimeLevel1) = State2(TimeLevel2) + Coeff * Tend
 void TimeStepper::updateStateByTend(OceanState *State1, int TimeLevel1,
                                     OceanState *State2, int TimeLevel2,
@@ -232,8 +443,10 @@ void TimeStepper::updateStateByTend(OceanState *State1, int TimeLevel1,
    updateVelocityByTend(State1, TimeLevel1, State2, TimeLevel2, Coeff);
 }
 
+//------------------------------------------------------------------------------
+// Updates tracers
 // NextTracers = (CurTracers * LayerThickness2(TimeLevel2)) +
-// Coeff * TracersTend) / LayerThickness1(TimeLevel1)
+//               Coeff * TracersTend) / LayerThickness1(TimeLevel1)
 void TimeStepper::updateTracersByTend(const Array3DReal &NextTracers,
                                       const Array3DReal &CurTracers,
                                       OceanState *State1, int TimeLevel1,
@@ -260,6 +473,7 @@ void TimeStepper::updateTracersByTend(const Array3DReal &NextTracers,
        });
 }
 
+//------------------------------------------------------------------------------
 // couple tracer array to layer thickness
 void TimeStepper::weightTracers(const Array3DReal &NextTracers,
                                 const Array3DReal &CurTracers,
@@ -277,6 +491,7 @@ void TimeStepper::weightTracers(const Array3DReal &NextTracers,
        });
 }
 
+//------------------------------------------------------------------------------
 // accumulate contributions to the tracer array at the next time level from
 // each Runge-Kutta stage
 void TimeStepper::accumulateTracersUpdate(const Array3DReal &AccumTracer,
@@ -296,6 +511,7 @@ void TimeStepper::accumulateTracersUpdate(const Array3DReal &AccumTracer,
        });
 }
 
+//------------------------------------------------------------------------------
 // normalize tracer array so final array stores concentrations
 void TimeStepper::finalizeTracersUpdate(const Array3DReal &NextTracers,
                                         OceanState *State,

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -1,7 +1,6 @@
 #ifndef OMEGA_TIMESTEPPER_H
 #define OMEGA_TIMESTEPPER_H
-//===-- timeStepping/TimeStepper.h - time stepper --------------------*- C++
-//-*-===//
+//===--- TimeStepper.h - time stepper --------------------*- C++ --*-------===//
 //
 /// \file
 /// \brief Contains the base class for all Omega time steppers
@@ -35,6 +34,8 @@ enum class TimeStepperType {
    Invalid
 };
 
+//------------------------------------------------------------------------------
+// Utility routine
 /// Translate string for time stepper type into enum
 TimeStepperType getTimeStepperFromStr(
     const std::string &InString ///< [in] choice of time stepping method
@@ -49,9 +50,11 @@ class TimeStepper {
  public:
    virtual ~TimeStepper() = default;
 
-   // The main method that every time stepper needs to define. Advances state by
-   // by one time step, from Time to Time + TimeStep
-   virtual void doStep(OceanState *State, TimeInstant Time) const = 0;
+   /// The main method that every time stepper needs to define. Advances state
+   /// by one time step, from Time to Time + TimeStep
+   virtual void doStep(OceanState *State,   ///< [inout] model state
+                       TimeInstant &SimTime ///< [inout] current simulation time
+   ) const = 0;
 
    /// 1st phase of Initialization for the default time stepper
    static int init1();
@@ -59,23 +62,54 @@ class TimeStepper {
    /// 2nd phase of Initialization for the default time stepper
    static int init2();
 
-   // Create a time stepper from name, type, tendencies, auxiliary state, mesh
-   // and halo
-   static TimeStepper *create(const std::string &Name, TimeStepperType Type,
-                              Tendencies *Tend, AuxiliaryState *AuxState,
-                              HorzMesh *Mesh, Halo *MeshHalo);
+   /// Create a time stepper when all components are known
+   static TimeStepper *
+   create(const std::string &InName,      ///< [in] name of time stepper
+          TimeStepperType InType,         ///< [in] type (time stepping method)
+          const TimeInstant &InStartTime, ///< [in] start time for time stepping
+          const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
+          const TimeInterval &InTimeStep, ///< [in] time step
+          Tendencies *InTend,             ///< [in] ptr to tendencies
+          AuxiliaryState *InAuxState,     ///< [in] ptr to aux state variables
+          HorzMesh *InMesh,               ///< [in] ptr to mesh information
+          Halo *InMeshHalo                ///< [in] ptr to halos
+   );
 
-   /// Get the default time stepper
-   static TimeStepper *getDefault();
+   /// Create a time stepper when time information is needed before state
+   /// and tendencies are defined. It creates an instance and only fills
+   /// the time information. Data pointers are attached later.
+   static TimeStepper *
+   create(const std::string &InName, ///< [in] name of time stepper
+          TimeStepperType InType,    ///< [in] type (time stepping method)
+          TimeInstant &InStartTime,  ///< [in] start time for time stepping
+          TimeInstant &InStopTime,   ///< [in] stop  time for time stepping
+          TimeInterval &InTimeStep   ///< [in] time step
+   );
 
-   /// Get time stepper by name
-   static TimeStepper *get(const std::string &Name);
+   /// For 2-step creation, this attaches all the data pointers to an instance
+   /// once the data and tendencies have been created.
+   void attachData(
+       Tendencies *InTend,         ///< [in] ptr to tendencies
+       AuxiliaryState *InAuxState, ///< [in] ptr to needed aux state variables
+       HorzMesh *InMesh,           ///< [in] ptr to mesh information
+       Halo *InMeshHalo            ///< [in] ptr to halos
+   );
 
+   // Delete/destroy functions
    /// Remove time stepper by name
    static void erase(const std::string &Name);
 
    /// Remove all time steppers
    static void clear();
+
+   // Retrieval functions
+   /// Get the default time stepper
+   static TimeStepper *getDefault();
+
+   /// Get time stepper by name
+   static TimeStepper *
+   get(const std::string &Name ///< [in] name of stepper to retrieve
+   );
 
    /// Get name of time stepper from instance
    std::string getName() const;
@@ -89,80 +123,146 @@ class TimeStepper {
    /// Get time step
    TimeInterval getTimeStep() const;
 
-   /// Set time step
-   void setTimeStep(const TimeInterval &TimeStepIn);
+   /// Get start time
+   TimeInstant getStartTime() const;
+
+   /// Get stop time
+   TimeInstant getStopTime() const;
+
+   /// Get a pointer to the clock
+   Clock *getClock();
+
+   /// Get a pointer to the end alarm
+   Alarm *getEndAlarm();
+
+   /// Change time step
+   void changeTimeStep(const TimeInterval &TimeStepIn ///< [in] new time step
+   );
 
    // these should be protected, they are public only because of CUDA
    // limitations
 
-   // State1(TimeLevel1) = State2(TimeLevel2) + Coeff * Tend
-   void updateStateByTend(OceanState *State1, int TimeLevel1,
-                          OceanState *State2, int TimeLevel2,
-                          TimeInterval Coeff) const;
+   /// Updates state using tendency terms
+   /// State1(TimeLevel1) = State2(TimeLevel2) + Coeff * Tend
+   void updateStateByTend(
+       OceanState *State1, ///< [out] updated state
+       int TimeLevel1,     ///< [in] time level index for new time
+       OceanState *State2, ///< [in] state data for current time
+       int TimeLevel2,     ///< [in] time level index for current time
+       TimeInterval Coeff  ///< [in] time-related coeff for tendency
+   ) const;
 
-   // LayerThickness1(TimeLevel1) = LayerThickness2(TimeLevel2) + Coeff *
-   // LayerThicknessTend
-   void updateThicknessByTend(OceanState *State1, int TimeLevel1,
-                              OceanState *State2, int TimeLevel2,
-                              TimeInterval Coeff) const;
+   /// Updates layer thickness using tendency terms
+   /// LayerThickness1(TimeLevel1) = LayerThickness2(TimeLevel2) +
+   ///                               Coeff * LayerThicknessTend
+   void updateThicknessByTend(
+       OceanState *State1, ///< [out] updated layer thickness in state
+       int TimeLevel1,     ///< [in] time level index for new time
+       OceanState *State2, ///< [in] state (thickness) for current time
+       int TimeLevel2,     ///< [in] time level index for current time
+       TimeInterval Coeff  ///< [in] time-related coeff for tendency
+   ) const;
 
-   // NormalVelocity1(TimeLevel1) = NormalVelocity2(TimeLevel2) + Coeff *
-   // NormalVelocityTend
-   void updateVelocityByTend(OceanState *State1, int TimeLevel1,
-                             OceanState *State2, int TimeLevel2,
-                             TimeInterval Coeff) const;
+   /// Updates velocity using tendency terms
+   /// NormalVelocity1(TimeLevel1) = NormalVelocity2(TimeLevel2) +
+   ///                               Coeff * NormalVelocityTend
+   void updateVelocityByTend(
+       OceanState *State1, ///< [out] updated state (velocity)
+       int TimeLevel1,     ///< [in] time level index for new time
+       OceanState *State2, ///< [in] state (velocity) for current time
+       int TimeLevel2,     ///< [in] time level index for current time
+       TimeInterval Coeff  ///< [in] time-related coeff for tendency
+   ) const;
 
-   // NextTracers = (CurTracers * LayerThickness2(TimeLevel2)) +
-   // Coeff * TracersTend) / LayerThickness1(TimeLevel1)
-   void updateTracersByTend(const Array3DReal &NextTracers,
-                            const Array3DReal &CurTracers, OceanState *State1,
-                            int TimeLevel1, OceanState *State2, int TimeLevel2,
-                            TimeInterval Coeff) const;
+   /// Updates tracers
+   /// NextTracers = (CurTracers * LayerThickness2(TimeLevel2)) +
+   ///               Coeff * TracersTend) / LayerThickness1(TimeLevel1)
+   void updateTracersByTend(
+       const Array3DReal &NextTracers, ///< [out] updated tracers
+       const Array3DReal &CurTracers,  ///< [in]  current tracers
+       OceanState *State1, ///< [in] state (thickness) at updated time
+       int TimeLevel1,     ///< [in] time level index for new time
+       OceanState *State2, ///< [in] state (thickness) for current time
+       int TimeLevel2,     ///< [in] time level index for current time
+       TimeInterval Coeff  ///< [in] time-related coeff for tendency
+   ) const;
 
-   // couple tracer array to layer thickness
-   void weightTracers(const Array3DReal &NextTracers,
-                      const Array3DReal &CurTracers, OceanState *CurState,
-                      int TimeLevel1) const;
+   /// couple tracer array to layer thickness
+   void weightTracers(
+       const Array3DReal &NextTracers, ///< [inout] tracers to modify
+       const Array3DReal &CurTracers,  ///< [inout] tracers at current time
+       OceanState *CurState,           ///< [in] state (thick) at current time
+       int TimeLevel1                  ///< [in] time index
+   ) const;
 
-   // accumulate contributions to the tracer array at the next time level from
-   // each Runge-Kutta stage
-   void accumulateTracersUpdate(const Array3DReal &AccumTracer,
-                                TimeInterval Coeff) const;
+   /// accumulate contributions to the tracer array at the next time level from
+   /// each Runge-Kutta stage
+   void accumulateTracersUpdate(
+       const Array3DReal &AccumTracer, ///< [inout] accumulated tracers
+       TimeInterval Coeff ///< [in] time-related coeff for accumulation
+   ) const;
 
-   // normalize tracer array so final array stores concentrations
-   void finalizeTracersUpdate(const Array3DReal &NextTracers, OceanState *State,
-                              int TimeLevel) const;
+   /// normalize tracer array so final array stores concentrations
+   void finalizeTracersUpdate(
+       const Array3DReal &NextTracers, ///< [inout] tracers to normalize
+       OceanState *State,              ///< [in] state with thickness data
+       int TimeLevel                   ///< [in] time level index
+   ) const;
 
  protected:
-   // Name of time stepper
+   /// Name of time stepper
    std::string Name;
 
-   // Type of time stepper
+   /// Type of time stepper
    TimeStepperType Type;
 
-   // Number of time levels required
+   /// Number of time levels required
    int NTimeLevels;
 
-   // Time step
+   /// Time step
    TimeInterval TimeStep;
 
-   // Pointers to objects needed by every time stepper
-   Tendencies *Tend;
-   AuxiliaryState *AuxState;
-   HorzMesh *Mesh;
-   Halo *MeshHalo;
+   /// Start time
+   TimeInstant StartTime;
 
+   /// Stop time
+   TimeInstant StopTime;
+
+   /// Alarm that rings at StopTime
+   std::unique_ptr<Alarm> EndAlarm;
+
+   /// Clock for this time stepper
+   /// For the default time stepper, this is the model clock
+   std::unique_ptr<Clock> StepClock;
+
+   // Pointers to objects needed by every time stepper
+   Tendencies *Tend;         /// Ptr to tendency terms
+   AuxiliaryState *AuxState; /// Ptr to auxiliary state data
+   HorzMesh *Mesh;           /// Ptr to horizontal mesh info
+   Halo *MeshHalo;           /// Ptr to defined halos
+
+   /// Function for any method-specific modifications for the default stepper
    virtual void finalizeInit() {}
 
-   TimeStepper(const std::string &Name, TimeStepperType Type, int NTimeLevels,
-               Tendencies *Tend, AuxiliaryState *AuxState, HorzMesh *Mesh,
-               Halo *MeshHalo);
+   /// Constructor creates a new instance and fills in the time
+   /// related data. attachData function is used to add the data pointers
+   TimeStepper(
+       const std::string &InName,      ///< [in] name of time stepper
+       TimeStepperType InType,         ///< [in] type (time stepping method)
+       I4 InNTimeLevels,               ///< [in] num time levels for method
+       const TimeInstant &InStartTime, ///< [in] start time for time stepping
+       const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
+       const TimeInterval &InTimeStep  ///< [in] time step
+   );
 
+   // Disable copy constructor
    TimeStepper(const TimeStepper &) = delete;
    TimeStepper(TimeStepper &&)      = delete;
 
  private:
+   /// Default model time stepper
    static TimeStepper *DefaultTimeStepper;
+   /// All defined time steppers
    static std::map<std::string, std::unique_ptr<TimeStepper>> AllTimeSteppers;
 };
 

--- a/components/omega/test/drivers/StandaloneDriverTest.cpp
+++ b/components/omega/test/drivers/StandaloneDriverTest.cpp
@@ -14,6 +14,7 @@
 #include "OceanDriver.h"
 #include "OmegaKokkos.h"
 #include "TimeMgr.h"
+#include "TimeStepper.h"
 
 #include "mpi.h"
 
@@ -29,19 +30,21 @@ int main(int argc, char *argv[]) {
    MPI_Init(&argc, &argv); // initialize MPI
    Kokkos::initialize();   // initialize Kokkos
 
-   // Time management objects
-   OMEGA::TimeInstant CurrTime;
-   OMEGA::Alarm EndAlarm;
-
-   ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD, CurrTime, EndAlarm);
+   ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD);
    if (ErrCurr == 0) {
       LOG_INFO("DriverTest: Omega initialize PASS");
    } else {
       LOG_INFO("DriverTest: Omega initialize FAIL");
    }
 
+   // Time management objects
+   OMEGA::TimeStepper *DefStepper = OMEGA::TimeStepper::getDefault();
+   OMEGA::Clock *ModelClock       = DefStepper->getClock();
+   OMEGA::Alarm *EndAlarm         = DefStepper->getEndAlarm();
+   OMEGA::TimeInstant CurrTime    = ModelClock->getCurrentTime();
+
    if (ErrCurr == 0) {
-      ErrCurr = OMEGA::ocnRun(CurrTime, EndAlarm);
+      ErrCurr = OMEGA::ocnRun(CurrTime);
    }
    if (ErrCurr == 0) {
       LOG_INFO("DriverTest: Omega model run PASS");

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -89,7 +89,7 @@ int initIOStreamTest(std::shared_ptr<Clock> &ModelClock // Model clock
 
    // Create the model clock and time step
    // Get Calendar from time management config group
-   Config TimeMgmtConfig("TimeManagement");
+   Config TimeMgmtConfig("TimeIntegration");
    Err = OmegaConfig->get(TimeMgmtConfig);
    if (Err != 0) {
       LOG_CRITICAL("ocnInit: TimeManagement group not found in Config");


### PR DESCRIPTION
Model clock and time information is best handled in the time stepper. This allows the clock, and various alarms to be carried between init and run methods and is needed to better support other capabilities like streams that use alarms. The commit:
  - adds a clock, timestep, end alarm and time info to the TimeStepper class
  - splits the TimeStepper construction to better support the split initialization of the default time stepper
  - moves the clock advance into the doStep method
  - updates documentation
  - modifies some formatting
  - merges the TimeMgr config section with TimeIntegration

Tested on Chrysalis/Intel will update with Frontier tests below

Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.



