### PR TITLE
corrected paths for quick start: mesh symlinks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Checklist
   * [ ] Design document has been generated and added to the docs
   * [ ] User's Guide has been updated
   * [ ] Developer's Guide has been updated
-  * [ ] Documentation has been [built locally](https://e3sm-project.github.io/Omega/develop/devGuide/BuildDocs.html) and changes look as expected
+  * [ ] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
 * [ ] Testing
   * [ ] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
   * [ ] CTest unit tests for new features have been added per the approved design. 

--- a/components/omega/doc/devGuide/BuildDocs.md
+++ b/components/omega/doc/devGuide/BuildDocs.md
@@ -9,7 +9,7 @@ that you need to build the documentation.
 From the root of an Omega branch, run the following script to build the docs:
 
 ```bash
-cd components/omega/docs
+cd components/omega/doc
 make clean
 make html
 ```
@@ -17,5 +17,5 @@ make html
 You can view the documentation by opening `_build/html/index.html` in your
 choice of browser.
 
-If you run into errors or warnings related to changes you have meade when you
+If you run into errors or warnings related to changes you have made when you
 build the docs, check with the development team for help on fixing them.

--- a/components/omega/doc/devGuide/QuickStart.md
+++ b/components/omega/doc/devGuide/QuickStart.md
@@ -142,9 +142,11 @@ to be copied or linked to specifically named files under the `test` directory. A
 wget -O ocean_test_mesh.nc https://web.lcrc.anl.gov/public/e3sm/inputdata/ocn/mpas-o/oQU240/ocean.QU.240km.151209.nc
 wget -O global_test_mesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/polaris_cache/global_convergence/icos/cosine_bell/Icos480/init/initial_state.230220.nc
 wget -O planar_test_mesh.nc https://gist.github.com/mwarusz/f8caf260398dbe140d2102ec46a41268/raw/e3c29afbadc835797604369114321d93fd69886d/PlanarPeriodic48x48.nc
-ln -sf  ocean_test_mesh.nc test/OmegaMesh.nc
-ln -sf  global_test_mesh.nc test/OmegaSphereMesh.nc
-ln -sf  planar_test_mesh.nc test/OmegaPlanarMesh.nc
+cd test
+ln -sf  ../ocean_test_mesh.nc OmegaMesh.nc
+ln -sf  ../global_test_mesh.nc OmegaSphereMesh.nc
+ln -sf  ../planar_test_mesh.nc OmegaPlanarMesh.nc
+cd ..
 ```
 
 ### Running CTests


### PR DESCRIPTION
The Omega quick start guide had a minor mistake in the command for the meshes symlinks.
Correct syntax is:
```ln -sf  ../global_test_mesh.nc test/OmegaSphereMesh.nc```
or
```
cd test
ln -sf  ../global_test_mesh.nc OmegaSphereMesh.nc
```
I proposed the latter because of its readability.

Also corrected minor typos in BuildDocs
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [ ] Design document has been generated and added to the docs
  * [ ] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [ ] Testing
  * [ ] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [ ] CTest unit tests for new features have been added per the approved design. 
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
  * [ ] Unit tests have passed. Please provide a relevant CDash build entry for verification.
  * [ ] Polaris test suite has passed
  * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
* [ ] Stealth Features
  * [ ] If any stealth features are included in the PR, please confirm that they have been documented.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->