### PR TITLE
Fix segfault and other issues in time stepper test

### DIFF
--- a/components/omega/src/base/Halo.h
+++ b/components/omega/src/base/Halo.h
@@ -273,11 +273,10 @@ class Halo {
    /// neighboring task and pack them into the proper send buffer for
    /// that Neighbor.
    template <typename T>
-   typename std::enable_if_t<ArrayRank<T>::Is1D, int>
+   std::enable_if_t<ArrayRank<T>::Is1D>
    packBuffer(const T &Array,      // 1D Kokkos array of any type
               const I4 CurNeighbor // current neighbor
    ) {
-      I4 Err = 0;
 
       OMEGA_SCOPE(LocList, Neighbors[CurNeighbor].SendLists[CurElem]);
       OMEGA_SCOPE(LocNeighbor, Neighbors[CurNeighbor]);
@@ -301,16 +300,13 @@ class Halo {
             LocBuffH(IExch) = RVal;
          }
       }
-
-      return Err;
    }
 
    template <typename T>
-   typename std::enable_if_t<ArrayRank<T>::Is2D, int>
+   std::enable_if_t<ArrayRank<T>::Is2D>
    packBuffer(const T &Array,      // 2D Kokkos array of any type
               const I4 CurNeighbor // current neighbor
    ) {
-      I4 Err = 0;
 
       OMEGA_SCOPE(LocList, Neighbors[CurNeighbor].SendLists[CurElem]);
       OMEGA_SCOPE(LocNeighbor, Neighbors[CurNeighbor]);
@@ -342,15 +338,13 @@ class Halo {
             }
          }
       }
-      return Err;
    }
 
    template <typename T>
-   typename std::enable_if_t<ArrayRank<T>::Is3D, int>
+   std::enable_if_t<ArrayRank<T>::Is3D>
    packBuffer(const T &Array,      // 3D Kokkos array of any type
               const I4 CurNeighbor // current neighbor
    ) {
-      I4 Err = 0;
 
       OMEGA_SCOPE(LocList, Neighbors[CurNeighbor].SendLists[CurElem]);
       OMEGA_SCOPE(LocNeighbor, Neighbors[CurNeighbor]);
@@ -387,15 +381,13 @@ class Halo {
             }
          }
       }
-      return Err;
    }
 
    template <typename T>
-   typename std::enable_if_t<ArrayRank<T>::Is4D, int>
+   std::enable_if_t<ArrayRank<T>::Is4D>
    packBuffer(const T &Array,      // 4D Kokkos array of any type
               const I4 CurNeighbor // current neighbor
    ) {
-      I4 Err = 0;
 
       OMEGA_SCOPE(LocList, Neighbors[CurNeighbor].SendLists[CurElem]);
       OMEGA_SCOPE(LocNeighbor, Neighbors[CurNeighbor]);
@@ -437,15 +429,13 @@ class Halo {
             }
          }
       }
-      return Err;
    }
 
    template <typename T>
-   typename std::enable_if_t<ArrayRank<T>::Is5D, int>
+   std::enable_if_t<ArrayRank<T>::Is5D>
    packBuffer(const T &Array,      // 5D Kokkos array of any type
               const I4 CurNeighbor // current neighbor
    ) {
-      I4 Err = 0;
 
       OMEGA_SCOPE(LocList, Neighbors[CurNeighbor].SendLists[CurElem]);
       OMEGA_SCOPE(LocNeighbor, Neighbors[CurNeighbor]);
@@ -492,7 +482,6 @@ class Halo {
             }
          }
       }
-      return Err;
    }
 
    /// Buffer unpack specialized function templates for supported Kokkos array
@@ -500,11 +489,10 @@ class Halo {
    /// elements of the proper receive buffer for that Neighbor into the
    /// corresponding halo elements of the input Array
    template <typename T>
-   typename std::enable_if_t<ArrayRank<T>::Is1D, int>
+   std::enable_if_t<ArrayRank<T>::Is1D>
    unpackBuffer(const T &Array,      // 1D Kokkos array of any type
                 const I4 CurNeighbor // current neighbor
    ) {
-      I4 Err = 0;
 
       using ValType = typename T::non_const_value_type;
 
@@ -527,16 +515,13 @@ class Halo {
             Array(IArr)   = reinterpret_cast<ValType &>(LocBuffH(IExch));
          }
       }
-
-      return Err;
    }
 
    template <typename T>
-   typename std::enable_if_t<ArrayRank<T>::Is2D, int>
+   std::enable_if_t<ArrayRank<T>::Is2D>
    unpackBuffer(const T &Array,      // 2D Kokkos array of any type
                 const I4 CurNeighbor // current neighbor
    ) {
-      I4 Err = 0;
 
       using ValType = typename T::non_const_value_type;
 
@@ -566,16 +551,13 @@ class Halo {
             }
          }
       }
-
-      return Err;
    }
 
    template <typename T>
-   typename std::enable_if_t<ArrayRank<T>::Is3D, int>
+   std::enable_if_t<ArrayRank<T>::Is3D>
    unpackBuffer(const T &Array,      // 3D Kokkos array of any type
                 const I4 CurNeighbor // current neighbor
    ) {
-      I4 Err = 0;
 
       using ValType = typename T::non_const_value_type;
 
@@ -611,16 +593,13 @@ class Halo {
             }
          }
       }
-
-      return Err;
    }
 
    template <typename T>
-   typename std::enable_if_t<ArrayRank<T>::Is4D, int>
+   std::enable_if_t<ArrayRank<T>::Is4D>
    unpackBuffer(const T &Array,      // 4D Kokkos array of any type
                 const I4 CurNeighbor // current neighbor
    ) {
-      I4 Err = 0;
 
       using ValType = typename T::non_const_value_type;
 
@@ -662,16 +641,13 @@ class Halo {
             }
          }
       }
-
-      return Err;
    }
 
    template <typename T>
-   typename std::enable_if_t<ArrayRank<T>::Is5D, int>
+   std::enable_if_t<ArrayRank<T>::Is5D>
    unpackBuffer(const T &Array,      // 5D Kokkos array of any type
                 const I4 CurNeighbor // current neighbor
    ) {
-      I4 Err = 0;
 
       using ValType = typename T::non_const_value_type;
 
@@ -718,8 +694,6 @@ class Halo {
             }
          }
       }
-
-      return Err;
    }
 
    //---------------------------------------------------------------------------

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -53,8 +53,8 @@ void RungeKutta4Stepper::finalizeInit() {
    int NCellsSize  = Mesh->NCellsSize;
    int NTimeLevels = 1; // for provisional tracer
 
-   ProvisState =
-       OceanState::create("Provis", Mesh, MeshHalo, NVertLevels, NTimeLevels);
+   ProvisState = OceanState::create("Provis" + Name, Mesh, MeshHalo,
+                                    NVertLevels, NTimeLevels);
    if (!ProvisState)
       LOG_CRITICAL("Error creating Provis state");
 

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -172,6 +172,9 @@ int initTimeStepperTest(const std::string &mesh) {
       return Err;
    }
 
+   // Horz dimensions will be created in HorzMesh
+   auto VertDim = Dimension::create("NVertLevels", NVertLevels);
+
    // Note that the default time stepper is not used in subsequent tests
    // but is initialized here because the number of time levels is needed
    // to initialize the Tracers. If a later timestepper test uses more time
@@ -242,9 +245,6 @@ int initTimeStepperTest(const std::string &mesh) {
 
    auto *DefMesh = HorzMesh::getDefault();
    auto *DefHalo = Halo::getDefault();
-
-   // Horz dimensions created in HorzMesh
-   auto VertDim = Dimension::create("NVertLevels", NVertLevels);
 
    int NTracers          = Tracers::getNumTracers();
    const int NTimeLevels = 2;

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -151,10 +151,24 @@ int initTimeStepperTest(const std::string &mesh) {
    initLogging(DefEnv);
 
    // Open config file
-   OMEGA::Config("Omega");
-   Err = OMEGA::Config::readAll("omega.yml");
+   Config("Omega");
+   Err = Config::readAll("omega.yml");
    if (Err != 0) {
       LOG_CRITICAL("TimeStepperTest: Error reading config file");
+      return Err;
+   }
+
+   // Reset NVertLevels to 1 regardless of config value
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config DimConfig("Dimension");
+   Err = OmegaConfig->get(DimConfig);
+   if (Err != 0) {
+      LOG_CRITICAL("TimeStepperTest: Dimension group not found in Config");
+      return Err;
+   }
+   Err = DimConfig.set("NVertLevels", NVertLevels);
+   if (Err != 0) {
+      LOG_CRITICAL("TimeStepperTest: Unable to reset NVertLevels in Config");
       return Err;
    }
 

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -212,6 +212,12 @@ int initTimeStepperTest(const std::string &mesh) {
       LOG_ERROR("TimeStepperTest: error initializing tracers infrastructure");
    }
 
+   int AuxStateErr = AuxiliaryState::init();
+   if (AuxStateErr != 0) {
+      Err++;
+      LOG_ERROR("TimeStepperTest: error initializing default aux state");
+   }
+
    Err = Tendencies::init();
    if (Err != 0) {
       LOG_CRITICAL("Error initializing default tendencies");


### PR DESCRIPTION
This PR fixes a couple of issues in the time stepper test:
- Since this test assumes one vertical level, the config value of `NVertLevels` needs to be reset to 1.
- The default time stepper needs to be initialized in this test, even though it is not used. In order for it to be initialized properly the default auxiliary state needs to be initialized also.
- If two different RK4 steppers are created their provisional states need to have different names.

Unfortunately, fixing these issues does not fix the segfault on pm-gpu with gnugpu. It appears that this segfault is caused by a compiler bug. The final commit in this PR is a workaround, which fixes the segfault by removing error codes from the halo pack and unpack functions. I think this is acceptable, because there wasn't any error handling in those functions.  
 
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [] Testing
  * [] Unit tests have passed. Please provide a relevant CDash build entry for verification.
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

Aside from #183, every test is passing on pm-gpu.


