### PR TITLE
Adds a CF-compliant time dimension for Omega IO

### DIFF
--- a/components/omega/doc/devGuide/Field.md
+++ b/components/omega/doc/devGuide/Field.md
@@ -57,7 +57,8 @@ dimension list since it will be added during I/O. Fields that do not change
 with time should include this argument with the value false so that the time
 dimension is not added. Actual field data stored in an array is attached in a
 separate call as described below. Scalar fields can be added by setting the
-NumDims to zero (the DimNames is then ignored). Scalar data is attached using
+NumDims to zero (the Dimensions vector is ignored but an empty vector
+must still be supplied in the argument list). Scalar data is attached using
 a 1D array with size 1. Fields without a data array can be created with:
 ```c++
    std::shared_ptr<Field> MyField =

--- a/components/omega/doc/devGuide/Field.md
+++ b/components/omega/doc/devGuide/Field.md
@@ -39,7 +39,8 @@ Fields are created with standard metadata using
                  ValidMax,    ///< [in] max valid field value  field data)
                  FillValue,   ///< [in] scalar used for undefined entries
                  NumDims,     ///< [in] number of dimensions (int)
-                 Dimensions   ///< dim names for each dim (vector of strings)
+                 Dimensions,  ///< [in] dim names (vector of strings)
+                 InTimeDependent ///< [in] (opt, default true) if time varying
    );
 ```
 This interface enforces a list of required metadata. If a CF standard name does
@@ -49,8 +50,15 @@ for some intermediate calculations or unique analyses. If there is no
 restriction on valid range, an appropriately large range should be provided for
 the data type. Similarly, if a FillValue is not being used, a very unique
 number should be supplied to prevent accidentally treating valid data as a
-FillValue.  Actual field data stored in an array is attached in a separate
-call as described below. Fields without a data array can be created with:
+FillValue. The optional TimeDependent argument can be omitted and is assumed
+to be true by default. Fields with this attribute will be output with the
+unlimited time dimension added. Time should not be added explicitly in the
+dimension list since it will be added during I/O. Fields that do not change
+with time should include this argument with the value false so that the time
+dimension is not added. Actual field data stored in an array is attached in a
+separate call as described below. Scalar fields can be added by setting the
+NumDims to zero (the DimNames is then ignored). Scalar data is attached using
+a 1D array with size 1. Fields without a data array can be created with:
 ```c++
    std::shared_ptr<Field> MyField =
    Field::create(FieldName ///< [in] Name of field
@@ -108,9 +116,10 @@ captured correctly. If the location of the data changes (eg the time
 level changes and the pointer points to a different time slice), the data must
 be updated by calling the attach routine to replace the pointer to the new
 location. It is up to the developer to insert the appropriate call to reattach
-the data. The attach function primarily sets the pointer to the data location
-but it also sets the data type of the variable and its memory location using
-two enum classes:
+the data. As mentioned previously, scalar data should be attached using the
+appropriate 1D HostArray with a size of 1. The attach function primarily sets
+the pointer to the data location but it also sets the data type of the variable
+and its memory location using two enum classes:
 ```c++
 enum class FieldType {Unknown, I4, I8, R4, R8};
 enum class FieldMemLoc {Unknown, Device, Host, Both};
@@ -155,7 +164,15 @@ The dimension information can be retrieved using:
    int Err = MyField->getDimNames(MyDimNames);
 ```
 Once the dimension names have been retrieved, the Dimension class API can be
-used to extract further dimension information.
+used to extract further dimension information. Two other field quantities
+can be retrieved, but are used only by the IOStream capability:
+```c++
+   bool IsTimeDependent = MyField->isTimeDependent();
+   bool IsDistributed   = MyField->isDistributed();
+```
+The first determines whether the unlimited time dimension should be added
+during IO operations. The second determines whether any of the dimensions
+are distributed across MPI tasks so that parallel IO is required.
 
 The data and metadata stored in a field can be retrieved using several
 functions.  To retrieve a pointer to the full Field, use:

--- a/components/omega/src/base/IO.h
+++ b/components/omega/src/base/IO.h
@@ -50,6 +50,9 @@ namespace IO {
 /// ID for global metadata (ie metadata not associated with a variable)
 constexpr int GlobalID = PIO_GLOBAL;
 
+/// Length for unlimited dimensions
+constexpr int Unlimited = PIO_UNLIMITED;
+
 /// Choice of parallel IO rearranger algorithm
 enum Rearranger {
    RearrBox     = PIO_REARR_BOX,    ///< box rearranger (default)

--- a/components/omega/src/infra/Field.cpp
+++ b/components/omega/src/infra/Field.cpp
@@ -16,6 +16,7 @@
 #include "Field.h"
 #include "DataTypes.h"
 #include "Dimension.h"
+#include "IO.h"
 #include "Logging.h"
 #include <iostream>
 #include <map>
@@ -30,7 +31,8 @@ std::map<std::string, std::shared_ptr<FieldGroup>> FieldGroup::AllGroups;
 
 //------------------------------------------------------------------------------
 // Initializes the fields for global code and simulation metadata
-int Field::init() {
+int Field::init(const Clock *ModelClock // [in] default model clock
+) {
 
    int Err = 0;
 
@@ -38,6 +40,24 @@ int Field::init() {
    // code or the simulation/experiment
    std::shared_ptr<Field> CodeField = create(CodeMeta);
    std::shared_ptr<Field> SimField  = create(SimMeta);
+
+   // Define an unlimited time dimension for many time-dependent fields
+   // for CF-compliant output
+   std::shared_ptr<Dimension> TimeDim =
+       Dimension::create("time", IO::Unlimited);
+
+   // Define a time field with required metadata for CF-compliant output
+   // It is defined here as a scalar field but the time axis will be added
+   // during IO
+   TimeInstant StartTime    = ModelClock->getStartTime();
+   std::string StartTimeStr = StartTime.getString(4, 0, " ");
+   std::string UnitString   = "seconds since " + StartTimeStr;
+   CalendarKind CalKind     = Calendar::getKind();
+   std::string CalName      = CalendarCFName[CalKind];
+   std::vector<std::string> DimNames; // empty dim names vector
+   std::shared_ptr<Field> TimeField =
+       create("time", "time", UnitString, "time", 0.0, 1.e20, 0.0, 0, DimNames);
+   TimeField->addMetadata("calendar", CalName);
 
    return Err;
 }
@@ -70,7 +90,8 @@ Field::create(const std::string &FieldName,   // [in] Name of variable/field
               const std::any ValidMax,        // [in] max valid field value
               const std::any FillValue, // [in] scalar for undefined entries
               const int NumDims,        // [in] number of dimensions
-              const std::vector<std::string> &Dimensions // [in] dim names
+              const std::vector<std::string> &Dimensions, // [in] dim names
+              bool InTimeDependent // [in] flag for time dependent field
 ) {
 
    // Check to make sure a field of that name has not already been defined
@@ -107,16 +128,24 @@ Field::create(const std::string &FieldName,   // [in] Name of variable/field
    ThisField->FieldMeta["FillValue"]     = FillValue;
    ThisField->FieldMeta["_FillValue"]    = FillValue;
 
+   // Set the time-dependent flag
+   ThisField->TimeDependent = InTimeDependent;
+
    // Number of dimensions for the field
    ThisField->NDims = NumDims;
 
    // Dimension names for retrieval of dimension info
    // These must be in the same index order as the stored data
+   // Also determine whether this is a distributed field - true if any of
+   // the dimensions are distributed.
+   ThisField->Distributed = false;
    ThisField->DimNames;
    if (NumDims > 0) {
       ThisField->DimNames.resize(NumDims);
       for (int I = 0; I < NumDims; ++I) {
          ThisField->DimNames[I] = Dimensions[I];
+         if (Dimension::isDistributedDim(Dimensions[I]))
+            ThisField->Distributed = true;
       }
    }
 
@@ -299,6 +328,17 @@ bool Field::isFieldOnHost(const std::string &FieldName // [in] name of field
 //------------------------------------------------------------------------------
 // Returns the number of dimensions for the field
 int Field::getNumDims() const { return NDims; }
+
+//------------------------------------------------------------------------------
+// Determines whether the field is time dependent and requires the unlimited
+// time dimension during IO
+bool Field::isTimeDependent() const { return TimeDependent; }
+
+//------------------------------------------------------------------------------
+// Determinse whether a field is distributed across tasks or whether a copy
+// is entirely local. This is needed to determine whether a parallel IO or
+// a non-distributed IO will be used.
+bool Field::isDistributed() const { return Distributed; }
 
 //------------------------------------------------------------------------------
 // Returns a vector of dimension names associated with each dimension

--- a/components/omega/src/infra/Field.cpp
+++ b/components/omega/src/infra/Field.cpp
@@ -91,7 +91,7 @@ Field::create(const std::string &FieldName,   // [in] Name of variable/field
               const std::any FillValue, // [in] scalar for undefined entries
               const int NumDims,        // [in] number of dimensions
               const std::vector<std::string> &Dimensions, // [in] dim names
-              bool InTimeDependent // [in] flag for time dependent field
+              bool TimeDependent // [in] flag for time dependent field
 ) {
 
    // Check to make sure a field of that name has not already been defined
@@ -129,7 +129,7 @@ Field::create(const std::string &FieldName,   // [in] Name of variable/field
    ThisField->FieldMeta["_FillValue"]    = FillValue;
 
    // Set the time-dependent flag
-   ThisField->TimeDependent = InTimeDependent;
+   ThisField->TimeDependent = TimeDependent;
 
    // Number of dimensions for the field
    ThisField->NDims = NumDims;

--- a/components/omega/src/infra/Field.cpp
+++ b/components/omega/src/infra/Field.cpp
@@ -55,8 +55,8 @@ int Field::init(const Clock *ModelClock // [in] default model clock
    CalendarKind CalKind     = Calendar::getKind();
    std::string CalName      = CalendarCFName[CalKind];
    std::vector<std::string> DimNames; // empty dim names vector
-   std::shared_ptr<Field> TimeField =
-       create("time", "time", UnitString, "time", 0.0, 1.e20, 0.0, 0, DimNames);
+   std::shared_ptr<Field> TimeField = create("time", "time", UnitString, "time",
+                                             0.0, 1.e20, -9.99e30, 0, DimNames);
    TimeField->addMetadata("calendar", CalName);
 
    return Err;

--- a/components/omega/src/infra/Field.h
+++ b/components/omega/src/infra/Field.h
@@ -154,7 +154,7 @@ class Field {
           const std::any FillValue,       ///< [in] scalar for undefined entries
           const int NumDims,              ///< [in] number of dimensions
           const std::vector<std::string> &Dimensions, ///< [in] dim names
-          const bool InTimeDependent = true ///< [in] opt flag for unlim time
+          const bool TimeDependent = true ///< [in] opt flag for unlim time
    );
 
    //---------------------------------------------------------------------------

--- a/components/omega/src/infra/IOStream.h
+++ b/components/omega/src/infra/IOStream.h
@@ -84,11 +84,17 @@ class IOStream {
    /// Computes the parallel decomposition (offsets) for a field.
    /// Needed for parallel I/O
    int computeDecomp(
-       std::shared_ptr<Field> FieldPtr,       ///< [in] field
-       std::map<std::string, int> &AllDimIDs, ///< [in] dimension IDs
+       std::shared_ptr<Field> FieldPtr, ///< [in] field
        int &DecompID, ///< [out] ID assigned to the defined decomposition
        I4 &LocalSize, ///< [out] size of the local array for this field
        std::vector<int> &DimLengths // [out] local dim lengths
+   );
+
+   /// Retrieves field size information for non-distributed fields
+   /// (distributed fields get this info from computeDecomp)
+   void getFieldSize(std::shared_ptr<Field> FieldPtr, ///< [in] field
+                     I4 &LocalSize, ///< [out] size of the local array
+                     std::vector<int> &DimLengths ///< [out] local dim lengths
    );
 
    /// Private function that performs most of the stream read - called by the

--- a/components/omega/src/infra/TimeMgr.h
+++ b/components/omega/src/infra/TimeMgr.h
@@ -82,6 +82,11 @@ const std::string CalendarKindName[NUM_SUPPORTED_CALENDARS] = {
     "Gregorian", "No Leap", "Julian",      "Julian Day", "Modified Julian Day",
     "360 Day",   "Custom",  "No Calendar", "Invalid"};
 
+/// Standard CF-compliant name associated with each supported calendar type
+const std::string CalendarCFName[NUM_SUPPORTED_CALENDARS] = {
+    "gregorian", "noleap", "julian", "julian_day", "modified_julian_day",
+    "360_day",   "custom", "none",   "invalid"};
+
 /// The TimeFrac class includes the core representation, functions and
 /// operators for time within OMEGA.
 ///

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -91,7 +91,7 @@ int initOmegaModules(MPI_Comm Comm) {
       return Err;
    }
 
-   Err = Field::init();
+   Err = Field::init(ModelClock);
    if (Err != 0) {
       LOG_CRITICAL("ocnInit: Error initializing Fields");
       return Err;

--- a/components/omega/test/infra/FieldTest.cpp
+++ b/components/omega/test/infra/FieldTest.cpp
@@ -18,6 +18,7 @@
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
+#include "TimeMgr.h"
 #include "mpi.h"
 #include <vector>
 
@@ -128,8 +129,13 @@ int initFieldTest() {
    std::shared_ptr<Dimension> StuffDim =
        Dimension::create("NStuff", NVertLevels);
 
+   // Create a model clock for time info
+   TimeInstant SimStartTime(0001, 1, 1, 0, 0, 0.0);
+   TimeInterval TimeStep(2, TimeUnits::Hours);
+   Clock *ModelClock = new Clock(SimStartTime, TimeStep);
+
    // Initialize Field class - creates Model and Sim metadata fields
-   int Err1 = Field::init();
+   int Err1 = Field::init(ModelClock);
    TstEval<int>("Field initialization", Err1, ErrRef, Err);
 
    // Add some global (Model and Simulation) metadata

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -95,12 +95,22 @@ int initIOStreamTest(Clock *&ModelClock // Model clock
    Decomp::init();
    Decomp *DefDecomp = Decomp::getDefault();
 
+   // Initialize time stepper for time levels and clock
+   Err1 = TimeStepper::init1();
+   TestEval("Ocean time step initialization", Err1, ErrRef, Err);
+
    // Initialize Halo updates
    Halo::init();
    OMEGA::Halo *DefHalo = OMEGA::Halo::getDefault();
 
+   // Override the input time stepper clock with a clock more suitable
+   // for testing streams
+   TimeInstant SimStartTime(0001, 1, 1, 0, 0, 0.0);
+   TimeInterval TimeStep(2, TimeUnits::Hours);
+   ModelClock = new Clock(SimStartTime, TimeStep);
+
    // Initialize Field
-   Err1 = Field::init();
+   Err1 = Field::init(ModelClock);
    TestEval("IO Field initialization", Err1, ErrRef, Err);
 
    // Initialize IOStreams
@@ -211,7 +221,6 @@ int main(int argc, char **argv) {
       TimeInstant StopTime(0002, 1, 1, 0, 0, 0.0);
       Alarm StopAlarm("Stop Time", StopTime);
       Err1 = ModelClock->attachAlarm(&StopAlarm);
-      TestEval("Attach stop alarm", Err1, ErrRef, Err);
 
       // Overwrite
       // Step forward in time and write files if it is time

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -95,19 +95,9 @@ int initIOStreamTest(Clock *&ModelClock // Model clock
    Decomp::init();
    Decomp *DefDecomp = Decomp::getDefault();
 
-   // Initialize time stepper for time levels and clock
-   Err1 = TimeStepper::init1();
-   TestEval("Ocean time step initialization", Err1, ErrRef, Err);
-
    // Initialize Halo updates
    Halo::init();
    OMEGA::Halo *DefHalo = OMEGA::Halo::getDefault();
-
-   // Override the input time stepper clock with a clock more suitable
-   // for testing streams
-   TimeInstant SimStartTime(0001, 1, 1, 0, 0, 0.0);
-   TimeInterval TimeStep(2, TimeUnits::Hours);
-   ModelClock = new Clock(SimStartTime, TimeStep);
 
    // Initialize Field
    Err1 = Field::init(ModelClock);

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -77,7 +77,7 @@ int initStateTest() {
    }
 
    // Initialize Field infrastructure
-   Err = Field::init();
+   Err = Field::init(ModelClock);
    if (Err != 0) {
       LOG_CRITICAL("State: Error initializing Fields");
       return Err;


### PR DESCRIPTION
Adds a CF-compliant unlimited time dimension
    
      - adds support for an unlimited time dimension
      - adds the CF-compliant time field with appropriate units
      - adds additional Field properties to support time-dependent fields
      - extends the support for non-distributed field IO into IOStream
      - updates documentation

This still only supports one time slice per file. A subsequent modification will add support for multiple slices in a file. 

No additional unit tests were added, but I have manually confirmed the fields and dimensions appear correctly in the output files. Additional tests will be added as part of the upcoming multi-slice capability.

Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.



