### PR TITLE
Adds retrievals for some Alarm members in Omega TimeMgr

### DIFF
--- a/components/omega/doc/devGuide/TimeMgr.md
+++ b/components/omega/doc/devGuide/TimeMgr.md
@@ -159,15 +159,23 @@ is set as the new ring time:
 ```c++
 SingleAlarm.reset(NewAlarmTime);
 ```
-If the Alarm is periodic, the new ring time will be set to the next interval
-boundary after the input time:
+If the Alarm is periodic, the ringing will be switched off as above and the
+new ring time will be set to the next interval boundary after the input time.
+The interval boundary is an integer number of intervals after the start time
+provided on Alarm creation.
 ```c++
 PeriodicAlarm.reset(CurrentTime);
 ```
-This Alarm will ring next at `CurrentTime + AlarmInterval`. An Alarm can be
-permanently stopped using the `stop` method:
+An Alarm can be permanently stopped using the `stop` method:
 ```c++
 SingleAlarm.stop();
+```
+It is sometimes useful to retrieve other aspects of a periodic Alarm, namely
+the Alarm interval and the last time the Alarm was ringing. Two retrieval
+functions are provided that return const pointers to these values:
+```c++
+const TimeInterval *AlarmInterval = PeriodicAlarm.getInterval();
+const TimeInstant *PriorRingTime = PeriodicAlarm.getRingTimePrev();
 ```
 
 ### 6. Clock

--- a/components/omega/src/infra/TimeMgr.cpp
+++ b/components/omega/src/infra/TimeMgr.cpp
@@ -48,6 +48,39 @@
 namespace OMEGA {
 
 //------------------------------------------------------------------------------
+// Utility function to extract time units from a string
+TimeUnits TimeUnitsFromString(
+    const std::string TimeUnitString ///< string describing time units
+) {
+
+   // First convert to lower case for easier comparison
+   std::string CompStr = TimeUnitString;
+   std::transform(CompStr.begin(), CompStr.end(), CompStr.begin(),
+                  [](unsigned char C) { return std::tolower(C); });
+
+   // Now convert the string to the associated enum TimeUnit
+
+   if (CompStr == "year" or CompStr == "years" or CompStr == "nyears") {
+      return TimeUnits::Years;
+   } else if (CompStr == "month" or CompStr == "months" or
+              CompStr == "nmonths") {
+      return TimeUnits::Months;
+   } else if (CompStr == "day" or CompStr == "days" or CompStr == "ndays") {
+      return TimeUnits::Days;
+   } else if (CompStr == "hour" or CompStr == "hours" or CompStr == "nhours") {
+      return TimeUnits::Hours;
+   } else if (CompStr == "minute" or CompStr == "minutes" or
+              CompStr == "nminutes") {
+      return TimeUnits::Minutes;
+   } else if (CompStr == "second" or CompStr == "seconds" or
+              CompStr == "nseconds") {
+      return TimeUnits::Seconds;
+   } else {
+      return TimeUnits::None;
+   }
+};
+
+//------------------------------------------------------------------------------
 // TimeFrac definitions
 //------------------------------------------------------------------------------
 
@@ -4067,6 +4100,16 @@ I4 Alarm::rename(const std::string NewName ///< [in] new name for alarm
 // Returns the name of an alarm.
 
 std::string Alarm::getName() const { return Name; }
+
+//------------------------------------------------------------------------------
+// Alarm::getInterval - retrieves the time interval for periodic alarms
+
+const TimeInterval *Alarm::getInterval() const { return &RingInterval; }
+
+//------------------------------------------------------------------------------
+// Alarm::getRingTimePrev - get last time the alarm rang
+
+const TimeInstant *Alarm::getRingTimePrev(void) const { return &RingTimePrev; }
 
 //------------------------------------------------------------------------------
 // Clock definitions

--- a/components/omega/src/infra/TimeMgr.h
+++ b/components/omega/src/infra/TimeMgr.h
@@ -62,6 +62,11 @@ enum class TimeUnits {
    Years,    ///< time units in years
 };
 
+/// Utility function to extract time units from a string
+TimeUnits TimeUnitsFromString(
+    const std::string TimeUnitString ///< string describing time units
+);
+
 #define NUM_SUPPORTED_CALENDARS 9
 
 /// This enum represents supported calendar types
@@ -807,7 +812,11 @@ class Alarm {
    /// Get alarm name
    std::string getName(void) const;
 
-   I4 print(void) const;
+   /// Get alarm interval
+   const TimeInterval *getInterval(void) const;
+
+   /// Get last time the alarm rang
+   const TimeInstant *getRingTimePrev(void) const;
 
 }; // end class Alarm
 

--- a/components/omega/test/infra/TimeMgrTest.cpp
+++ b/components/omega/test/infra/TimeMgrTest.cpp
@@ -3555,6 +3555,25 @@ int testAlarm(void) {
 
    TimeInstant CurTime = StartTime;
 
+   // Test retrieval of the time interval
+   const TimeInterval *NewInterval = AlarmEveryYear.getInterval();
+   if (*NewInterval == IntervalAnnual) {
+      LOG_INFO("TimeMgrTest/Alarm: retrieve interval: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Alarm: retrieve interval: FAIL");
+   }
+
+   // Test initial retrieval of the previous ring time (should be time0)
+   TimeInstant PriorRingTimeTest    = Time0;
+   const TimeInstant *PriorRingTime = AlarmEveryYear.getRingTimePrev();
+   if (*PriorRingTime == PriorRingTimeTest) {
+      LOG_INFO("TimeMgrTest/Alarm: retrieve initial ring time: PASS");
+   } else {
+      ++ErrAll;
+      LOG_ERROR("TimeMgrTest/Alarm: retrieve initial ring time: FAIL");
+   }
+
    // quick test of update status function
    Err1 = AlarmNewYear2020.updateStatus(CurTime);
    Err2 = AlarmEveryYear.updateStatus(CurTime);
@@ -3572,6 +3591,12 @@ int testAlarm(void) {
    } else {
       ++ErrAll;
       LOG_ERROR("TimeMgrTest/Alarm: initial reset: FAIL");
+   }
+   // reset the previous ring time to proper value corresponding to current time
+   TimeInstant TestTime = Time0;
+   while (TestTime < CurTime) {
+      PriorRingTimeTest = TestTime;
+      TestTime += IntervalAnnual;
    }
 
    // now integrate forward for 18 months
@@ -3610,6 +3635,13 @@ int testAlarm(void) {
          }
       }
 
+      // Test retrieval of previous ring time
+      const TimeInstant *PriorRingTime = AlarmEveryYear.getRingTimePrev();
+      if (*PriorRingTime != PriorRingTimeTest) {
+         ++ErrAll;
+         LOG_ERROR("TimeMgrTest/Alarm: retrieve prior ring time: FAIL");
+      }
+
       // Test whether interval alarm should be ringing or not
       if (N == 5 || N == 17) {
          if (AlarmEveryYear.isRinging()) {
@@ -3625,6 +3657,7 @@ int testAlarm(void) {
             ++ErrAll;
             LOG_ERROR("TimeMgrTest/Alarm: periodic annual alarm reset: FAIL");
          }
+         PriorRingTimeTest += IntervalAnnual;
       } else {
          if (AlarmEveryYear.isRinging()) {
             ++ErrAll;


### PR DESCRIPTION
Adds retrievals for the alarm interval and last ring time for periodic alarms. Related tests are added to the unit tests and documentation is updated. These are needed for some upcoming streams additions but should also be generally useful (eg for forcing and other future functionality).

All unit tests pass on Chicoma.

Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
after.


