### PR TITLE
Copy certain coordinate arrays to the device

### DIFF
--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -690,6 +690,10 @@ void HorzMesh::copyToDevice() {
    WeightsOnEdge     = createDeviceMirrorCopy(WeightsOnEdgeH);
    FVertex           = createDeviceMirrorCopy(FVertexH);
    BottomDepth       = createDeviceMirrorCopy(BottomDepthH);
+   XCell             = createDeviceMirrorCopy(XCellH);
+   YCell             = createDeviceMirrorCopy(YCellH);
+   XEdge             = createDeviceMirrorCopy(XEdgeH);
+   YEdge             = createDeviceMirrorCopy(YEdgeH);
 
 } // end copyToDevice
 

--- a/components/omega/src/ocn/HorzMesh.h
+++ b/components/omega/src/ocn/HorzMesh.h
@@ -154,14 +154,22 @@ class HorzMesh {
 
    // Coordinates
 
+   Array1DReal XCell;        ///< X Coordinates of cell centers (m)
    HostArray1DReal XCellH;   ///< X Coordinates of cell centers (m)
+
+   Array1DReal YCell;        ///< Y Coordinates of cell centers (m)
    HostArray1DReal YCellH;   ///< Y Coordinates of cell centers (m)
+
    HostArray1DReal ZCellH;   ///< Z Coordinates of cell centers (m)
    HostArray1DReal LonCellH; ///< Longitude location of cell centers (radians)
    HostArray1DReal LatCellH; ///< Latitude location of cell centers (radians)
 
+   Array1DReal XEdge;        ///< X Coordinate of edge midpoints (m)
    HostArray1DReal XEdgeH;   ///< X Coordinate of edge midpoints (m)
+
+   Array1DReal YEdge;        ///< Y Coordinate of edge midpoints (m)
    HostArray1DReal YEdgeH;   ///< Y Coordinate of edge midpoints (m)
+
    HostArray1DReal ZEdgeH;   ///< Z Coordinate of edge midpoints (m)
    HostArray1DReal LonEdgeH; ///< Longitude location of edge midpoints (radians)
    HostArray1DReal LatEdgeH; ///< Latitude location of edge midpoints (radians)

--- a/components/omega/src/ocn/HorzMesh.h
+++ b/components/omega/src/ocn/HorzMesh.h
@@ -154,21 +154,21 @@ class HorzMesh {
 
    // Coordinates
 
-   Array1DReal XCell;        ///< X Coordinates of cell centers (m)
-   HostArray1DReal XCellH;   ///< X Coordinates of cell centers (m)
+   Array1DReal XCell;      ///< X Coordinates of cell centers (m)
+   HostArray1DReal XCellH; ///< X Coordinates of cell centers (m)
 
-   Array1DReal YCell;        ///< Y Coordinates of cell centers (m)
-   HostArray1DReal YCellH;   ///< Y Coordinates of cell centers (m)
+   Array1DReal YCell;      ///< Y Coordinates of cell centers (m)
+   HostArray1DReal YCellH; ///< Y Coordinates of cell centers (m)
 
    HostArray1DReal ZCellH;   ///< Z Coordinates of cell centers (m)
    HostArray1DReal LonCellH; ///< Longitude location of cell centers (radians)
    HostArray1DReal LatCellH; ///< Latitude location of cell centers (radians)
 
-   Array1DReal XEdge;        ///< X Coordinate of edge midpoints (m)
-   HostArray1DReal XEdgeH;   ///< X Coordinate of edge midpoints (m)
+   Array1DReal XEdge;      ///< X Coordinate of edge midpoints (m)
+   HostArray1DReal XEdgeH; ///< X Coordinate of edge midpoints (m)
 
-   Array1DReal YEdge;        ///< Y Coordinate of edge midpoints (m)
-   HostArray1DReal YEdgeH;   ///< Y Coordinate of edge midpoints (m)
+   Array1DReal YEdge;      ///< Y Coordinate of edge midpoints (m)
+   HostArray1DReal YEdgeH; ///< Y Coordinate of edge midpoints (m)
 
    HostArray1DReal ZEdgeH;   ///< Z Coordinate of edge midpoints (m)
    HostArray1DReal LonEdgeH; ///< Longitude location of edge midpoints (radians)


### PR DESCRIPTION
This tiny PR copies certain coordinate arrays (`XCell, YCell, XEdge, YEdge`) required for the test cases (e.g., the manufactured solution) to the device.

This could be incorporated into the manufactured solution PR; however, separating it for debugging and testing purposes would be more advantageous.

Passed unit tests on Frontier using both CPU and GPU.

* [x] Testing
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.