### PR TITLE
Pacer integration into Omega standalone driver

### DIFF
--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -66,13 +66,13 @@ if (NOT TARGET pacer)
     add_library(pacer ${E3SM_ROOT}/share/pacer/Pacer.cpp)
 
     target_include_directories(
-        pacer	
+        pacer
         PRIVATE
         ${E3SM_ROOT}/share/timing
     )
 
     target_link_libraries(
-        pacer	
+        pacer
         PUBLIC
         gptl
     )

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -56,9 +56,26 @@ endif()
 # Add E3SM GPTL library
 if (NOT TARGET gptl)
 	add_subdirectory(
-	  ${E3SM_EXTERNALS_ROOT}/../share/timing
+	  ${E3SM_ROOT}/share/timing
 	  ${CMAKE_CURRENT_BINARY_DIR}/gptl
 	)
+endif()
+
+# Add the Pacer library
+if (NOT TARGET pacer)
+    add_library(pacer ${E3SM_ROOT}/share/pacer/Pacer.cpp)
+
+    target_include_directories(
+        pacer	
+        PRIVATE
+        ${E3SM_ROOT}/share/timing
+    )
+
+    target_link_libraries(
+        pacer	
+        PUBLIC
+        gptl
+    )
 endif()
 
 # Add the parmetis and related libraries

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -53,6 +53,14 @@ if (NOT TARGET pioc)
 	)
 endif()
 
+# Add E3SM GPTL library
+if (NOT TARGET gptl)
+	add_subdirectory(
+	  ${E3SM_EXTERNALS_ROOT}/../share/timing
+	  ${CMAKE_CURRENT_BINARY_DIR}/gptl
+	)
+endif()
+
 # Add the parmetis and related libraries
 
 if(Parmetis_FOUND)

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -10,6 +10,8 @@ target_include_directories(
     ${OMEGA_SOURCE_DIR}/src/infra
     ${OMEGA_SOURCE_DIR}/src/ocn
     ${OMEGA_SOURCE_DIR}/src/timeStepping
+    ${E3SM_ROOT}/share/timing
+    ${E3SM_ROOT}/share/pacer
     ${PIOC_SOURCE_DIR}
     ${PIOC_BINARY_DIR}
     ${Parmetis_INCLUDE_DIRS}
@@ -45,6 +47,7 @@ target_link_libraries(
     parmetis
     metis
     gptl
+    pacer
 )
 
 if(GKlib_FOUND)

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
     yaml-cpp
     parmetis
     metis
+    gptl
 )
 
 if(GKlib_FOUND)

--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -10,7 +10,7 @@
 #include "TimeMgr.h"
 #include "TimeStepper.h"
 
-#include "mpi.h"
+#include <mpi.h>
 #include "Pacer.h"
 
 #include <iostream>

--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
    if (ErrCurr != 0)
       LOG_ERROR("Error initializing OMEGA");
    Pacer::stop("Init");
-   //
+
    // Get time information
    OMEGA::TimeStepper *DefStepper = OMEGA::TimeStepper::getDefault();
    OMEGA::Alarm *EndAlarm         = DefStepper->getEndAlarm();
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
    } else {
       LOG_ERROR("OMEGA terminating due to error");
    }
-   
+
    Pacer::print("omega");
    Pacer::finalize();
 

--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -10,8 +10,8 @@
 #include "TimeMgr.h"
 #include "TimeStepper.h"
 
-#include <mpi.h>
 #include "Pacer.h"
+#include <mpi.h>
 
 #include <iostream>
 

--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
    MPI_Init(&argc, &argv); // initialize MPI
    Kokkos::initialize();   // initialize Kokkos
    Pacer::initialize(MPI_COMM_WORLD);
-   Pacer::setPrefix("Omega");
+   Pacer::setPrefix("Omega:");
 
    Pacer::start("Init");
    ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD);

--- a/components/omega/test/drivers/StandaloneDriverTest.cpp
+++ b/components/omega/test/drivers/StandaloneDriverTest.cpp
@@ -17,6 +17,7 @@
 #include "TimeStepper.h"
 
 #include "mpi.h"
+#include "Pacer.h"
 
 //------------------------------------------------------------------------------
 // The test driver for the standalone driver
@@ -29,13 +30,17 @@ int main(int argc, char *argv[]) {
 
    MPI_Init(&argc, &argv); // initialize MPI
    Kokkos::initialize();   // initialize Kokkos
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
 
+   Pacer::start("Init");
    ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD);
    if (ErrCurr == 0) {
       LOG_INFO("DriverTest: Omega initialize PASS");
    } else {
       LOG_INFO("DriverTest: Omega initialize FAIL");
    }
+   Pacer::stop("Init");
 
    // Time management objects
    OMEGA::TimeStepper *DefStepper = OMEGA::TimeStepper::getDefault();
@@ -43,6 +48,7 @@ int main(int argc, char *argv[]) {
    OMEGA::Alarm *EndAlarm         = DefStepper->getEndAlarm();
    OMEGA::TimeInstant CurrTime    = ModelClock->getCurrentTime();
 
+   Pacer::start("RunLoop");
    if (ErrCurr == 0) {
       ErrCurr = OMEGA::ocnRun(CurrTime);
    }
@@ -51,18 +57,24 @@ int main(int argc, char *argv[]) {
    } else {
       LOG_INFO("DriverTest: Omega model run FAIL");
    }
+   Pacer::stop("RunLoop");
 
+   Pacer::start("Finalize");
    ErrFinalize = OMEGA::ocnFinalize(CurrTime);
    if (ErrFinalize == 0) {
       LOG_INFO("DriverTest: Omega finalize PASS");
    } else {
       LOG_INFO("DriverTest: Omega finalize FAIL");
    }
+   Pacer::stop("Finalize");
 
    ErrAll = abs(ErrCurr) + abs(ErrFinalize);
    if (ErrAll == 0) {
       LOG_INFO("DriverTest: Successful completion");
    }
+
+   Pacer::print("omega_driver_test");
+   Pacer::finalize();
 
    Kokkos::finalize();
    MPI_Finalize();

--- a/components/omega/test/drivers/StandaloneDriverTest.cpp
+++ b/components/omega/test/drivers/StandaloneDriverTest.cpp
@@ -16,8 +16,8 @@
 #include "TimeMgr.h"
 #include "TimeStepper.h"
 
-#include "mpi.h"
 #include "Pacer.h"
+#include <mpi.h>
 
 //------------------------------------------------------------------------------
 // The test driver for the standalone driver


### PR DESCRIPTION
This PR adds Pacer timing API and top-level timers to the standalone Omega driver. It includes CMake logic to build and link with Pacer and GPTL.

This PR depends on upstream E3SM PR: https://github.com/E3SM-Project/E3SM/pull/6772
So, we need to sync the Omega repo with upstream once the above PR is merged into E3SM. Then this PR brings in the timing functionality to Omega.

Checklist
* [X] Documentation and Testing: Additional details and testing with standalone driver on Frontier is at https://acme-climate.atlassian.net/wiki/spaces/OO/pages/4775346241/Pacer+timing+interface


