### PR TITLE
fixes reading dimensions for Omega decomposition and unused dimensions

### DIFF
--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -331,7 +331,8 @@ int getDimFromFile(int FileID, // [in] ID of the file containing dim
    // First get the dimension ID
    Err = PIOc_inq_dimid(FileID, DimName.c_str(), &DimID);
    if (Err != PIO_NOERR) {
-      LOG_ERROR("PIO error while reading dimension {} ", DimName);
+      // Dimension missing in file - return error but let calling routine
+      // decide how to respond
       return Err;
    }
 
@@ -701,7 +702,8 @@ int readArray(void *Array,                // [out] array to be read
    // Find variable ID from file
    Err = PIOc_inq_varid(FileID, VarName.c_str(), &VarID);
    if (Err != PIO_NOERR) {
-      LOG_ERROR("IO::readArray: Error finding varid for variable {}", VarName);
+      // Variable not in file. Return error but let calling routine decide
+      // how to respond
       return Err;
    }
 

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -659,15 +659,12 @@ int IOStream::defineAllDims(
          if (Err != 0) { // can't find dim in file
             // Try again using old name for back compatibility to MPAS
             Err = IO::getDimFromFile(FileID, OldDimName, DimID, InLength);
-            if (Err == 0) {
-               LOG_INFO("Ignore PIO Error for Dimension {}: ", DimName);
-               LOG_INFO("Found under old dimension name {}: ", OldDimName);
-            } else {
-               if (Err != 0)
-                  LOG_WARN("Dimension {} not found in input stream {}", DimName,
-                           Name);
-            }
-            continue;
+            // If still not found, we skip this dimension, assuming it
+            // is not used for any variables to be read from the file. A later
+            // error check will catch any case where the dimension is actually
+            // needed but missing.
+            if (Err != 0)
+               continue;
          }
          // Check dimension length in input file matches what is expected
          if (InLength != Length) {
@@ -1730,10 +1727,7 @@ int IOStream::readFieldData(
       } else {
          Err = IO::readNDVar(DataPtr, OldFieldName, FileID, FieldID);
       }
-      if (Err == 0) {
-         LOG_INFO("Ignore PIO error for field {} ", FieldName);
-         LOG_INFO("Found field under old name {} ", OldFieldName);
-      } else {
+      if (Err != 0) { // still not found - return error
          LOG_ERROR("Error reading data array for {} in stream {}", FieldName,
                    Name);
          return Err;


### PR DESCRIPTION
The original Decomp read only legacy MPAS mesh files with older dimension/variable names. This adds support for the newer names in Omega conventions.  Additional changes modify the behavior when missing variables or dimensions are encountered. Defined dimensions that are missing or unused in input files are ignored during the file read. Also, error or warning messages for missing dimensions or variables at the base IO level are now suppressed and the error is passed to the calling routine to determine the proper behavior. This eliminates warnings for harmless situations that can cause confusion and unnecessary output in the log file.

All unit tests pass on Chrysalis/Intel.

Checklist
* [ ] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
  * [ ] Polaris test suite has passed

fixes #172, fixes #173


