### PR TITLE
Added return codes to IOStream for better managing missing/skipped streams

### DIFF
--- a/components/omega/src/infra/IOStream.h
+++ b/components/omega/src/infra/IOStream.h
@@ -168,6 +168,13 @@ class IOStream {
 
  public:
    //---------------------------------------------------------------------------
+   /// Return codes - these will be removed once Error Handler is completed
+
+   static constexpr int Success{0}; ///< Successful read/write completion
+   static constexpr int Skipped{1}; ///< Normal early return (eg if not time)
+   static constexpr int Fail{2};    ///< Fail
+
+   //---------------------------------------------------------------------------
    /// Default empty constructor
    IOStream();
 

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -192,7 +192,7 @@ int main(int argc, char **argv) {
       // Read restart file for initial temperature and salinity data
       Metadata ReqMetadata; // leave empty for now - no required metadata
       Err1 = IOStream::read("InitialState", ModelClock, ReqMetadata);
-      TestEval("Read restart file", Err1, ErrRef, Err);
+      TestEval("Read restart file", Err1, IOStream::Success, Err);
 
       // Overwrite salinity array with values associated with global cell
       // ID to test proper indexing of IO
@@ -230,7 +230,7 @@ int main(int argc, char **argv) {
       std::this_thread::sleep_for(std::chrono::seconds(5));
       bool ForceRead = true;
       Err1 = IOStream::read("RestartRead", ModelClock, ReqMetadata, ForceRead);
-      TestEval("Restart force read", Err1, ErrRef, Err);
+      TestEval("Restart force read", Err1, IOStream::Success, Err);
 
       Err1             = 0;
       auto DataReducer = Kokkos::Sum<I4>(Err1);

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -161,7 +161,7 @@ int initStateTest() {
    // Read the state variables from the initial state stream
    Metadata ReqMeta; // no global metadata needed for init state read
    Err = IOStream::read("InitialState", ModelClock, ReqMeta);
-   if (!StreamsValid) {
+   if (Err != IOStream::Success) {
       LOG_CRITICAL("ocnInit: Error reading initial state from stream");
       return Err;
    }


### PR DESCRIPTION
This is a short-term fix to address problems with missing or skipped streams. It will be replaced once the Error Handler capabilities are implemented.  It adds return codes so that calling routines can determine how to handle errors and removes the critical error when a stream is missing.

Checklist
* [ ] Documentation:
  * [ ] Developer's Guide has been updated
* [ ] Testing
  * [ ] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [ ] CTest unit tests for new features have been added per the approved design. 
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
  * [ ] Unit tests have passed. Please provide a relevant CDash build entry for verification.
  * [ ] Polaris test suite has passed

Fixes #175 , Fixes #181 
