### PR TITLE
Fix reductions ctest for nvidia on perlmutter

### DIFF
--- a/components/omega/test/base/ReductionsTest.cpp
+++ b/components/omega/test/base/ReductionsTest.cpp
@@ -288,8 +288,8 @@ int main(int argc, char *argv[]) {
       // test MIN, MAX of arrays
       HostArray1DI4 HostA1DI4Work("HostA1DI4Work", NumCells * MySize);
       HostArray1DI4 HostA1DI4Min("HostA1DI4Min", NumCells * MySize);
-      for (i = 0; i < MySize; i++) {
-         for (j = 0; j < NumCells; j++) {
+      for (j = 0; j < NumCells; j++) {
+         for (i = 0; i < MySize; i++) {
             k = i * NumCells + j;
             if (MyTask == i) {
                HostA1DI4Work(k) = (i + 1) * k; // processor-specific work array


### PR DESCRIPTION
Release build with -O2 flag (from E3SM) incorrectly optimized out inner-loop if-true-stmt.
This re-orders for-loops to prevent branch prediction.

Fixes E3SM-Project/Omega#161

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


