### PR TITLE
Integrates streams into Omega drivers and tests

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -31,7 +31,7 @@ Omega:
     TracerHyperDiffTendencyEnable: true
     EddyDiff4: 0.0
   Tracers:
-    Base: [Temp, Salt]
+    Base: [Temperature, Salinity]
     Debug: [Debug1, Debug2, Debug3]
   IOStreams:
     # InitialState should only be used when starting from scratch

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -87,6 +87,8 @@ Omega:
       UseStartEnd: false
       Contents:
         - Tracers
+        - State
+        - SshCellDefault
     Highfreq:
       UsePointerFile: false
       Filename: ocn.hifreq.$Y-$M-$D_$h.$m.$s

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -46,7 +46,8 @@ Omega:
       FreqUnits: OnStartup
       UseStartEnd: false
       Contents:
-        - Restart
+        - State
+        - Base
     # Restarts are used to initialize for all job submissions after the very
     # first startup job. We use UseStartEnd with a start time just after the
     # simulation start time so that omega does not attempt to use a restart

--- a/components/omega/doc/devGuide/Field.md
+++ b/components/omega/doc/devGuide/Field.md
@@ -168,7 +168,12 @@ The Metadata associated with a field can be retrieved individually using:
    int Err = MyField->getMetadata(MetadataName, MetaValue);
 ```
 where the MetaValue can be a scalar of any supported data type (I4, I8, R4, R8,
-bool, std::string). The existence of a metadata entry can be determined with:
+bool, std::string). If the value of a metadata entry needs to be changed,
+an update function is provided:
+```c++
+   int Err = MyField->updateMetadata(MetadataName, NewMetaValue);
+```
+The existence of a metadata entry can be determined with:
 ```c++
    bool MetaExists = MyField->hasMetadata(MetadataName);
 ```

--- a/components/omega/src/infra/Field.cpp
+++ b/components/omega/src/infra/Field.cpp
@@ -399,6 +399,27 @@ int Field::addMetadata(
 }
 
 //------------------------------------------------------------------------------
+// Updates a metadata entry with a new value
+int Field::updateMetadata(const std::string &MetaName, // [in] Name of metadata
+                          const std::any Value         // [in] Value of metadata
+) {
+   int RetVal = 0;
+
+   if (hasMetadata(MetaName)) {
+      FieldMeta[MetaName] = Value;
+
+   } else {
+      LOG_ERROR("Failed to update metadata {} for field {} because the field "
+                "has no entry with that name.",
+                MetaName, FldName);
+
+      RetVal = -1;
+   }
+
+   return RetVal;
+}
+
+//------------------------------------------------------------------------------
 // Removes a metadata entry with the given name
 int Field::removeMetadata(
     const std::string &MetaName // [in] Name of metadata entry to remove

--- a/components/omega/src/infra/Field.h
+++ b/components/omega/src/infra/Field.h
@@ -248,6 +248,11 @@ class Field {
    int addMetadata(const std::initializer_list<std::pair<std::string, std::any>>
                        &MetaPairs);
 
+   /// Updates a metadata entry with a new value
+   int updateMetadata(const std::string &MetaName, ///< [in] Name of metadata
+                      const std::any Value         ///< [in] Value of metadata
+   );
+
    /// Removes a metadata entry with the given name
    int
    removeMetadata(const std::string &MetaName ///< [in] Name of entry to remove

--- a/components/omega/src/infra/IOStream.h
+++ b/components/omega/src/infra/IOStream.h
@@ -71,7 +71,7 @@ class IOStream {
    /// clock so that stream alarm can be attached to this clock during creation.
    static int create(const std::string &StreamName, ///< [in] name of stream
                      Config &StreamConfig, ///< [in] input stream configuration
-                     Clock &ModelClock     ///< [inout] Omega model clock
+                     Clock *&ModelClock    ///< [inout] Omega model clock
    );
 
    /// Define all dimensions used. Returns an error code as well as a map
@@ -94,7 +94,7 @@ class IOStream {
    /// Private function that performs most of the stream read - called by the
    /// public read method
    int readStream(
-       const Clock &ModelClock, ///< [in] Model clock for alarms, time stamp
+       const Clock *ModelClock, ///< [in] Model clock for alarms, time stamp
        Metadata &ReqMetadata, ///< [inout] global metadata to extract from file
        bool ForceRead = false ///< [in] Optional: read even if not time
    );
@@ -102,7 +102,7 @@ class IOStream {
    /// Private function that performs most of the stream write - called by the
    /// public write method
    int writeStream(
-       const Clock &ModelClock, ///< [in] Model clock for alarms, time stamp
+       const Clock *ModelClock, ///< [in] Model clock for alarms, time stamp
        bool ForceWrite = false, ///< [in] Optional: write even if not time
        bool FinalCall  = false  ///< [in] Optional flag for shutdown
    );
@@ -151,7 +151,7 @@ class IOStream {
    ///    $s = seconds part of simulation time stamp
    static std::string buildFilename(
        const std::string &FilenameTemplate, ///< [in] template string for name
-       const Clock &ModelClock              ///< [in] model clock for sim time
+       const Clock *ModelClock              ///< [in] model clock for sim time
    );
 
    /// Sets ReducePrecision flag based on an input string, performing string
@@ -169,14 +169,14 @@ class IOStream {
    /// Creates all streams defined in the input configuration file. This does
    /// not validate the contents of the streams since the relevant Fields
    /// may not have been defined yet. Returns an error code.
-   static int init(Clock &ModelClock ///< [inout] Omega model clock
+   static int init(Clock *&ModelClock ///< [inout] Omega model clock
    );
 
    //---------------------------------------------------------------------------
    /// Performs a final write of any streams that have the OnShutdown option and
    /// then removes all streams to clean up. Returns an error code.
    static int
-   finalize(const Clock &ModelClock ///< [in] Model clock needed for time stamps
+   finalize(const Clock *ModelClock ///< [in] Model clock needed for time stamps
    );
 
    //---------------------------------------------------------------------------
@@ -222,7 +222,7 @@ class IOStream {
    //---------------------------------------------------------------------------
    /// Reads a stream if it is time. Returns an error code.
    static int read(const std::string &StreamName, ///< [in] Name of stream
-                   const Clock &ModelClock, ///< [in] Model clock for time info
+                   const Clock *ModelClock, ///< [in] Model clock for time info
                    Metadata &ReqMetadata, ///< [inout] Metadata desired in file
                    bool ForceRead = false ///< [in] opt: read even if not time
    );
@@ -231,7 +231,7 @@ class IOStream {
    /// Writes a stream if it is time. Returns an error code.
    static int
    write(const std::string &StreamName, ///< [in] Name of stream
-         const Clock &ModelClock,       ///< [in] Model clock for time stamps
+         const Clock *ModelClock,       ///< [in] Model clock for time stamps
          bool ForceWrite = false        ///< [in] opt: write even if not time
    );
 
@@ -239,7 +239,7 @@ class IOStream {
    /// Loops through all streams and writes them if it is time. This is
    /// useful if most I/O is consolidated at one point (eg end of step).
    static int
-   writeAll(const Clock &ModelClock ///< [in] Model clock for time stamps
+   writeAll(const Clock *ModelClock ///< [in] Model clock for time stamps
    );
 
    //---------------------------------------------------------------------------

--- a/components/omega/src/infra/TimeMgr.cpp
+++ b/components/omega/src/infra/TimeMgr.cpp
@@ -4137,6 +4137,16 @@ I4 Clock::setCurrentTime(
       NextTime = CurrTime + TimeStep;
    }
 
+   // Update status of all attached alarms based on new time
+   I4 Err1{0};
+   for (I4 N = 0; N < NumAlarms; ++N) {
+      Err1 = Alarms[N]->updateStatus(CurrTime);
+      if (Err1 != 0) {
+         ++Err;
+         LOG_ERROR("Clock::setCurrentTime error updating alarm # {}", N);
+         break;
+      }
+   }
    return Err;
 
 } // end Clock::setCurrentTime

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -205,7 +205,7 @@ int initOmegaModules(MPI_Comm Comm) {
    // Update Halos and Device arrays with new state and tracer fields
 
    OceanState *DefState = OceanState::getDefault();
-   I4 CurTimeLevel      = DefState->CurLevel;
+   I4 CurTimeLevel      = 0;
    DefState->exchangeHalo(CurTimeLevel);
    DefState->copyToDevice(CurTimeLevel);
 

--- a/components/omega/src/ocn/OceanRun.cpp
+++ b/components/omega/src/ocn/OceanRun.cpp
@@ -5,8 +5,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "IOStream.h"
 #include "OceanDriver.h"
 #include "OceanState.h"
+#include "TimeMgr.h"
 #include "TimeStepper.h"
 
 namespace OMEGA {
@@ -27,9 +29,11 @@ int ocnRun(TimeInstant &CurrTime ///< [inout] current sim time
    TimeInterval TimeStep = DefTimeStepper->getTimeStep();
    TimeInstant SimTime   = OmegaClock->getCurrentTime();
 
-   I8 IStep = 0;
+   // Get Simulation metadata field for later updates
+   std::shared_ptr<Field> SimInfo = Field::get(SimMeta);
 
    // time loop, integrate until EndAlarm or error encountered
+   I8 IStep = 0;
    while (Err == 0 && !(EndAlarm->isRinging())) {
 
       // track step count
@@ -41,6 +45,12 @@ int ocnRun(TimeInstant &CurrTime ///< [inout] current sim time
       DefTimeStepper->doStep(DefOceanState, SimTime);
 
       // write restart file/output, anything needed post-timestep
+
+      Err = IOStream::writeAll(OmegaClock);
+      if (Err != 0) {
+         LOG_CRITICAL("Error writing streams at end of step");
+         break;
+      }
 
       LOG_INFO("ocnRun: Time step {} complete, clock time: {}", IStep,
                SimTime.getString(4, 4, "-"));

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -12,7 +12,6 @@
 #include "Decomp.h"
 #include "Field.h"
 #include "Halo.h"
-#include "IO.h"
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
@@ -53,7 +52,8 @@ int OceanState::init() {
    OceanState::DefaultOceanState =
        create("Default", DefHorzMesh, DefHalo, NVertLevels, NTimeLevels);
 
-   DefaultOceanState->loadStateFromFile(DefHorzMesh->MeshFileName, DefDecomp);
+   // State values are filled by a later read of the initial state or
+   // restart file
 
    return Err;
 }
@@ -182,76 +182,6 @@ void OceanState::clear() {
 } // end clear
 
 //------------------------------------------------------------------------------
-// Load state from file
-void OceanState::loadStateFromFile(const std::string &StateFileName,
-                                   Decomp *MeshDecomp) {
-
-   int StateFileID;
-   I4 CellDecompR8;
-   I4 EdgeDecompR8;
-
-   // Open the state file for reading (assume IO has already been initialized)
-   I4 Err;
-   Err = IO::openFile(StateFileID, StateFileName, IO::ModeRead);
-   if (Err != 0)
-      LOG_CRITICAL("OceanState: error opening state file");
-
-   // Create the parallel IO decompositions required to read in state variables
-   initParallelIO(CellDecompR8, EdgeDecompR8, MeshDecomp);
-
-   // Read layerThickness and normalVelocity
-   read(StateFileID, CellDecompR8, EdgeDecompR8);
-
-   // Destroy the parallel IO decompositions
-   finalizeParallelIO(CellDecompR8, EdgeDecompR8);
-
-   // Sync with device
-   copyToDevice(0);
-
-} // end loadStateFromFile
-
-//------------------------------------------------------------------------------
-// Initialize the parallel IO decompositions for the mesh variables
-void OceanState::initParallelIO(I4 &CellDecompR8, I4 &EdgeDecompR8,
-                                Decomp *MeshDecomp) {
-
-   I4 Err;
-   I4 NDims             = 3;
-   IO::Rearranger Rearr = IO::RearrBox;
-
-   // Create the IO decomp for arrays with (NCells) dimensions
-   std::vector<I4> CellDims{1, MeshDecomp->NCellsGlobal, NVertLevels};
-   std::vector<I4> CellID(NCellsAll * NVertLevels, -1);
-   for (int Cell = 0; Cell < NCellsAll; ++Cell) {
-      for (int Level = 0; Level < NVertLevels; ++Level) {
-         I4 GlobalID = (MeshDecomp->CellIDH(Cell) - 1) * NVertLevels + Level;
-         CellID[Cell * NVertLevels + Level] = GlobalID;
-      }
-   }
-
-   Err = IO::createDecomp(CellDecompR8, IO::IOTypeR8, NDims, CellDims,
-                          NCellsAll * NVertLevels, CellID, Rearr);
-   if (Err != 0)
-      LOG_CRITICAL("OceanState: error creating cell IO decomposition");
-
-   // Create the IO decomp for arrays with (NEdges) dimensions
-   std::vector<I4> EdgeDims{1, MeshDecomp->NEdgesGlobal, NVertLevels};
-   std::vector<I4> EdgeID(NEdgesAll * NVertLevels, -1);
-   for (int Edge = 0; Edge < NEdgesAll; ++Edge) {
-      for (int Level = 0; Level < NVertLevels; ++Level) {
-         I4 GlobalID = (MeshDecomp->EdgeIDH(Edge) - 1) * NVertLevels + Level;
-         EdgeID[Edge * NVertLevels + Level] = GlobalID;
-      }
-   }
-
-   Err = IO::createDecomp(EdgeDecompR8, IO::IOTypeR8, NDims, EdgeDims,
-                          NEdgesAll * NVertLevels, EdgeID, Rearr);
-   if (Err != 0)
-      LOG_CRITICAL("OceanState: error creating edge IO decomposition");
-
-} // end initParallelIO
-
-//------------------------------------------------------------------------------
 // Define IO fields and metadata
 void OceanState::defineFields() {
 
@@ -339,61 +269,6 @@ void OceanState::defineFields() {
                 LayerThicknessFldName);
 
 } // end defineIOFields
-
-//------------------------------------------------------------------------------
-// Destroy parallel decompositions
-void OceanState::finalizeParallelIO(I4 CellDecompR8, I4 EdgeDecompR8) {
-
-   int Err = 0; // default return code
-
-   // Destroy the IO decomp for arrays with (NCells) dimensions
-   Err = IO::destroyDecomp(CellDecompR8);
-   if (Err != 0)
-      LOG_CRITICAL("OceanState: error destroying cell IO decomposition");
-
-   // Destroy the IO decomp for arrays with (NEdges) dimensions
-   Err = IO::destroyDecomp(EdgeDecompR8);
-   if (Err != 0)
-      LOG_CRITICAL("OceanState: error destroying edge IO decomposition");
-
-} // end finalizeParallelIO
-
-//------------------------------------------------------------------------------
-// Read Ocean State
-void OceanState::read(int StateFileID, I4 CellDecompR8, I4 EdgeDecompR8) {
-
-   I4 Err;
-   I4 TimeIndex;
-
-   Err = getTimeIndex(TimeIndex, 0);
-
-   // Read LayerThickness into a temporary double-precision array
-   int LayerThicknessID;
-   HostArray2DR8 TmpLayerThicknessR8("TmpLayerThicknessR8", NCellsSize,
-                                     NVertLevels);
-   Err = IO::readArray(TmpLayerThicknessR8.data(), NCellsAll, "layerThickness",
-                       StateFileID, CellDecompR8, LayerThicknessID);
-   if (Err != 0)
-      LOG_CRITICAL("OceanState: error reading layerThickness");
-
-   // Copy the thickness data into the final state array of user-specified
-   // precision
-   deepCopy(LayerThicknessH[TimeIndex], TmpLayerThicknessR8);
-
-   // Read NormalVelocity  into a temporary double-precision array
-   int NormalVelocityID;
-   HostArray2DR8 TmpNormalVelocityR8("TmpNormalVelocityR8", NEdgesSize,
-                                     NVertLevels);
-   Err = IO::readArray(TmpNormalVelocityR8.data(), NEdgesAll, "normalVelocity",
-                       StateFileID, EdgeDecompR8, NormalVelocityID);
-   if (Err != 0)
-      LOG_CRITICAL("OceanState: error reading normalVelocity");
-
-   // Copy the velocity data into the final state array of user-specified
-   // precision
-   deepCopy(NormalVelocityH[TimeIndex], TmpNormalVelocityR8);
-
-} // end read
 
 //------------------------------------------------------------------------------
 // Get layer thickness device array

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -301,6 +301,10 @@ void OceanState::defineFields() {
    }
    auto StateGroup = FieldGroup::create(StateGroupName);
 
+   // Add restart group if needed
+   if (!FieldGroup::exists("Restart"))
+      auto RestartGroup = FieldGroup::create("Restart");
+
    Err = StateGroup->addField(NormalVelocityFldName);
    if (Err != 0)
       LOG_ERROR("Error adding {} to field group {}", NormalVelocityFldName,
@@ -309,6 +313,15 @@ void OceanState::defineFields() {
    if (Err != 0)
       LOG_ERROR("Error adding {} to field group {}", LayerThicknessFldName,
                 StateGroupName);
+
+   Err = FieldGroup::addFieldToGroup(NormalVelocityFldName, "Restart");
+   if (Err != 0)
+      LOG_ERROR("Error adding {} to Restart field group",
+                NormalVelocityFldName);
+   Err = FieldGroup::addFieldToGroup(LayerThicknessFldName, "Restart");
+   if (Err != 0)
+      LOG_ERROR("Error adding {} to Restart field group",
+                LayerThicknessFldName);
 
    // Associate Field with data
    I4 TimeIndex;

--- a/components/omega/src/ocn/OceanState.h
+++ b/components/omega/src/ocn/OceanState.h
@@ -28,12 +28,6 @@ namespace OMEGA {
 class OceanState {
 
  private:
-   void initParallelIO(I4 &CellDecompR8, I4 &EdgeDecompR8, Decomp *MeshDecomp);
-
-   void finalizeParallelIO(I4 CellDecompR8, I4 EdgeDecompR8);
-
-   void read(int StateFileID, I4 CellDecompR8, I4 EdgeDecompR8);
-
    void defineFields();
 
    Halo *MeshHalo;
@@ -114,9 +108,6 @@ class OceanState {
           const int NVertLevels,   ///< [in] Number of vertical levels
           const int NTimeLevels    ///< [in] Number of time levels
    );
-
-   /// load state from file
-   void loadStateFromFile(const std::string &StateFileName, Decomp *MeshDecomp);
 
    /// Get layer thickness device array at given time level
    I4 getLayerThickness(Array2DReal &LayerThick, const I4 TimeLevel) const;

--- a/components/omega/src/ocn/TracerDefs.inc
+++ b/components/omega/src/ocn/TracerDefs.inc
@@ -21,7 +21,7 @@ inline static I4 IndxDebug3 = Tracers::IndxInvalid;
 // Tracer definitions packaged in a defineAllTracers function
 static void defineAllTracers() {
 
-   define("Temp",                               ///< [in] Name of tracer
+   define("Temperature",                        ///< [in] Name of tracer
           "Conservative Temperature",           ///< [in] Long name, description
           "degree_C",                           ///< [in] Units
           "sea_water_conservative_temperature", ///< [in] CF standard Name
@@ -30,8 +30,8 @@ static void defineAllTracers() {
           1.e33,                                ///< [in] value of undef entries
           IndxTemp);                            ///< [out] (optional) static index
 
-   define("Salt", "Absolute Salinity", "g kg-1", "sea_water_absolute_salinity",
-          0.0, 50.0, 1.e33, IndxSalt);
+   define("Salinity", "Absolute Salinity", "g kg-1",
+          "sea_water_absolute_salinity", 0.0, 50.0, 1.e33, IndxSalt);
 
    define("Debug1", "Debug Tracer 1", "none", "none", 0.0, 100.0, 1.e33,
           IndxDebug1);

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -115,6 +115,11 @@ I4 Tracers::init() {
    // total number of tracers
    NumTracers = TracerIndex;
 
+   // A tracer dimension is sometimes needed for aux variables so we
+   // define it here
+   std::shared_ptr<Dimension> TracerDim =
+      Dimension::create("NTracers", NumTracers);
+
    // Initialize tracers arrays for device and host
    TracerArrays.resize(NTimeLevels);
    TracerArraysH.resize(NTimeLevels);

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -139,6 +139,11 @@ I4 Tracers::init() {
    }
 
    // Add Fields to FieldGroup
+   // Create an overall Tracer and Restart group
+   auto AllTracerGrp = FieldGroup::create("Tracers");
+   if (!FieldGroup::exists("Restart"))
+      auto RestartGroup = FieldGroup::create("Restart");
+
    for (const auto &GroupPair : TracerGroups) {
       auto GroupName                   = GroupPair.first;
       std::string TracerFieldGroupName = GroupName;
@@ -156,6 +161,20 @@ I4 Tracers::init() {
             LOG_ERROR("Error adding {} to field group {}", TracerFieldName,
                       TracerFieldGroupName);
             return -7;
+         }
+
+         // Add tracer Field to all tracer group
+         Err = AllTracerGrp->addField(TracerFieldName);
+         if (Err != 0) {
+            LOG_ERROR("Error adding {} to All Tracer group", TracerFieldName);
+            return 8;
+         }
+
+         // Add tracer Field to restart group
+         Err = FieldGroup::addFieldToGroup(TracerFieldName, "Restart");
+         if (Err != 0) {
+            LOG_ERROR("Error adding {} to Restart group", TracerFieldName);
+            return 8;
          }
 
          // Associate Field with data

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -118,7 +118,7 @@ I4 Tracers::init() {
    // A tracer dimension is sometimes needed for aux variables so we
    // define it here
    std::shared_ptr<Dimension> TracerDim =
-      Dimension::create("NTracers", NumTracers);
+       Dimension::create("NTracers", NumTracers);
 
    // Initialize tracers arrays for device and host
    TracerArrays.resize(NTimeLevels);

--- a/components/omega/test/infra/FieldTest.cpp
+++ b/components/omega/test/infra/FieldTest.cpp
@@ -564,6 +564,11 @@ int main(int argc, char **argv) {
       TstEval<std::string>("Get All Metadata string",
                            std::any_cast<std::string>(MetaVal), RefStr, Err);
 
+      // Test updating a metadata value
+      Err1 = CodeField->updateMetadata("CodeI8", MetaI8 + 2);
+      Err1 = CodeField->getMetadata("CodeI8", MetaI8);
+      TstEval<I8>("Update I8 Metadata", MetaI8, RefI8 + 2, Err);
+
       // Test removal of a metadata entry with the given name
       Err1 = CodeField->removeMetadata("CodeBool");
       TstEval<int>("Remove metadata call", Err1, ErrRef, Err);

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -171,14 +171,21 @@ int initIOStreamTest(Clock *&ModelClock // Model clock
        Field::create("Salinity", "Salinity at cell centers", "",
                      "sea_water_salinity", 0.0, 100.0, FillValue, 2, DimNames);
 
-   // Create Tracer group
+   // Create Tracer group and Base tracer group
    auto TracerGroup = FieldGroup::create("Tracers");
+   auto BaseGroup   = FieldGroup::create("Base");
 
    // Add fields to tracer group
    Err1 = TracerGroup->addField("Temperature");
    TestEval("Add Temperature to tracer group", Err1, ErrRef, Err);
    Err1 = TracerGroup->addField("Salinity");
    TestEval("Add Salinity to tracer group", Err1, ErrRef, Err);
+
+   // Add fields to base tracer group
+   Err1 = BaseGroup->addField("Temperature");
+   TestEval("Add Temperature to base tracer group", Err1, ErrRef, Err);
+   Err1 = BaseGroup->addField("Salinity");
+   TestEval("Add Salinity to base tracer group", Err1, ErrRef, Err);
 
    // Also create a Restart group
    if (!FieldGroup::exists("Restart"))

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -181,12 +181,13 @@ int initIOStreamTest(Clock *&ModelClock // Model clock
    TestEval("Add Salinity to tracer group", Err1, ErrRef, Err);
 
    // Also create a Restart group
-   auto RestartGroup = FieldGroup::create("Restart");
+   if (!FieldGroup::exists("Restart"))
+      auto RestartGroup = FieldGroup::create("Restart");
 
    // Add fields to restart group
-   Err1 = RestartGroup->addField("Temperature");
+   Err1 = FieldGroup::addFieldToGroup("Temperature", "Restart");
    TestEval("Add Temperature to restart group", Err1, ErrRef, Err);
-   Err1 = RestartGroup->addField("Salinity");
+   Err1 = FieldGroup::addFieldToGroup("Salinity", "Restart");
    TestEval("Add Salinity to restart group", Err1, ErrRef, Err);
 
    // End of init

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -9,6 +9,7 @@
 //
 //===-----------------------------------------------------------------------===/
 
+#include "AuxiliaryState.h"
 #include "IOStream.h"
 #include "Config.h"
 #include "DataTypes.h"
@@ -23,6 +24,7 @@
 #include "OmegaKokkos.h"
 #include "TimeMgr.h"
 #include "TimeStepper.h"
+#include "Tracers.h"
 #include "mpi.h"
 #include <chrono>
 #include <thread>
@@ -71,6 +73,20 @@ int initIOStreamTest(Clock *&ModelClock // Model clock
    TestEval("Config read all", Err1, ErrRef, Err);
    Config *OmegaConfig = Config::getOmegaConfig();
 
+   // Initialize the default time stepper (phase 1) that includes the
+   // num time levels, calendar, model clock and start/stop times and alarms
+   Err = TimeStepper::init1();
+   if (Err != 0) {
+      LOG_CRITICAL("ocnInit: Error phase 1 initializing default time stepper");
+      return Err;
+   }
+
+   // Use alternative model clock rather than the input config
+   // for testing
+   TimeInstant SimStartTime(0001, 1, 1, 0, 0, 0.0);
+   TimeInterval TimeStep(2, TimeUnits::Hours);
+   ModelClock = new Clock(SimStartTime, TimeStep);
+
    // Initialize base-level IO
    Err1 = IO::init(DefComm);
    TestEval("IO Initialization", Err1, ErrRef, Err);
@@ -87,27 +103,6 @@ int initIOStreamTest(Clock *&ModelClock // Model clock
    Err1 = Field::init();
    TestEval("IO Field initialization", Err1, ErrRef, Err);
 
-   // Create the model clock and time step
-   // Get Calendar from time management config group
-   Config TimeMgmtConfig("TimeIntegration");
-   Err = OmegaConfig->get(TimeMgmtConfig);
-   if (Err != 0) {
-      LOG_CRITICAL("ocnInit: TimeManagement group not found in Config");
-      return Err;
-   }
-   std::string ConfigCalStr;
-   Err = TimeMgmtConfig.get("CalendarType", ConfigCalStr);
-   if (Err != 0) {
-      LOG_CRITICAL("ocnInit: CalendarType not found in TimeMgmtConfig");
-      return Err;
-   }
-   Calendar::init(ConfigCalStr);
-
-   // Use internal start time and time step rather than Config
-   TimeInstant SimStartTime(0001, 1, 1, 0, 0, 0.0);
-   TimeInterval TimeStep(2, TimeUnits::Hours);
-   ModelClock = new Clock(SimStartTime, TimeStep);
-
    // Initialize IOStreams
    Err1 = IOStream::init(ModelClock);
    TestEval("IOStream Initialization", Err1, ErrRef, Err);
@@ -123,13 +118,17 @@ int initIOStreamTest(Clock *&ModelClock // Model clock
    std::shared_ptr<Dimension> VertDim =
        Dimension::create("NVertLevels", NVertLevels);
 
-   // Initialize time stepper needed before ocean state (for time levels)
-   Err1 = TimeStepper::init1();
-   TestEval("Ocean time step initialization", Err1, ErrRef, Err);
-
    // Initialize State
    Err1 = OceanState::init();
    TestEval("Ocean state initialization", Err1, ErrRef, Err);
+
+   // Initialize Aux State
+   Err1 = AuxiliaryState::init();
+   TestEval("Ocean aux state initialization", Err1, ErrRef, Err);
+
+   // Initialize Tracers
+   Err1 = Tracers::init();
+   TestEval("Ocean tracer initialization", Err1, ErrRef, Err);
 
    // Add some global (Model and Simulation) metadata
    std::shared_ptr<Field> CodeField = Field::get(CodeMeta);
@@ -152,50 +151,9 @@ int initIOStreamTest(Clock *&ModelClock // Model clock
    Err1 = SimField->addMetadata("SimStartTime", StartTimeStr);
    TestEval("Add SimStartTime metadata", Err1, ErrRef, Err);
 
-   // Define temperature and salinity tracer fields and create a tracer
-   // group
-
-   std::vector<std::string> DimNames(2);
-   DimNames[0] = "NCells";
-   DimNames[1] = "NVertLevels";
-
-   // 2D Fields on device
-
-   DimNames[0]    = "NCells";
-   DimNames[1]    = "NVertLevels";
-   Real FillValue = -1.2345e-30;
-   auto TempField = Field::create(
-       "Temperature", "Potential temperature at cell centers", "deg C",
-       "sea_water_pot_tem", -3.0, 100.0, FillValue, 2, DimNames);
-   auto SaltField =
-       Field::create("Salinity", "Salinity at cell centers", "",
-                     "sea_water_salinity", 0.0, 100.0, FillValue, 2, DimNames);
-
-   // Create Tracer group and Base tracer group
-   auto TracerGroup = FieldGroup::create("Tracers");
-   auto BaseGroup   = FieldGroup::create("Base");
-
-   // Add fields to tracer group
-   Err1 = TracerGroup->addField("Temperature");
-   TestEval("Add Temperature to tracer group", Err1, ErrRef, Err);
-   Err1 = TracerGroup->addField("Salinity");
-   TestEval("Add Salinity to tracer group", Err1, ErrRef, Err);
-
-   // Add fields to base tracer group
-   Err1 = BaseGroup->addField("Temperature");
-   TestEval("Add Temperature to base tracer group", Err1, ErrRef, Err);
-   Err1 = BaseGroup->addField("Salinity");
-   TestEval("Add Salinity to base tracer group", Err1, ErrRef, Err);
-
-   // Also create a Restart group
-   if (!FieldGroup::exists("Restart"))
-      auto RestartGroup = FieldGroup::create("Restart");
-
-   // Add fields to restart group
-   Err1 = FieldGroup::addFieldToGroup("Temperature", "Restart");
-   TestEval("Add Temperature to restart group", Err1, ErrRef, Err);
-   Err1 = FieldGroup::addFieldToGroup("Salinity", "Restart");
-   TestEval("Add Salinity to restart group", Err1, ErrRef, Err);
+   // Validate all streams (Mesh stream already validated in HorzMesh?)
+   bool AllValidated = IOStream::validateAll();
+   TestEval("IOStream Validation", AllValidated, true, Err);
 
    // End of init
    return Err;
@@ -231,23 +189,6 @@ int main(int argc, char **argv) {
       I4 NCellsOwned    = DefDecomp->NCellsOwned;
       Array1DI4 CellID  = DefDecomp->CellID;
 
-      // Create data arrays
-
-      Array2DR8 Temp("Temp", NCellsSize, NVertLevels);
-      Array2DR8 Salt("Salt", NCellsSize, NVertLevels);
-      Array2DR8 Test("Test", NCellsSize, NVertLevels);
-
-      // Attach data arrays to fields
-
-      Err1 = Field::attachFieldData<Array2DR8>("Temperature", Temp);
-      TestEval("Attach temperature data to field", Err1, ErrRef, Err);
-      Err1 = Field::attachFieldData<Array2DR8>("Salinity", Salt);
-      TestEval("Attach salinity data to field", Err1, ErrRef, Err);
-
-      // Validate all streams (Mesh stream already validated in HorzMesh?)
-      bool AllValidated = IOStream::validateAll();
-      TestEval("IOStream Validation", AllValidated, true, Err);
-
       // Read restart file for initial temperature and salinity data
       Metadata ReqMetadata; // leave empty for now - no required metadata
       Err1 = IOStream::read("InitialState", ModelClock, ReqMetadata);
@@ -255,6 +196,11 @@ int main(int argc, char **argv) {
 
       // Overwrite salinity array with values associated with global cell
       // ID to test proper indexing of IO
+      Array2DReal Test("Test", NCellsSize, NVertLevels);
+      Array2DReal Salt;
+      Err1 = Tracers::getByIndex(Salt, 0, Tracers::IndxSalt);
+      TestEval("Retrieve Salinity", Err1, ErrRef, Err);
+
       parallelFor(
           {NCellsSize, NVertLevels}, KOKKOS_LAMBDA(int Cell, int K) {
              Salt(Cell, K) = 0.0001_Real * (CellID(Cell) + K);
@@ -305,7 +251,9 @@ int main(int argc, char **argv) {
 
    // Clean up environments
    TimeStepper::clear();
+   Tracers::clear();
    OceanState::clear();
+   AuxiliaryState::clear();
    HorzMesh::clear();
    Field::clear();
    Dimension::clear();

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -9,8 +9,8 @@
 //
 //===-----------------------------------------------------------------------===/
 
-#include "AuxiliaryState.h"
 #include "IOStream.h"
+#include "AuxiliaryState.h"
 #include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -17,6 +17,7 @@
 #include "Halo.h"
 #include "HorzMesh.h"
 #include "IO.h"
+#include "IOStream.h"
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OceanState.h"
@@ -25,6 +26,8 @@
 #include "mpi.h"
 
 #include <iostream>
+
+using namespace OMEGA;
 
 //------------------------------------------------------------------------------
 // The initialization routine for State testing. It calls various
@@ -37,74 +40,167 @@ int initStateTest() {
    // Initialize the Machine Environment class - this also creates
    // the default MachEnv. Then retrieve the default environment and
    // some needed data members.
-   OMEGA::MachEnv::init(MPI_COMM_WORLD);
-   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
-   MPI_Comm DefComm       = DefEnv->getComm();
+   MachEnv::init(MPI_COMM_WORLD);
+   MachEnv *DefEnv  = MachEnv::getDefault();
+   MPI_Comm DefComm = DefEnv->getComm();
 
-   OMEGA::initLogging(DefEnv);
+   // Initialize Logging
+   initLogging(DefEnv);
 
-   // Open config file
-   OMEGA::Config("Omega");
-   Err = OMEGA::Config::readAll("omega.yml");
+   // Read Omega config file
+   Config("Omega");
+   Err = Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("State: Error reading config file");
       return Err;
    }
 
-   // Initialize the default time stepper
-   Err = OMEGA::TimeStepper::init1();
+   // Initialize the default time stepper and retrieve the model clock
+   Err = TimeStepper::init1();
    if (Err != 0)
       LOG_ERROR("State: error initializing default time stepper");
 
+   TimeStepper *DefStepper = TimeStepper::getDefault();
+   Clock *ModelClock       = DefStepper->getClock();
+
    // Initialize the IO system
-   Err = OMEGA::IO::init(DefComm);
+   Err = IO::init(DefComm);
    if (Err != 0)
       LOG_ERROR("State: error initializing parallel IO");
 
+   // Initialize IOStreams - this does not yet validate the contents
+   // of each file, only creates streams from Config
+   Err = IOStream::init(ModelClock);
+   if (Err != 0) {
+      LOG_CRITICAL("State: Error initializing IOStreams");
+      return Err;
+   }
+
+   // Initialize Field infrastructure
+   Err = Field::init();
+   if (Err != 0) {
+      LOG_CRITICAL("State: Error initializing Fields");
+      return Err;
+   }
+
    // Create the default decomposition (initializes the decomposition)
-   Err = OMEGA::Decomp::init();
+   Err = Decomp::init();
    if (Err != 0)
       LOG_ERROR("State: error initializing default decomposition");
 
    // Initialize the default halo
-   Err = OMEGA::Halo::init();
+   Err = Halo::init();
    if (Err != 0)
       LOG_ERROR("State: error initializing default halo");
 
    // Initialize the default mesh
-   Err = OMEGA::HorzMesh::init();
+   Err = HorzMesh::init();
    if (Err != 0)
       LOG_ERROR("State: error initializing default mesh");
+
+   // Get the number of vertical levels from Config
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config DimConfig("Dimension");
+   Err = OmegaConfig->get(DimConfig);
+   if (Err != 0) {
+      LOG_CRITICAL("State: Dimension group not found in Config");
+      return Err;
+   }
+   I4 NVertLevels;
+   Err = DimConfig.get("NVertLevels", NVertLevels);
+   if (Err != 0) {
+      LOG_CRITICAL("State: NVertLevels not found in Dimension Config");
+      return Err;
+   }
+   // Create vertical dimension
+   auto VertDim = Dimension::create("NVertLevels", NVertLevels);
+
+   // Initialize tracers
+   Err = Tracers::init();
+   if (Err != 0) {
+      LOG_CRITICAL("State: Error initializing tracers infrastructure");
+      return Err;
+   }
+
+   // Initialize Aux State variables
+   Err = AuxiliaryState::init();
+   if (Err != 0) {
+      LOG_CRITICAL("State: Error initializing default aux state");
+      return Err;
+   }
+
+   // Create tendencies
+   Err = Tendencies::init();
+   if (Err != 0) {
+      LOG_CRITICAL("State: Error initializing default tendencies");
+      return Err;
+   }
+
+   // Finish time stepper initialization
+   Err = TimeStepper::init2();
+   if (Err != 0) {
+      LOG_CRITICAL("State: Error phase 2 initializing default time stepper");
+      return Err;
+   }
+
+   // Create a default ocean state
+   Err = OceanState::init();
+   if (Err != 0) {
+      LOG_CRITICAL("ocnInit: Error initializing default state");
+      return Err;
+   }
+
+   // Now that all fields have been defined, validate all the streams
+   // contents
+   bool StreamsValid = IOStream::validateAll();
+   if (!StreamsValid) {
+      LOG_CRITICAL("ocnInit: Error validating IO Streams");
+      return Err;
+   }
+
+   // Read the state variables from the initial state stream
+   Metadata ReqMeta; // no global metadata needed for init state read
+   Err = IOStream::read("InitialState", ModelClock, ReqMeta);
+   if (!StreamsValid) {
+      LOG_CRITICAL("ocnInit: Error reading initial state from stream");
+      return Err;
+   }
+
+   // Finish initialization of initial state by filling halos and copying
+   // to device. Current time level is zero.
+   OceanState *DefState = OceanState::getDefault();
+   DefState->exchangeHalo(0);
+   DefState->copyToDevice(0);
 
    return Err;
 }
 
 // Check for differences between layer thickness and normal velocity host arrays
-int checkHost(OMEGA::OceanState *DefState, OMEGA::OceanState *TestState,
-              int DefLevel, int TestLevel) {
+int checkHost(OceanState *RefState, OceanState *TstState, int RefTimeLevel,
+              int TstTimeLevel) {
 
    int count = 0;
-   OMEGA::HostArray2DReal LayerThicknessH_def;
-   OMEGA::HostArray2DReal LayerThicknessH_test;
-   DefState->getLayerThicknessH(LayerThicknessH_def, DefLevel);
-   TestState->getLayerThicknessH(LayerThicknessH_test, TestLevel);
-   for (int Cell = 0; Cell < DefState->NCellsAll; Cell++) {
-      for (int Level = 0; Level < DefState->NVertLevels; Level++) {
-         if (LayerThicknessH_def(Cell, Level) !=
-             LayerThicknessH_test(Cell, Level)) {
+   HostArray2DReal LayerThicknessHRef;
+   HostArray2DReal LayerThicknessHTst;
+   RefState->getLayerThicknessH(LayerThicknessHRef, RefTimeLevel);
+   TstState->getLayerThicknessH(LayerThicknessHTst, TstTimeLevel);
+   for (int Cell = 0; Cell < RefState->NCellsAll; Cell++) {
+      for (int Level = 0; Level < RefState->NVertLevels; Level++) {
+         if (LayerThicknessHRef(Cell, Level) !=
+             LayerThicknessHTst(Cell, Level)) {
             count++;
          }
       }
    }
 
-   OMEGA::HostArray2DReal NormalVelocityH_def;
-   OMEGA::HostArray2DReal NormalVelocityH_test;
-   DefState->getNormalVelocityH(NormalVelocityH_def, DefLevel);
-   TestState->getNormalVelocityH(NormalVelocityH_test, TestLevel);
-   for (int Edge = 0; Edge < DefState->NEdgesAll; Edge++) {
-      for (int Level = 0; Level < DefState->NVertLevels; Level++) {
-         if (NormalVelocityH_def(Edge, Level) !=
-             NormalVelocityH_test(Edge, Level)) {
+   HostArray2DReal NormalVelocityHRef;
+   HostArray2DReal NormalVelocityHTst;
+   RefState->getNormalVelocityH(NormalVelocityHRef, RefTimeLevel);
+   TstState->getNormalVelocityH(NormalVelocityHTst, TstTimeLevel);
+   for (int Edge = 0; Edge < RefState->NEdgesAll; Edge++) {
+      for (int Level = 0; Level < RefState->NVertLevels; Level++) {
+         if (NormalVelocityHRef(Edge, Level) !=
+             NormalVelocityHTst(Edge, Level)) {
             count++;
          }
       }
@@ -115,34 +211,34 @@ int checkHost(OMEGA::OceanState *DefState, OMEGA::OceanState *TestState,
 
 // Check for differences between layer thickness and normal velocity device
 // arrays
-int checkDevice(OMEGA::OceanState *DefState, OMEGA::OceanState *TestState,
-                int DefLevel, int TestLevel) {
+int checkDevice(OceanState *RefState, OceanState *TstState, int RefTimeLevel,
+                int TstTimeLevel) {
 
    int count1;
-   OMEGA::Array2DReal LayerThickness_def;
-   OMEGA::Array2DReal LayerThickness_test;
-   DefState->getLayerThickness(LayerThickness_def, DefLevel);
-   TestState->getLayerThickness(LayerThickness_test, TestLevel);
-   OMEGA::parallelReduce(
-       "reduce", {DefState->NCellsAll, DefState->NVertLevels},
+   Array2DReal LayerThicknessRef;
+   Array2DReal LayerThicknessTst;
+   RefState->getLayerThickness(LayerThicknessRef, RefTimeLevel);
+   TstState->getLayerThickness(LayerThicknessTst, TstTimeLevel);
+   parallelReduce(
+       "reduce", {RefState->NCellsAll, RefState->NVertLevels},
        KOKKOS_LAMBDA(int Cell, int Level, int &Accum) {
-          if (LayerThickness_def(Cell, Level) !=
-              LayerThickness_test(Cell, Level)) {
+          if (LayerThicknessRef(Cell, Level) !=
+              LayerThicknessTst(Cell, Level)) {
              Accum++;
           }
        },
        count1);
 
    int count2;
-   OMEGA::Array2DReal NormalVelocity_def;
-   OMEGA::Array2DReal NormalVelocity_test;
-   DefState->getNormalVelocity(NormalVelocity_def, DefLevel);
-   TestState->getNormalVelocity(NormalVelocity_test, TestLevel);
-   OMEGA::parallelReduce(
-       "reduce", {DefState->NCellsAll, DefState->NVertLevels},
+   Array2DReal NormalVelocityRef;
+   Array2DReal NormalVelocityTst;
+   RefState->getNormalVelocity(NormalVelocityRef, RefTimeLevel);
+   TstState->getNormalVelocity(NormalVelocityTst, TstTimeLevel);
+   parallelReduce(
+       "reduce", {RefState->NCellsAll, RefState->NVertLevels},
        KOKKOS_LAMBDA(int Cell, int Level, int &Accum) {
-          if (NormalVelocity_def(Cell, Level) !=
-              NormalVelocity_test(Cell, Level)) {
+          if (NormalVelocityRef(Cell, Level) !=
+              NormalVelocityTst(Cell, Level)) {
              Accum++;
           }
        },
@@ -164,181 +260,215 @@ int main(int argc, char *argv[]) {
    Kokkos::initialize();
    {
 
-      // Call initialization routine to create the default decomposition
+      // Call initialization routine to create default state and other
+      // quantities
       int Err = initStateTest();
       if (Err != 0)
          LOG_CRITICAL("State: Error initializing");
 
-      // Get MPI vars if needed
-      OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
-      MPI_Comm Comm          = DefEnv->getComm();
-      OMEGA::I4 MyTask       = DefEnv->getMyTask();
-      OMEGA::I4 NumTasks     = DefEnv->getNumTasks();
-      bool IsMaster          = DefEnv->isMasterTask();
+      // Get default mesh, halo and time data
+      HorzMesh *DefHorzMesh   = HorzMesh::getDefault();
+      Halo *DefHalo           = Halo::getDefault();
+      TimeStepper *DefStepper = TimeStepper::getDefault();
+      Clock *ModelClock       = DefStepper->getClock();
+      int NTimeLevelsDef      = DefStepper->getNTimeLevels();
 
-      OMEGA::HorzMesh *DefHorzMesh = OMEGA::HorzMesh::getDefault();
-      OMEGA::Decomp *DefDecomp     = OMEGA::Decomp::getDefault();
-      OMEGA::Halo *DefHalo         = OMEGA::Halo::getDefault();
+      // Test retrieval of the default state
+      OceanState *DefState = OceanState::getDefault();
+      int NVertLevels      = DefState->NVertLevels;
+      int NCellsAll        = DefState->NCellsAll;
+      int NEdgesAll        = DefState->NEdgesAll;
+      int CurTime          = 0;
+      int NewTime          = 1;
+      if (DefState and NVertLevels > 0) {
+         LOG_INFO("State: Default state retrieval PASS");
+      } else {
+         RetVal += 1;
+         LOG_INFO("State: Default state retrieval FAIL");
+      }
 
-      // These hard-wired variables need to be upated
-      // with retrivals/config options
-      int NVertLevels = 60;
-      int NTimeLevels = 2;
+      // Get default state arrays and check for reasonable values
+      HostArray2DReal LayerThickHDef;
+      HostArray2DReal NormalVelocityHDef;
+      Array2DReal LayerThickDef;
+      Array2DReal NormalVelocityDef;
+      DefState->getLayerThicknessH(LayerThickHDef, CurTime);
+      DefState->getLayerThickness(LayerThickDef, CurTime);
+      DefState->getNormalVelocityH(NormalVelocityHDef, CurTime);
+      DefState->getNormalVelocity(NormalVelocityDef, CurTime);
 
-      // Create dimensions (Horz dims computed in Mesh init)
-      auto VertDim = OMEGA::Dimension::create("NVertLevels", NVertLevels);
+      int Count1 = 0;
+      int Count2 = 0;
+      for (int Cell = 0; Cell < NCellsAll; Cell++) {
+         for (int Level = 0; Level < NVertLevels; Level++) {
+            R8 val = LayerThickHDef(Cell, Level);
+            if (val != 0.0)
+               ++Count1;                     // check for all-zero array
+            if (val < 0.0 and val > 300.0) { // out of range
+               Count2++;
+            }
+         }
+      }
+      if (Count2 == 0 and Count1 > 0) {
+         LOG_INFO("State: State read PASS");
+      } else {
+         RetVal += 1;
+         LOG_INFO("State: State read FAIL");
+         LOG_INFO("State: Out-of-range {} Non-zero: {}", Count2, Count1);
+      }
 
+      // Test time swapping with 2 and higher numbers of time levels
       for (int NTimeLevels = 2; NTimeLevels < 5; NTimeLevels++) {
 
-         int NewLevel = 1;
-         int CurLevel = 0;
+         // Create new reference and test states with the number of time levels
+         OceanState *RefState = OceanState::create(
+             "Reference", DefHorzMesh, DefHalo, NVertLevels, NTimeLevels);
+         OceanState *TstState = OceanState::create("Test", DefHorzMesh, DefHalo,
+                                                   NVertLevels, NTimeLevels);
 
-         // Create "default" state
-         if (NTimeLevels == 2) {
-
-            OMEGA::OceanState::init();
-            OMEGA::OceanState *DefOceanState = OMEGA::OceanState::getDefault();
-
-         } else {
-            OMEGA::OceanState *DefState = OMEGA::OceanState::create(
-                "Default", DefHorzMesh, DefHalo, NVertLevels, NTimeLevels);
-            DefState->loadStateFromFile(DefHorzMesh->MeshFileName, DefDecomp);
-         }
-
-         // Test retrieval of the default state
-         OMEGA::OceanState *DefState = OMEGA::OceanState::get("Default");
-         if (DefState) { // true if non-null ptr
-            LOG_INFO("State: Default state retrieval (NTimeLevels={}) PASS",
+         // Test successful creation
+         if (TstState and RefState) { // true if non-null ptr
+            LOG_INFO("State: Test state creation (NTimeLevels={}) PASS",
                      NTimeLevels);
          } else {
             RetVal += 1;
-            LOG_INFO("State: Default state retrieval (NTimeLevels={}) FAIL",
+            LOG_INFO("State: Test state creation (NTimeLevels={}) FAIL",
                      NTimeLevels);
          }
 
-         // Create "test" state
-         OMEGA::OceanState::create("Test", DefHorzMesh, DefHalo, NVertLevels,
-                                   NTimeLevels);
+         // Create test arrays
+         HostArray2DReal LayerThickHRef;
+         HostArray2DReal LayerThickHTst;
+         HostArray2DReal NormalVelocityHRef;
+         HostArray2DReal NormalVelocityHTst;
 
-         OMEGA::OceanState *TestState = OMEGA::OceanState::get("Test");
-
-         if (TestState) { // true if non-null ptr
-            LOG_INFO("State: Test state retrieval (NTimeLevels={}) PASS",
-                     NTimeLevels);
-         } else {
-            RetVal += 1;
-            LOG_INFO("State: Test state retrieval (NTimeLevels={}) FAIL",
-                     NTimeLevels);
-         }
-
-         // Initially fill test state with the same values as the default state
-         TestState->loadStateFromFile(DefHorzMesh->MeshFileName, DefDecomp);
-
-         // Test that reasonable values have been read in for LayerThickness
-         OMEGA::HostArray2DReal LayerThickH;
-         DefState->getLayerThicknessH(LayerThickH, CurLevel);
-         int count = 0;
-         for (int Cell = 0; Cell < DefState->NCellsAll; Cell++) {
-            int colCount = 0;
-            for (int Level = 0; Level < DefState->NVertLevels; Level++) {
-               OMEGA::R8 val = LayerThickH(Cell, Level);
-               if (val > 0.0 && val < 300.0) {
-                  colCount++;
-               }
+         // Fill reference and test states at current time with Default state
+         RefState->getLayerThicknessH(LayerThickHRef, CurTime);
+         TstState->getLayerThicknessH(LayerThickHTst, CurTime);
+         RefState->getNormalVelocityH(NormalVelocityHRef, CurTime);
+         TstState->getNormalVelocityH(NormalVelocityHTst, CurTime);
+         for (int Cell = 0; Cell < NCellsAll; Cell++) {
+            for (int Level = 0; Level < NVertLevels; Level++) {
+               LayerThickHRef(Cell, Level) = LayerThickHDef(Cell, Level);
+               LayerThickHTst(Cell, Level) = LayerThickHDef(Cell, Level);
             }
-            if (colCount < 2) {
-               count++;
+         }
+         for (int Edge = 0; Edge < NEdgesAll; Edge++) {
+            for (int Level = 0; Level < NVertLevels; Level++) {
+               NormalVelocityHRef(Edge, Level) =
+                   NormalVelocityHDef(Edge, Level);
+               NormalVelocityHTst(Edge, Level) =
+                   NormalVelocityHDef(Edge, Level);
+            }
+         }
+         RefState->copyToDevice(CurTime);
+         TstState->copyToDevice(CurTime);
+
+         // Fill reference and test states at next time levels with the
+         // Default state + 1
+         RefState->getLayerThicknessH(LayerThickHRef, NewTime);
+         TstState->getLayerThicknessH(LayerThickHTst, NewTime);
+         RefState->getNormalVelocityH(NormalVelocityHRef, NewTime);
+         TstState->getNormalVelocityH(NormalVelocityHTst, NewTime);
+         for (int Cell = 0; Cell < NCellsAll; Cell++) {
+            for (int Level = 0; Level < NVertLevels; Level++) {
+               LayerThickHRef(Cell, Level) = LayerThickHDef(Cell, Level) + 1;
+               LayerThickHTst(Cell, Level) = LayerThickHDef(Cell, Level) + 1;
             }
          }
 
-         if (count == 0) {
-            LOG_INFO("State: State read (NTimeLevels={}) PASS", NTimeLevels);
-         } else {
-            RetVal += 1;
-            LOG_INFO("State: State read (NTimeLevels={}) FAIL", NTimeLevels);
-         }
-
-         // Initialize NormalVelocity values
-         OMEGA::HostArray2DReal NormalVelocityHDef;
-         OMEGA::HostArray2DReal NormalVelocityHTest;
-         DefState->getNormalVelocityH(NormalVelocityHDef, CurLevel);
-         TestState->getNormalVelocityH(NormalVelocityHTest, CurLevel);
-         for (int Edge = 0; Edge < DefState->NEdgesAll; Edge++) {
-            for (int Level = 0; Level < DefState->NVertLevels; Level++) {
-               NormalVelocityHDef(Edge, Level)  = Edge;
-               NormalVelocityHTest(Edge, Level) = Edge;
+         for (int Edge = 0; Edge < NEdgesAll; Edge++) {
+            for (int Level = 0; Level < NVertLevels; Level++) {
+               NormalVelocityHRef(Edge, Level) =
+                   NormalVelocityHDef(Edge, Level) + 1;
+               NormalVelocityHTst(Edge, Level) =
+                   NormalVelocityHDef(Edge, Level) + 1;
             }
          }
-         DefState->exchangeHalo(CurLevel);
-         TestState->exchangeHalo(CurLevel);
+         RefState->copyToDevice(NewTime);
+         TstState->copyToDevice(NewTime);
 
-         // Test that initally the 0 time levels of the
-         // Def and Test state arrays match
-         int count1 = checkHost(DefState, TestState, CurLevel, CurLevel);
-         DefState->copyToDevice(CurLevel);
-         TestState->copyToDevice(CurLevel);
-         int count2 = checkDevice(DefState, TestState, CurLevel, CurLevel);
-
-         if (count1 + count2 == 0) {
-            LOG_INFO(
-                "State: Default test state comparison (NTimeLevels={}) PASS",
-                NTimeLevels);
-         } else {
-            RetVal += 1;
-            LOG_INFO(
-                "State: Default test state comparison (NTimeLevels={}) FAIL",
-                NTimeLevels);
+         // Check initial values
+         for (int N = 0; N <= 1; ++N) {
+            Count1 = checkHost(RefState, TstState, N, N);
+            Count2 = checkDevice(RefState, TstState, N, N);
+            if (Count1 == 0 and Count2 == 0) {
+               LOG_INFO(
+                   "State: State compare (TimeLevel {}, NTimeLevels {}) PASS",
+                   N, NTimeLevels);
+            } else {
+               RetVal += 1;
+               LOG_INFO(
+                   "State: State compare (TimeLevel {}, NTimeLevels {}) FAIL",
+                   N, NTimeLevels);
+            }
          }
 
-         // Perform time level update.
-         DefState->updateTimeLevels();
+         // Perform time level updates.
+         for (int N = 1; N < NTimeLevels; ++N) {
+            TstState->updateTimeLevels();
 
-         // Test that the time level update is correct.
-         // Time levels should be different after one update
-         count1 = checkHost(DefState, TestState, CurLevel, CurLevel);
-         count2 = checkDevice(DefState, TestState, CurLevel, CurLevel);
+            // The time index represents the n + Ith level so the new
+            // time n + 1 has index 1. Current time is 0. Previous
+            // times (n-1, n-2, etc.) are represented by negative indices
+            // (-1, -2, etc respectively) but cannot extend below
+            // -(NTimeLevels-2). After an update the time indices shift to
+            // one older level, but wraps around if they extend below the
+            // lower limit.
+            int CurTimeUpdate = CurTime - N;
+            int NewTimeUpdate = NewTime - N;
+            if (CurTimeUpdate < NTimeLevels - 2)
+               CurTimeUpdate += NTimeLevels;
+            if (NewTimeUpdate < NTimeLevels - 2)
+               NewTimeUpdate += NTimeLevels;
 
-         if (count1 + count2 != 0) {
-            LOG_INFO("State: time levels different after single update "
-                     "(NTimeLevels={}) PASS",
-                     NTimeLevels);
-         } else {
-            RetVal += 1;
-            LOG_INFO("State: time levels different after single update "
-                     "(NTimeLevels={}) FAIL",
-                     NTimeLevels);
+            // Check updated levels show up in the right place
+            Count1 = checkHost(RefState, TstState, CurTime, CurTimeUpdate);
+            Count2 = checkDevice(RefState, TstState, CurTime, CurTimeUpdate);
+
+            if (Count1 == 0 and Count2 == 0) {
+               LOG_INFO("State: NTimeLevels={} After update {} "
+                        "Current level: PASS",
+                        NTimeLevels, N);
+            } else {
+               RetVal += 1;
+               LOG_INFO("State: NTimeLevels={} After update {} "
+                        "Current level: FAIL",
+                        NTimeLevels, N);
+            }
+
+            Count1 = checkHost(RefState, TstState, NewTime, NewTimeUpdate);
+            Count2 = checkDevice(RefState, TstState, NewTime, NewTimeUpdate);
+
+            if (Count1 == 0 and Count2 == 0) {
+               LOG_INFO("State: NTimeLevels={} After update {} "
+                        "New time level: PASS",
+                        NTimeLevels, N);
+            } else {
+               RetVal += 1;
+               LOG_INFO("State: NTimeLevels={} After update {} "
+                        "New time level: FAIL",
+                        NTimeLevels, N);
+            }
          }
 
-         // Perform time level updates to cycle back to inital index
-         for (int i = 0; i < NTimeLevels - 1; i++) {
-            DefState->updateTimeLevels();
-         }
-
-         // Test that the time level update is correct.
-         // Time levels should be the same again
-         count1 = checkHost(DefState, TestState, CurLevel, CurLevel);
-         count2 = checkDevice(DefState, TestState, CurLevel, CurLevel);
-
-         if (count1 + count2 == 0) {
-            LOG_INFO("State: time level update (NTimeLevels={}) PASS",
-                     NTimeLevels);
-         } else {
-            RetVal += 1;
-            LOG_INFO("State: time level update (NTimeLevels={}) FAIL",
-                     NTimeLevels);
-         }
-
-         OMEGA::OceanState::clear();
+         // Erase the reference and test cases to prep for next cycle
+         OceanState::erase("Reference");
+         OceanState::erase("Test");
       }
 
       // Finalize Omega objects
-      OMEGA::TimeStepper::clear();
-      OMEGA::HorzMesh::clear();
-      OMEGA::Decomp::clear();
-      OMEGA::MachEnv::removeAll();
-      OMEGA::FieldGroup::clear();
-      OMEGA::Field::clear();
-      OMEGA::Dimension::clear();
+      OceanState::clear();
+      Tracers::clear();
+      AuxiliaryState::clear();
+      Tendencies::clear();
+      TimeStepper::clear();
+      HorzMesh::clear();
+      Decomp::clear();
+      MachEnv::removeAll();
+      FieldGroup::clear();
+      Field::clear();
+      Dimension::clear();
 
       if (RetVal == 0)
          LOG_INFO("State: Successful completion");

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -415,11 +415,12 @@ int main(int argc, char *argv[]) {
             // -(NTimeLevels-2). After an update the time indices shift to
             // one older level, but wraps around if they extend below the
             // lower limit.
+            int NMin          = -(NTimeLevels - 2);
             int CurTimeUpdate = CurTime - N;
             int NewTimeUpdate = NewTime - N;
-            if (CurTimeUpdate < NTimeLevels - 2)
+            if (CurTimeUpdate < NMin)
                CurTimeUpdate += NTimeLevels;
-            if (NewTimeUpdate < NTimeLevels - 2)
+            if (NewTimeUpdate < NMin)
                NewTimeUpdate += NTimeLevels;
 
             // Check updated levels show up in the right place

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -436,7 +436,7 @@ int main(int argc, char *argv[]) {
       count = 0;
 
       Array2DReal SaltTracerByName;
-      Err = Tracers::getByName(SaltTracerByName, 1, "Salt");
+      Err = Tracers::getByName(SaltTracerByName, 0, "Salinity");
 
       Array2DReal SaltTracerByIndexVar;
       Err = Tracers::getByIndex(SaltTracerByIndexVar, 1, Tracers::IndxSalt);

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -436,7 +436,7 @@ int main(int argc, char *argv[]) {
       count = 0;
 
       Array2DReal SaltTracerByName;
-      Err = Tracers::getByName(SaltTracerByName, 0, "Salinity");
+      Err = Tracers::getByName(SaltTracerByName, 1, "Salinity");
 
       Array2DReal SaltTracerByIndexVar;
       Err = Tracers::getByIndex(SaltTracerByIndexVar, 1, Tracers::IndxSalt);


### PR DESCRIPTION
IO Streams are now used for all data writing and the initialization of state and tracer fields in the ocean routines and some test drivers. It adds a writeAllStreams to the end of a step in the OceanRun routine and adds the reading of InitialState or Restart streams to initialize ocean data in OceanInit. When reading the Restart, it resets the current simulation time to match the input restart time. It also required some other changes to infrastructure routines, including:
* Modifying streams to use a clock pointer rather than clock reference
* Adding updates to Alarms when the clock setCurrentTime function is called
* Adding an updateMetadata function to modify an existing metadata field
* Adding Restart and Tracers field groups to match the input configuration file
* Modifying the default configuration input so that InitialState only reads Base tracers and State (for now)
This also includes the changes in #155 so will need to be rebased once that PR is merged.

This passes all unit tests on Chrysalis/Intel. It also writes proper files in some longer test runs, but I have not yet tested exact restart. Will be testing that soon in addition to other machines. Some additional documentation changes may still be needed.

Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [ ] Testing
  * [ ] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [ ] CTest unit tests for new features have been added per the approved design. 
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
  * [ ] Unit tests have passed. Please provide a relevant CDash build entry for verification.
  * [ ] Polaris test suite has passed
  * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.



