### PR TITLE
Adds a time-slice capability to Omega IO and IOStream

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -93,15 +93,17 @@ Omega:
         - SshCellDefault
     Highfreq:
       UsePointerFile: false
-      Filename: ocn.hifreq.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.hifreq.$Y-$M
       Mode: write
-      IfExists: replace
+      IfExists: append
       Precision: single
       Freq: 10
       FreqUnits: days
+      FileFreq: 1
+      FileFreqUnits: months
       UseStartEnd: true
       StartTime: 0001-06-01_00:00:00
-      EndTime: 0001-06-30_00:00:00
+      EndTime: 0001-07-31_00:00:00
       Contents:
         - Tracers
   ManufacturedSolution:

--- a/components/omega/doc/devGuide/Field.md
+++ b/components/omega/doc/devGuide/Field.md
@@ -40,7 +40,8 @@ Fields are created with standard metadata using
                  FillValue,   ///< [in] scalar used for undefined entries
                  NumDims,     ///< [in] number of dimensions (int)
                  Dimensions,  ///< [in] dim names (vector of strings)
-                 InTimeDependent ///< [in] (opt, default true) if time varying
+                 TimeDependent   ///< [in] (opt, default true) if time varying
+                 RetainPrecision ///< [in] (opt, false) retain full prec in IO
    );
 ```
 This interface enforces a list of required metadata. If a CF standard name does
@@ -55,7 +56,14 @@ to be true by default. Fields with this attribute will be output with the
 unlimited time dimension added. Time should not be added explicitly in the
 dimension list since it will be added during I/O. Fields that do not change
 with time should include this argument with the value false so that the time
-dimension is not added. Actual field data stored in an array is attached in a
+dimension is not added. The argument RetainPrecision is also optional and should
+be used if the full precision of the field needs to be retained during IO even
+if it is a part of an IO stream that requests reduced precision. An example is
+the time field that can require full precision to represent the seconds from a
+reference time far in the past. The default is false and the argument does not
+need to be supplied in most cases. However, if it is needed, then the
+TimeDependent argument must also be explicitly included due to the language
+rules on argument ordering. Actual field data stored in an array is attached in a
 separate call as described below. Scalar fields can be added by setting the
 NumDims to zero (the Dimensions vector is ignored but an empty vector
 must still be supplied in the argument list). Scalar data is attached using

--- a/components/omega/doc/devGuide/IO.md
+++ b/components/omega/doc/devGuide/IO.md
@@ -101,6 +101,14 @@ reading of variable metadata. For writing, a FillValue is supplied to fill
 undefined locations in an array and the variable ID must have been assigned
 in a prior defineVar call prior to the write as described below.
 
+Writing or reading multiple time slices (where there in an unlimited time
+dimension) is also possible and an additional optional Frame argument
+specifies the time index along that dimension that should be read/written:
+```c++
+int Err = IO::readArray (&Array, Size, VariableName, FileID, DecompID, VarID, Frame);
+int Err = IO::writeArray(&Array, Size, &FillValue,   FileID, DecompID, VarID, Frame);
+```
+
 For arrays or scalars that are not distributed, the non-distributed variable
 interface must be used:
 ```c++
@@ -110,6 +118,17 @@ int Err = IO::writeNDVar(&Array, FileID, VarID);
 with arguments similar to the distributed array calls above. Note that
 when defining dimensions for these fields, the dimensions must be
 non-distributed. For scalars, the number of dimensions should be zero.
+Multiple time slices can be also be read/written for non-distributed fields,
+but require two additional arguments. As in the distributed array, the
+Frame (index of the time slice) must be provided. In addition, a vector
+``std::vector<int> DimLengths`` containing the length of the non-time
+dimensions must be provided:
+```c++
+int Err = IO::readNDVar(&Array, VariableName, FileID, VarID, Frame, DimLengths);
+int Err = IO::writeNDVar(&Array, FileID, VarID, Frame, DimLengths);
+```
+Note that the full arrays in this case are written so if any masking or
+pruning of points is required, it should be performed before the call.
 
 The IO subsystem must know how the data is laid out in the parallel
 decomposition. Both the dimensions of the array and the decomposition

--- a/components/omega/doc/devGuide/IO.md
+++ b/components/omega/doc/devGuide/IO.md
@@ -220,7 +220,12 @@ the MetaValue is the value of the MetaData. All supported Omega data types are
 allowed except boolean which must be converted to an integer type. The FileID
 is once again the ID of the open data file and VarID is the variable to which
 this metadata is attached. For global file and simulation metadata not attached
-to a variable, the ID ``IO::GlobalID`` is used to denote global metadata.
+to a variable, the ID ``IO::GlobalID`` is used to denote global metadata. If
+data is being appended to a file (eg for multiple time slices), writeMeta will
+check first to see if metadata already exists with the same value. If the
+entry is absent, new metadata will be written. If it exists but with a
+different value, the writeMeta function will replace the current entry with
+the new value.
 
 For an example of the full read/write process, the IO unit test contains
 the full reading and writing of a data file and associated metadata. We

--- a/components/omega/doc/userGuide/IOStreams.md
+++ b/components/omega/doc/userGuide/IOStreams.md
@@ -46,12 +46,14 @@ Omega:
         - Tracers
     Highfreq:
       UsePointerFile: false
-      Filename: ocn.hifreq.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.hifreq.$Y-$M
       Mode: write
-      IfExists: replace
+      IfExists: append
       Precision: single
       Freq: 10
       FreqUnits: days
+      FileFreq: 1
+      FileFreqUnits: months
       UseStartEnd: true
       StartTime: 0001-06-01_00.00.00
       EndTime: 0001-06-30_00.00.00
@@ -93,7 +95,7 @@ a template can be:
    - Fail if you want the code to exit with an error
    - Replace if you want to replace the existing file with the new file
    - Append if you want to append (eg multiple time slices) to the existing
-     file (this option is not currently supported).
+     file
 - **Precision:** A field that determines whether floating point numbers are
    written in full (double) precision or reduced (single). Acceptable values
    are double or single. If not present, double is assumed, but a warning
@@ -114,6 +116,16 @@ a template can be:
    - Hours for a frequency every Freq hours (*not* Freq times per hour)
    - Minutes for a frequency every Freq minutes (*not* Freq times per minute)
    - Seconds for a frequency every Freq seconds (*not* Freq times per seconds)
+- **FileFreq:** An optional entry for including multiple time slices in a
+   single file (only supported for output presently)
+- **FreqUnits:** A field that, combined with the integer frequency,
+   determines the frequency of new files when multiple time slices are
+   included in a file. The file frequency must be less than or equal to
+   the data frequency. Acceptable values include all of the frequency values
+   listed above except the one-time values (eg OnStartup/Shutdown or AtTime).
+   The filename template should reflect the frequency and the time used for
+   the file will correspond to the template at the time the file is first
+   opened.
 - **UseStartEnd:** A required entry that is true or false and is used if the
    I/O is desired only within a certain time interval. An example might be
    for specifying high-frequency output within a certain period of a simulation.

--- a/components/omega/doc/userGuide/IOStreams.md
+++ b/components/omega/doc/userGuide/IOStreams.md
@@ -95,7 +95,8 @@ a template can be:
    - Fail if you want the code to exit with an error
    - Replace if you want to replace the existing file with the new file
    - Append if you want to append (eg multiple time slices) to the existing
-     file
+     file. When re-running an interval, this will also over-write existing
+     slices corresponding to the simulation time if they exist in the file.
 - **Precision:** A field that determines whether floating point numbers are
    written in full (double) precision or reduced (single). Acceptable values
    are double or single. If not present, double is assumed, but a warning
@@ -118,7 +119,7 @@ a template can be:
    - Seconds for a frequency every Freq seconds (*not* Freq times per seconds)
 - **FileFreq:** An optional entry for including multiple time slices in a
    single file (only supported for output presently)
-- **FreqUnits:** A field that, combined with the integer frequency,
+- **FileFreqUnits:** A field that, combined with the integer frequency,
    determines the frequency of new files when multiple time slices are
    included in a file. The file frequency must be less than or equal to
    the data frequency. Acceptable values include all of the frequency values

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(
     metis
     gptl
     pacer
+    stdc++fs
 )
 
 if(GKlib_FOUND)

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -395,6 +395,17 @@ int writeMeta(const std::string &MetaName, // [in] name of metadata
    IODataType MetaType = IOTypeI4;
    PIO_Offset Length   = 1;
 
+   // Check to see if metadata already exists and has the same value
+   I4 TmpValue;
+   Err = PIOc_get_att(FileID, VarID, MetaName.c_str(), &TmpValue);
+   if (Err == PIO_NOERR) { // Metadata already exists, check value is same
+      if (TmpValue == MetaValue) { // no need to write
+         Err = 0;
+         return Err;
+      }
+   }
+
+   // Write the metadata
    Err = PIOc_put_att(FileID, VarID, MetaName.c_str(), MetaType, Length,
                       &MetaValue);
    if (Err != PIO_NOERR) {
@@ -417,6 +428,17 @@ int writeMeta(const std::string &MetaName, // [in] name of metadata
    IODataType MetaType = IOTypeI8;
    PIO_Offset Length   = 1;
 
+   // Check to see if metadata already exists and has the same value
+   I8 TmpValue;
+   Err = PIOc_get_att(FileID, VarID, MetaName.c_str(), &TmpValue);
+   if (Err == PIO_NOERR) { // Metadata already exists, check value is same
+      if (TmpValue == MetaValue) { // no need to write
+         Err = 0;
+         return Err;
+      }
+   }
+
+   // Write the metadata
    Err = PIOc_put_att(FileID, VarID, MetaName.c_str(), MetaType, Length,
                       &MetaValue);
    if (Err != PIO_NOERR) {
@@ -439,6 +461,17 @@ int writeMeta(const std::string &MetaName, // [in] name of metadata
    IODataType MetaType = IOTypeR4;
    PIO_Offset Length   = 1;
 
+   // Check to see if metadata already exists and has the same value
+   R4 TmpValue;
+   Err = PIOc_get_att(FileID, VarID, MetaName.c_str(), &TmpValue);
+   if (Err == PIO_NOERR) { // Metadata already exists, check value is same
+      if (TmpValue == MetaValue) { // no need to write
+         Err = 0;
+         return Err;
+      }
+   }
+
+   // Write the metadata
    Err = PIOc_put_att(FileID, VarID, MetaName.c_str(), MetaType, Length,
                       &MetaValue);
    if (Err != PIO_NOERR) {
@@ -461,6 +494,17 @@ int writeMeta(const std::string &MetaName, // [in] name of metadata
    IODataType MetaType = IOTypeR8;
    PIO_Offset Length   = 1;
 
+   // Check to see if metadata already exists and has the same value
+   R8 TmpValue;
+   Err = PIOc_get_att(FileID, VarID, MetaName.c_str(), &TmpValue);
+   if (Err == PIO_NOERR) { // Metadata already exists, check value is same
+      if (TmpValue == MetaValue) { // no need to write
+         Err = 0;
+         return Err;
+      }
+   }
+
+   // Write the metadata
    Err = PIOc_put_att(FileID, VarID, MetaName.c_str(), MetaType, Length,
                       &MetaValue);
    if (Err != PIO_NOERR) {
@@ -483,6 +527,18 @@ int writeMeta(const std::string &MetaName,  // [in] name of metadata
    IODataType MetaType = IOTypeChar;
    PIO_Offset Length   = MetaValue.length() + 1; // add 1 for char terminator
 
+   // Check to see if metadata already exists and has the same value
+   std::string TmpValue = MetaValue;
+   Err =
+       PIOc_get_att(FileID, VarID, MetaName.c_str(), (void *)TmpValue.c_str());
+   if (Err == PIO_NOERR) { // Metadata already exists, check value is same
+      if (TmpValue == MetaValue) { // no need to write
+         Err = 0;
+         return Err;
+      }
+   }
+
+   // Write the metadata
    Err = PIOc_put_att(FileID, VarID, MetaName.c_str(), MetaType, Length,
                       (void *)MetaValue.c_str());
    if (Err != PIO_NOERR) {
@@ -621,7 +677,6 @@ int defineVar(int FileID,                 // [in] ID of the file containing var
 
    // First check to see if the variable exists (if reading or if appending
    // to an existing file)
-
    Err = PIOc_inq_varid(FileID, VarName.c_str(), &VarID);
 
    // If the variable is not found, define the new variable
@@ -726,7 +781,7 @@ int readArray(void *Array,                // [out] array to be read
       return Err;
    }
 
-   if (Frame != -1) {
+   if (Frame >= 0) {
       Err = PIOc_setframe(FileID, VarID, Frame);
       if (Err != PIO_NOERR) {
          LOG_ERROR("Error setting frame while reading distributed array");
@@ -765,7 +820,7 @@ int readNDVar(void *Variable,             // [out] array to be read
       return Err;
    }
 
-   if (Frame != -1) { // time dependent field so must use get_vara
+   if (Frame >= 0) { // time dependent field so must use get_vara
 
       int NDims = DimLengths->size();
       // Start and count arguments include the unlimited time dim (Frame)
@@ -810,7 +865,7 @@ int writeArray(void *Array,     // [in] array to be written
 ) {
    int Err = 0;
 
-   if (Frame != -1) {
+   if (Frame >= 0) {
       Err = PIOc_setframe(FileID, VarID, Frame);
       if (Err != PIO_NOERR) {
          LOG_ERROR("Error setting frame while writing distributed array");
@@ -854,7 +909,7 @@ int writeNDVar(void *Variable, // [in] variable to be written
 ) {
    int Err = 0;
 
-   if (Frame != -1) { // time dependent field so must use put_vara
+   if (Frame >= 0) { // time dependent field so must use put_vara
       int NDims = DimLengths->size();
       // Start and count arguments include the unlimited time dim (Frame)
       std::vector<PIO_Offset> Start(NDims + 1, 0);

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -600,7 +600,7 @@ int readMeta(const std::string &MetaName, // [in] name of metadata
 // Defines a variable for an output file. The name and dimensions of
 // the variable must be supplied. An ID is assigned to the variable
 // for later use in the writing of the variable.
-int defineVar(int FileID,                 // [in] ID of the file containing dim
+int defineVar(int FileID,                 // [in] ID of the file containing var
               const std::string &VarName, // [in] name of variable
               IODataType VarType,         // [in] data type for the variable
               int NDims,                  // [in] number of dimensions
@@ -610,10 +610,21 @@ int defineVar(int FileID,                 // [in] ID of the file containing dim
 
    int Err = 0;
 
-   Err = PIOc_def_var(FileID, VarName.c_str(), VarType, NDims, DimIDs, &VarID);
+   // First check to see if the variable exists (if reading or if appending
+   // to an existing file)
+
+   Err = PIOc_inq_varid(FileID, VarName.c_str(), &VarID);
+
+   // If the variable is not found, define the new variable
    if (Err != PIO_NOERR) {
-      LOG_ERROR("IO::defineVar: PIO error while defining variable {}", VarName);
-      Err = -1;
+
+      Err =
+          PIOc_def_var(FileID, VarName.c_str(), VarType, NDims, DimIDs, &VarID);
+      if (Err != PIO_NOERR) {
+         LOG_ERROR("IO::defineVar: PIO error while defining variable {}",
+                   VarName);
+         Err = 1;
+      }
    }
 
    return Err;

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -14,6 +14,7 @@
 #include "mpi.h"
 #include "pio.h"
 
+#include <filesystem>
 #include <map>
 #include <string>
 
@@ -270,9 +271,17 @@ int openFile(
          break;
 
       // If the write should append or add to an existing file
-      // we open the file for reading and writing
+      // we open the file for reading and writing, but also must create
+      // the file if it doesn't already exist
       case IfExists::Append:
-         Err = PIOc_openfile(SysID, &FileID, &Format, Filename.c_str(), InMode);
+         if (std::filesystem::exists(Filename)) {
+            Err = PIOc_openfile(SysID, &FileID, &Format, Filename.c_str(),
+                                InMode);
+         } else {
+            Err = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
+                                  InMode);
+         }
+
          if (Err != PIO_NOERR)
             LOG_ERROR("IO::openFile: PIO error opening file {} for writing",
                       Filename);

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -270,7 +270,7 @@ int openFile(
          break;
 
       // If the write should append or add to an existing file
-      // we open the file for writing
+      // we open the file for reading and writing
       case IfExists::Append:
          Err = PIOc_openfile(SysID, &FileID, &Format, Filename.c_str(), InMode);
          if (Err != PIO_NOERR)
@@ -331,8 +331,7 @@ int getDimFromFile(int FileID, // [in] ID of the file containing dim
    // First get the dimension ID
    Err = PIOc_inq_dimid(FileID, DimName.c_str(), &DimID);
    if (Err != PIO_NOERR) {
-      // Dimension missing in file - return error but let calling routine
-      // decide how to respond
+      LOG_ERROR("PIO error while reading dimension {} ", DimName);
       return Err;
    }
 
@@ -694,7 +693,8 @@ int readArray(void *Array,                // [out] array to be read
               const std::string &VarName, // [in] name of variable to read
               int FileID,                 // [in] ID of open file to read from
               int DecompID,               // [in] decomposition ID for this var
-              int &VarID // [out] Id assigned to variable for later use
+              int &VarID, // [out] Id assigned to variable for later use
+              int Frame   // [in] opt frame if multiple time slices
 ) {
 
    int Err = 0; // default return code
@@ -702,9 +702,16 @@ int readArray(void *Array,                // [out] array to be read
    // Find variable ID from file
    Err = PIOc_inq_varid(FileID, VarName.c_str(), &VarID);
    if (Err != PIO_NOERR) {
-      // Variable not in file. Return error but let calling routine decide
-      // how to respond
+      LOG_ERROR("IO::readArray: Error finding varid for variable {}", VarName);
       return Err;
+   }
+
+   if (Frame != -1) {
+      Err = PIOc_setframe(FileID, VarID, Frame);
+      if (Err != PIO_NOERR) {
+         LOG_ERROR("Error setting frame while reading distributed array");
+         return Err;
+      }
    }
 
    // PIO Read array call to read the distributed array
@@ -724,7 +731,9 @@ int readArray(void *Array,                // [out] array to be read
 int readNDVar(void *Variable,             // [out] array to be read
               const std::string &VarName, // [in] name of variable to read
               int FileID,                 // [in] ID of open file to read from
-              int &VarID // [out] Id assigned to variable for later use
+              int &VarID, // [out] Id assigned to variable for later use
+              int Frame,  // [in] opt frame/slice for multiframe streams
+              std::vector<int> *DimLengths // [in] dim lengths for multiframe
 ) {
 
    int Err = 0; // default return code
@@ -736,11 +745,31 @@ int readNDVar(void *Variable,             // [out] array to be read
       return Err;
    }
 
-   // PIO Read array call to read the distributed array
-   Err = PIOc_get_var(FileID, VarID, Variable);
-   if (Err != PIO_NOERR)
-      LOG_ERROR("IO::readNDVar: Error in SCORPIO get_var for variable {}",
-                VarName);
+   if (Frame != -1) { // time dependent field so must use get_vara
+
+      int NDims = DimLengths->size();
+      // Start and count arguments include the unlimited time dim (Frame)
+      std::vector<PIO_Offset> Start(NDims + 1, 0);
+      std::vector<PIO_Offset> Count(NDims + 1, 0);
+      Start[0] = Frame;
+      Count[0] = 1;
+      for (int IDim = 1; IDim <= NDims; ++IDim) {
+         Count[IDim] = DimLengths->at(IDim - 1);
+      }
+
+      Err = PIOc_get_vara(FileID, VarID, Start.data(), Count.data(), Variable);
+      if (Err != PIO_NOERR)
+         LOG_ERROR("IO::readNDVar: Error in PIO get_vara for variable {}",
+                   VarName);
+
+   } else { // Not a time-dependent field, can use default get_var
+
+      // PIO get call to read non-distributed array
+      Err = PIOc_get_var(FileID, VarID, Variable);
+      if (Err != PIO_NOERR)
+         LOG_ERROR("IO::readNDVar: Error in PIO get_var for variable {}",
+                   VarName);
+   }
 
    return Err;
 
@@ -756,9 +785,18 @@ int writeArray(void *Array,     // [in] array to be written
                void *FillValue, // [in] value to use for missing entries
                int FileID,      // [in] ID of open file to write to
                int DecompID,    // [in] decomposition ID for this var
-               int VarID        // [in] variable ID assigned by defineVar
+               int VarID,       // [in] variable ID assigned by defineVar
+               int Frame        // [in] frame/slice for multiframe streams
 ) {
    int Err = 0;
+
+   if (Frame != -1) {
+      Err = PIOc_setframe(FileID, VarID, Frame);
+      if (Err != PIO_NOERR) {
+         LOG_ERROR("Error setting frame while writing distributed array");
+         return Err;
+      }
+   }
 
    PIO_Offset Asize = Size;
 
@@ -784,18 +822,38 @@ int writeArray(void *Array,     // [in] array to be written
 //------------------------------------------------------------------------------
 // Writes a non-distributed variable. This generic interface uses void pointers.
 // All arrays are assumed to be in contiguous storage and the variable
-// must have a valid ID assigned by the defineVar function.
+// must have a valid ID assigned by the defineVar function. For time-dependent
+// fields, optional arguments for the frame of the unlimited time axis and a
+// vector of dimension lengths must be provided.
 
 int writeNDVar(void *Variable, // [in] variable to be written
                int FileID,     // [in] ID of open file to write to
-               int VarID       // [in] variable ID assigned by defineVar
+               int VarID,      // [in] variable ID assigned by defineVar
+               int Frame,      // [in] frame/slice for multiframe streams
+               std::vector<int> *DimLengths // [in] dimension lengths
 ) {
    int Err = 0;
 
-   Err = PIOc_put_var(FileID, VarID, Variable);
-   if (Err != PIO_NOERR) {
-      LOG_ERROR("Error in PIO writing non-distributed variable");
-      return Err;
+   if (Frame != -1) { // time dependent field so must use put_vara
+      int NDims = DimLengths->size();
+      // Start and count arguments include the unlimited time dim (Frame)
+      std::vector<PIO_Offset> Start(NDims + 1, 0);
+      std::vector<PIO_Offset> Count(NDims + 1, 0);
+      Start[0] = Frame;
+      Count[0] = 1;
+      for (int IDim = 1; IDim <= NDims; ++IDim) {
+         Count[IDim] = DimLengths->at(IDim - 1);
+      }
+
+      Err = PIOc_put_vara(FileID, VarID, Start.data(), Count.data(), Variable);
+      if (Err != PIO_NOERR)
+         LOG_ERROR("Error in PIO put_vara while writing variable");
+
+   } else {
+
+      Err = PIOc_put_var(FileID, VarID, Variable);
+      if (Err != PIO_NOERR)
+         LOG_ERROR("Error in PIO put_var while writing variable");
    }
 
    return Err;

--- a/components/omega/src/base/IO.h
+++ b/components/omega/src/base/IO.h
@@ -76,9 +76,9 @@ enum FileFmt {
 
 /// File operations
 enum Mode {
-   ModeUnknown, /// Unknown or undefined
-   ModeRead,    /// Read  (input)
-   ModeWrite,   /// Write (output)
+   ModeRead  = PIO_NOWRITE, /// Read  (input)
+   ModeWrite = PIO_WRITE,   /// Write (output) or ReadWrite (modify/append)
+   ModeUnknown,             /// Unknown or undefined
 };
 
 /// Behavior (for output files) when a file already exists
@@ -274,19 +274,24 @@ int readArray(void *Array,                ///< [out] array to be read
               int Size,                   ///< [in] local size of array
               const std::string &VarName, ///< [in] name of variable to read
               int FileID,                 ///< [in] ID of open file to read from
-              int DecompID, ///< [in] decomposition ID for this var
-              int &VarID    ///< [out] variable ID in case metadata needed
+              int DecompID,  ///< [in] decomposition ID for this var
+              int &VarID,    ///< [out] variable ID in case metadata needed
+              int Frame = -1 ///< [in] opt frame if multiple time slices
 );
 
 /// Reads a non-distributed variable. We use a void pointer here to create
 /// a generic interface for all types. Arrays are assumed to be in contiguous
 /// storage so the arrays of any dimension are treated as a 1-d array with
 /// the full local size. The routine returns the variable as well as the id
-/// assigned to the variable should that be needed later.
+/// assigned to the variable should that be needed later. For time-dependent
+/// variables, the optional frame and dimension length information must be
+/// provided
 int readNDVar(void *Variable,             ///< [out] variable to be read
               const std::string &VarName, ///< [in] name of variable to read
               int FileID,                 ///< [in] ID of open file to read from
-              int &VarID ///< [out] variable ID in case metadata needed
+              int &VarID,     ///< [out] variable ID in case metadata needed
+              int Frame = -1, ///< [in] opt frame if multiple time slices
+              std::vector<int> *DimLengths = nullptr ///< [in] opt dim lengths
 );
 
 /// Writes a distributed array. A void pointer is used to create a generic
@@ -298,16 +303,21 @@ int writeArray(void *Array,     ///< [in] array to be written
                void *FillValue, ///< [in] value to use for missing entries
                int FileID,      ///< [in] ID of open file to write to
                int DecompID,    ///< [in] decomposition ID for this var
-               int VarID        ///< [in] variable ID assigned by defineVar
+               int VarID,       ///< [in] variable ID assigned by defineVar
+               int Frame = -1   ///< [in] opt current frame/slice for multiframe
 );
 
 /// Writes a non-distributed variable. A void pointer is used for a generic
 /// interface. Arrays are assumed to be in contiguous storage and the variable
 /// must have a valid ID assigned by the defineVar function. A void pointer
-/// to a scalar FillValue is also required to fill missing values.
+/// to a scalar FillValue is also required to fill missing values. For time-
+/// dependent fields, the optional Frame and Dimension length arguments must
+/// be provided.
 int writeNDVar(void *Variable, ///< [in] variable to be written
                int FileID,     ///< [in] ID of open file to write to
-               int VarID       ///< [in] variable ID assigned by defineVar
+               int VarID,      ///< [in] variable ID assigned by defineVar
+               int Frame = -1, ///< [in] opt current frame/slice for multiframe
+               std::vector<int> *DimLengths = nullptr ///< [in] opt dim lengths
 );
 
 } // end namespace IO

--- a/components/omega/src/infra/Field.cpp
+++ b/components/omega/src/infra/Field.cpp
@@ -55,8 +55,9 @@ int Field::init(const Clock *ModelClock // [in] default model clock
    CalendarKind CalKind     = Calendar::getKind();
    std::string CalName      = CalendarCFName[CalKind];
    std::vector<std::string> DimNames; // empty dim names vector
-   std::shared_ptr<Field> TimeField = create("time", "time", UnitString, "time",
-                                             0.0, 1.e20, -9.99e30, 0, DimNames);
+   std::shared_ptr<Field> TimeField =
+       create("time", "time", UnitString, "time", 0.0, 1.e20, -9.99e30, 0,
+              DimNames, true, true);
    TimeField->addMetadata("calendar", CalName);
 
    return Err;
@@ -91,7 +92,8 @@ Field::create(const std::string &FieldName,   // [in] Name of variable/field
               const std::any FillValue, // [in] scalar for undefined entries
               const int NumDims,        // [in] number of dimensions
               const std::vector<std::string> &Dimensions, // [in] dim names
-              bool TimeDependent // [in] flag for time dependent field
+              bool TimeDependent,  // [in] flag for time dependent field
+              bool RetainPrecision // [in] flag to retain full prec in IO
 ) {
 
    // Check to make sure a field of that name has not already been defined
@@ -130,6 +132,10 @@ Field::create(const std::string &FieldName,   // [in] Name of variable/field
 
    // Set the time-dependent flag
    ThisField->TimeDependent = TimeDependent;
+
+   // Set the flag to retain full precision in IO operations even
+   // if reduced precision for the stream/file is requested
+   ThisField->RetainPrecision = RetainPrecision;
 
    // Number of dimensions for the field
    ThisField->NDims = NumDims;
@@ -340,6 +346,11 @@ bool Field::isTimeDependent() const { return TimeDependent; }
 // is entirely local. This is needed to determine whether a parallel IO or
 // a non-distributed IO will be used.
 bool Field::isDistributed() const { return Distributed; }
+
+//------------------------------------------------------------------------------
+// Determinse whether full precision should be retained in IO operations
+// when reduced precision for the stream/file is requested
+bool Field::retainPrecision() const { return RetainPrecision; }
 
 //------------------------------------------------------------------------------
 // Returns a vector of dimension names associated with each dimension

--- a/components/omega/src/infra/Field.h
+++ b/components/omega/src/infra/Field.h
@@ -72,6 +72,10 @@ class Field {
    /// or whether it is entirely local
    bool Distributed;
 
+   /// Flag for whether full precision needs to be maintained in IO
+   /// operations when reduced precision is requested
+   bool RetainPrecision;
+
    /// Data attached to this field. This will be a pointer to the Kokkos
    /// array holding the data. We use a void pointer to manage all the
    /// various types and cast to the appropriate type when needed.
@@ -110,7 +114,8 @@ class Field {
           const std::any FillValue,       ///< [in] scalar for undefined entries
           const int NumDims,              ///< [in] number of dimensions
           const std::vector<std::string> &Dimensions, ///< [in] dim names
-          const bool TimeDependent = true ///< [in] opt flag for unlim time
+          const bool TimeDependent   = true, ///< [in] opt flag for unlim time
+          const bool RetainPrecision = false ///< [in] opt flag for full prec
    );
 
    //---------------------------------------------------------------------------
@@ -200,6 +205,10 @@ class Field {
    /// local. This is needed to determine whether IO uses parallel read/write
    /// or an undistributed read/write.
    bool isDistributed() const;
+
+   /// Determine whether full precision should be maintained in cases where
+   /// a reduced precision stream is requested.
+   bool retainPrecision() const;
 
    //---------------------------------------------------------------------------
    // Metadata functions

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -533,13 +533,13 @@ int IOStream::create(const std::string &StreamName, //< [in] name of stream
       NewStream->Multiframe = true;
 
       if (Err1 != 0) {
-         LOG_CRITICAL("File frequency units provided but file freq missing"
+         LOG_CRITICAL("File frequency units provided but file freq missing "
                       "for stream {}",
                       StreamName);
          return Fail;
       }
       if (Err2 != 0) {
-         LOG_CRITICAL("File frequency provided by file freq units missing"
+         LOG_CRITICAL("File frequency provided but file freq units missing "
                       "for stream {}",
                       StreamName);
          return Fail;
@@ -2621,7 +2621,7 @@ int IOStream::writeStream(
    std::map<std::string, int> AllDimIDs;
    Err = defineAllDims(OutFileID, AllDimIDs);
    if (Err != 0) {
-      LOG_ERROR("Error defined dimensions for file {}", OutFileName);
+      LOG_ERROR("Error defining dimensions for file {}", OutFileName);
       return Fail;
    }
 

--- a/components/omega/src/infra/IOStream.h
+++ b/components/omega/src/infra/IOStream.h
@@ -42,8 +42,11 @@ class IOStream {
    IO::Mode Mode;        ///< mode (read or write)
    bool ReducePrecision; ///< flag to use 32-bit precision for 64-bit floats
    Alarm MyAlarm;        ///< time mgr alarm for read/write
+   Alarm FileAlarm;      ///< time mgr alarm for opening a new file
    bool OnStartup;       ///< flag to read/write on model startup
    bool OnShutdown;      ///< flag to read/write on model shutdown
+   bool Multiframe;      ///< flag for multiple frames/time slices in file
+   int Frame;            ///< current frame/slice for multi-frame stream
 
    /// A pointer file is used if we wish OMEGA to read the name of the file
    /// from another file. This is useful for writing the name of a restart
@@ -157,7 +160,7 @@ class IOStream {
    ///    $s = seconds part of simulation time stamp
    static std::string buildFilename(
        const std::string &FilenameTemplate, ///< [in] template string for name
-       const Clock *ModelClock              ///< [in] model clock for sim time
+       const TimeInstant &FileTime          ///< [in] time to use in filename
    );
 
    /// Sets ReducePrecision flag based on an input string, performing string

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -43,8 +43,6 @@ I4 Tracers::init() {
 
    I4 Err = 0;
 
-   LOG_INFO("Tracers::init() called");
-
    // Retrieve mesh cell/edge/vertex totals from Decomp
    HorzMesh *DefHorzMesh = HorzMesh::getDefault();
 
@@ -245,8 +243,6 @@ I4 Tracers::define(const std::string &Name, const std::string &Description,
 // Deallocate tracer arrays
 //---------------------------------------------------------------------------
 I4 Tracers::clear() {
-
-   LOG_INFO("Tracers::clear() called");
 
    // Deallocate memory for tracer arrays
    TracerArrays.clear();

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -89,9 +89,9 @@ int main(int argc, char *argv[]) {
       // Retrieve the default decomposition
       Decomp *DefDecomp = Decomp::getDefault();
       if (DefDecomp) { // true if non-null ptr
-         LOG_INFO("IOTest: Default decomp retrieval PASS");
+         LOG_ERROR("IOTest: Default decomp retrieval PASS");
       } else {
-         LOG_INFO("IOTest: Default decomp retrieval FAIL");
+         LOG_ERROR("IOTest: Default decomp retrieval FAIL");
          return -1;
       }
 
@@ -111,11 +111,13 @@ int main(int argc, char *argv[]) {
       HostArray1DI8 RefI8Vert("RefI8Vert", NVertLevels);
       HostArray1DR4 RefR4Vert("RefR4Vert", NVertLevels);
       HostArray1DR8 RefR8Vert("RefR8Vert", NVertLevels);
+      HostArray1DR8 RefR8Time("RefR8Time", NVertLevels);
 
       HostArray2DI4 RefI4Cell("RefI4Cell", NCellsSize, NVertLevels);
       HostArray2DI8 RefI8Cell("RefI8Cell", NCellsSize, NVertLevels);
       HostArray2DR4 RefR4Cell("RefR4Cell", NCellsSize, NVertLevels);
       HostArray2DR8 RefR8Cell("RefR8Cell", NCellsSize, NVertLevels);
+      HostArray2DR8 RefR8Tim2("RefR8Tim2", NCellsSize, NVertLevels);
 
       HostArray2DI4 RefI4Edge("RefI4Edge", NEdgesSize, NVertLevels);
       HostArray2DI8 RefI8Edge("RefI8Edge", NEdgesSize, NVertLevels);
@@ -141,6 +143,7 @@ int main(int argc, char *argv[]) {
          RefI8Vert(K) = K * 2;
          RefR4Vert(K) = K * 3.1;
          RefR8Vert(K) = K * 4.1234567;
+         RefR8Time(K) = K * 5.1234567;
       }
 
       // Offset arrays - initialize to -1, corresponding to entries
@@ -155,6 +158,7 @@ int main(int argc, char *argv[]) {
             RefI8Cell(Cell, k)    = GlobalCellAdd * k * 1000000000;
             RefR4Cell(Cell, k)    = GlobalCellAdd * k * 123.45;
             RefR8Cell(Cell, k)    = GlobalCellAdd * k * 1.23456789;
+            RefR8Tim2(Cell, k)    = GlobalCellAdd * k * 2.23456789;
             int VectorAdd         = Cell * NVertLevels + k;
             OffsetCell[VectorAdd] = GlobalCellAdd * NVertLevels + k;
          }
@@ -207,73 +211,97 @@ int main(int argc, char *argv[]) {
 
       Err = IO::createDecomp(DecompCellI4, IO::IOTypeI4, 2, CellDims,
                              CellArraySize, OffsetCell, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating cell decomp I4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating cell decomp I4 FAIL");
       }
       Err = IO::createDecomp(DecompCellI8, IO::IOTypeI8, 2, CellDims,
                              CellArraySize, OffsetCell, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating cell decomp I8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating cell decomp I8 FAIL");
       }
       Err = IO::createDecomp(DecompCellR4, IO::IOTypeR4, 2, CellDims,
                              CellArraySize, OffsetCell, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating cell decomp R4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating cell decomp R4 FAIL");
       }
       Err = IO::createDecomp(DecompCellR8, IO::IOTypeR8, 2, CellDims,
                              CellArraySize, OffsetCell, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating cell decomp R8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating cell decomp R8 FAIL");
       }
       Err = IO::createDecomp(DecompEdgeI4, IO::IOTypeI4, 2, EdgeDims,
                              EdgeArraySize, OffsetEdge, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating edge decomp I4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating edge decomp I4 FAIL");
       }
       Err = IO::createDecomp(DecompEdgeI8, IO::IOTypeI8, 2, EdgeDims,
                              EdgeArraySize, OffsetEdge, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating edge decomp I8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating edge decomp I8 FAIL");
       }
       Err = IO::createDecomp(DecompEdgeR4, IO::IOTypeR4, 2, EdgeDims,
                              EdgeArraySize, OffsetEdge, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating edge decomp R4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating edge decomp R4 FAIL");
       }
       Err = IO::createDecomp(DecompEdgeR8, IO::IOTypeR8, 2, EdgeDims,
                              EdgeArraySize, OffsetEdge, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating edge decomp R8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating edge decomp R8 FAIL");
       }
       Err = IO::createDecomp(DecompVrtxI4, IO::IOTypeI4, 2, VrtxDims,
                              VrtxArraySize, OffsetVrtx, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating vertex decomp I4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating vertex decomp I4 FAIL");
       }
       Err = IO::createDecomp(DecompVrtxI8, IO::IOTypeI8, 2, VrtxDims,
                              VrtxArraySize, OffsetVrtx, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating vertex decomp I8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating vertex decomp I8 FAIL");
       }
       Err = IO::createDecomp(DecompVrtxR4, IO::IOTypeR4, 2, VrtxDims,
                              VrtxArraySize, OffsetVrtx, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating vertex decomp R4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating vertex decomp R4 FAIL");
       }
       Err = IO::createDecomp(DecompVrtxR8, IO::IOTypeR8, 2, VrtxDims,
                              VrtxArraySize, OffsetVrtx, IO::DefaultRearr);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: creating vertex decomp R8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error creating vertex decomp R8 FAIL");
       }
@@ -282,7 +310,9 @@ int main(int argc, char *argv[]) {
       int OutFileID;
       Err = IO::openFile(OutFileID, "IOTest.nc", IO::ModeWrite, IO::FmtDefault,
                          IO::IfExists::Replace);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: file open PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error opening file for output FAIL");
       }
@@ -291,25 +321,41 @@ int main(int argc, char *argv[]) {
       int DimEdgeID;
       int DimVrtxID;
       int DimVertID;
+      int DimTimeID; // unlimited time dim
       Err = IO::defineDim(OutFileID, "NVertLevels", NVertLevels, DimVertID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining vertical dimension PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error defining vertical dimension FAIL");
       }
       Err = IO::defineDim(OutFileID, "NCells", NCellsGlobal, DimCellID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining Cell dimension PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error defining Cell dimension FAIL");
       }
       Err = IO::defineDim(OutFileID, "NEdges", NEdgesGlobal, DimEdgeID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining Edge dimension PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error defining Edge dimension FAIL");
       }
       Err = IO::defineDim(OutFileID, "NVertices", NVerticesGlobal, DimVrtxID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining Vertex dimension PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error defining Vertex dimension FAIL");
+      }
+      Err = IO::defineDim(OutFileID, "Time", IO::Unlimited, DimTimeID);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining unlimited time dimension PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: error defining unlimited time dimension FAIL");
       }
 
       // Write some global file metadata
@@ -320,33 +366,45 @@ int main(int argc, char *argv[]) {
       std::string FileMetaDescr = "OMEGA IO Unit test file";
 
       Err = IO::writeMeta("FileMetaI4", FileMetaI4Ref, OutFileID, IO::GlobalID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing global I4 metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing global I4 metadata FAIL");
       }
       Err = IO::writeMeta("FileMetaI8", FileMetaI8Ref, OutFileID, IO::GlobalID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing global I8 metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing global I8 metadata FAIL");
       }
       Err = IO::writeMeta("FileMetaR4", FileMetaR4Ref, OutFileID, IO::GlobalID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing global R4 metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing global R4 metadata FAIL");
       }
       Err = IO::writeMeta("FileMetaR8", FileMetaR8Ref, OutFileID, IO::GlobalID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing global R8 metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing global R8 metadata FAIL");
       }
       Err = IO::writeMeta("FileMetaDescr", FileMetaDescr, OutFileID,
                           IO::GlobalID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing global char metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing global char metadata FAIL");
       }
       Err = IO::writeMeta("StringLiteral", "MyString", OutFileID, IO::GlobalID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing char literal metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing char literal metadata FAIL");
       }
@@ -359,11 +417,11 @@ int main(int argc, char *argv[]) {
       int VarIDI4Vert;
       int VarIDI8Vert;
       int VarIDR4Vert;
-      int VarIDR8Vert;
+      int VarIDR8Time; // combine two vert arrays in 2 time frames
       int VarIDCellI4;
       int VarIDCellI8;
       int VarIDCellR4;
-      int VarIDCellR8;
+      int VarIDTimeR8; // combine two cell arrays in 2 time frames
       int VarIDEdgeI4;
       int VarIDEdgeI8;
       int VarIDEdgeR4;
@@ -377,126 +435,168 @@ int main(int argc, char *argv[]) {
       int CellDimIDs[2] = {DimCellID, DimVertID};
       int EdgeDimIDs[2] = {DimEdgeID, DimVertID};
       int VrtxDimIDs[2] = {DimVrtxID, DimVertID};
+      int TimeDimIDs[2] = {DimTimeID, DimVertID};
+      int Tim2DimIDs[3] = {DimTimeID, DimCellID, DimVertID};
 
       Err = IO::defineVar(OutFileID, "ScalarI4", IO::IOTypeI4, 0, nullptr,
                           VarIDScalarI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining I4 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining I4 scalar FAIL");
       }
       Err = IO::defineVar(OutFileID, "ScalarI8", IO::IOTypeI8, 0, nullptr,
                           VarIDScalarI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining I8 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining I8 scalar FAIL");
       }
       Err = IO::defineVar(OutFileID, "ScalarR4", IO::IOTypeR4, 0, nullptr,
                           VarIDScalarR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining R4 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining R4 scalar FAIL");
       }
       Err = IO::defineVar(OutFileID, "ScalarR8", IO::IOTypeR8, 0, nullptr,
                           VarIDScalarR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining R8 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining R8 scalar FAIL");
       }
       Err = IO::defineVar(OutFileID, "I4Vert", IO::IOTypeI4, 1, VertDimIDs,
                           VarIDI4Vert);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining I4Vert array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining I4Vert array FAIL");
       }
       Err = IO::defineVar(OutFileID, "I8Vert", IO::IOTypeI8, 1, VertDimIDs,
                           VarIDI8Vert);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining I8Vert array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining I8Vert array FAIL");
       }
       Err = IO::defineVar(OutFileID, "R4Vert", IO::IOTypeR4, 1, VertDimIDs,
                           VarIDR4Vert);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining R4Vert array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining R4Vert array FAIL");
       }
-      Err = IO::defineVar(OutFileID, "R8Vert", IO::IOTypeR8, 1, VertDimIDs,
-                          VarIDR8Vert);
-      if (Err != 0) {
+      Err = IO::defineVar(OutFileID, "R8Time", IO::IOTypeR8, 2, TimeDimIDs,
+                          VarIDR8Time);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining time-dependent R8Vert array PASS");
+      } else {
          RetVal += 1;
-         LOG_ERROR("IOTest: Error defining R8Vert array FAIL");
+         LOG_ERROR("IOTest: Error defining time-dependent R8Vert array FAIL");
       }
       Err = IO::defineVar(OutFileID, "CellI4", IO::IOTypeI4, 2, CellDimIDs,
                           VarIDCellI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining CellI4 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining CellI4 array FAIL");
       }
       Err = IO::defineVar(OutFileID, "CellI8", IO::IOTypeI8, 2, CellDimIDs,
                           VarIDCellI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining CellI8 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining CellI8 array FAIL");
       }
       Err = IO::defineVar(OutFileID, "CellR4", IO::IOTypeR4, 2, CellDimIDs,
                           VarIDCellR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining CellR4 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining CellR4 array FAIL");
       }
-      Err = IO::defineVar(OutFileID, "CellR8", IO::IOTypeR8, 2, CellDimIDs,
-                          VarIDCellR8);
-      if (Err != 0) {
+      Err = IO::defineVar(OutFileID, "TimeR8", IO::IOTypeR8, 3, Tim2DimIDs,
+                          VarIDTimeR8);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining time-dependent CellR8 array PASS");
+      } else {
          RetVal += 1;
-         LOG_ERROR("IOTest: Error defining CellR8 array FAIL");
+         LOG_ERROR("IOTest: Error defining time-dependent CellR8 array FAIL");
       }
 
       Err = IO::defineVar(OutFileID, "EdgeI4", IO::IOTypeI4, 2, EdgeDimIDs,
                           VarIDEdgeI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining EdgeI4 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining EdgeI4 array FAIL");
       }
       Err = IO::defineVar(OutFileID, "EdgeI8", IO::IOTypeI8, 2, EdgeDimIDs,
                           VarIDEdgeI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining EdgeI8 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining EdgeI8 array FAIL");
       }
       Err = IO::defineVar(OutFileID, "EdgeR4", IO::IOTypeR4, 2, EdgeDimIDs,
                           VarIDEdgeR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining EdgeR4 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining EdgeR4 array FAIL");
       }
       Err = IO::defineVar(OutFileID, "EdgeR8", IO::IOTypeR8, 2, EdgeDimIDs,
                           VarIDEdgeR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining EdgeR8 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining EdgeR8 array FAIL");
       }
 
       Err = IO::defineVar(OutFileID, "VrtxI4", IO::IOTypeI4, 2, VrtxDimIDs,
                           VarIDVrtxI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining VrtxI4 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining VrtxI4 array FAIL");
       }
       Err = IO::defineVar(OutFileID, "VrtxI8", IO::IOTypeI8, 2, VrtxDimIDs,
                           VarIDVrtxI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining VrtxI8 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining VrtxI8 array FAIL");
       }
       Err = IO::defineVar(OutFileID, "VrtxR4", IO::IOTypeR4, 2, VrtxDimIDs,
                           VarIDVrtxR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining VrtxR4 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining VrtxR4 array FAIL");
       }
       Err = IO::defineVar(OutFileID, "VrtxR8", IO::IOTypeR8, 2, VrtxDimIDs,
                           VarIDVrtxR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: defining VrtxR8 array PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: Error defining VrtxR8 array FAIL");
       }
@@ -509,28 +609,38 @@ int main(int argc, char *argv[]) {
       std::string VarMetaDescrRef = "Test array for I4 on Cells";
 
       Err = IO::writeMeta("VarMetaI4", VarMetaI4Ref, OutFileID, VarIDCellI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing var I4 metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing var I4 metadata FAIL");
       }
       Err = IO::writeMeta("VarMetaI8", VarMetaI8Ref, OutFileID, VarIDCellI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing var I8 metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing var I8 metadata FAIL");
       }
       Err = IO::writeMeta("VarMetaR4", VarMetaR4Ref, OutFileID, VarIDCellI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing var R4 metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing var R4 metadata FAIL");
       }
       Err = IO::writeMeta("VarMetaR8", VarMetaR8Ref, OutFileID, VarIDCellI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing var R8 metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing var R8 metadata FAIL");
       }
       Err = IO::writeMeta("VarMetaDescr", VarMetaDescrRef, OutFileID,
                           VarIDCellI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing var char metadata PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing var char metadata FAIL");
       }
@@ -550,132 +660,197 @@ int main(int argc, char *argv[]) {
 
       // Write non-distributed variables
       Err = IO::writeNDVar(&RefI4Scalar, OutFileID, VarIDScalarI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing I4 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I4 scalar FAIL");
       }
 
       Err = IO::writeNDVar(&RefI8Scalar, OutFileID, VarIDScalarI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing I8 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I8 scalar FAIL");
       }
 
       Err = IO::writeNDVar(&RefR4Scalar, OutFileID, VarIDScalarR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R4 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R4 scalar FAIL");
       }
 
       Err = IO::writeNDVar(&RefR8Scalar, OutFileID, VarIDScalarR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R8 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R8 scalar FAIL");
       }
 
       Err = IO::writeNDVar(RefI4Vert.data(), OutFileID, VarIDI4Vert);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing I4Vert vector PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I4Vert vector FAIL");
       }
 
       Err = IO::writeNDVar(RefI8Vert.data(), OutFileID, VarIDI8Vert);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing I8Vert vector PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I8Vert vector FAIL");
       }
 
       Err = IO::writeNDVar(RefR4Vert.data(), OutFileID, VarIDR4Vert);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R4Vert vector PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R4Vert vector FAIL");
       }
 
-      Err = IO::writeNDVar(RefR8Vert.data(), OutFileID, VarIDR8Vert);
-      if (Err != 0) {
+      // Write R8 arrays as two time slices
+      std::vector<int> DimLengths(1);
+      DimLengths[0] = NVertLevels;
+      Err = IO::writeNDVar(RefR8Vert.data(), OutFileID, VarIDR8Time, 0,
+                           &DimLengths);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R8Time vector frame 0 PASS");
+      } else {
          RetVal += 1;
-         LOG_ERROR("IOTest: error writing R8Vert vector FAIL");
+         LOG_ERROR("IOTest: error writing R8Time vector frame 0 FAIL");
+      }
+
+      Err = IO::writeNDVar(RefR8Time.data(), OutFileID, VarIDR8Time, 1,
+                           &DimLengths);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R8Time vector frame 1 PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: error writing R8Time vector frame 1 FAIL");
       }
 
       // Write distributed arrays
       Err = IO::writeArray(RefI4Cell.data(), NCellsSize * NVertLevels, &FillI4,
                            OutFileID, DecompCellI4, VarIDCellI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing I4 array on cells PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I4 array on cells FAIL");
       }
       Err = IO::writeArray(RefI8Cell.data(), NCellsSize * NVertLevels, &FillI8,
                            OutFileID, DecompCellI8, VarIDCellI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing I8 array on cells PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I8 array on cells FAIL");
       }
       Err = IO::writeArray(RefR4Cell.data(), NCellsSize * NVertLevels, &FillR4,
                            OutFileID, DecompCellR4, VarIDCellR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R4 array on cells PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R4 array on cells FAIL");
       }
+      // Write R8 cell data as two time slices
       Err = IO::writeArray(RefR8Cell.data(), NCellsSize * NVertLevels, &FillR8,
-                           OutFileID, DecompCellR8, VarIDCellR8);
-      if (Err != 0) {
+                           OutFileID, DecompCellR8, VarIDTimeR8, 0);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R8 array on cells frame 0 PASS");
+      } else {
          RetVal += 1;
-         LOG_ERROR("IOTest: error writing R8 array on cells FAIL");
+         LOG_ERROR("IOTest: error writing R8 array on cells frame 0 FAIL");
+      }
+
+      Err = IO::writeArray(RefR8Tim2.data(), NCellsSize * NVertLevels, &FillR8,
+                           OutFileID, DecompCellR8, VarIDTimeR8, 1);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R8 array on cells frame 1 PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: error writing R8 array on cells frame 1 FAIL");
       }
 
       Err = IO::writeArray(RefI4Edge.data(), NEdgesSize * NVertLevels, &FillI4,
                            OutFileID, DecompEdgeI4, VarIDEdgeI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing I4 array on Edges PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I4 array on Edges FAIL");
       }
       Err = IO::writeArray(RefI8Edge.data(), NEdgesSize * NVertLevels, &FillI8,
                            OutFileID, DecompEdgeI8, VarIDEdgeI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing I8 array on Edges PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I8 array on Edges FAIL");
       }
       Err = IO::writeArray(RefR4Edge.data(), NEdgesSize * NVertLevels, &FillR4,
                            OutFileID, DecompEdgeR4, VarIDEdgeR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R4 array on Edges PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R4 array on Edges FAIL");
       }
       Err = IO::writeArray(RefR8Edge.data(), NEdgesSize * NVertLevels, &FillR8,
                            OutFileID, DecompEdgeR8, VarIDEdgeR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R8 array on Edges PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R8 array on Edges FAIL");
       }
 
       Err = IO::writeArray(RefI4Vrtx.data(), NVerticesSize * NVertLevels,
                            &FillI4, OutFileID, DecompVrtxI4, VarIDVrtxI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing I4 array on vertices PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I4 array on vertices FAIL");
       }
       Err = IO::writeArray(RefI8Vrtx.data(), NVerticesSize * NVertLevels,
                            &FillI8, OutFileID, DecompVrtxI8, VarIDVrtxI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing I8 array on vertices PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I8 array on vertices FAIL");
       }
       Err = IO::writeArray(RefR4Vrtx.data(), NVerticesSize * NVertLevels,
                            &FillR4, OutFileID, DecompVrtxR4, VarIDVrtxR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R4 array on vertices PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R4 array on vertices FAIL");
       }
       Err = IO::writeArray(RefR8Vrtx.data(), NVerticesSize * NVertLevels,
                            &FillR8, OutFileID, DecompVrtxR8, VarIDVrtxR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R8 array on vertices PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R8 array on vertices FAIL");
       }
 
       // Finished writing, close file
       Err = IO::closeFile(OutFileID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: closing output file PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error closing output file FAIL");
       }
@@ -683,7 +858,9 @@ int main(int argc, char *argv[]) {
       // Open a file for reading to verify read/write
       int InFileID;
       Err = IO::openFile(InFileID, "IOTest.nc", IO::ModeRead);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: opening file for reading PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error opening file for reading FAIL");
       }
@@ -694,30 +871,30 @@ int main(int argc, char *argv[]) {
       Err = IO::getDimFromFile(InFileID, "NVertLevels", NVertLevelsID,
                                NVertLevelsNew);
       if (Err == 0 and NVertLevelsNew == NVertLevels) {
-         LOG_INFO("IOTest: read/write vert dimension test PASS");
+         LOG_ERROR("IOTest: read/write vert dimension test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write vert dimension test FAIL");
+         LOG_ERROR("IOTest: read/write vert dimension test FAIL");
       }
 
       I4 NCellsNewID;
       I4 NCellsNew;
       Err = IO::getDimFromFile(InFileID, "NCells", NCellsNewID, NCellsNew);
       if (Err == 0 and NCellsNew == NCellsGlobal) {
-         LOG_INFO("IOTest: read/write cell dimension test PASS");
+         LOG_ERROR("IOTest: read/write cell dimension test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write cell dimension test FAIL");
+         LOG_ERROR("IOTest: read/write cell dimension test FAIL");
       }
 
       I4 NEdgesNewID;
       I4 NEdgesNew;
       Err = IO::getDimFromFile(InFileID, "NEdges", NEdgesNewID, NEdgesNew);
       if (Err == 0 and NEdgesNew == NEdgesGlobal) {
-         LOG_INFO("IOTest: read/write edge dimension test PASS");
+         LOG_ERROR("IOTest: read/write edge dimension test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write edge dimension test FAIL");
+         LOG_ERROR("IOTest: read/write edge dimension test FAIL");
       }
 
       I4 NVerticesNewID;
@@ -725,10 +902,20 @@ int main(int argc, char *argv[]) {
       Err = IO::getDimFromFile(InFileID, "NVertices", NVerticesNewID,
                                NVerticesNew);
       if (Err == 0 and NVerticesNew == NVerticesGlobal) {
-         LOG_INFO("IOTest: read/write vertex dimension test PASS");
+         LOG_ERROR("IOTest: read/write vertex dimension test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write vertex dimension test FAIL");
+         LOG_ERROR("IOTest: read/write vertex dimension test FAIL");
+      }
+
+      I4 NTimeNewID;
+      I4 NTimeNew;
+      Err = IO::getDimFromFile(InFileID, "Time", NTimeNewID, NTimeNew);
+      if (Err == 0 and NTimeNew == 2) {
+         LOG_ERROR("IOTest: read/write time dimension test PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: read/write time dimension test FAIL");
       }
 
       // Read global attributes
@@ -744,10 +931,10 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading file I4 metadata FAIL");
       }
       if (FileMetaI4New == FileMetaI4Ref) {
-         LOG_INFO("IOTest: read/write file metadata I4 test PASS");
+         LOG_ERROR("IOTest: read/write file metadata I4 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write file metadata I4 test FAIL");
+         LOG_ERROR("IOTest: read/write file metadata I4 test FAIL");
       }
 
       Err = IO::readMeta("FileMetaI8", FileMetaI8New, InFileID, IO::GlobalID);
@@ -756,10 +943,10 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading file I8 metadata FAIL");
       }
       if (FileMetaI8New == FileMetaI8Ref) {
-         LOG_INFO("IOTest: read/write file metadata I8 test PASS");
+         LOG_ERROR("IOTest: read/write file metadata I8 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write file metadata I8 test FAIL");
+         LOG_ERROR("IOTest: read/write file metadata I8 test FAIL");
       }
 
       Err = IO::readMeta("FileMetaR4", FileMetaR4New, InFileID, IO::GlobalID);
@@ -768,10 +955,10 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading file R4 metadata FAIL");
       }
       if (FileMetaR4New == FileMetaR4Ref) {
-         LOG_INFO("IOTest: read/write file metadata R4 test PASS");
+         LOG_ERROR("IOTest: read/write file metadata R4 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write file metadata R4 test FAIL");
+         LOG_ERROR("IOTest: read/write file metadata R4 test FAIL");
       }
 
       Err = IO::readMeta("FileMetaR8", FileMetaR8New, InFileID, IO::GlobalID);
@@ -780,10 +967,10 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading file R8 metadata FAIL");
       }
       if (FileMetaR8New == FileMetaR8Ref) {
-         LOG_INFO("IOTest: read/write file metadata R8 test PASS");
+         LOG_ERROR("IOTest: read/write file metadata R8 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write file metadata R8 test FAIL");
+         LOG_ERROR("IOTest: read/write file metadata R8 test FAIL");
       }
 
       Err = IO::readMeta("FileMetaDescr", FileMetaDescrNew, InFileID,
@@ -793,10 +980,10 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading file string metadata FAIL");
       }
       if (FileMetaDescrNew == FileMetaDescr) {
-         LOG_INFO("IOTest: read/write file metadata string test PASS");
+         LOG_ERROR("IOTest: read/write file metadata string test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write file metadata string test FAIL");
+         LOG_ERROR("IOTest: read/write file metadata string test FAIL");
       }
 
       std::string MyStringNew;
@@ -806,10 +993,10 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading file string literal FAIL");
       }
       if (MyStringNew == "MyString") {
-         LOG_INFO("IOTest: read/write file metadata string literal test PASS");
+         LOG_ERROR("IOTest: read/write file metadata string literal test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write file metadata string literal test FAIL");
+         LOG_ERROR("IOTest: read/write file metadata string literal test FAIL");
       }
       // Read new variables
 
@@ -822,11 +1009,13 @@ int main(int argc, char *argv[]) {
       HostArray1DI8 NewI8Vert("NewI8Vert", NVertLevels);
       HostArray1DR4 NewR4Vert("NewR4Vert", NVertLevels);
       HostArray1DR8 NewR8Vert("NewR8Vert", NVertLevels);
+      HostArray1DR8 NewR8Time("NewR8Time", NVertLevels);
 
       HostArray2DI4 NewI4Cell("NewI4Cell", NCellsSize, NVertLevels);
       HostArray2DI8 NewI8Cell("NewI8Cell", NCellsSize, NVertLevels);
       HostArray2DR4 NewR4Cell("NewR4Cell", NCellsSize, NVertLevels);
       HostArray2DR8 NewR8Cell("NewR8Cell", NCellsSize, NVertLevels);
+      HostArray2DR8 NewR8Tim2("NewR8Tim2", NCellsSize, NVertLevels);
 
       HostArray2DI4 NewI4Edge("NewI4Edge", NEdgesSize, NVertLevels);
       HostArray2DI8 NewI8Edge("NewI8Edge", NEdgesSize, NVertLevels);
@@ -840,125 +1029,184 @@ int main(int argc, char *argv[]) {
 
       // Read non-distributed variables
       Err = IO::readNDVar(&NewI4Scalar, "ScalarI4", InFileID, VarIDScalarI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading I4 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I4 scalar FAIL");
       }
 
       Err = IO::readNDVar(&NewI8Scalar, "ScalarI8", InFileID, VarIDScalarI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading I8 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I8 scalar FAIL");
       }
 
       Err = IO::readNDVar(&NewR4Scalar, "ScalarR4", InFileID, VarIDScalarR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R4 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R4 scalar FAIL");
       }
 
       Err = IO::readNDVar(&NewR8Scalar, "ScalarR8", InFileID, VarIDScalarR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R8 scalar PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R8 scalar FAIL");
       }
 
       Err = IO::readNDVar(NewI4Vert.data(), "I4Vert", InFileID, VarIDI4Vert);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading I4Vert vector PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I4Vert vector FAIL");
       }
 
       Err = IO::readNDVar(NewI8Vert.data(), "I8Vert", InFileID, VarIDI8Vert);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading I8Vert vector PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I8Vert vector FAIL");
       }
 
       Err = IO::readNDVar(NewR4Vert.data(), "R4Vert", InFileID, VarIDR4Vert);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R4Vert vector PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R4Vert vector FAIL");
       }
 
-      Err = IO::readNDVar(NewR8Vert.data(), "R8Vert", InFileID, VarIDR8Vert);
-      if (Err != 0) {
+      // Read R8 data as two time slices
+      Err = IO::readNDVar(NewR8Vert.data(), "R8Time", InFileID, VarIDR8Time, 0,
+                          &DimLengths);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R8Vert vector frame 0 PASS");
+      } else {
          RetVal += 1;
-         LOG_ERROR("IOTest: error reading R8Vert vector FAIL");
+         LOG_ERROR("IOTest: error reading R8Vert vector frame 0 FAIL");
+      }
+      Err = IO::readNDVar(NewR8Time.data(), "R8Time", InFileID, VarIDR8Time, 1,
+                          &DimLengths);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R8Vert vector frame 1 PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: error reading R8Vert vector frame 1 FAIL");
       }
 
       // Read distributed arrays
       Err = IO::readArray(NewI4Cell.data(), NCellsSize * NVertLevels, "CellI4",
                           InFileID, DecompCellI4, VarIDCellI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading I4 array on cells PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I4 array on cells FAIL");
       }
       Err = IO::readArray(NewI8Cell.data(), NCellsSize * NVertLevels, "CellI8",
                           InFileID, DecompCellI8, VarIDCellI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading I8 array on cells PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I8 array on cells FAIL");
       }
       Err = IO::readArray(NewR4Cell.data(), NCellsSize * NVertLevels, "CellR4",
                           InFileID, DecompCellR4, VarIDCellR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R4 array on cells PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R4 array on cells FAIL");
       }
-      Err = IO::readArray(NewR8Cell.data(), NCellsSize * NVertLevels, "CellR8",
-                          InFileID, DecompCellR8, VarIDCellR8);
-      if (Err != 0) {
+      // Read R8 Cell data as two time slices
+      Err = IO::readArray(NewR8Cell.data(), NCellsSize * NVertLevels, "TimeR8",
+                          InFileID, DecompCellR8, VarIDTimeR8, 0);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R8 array on cells frame 0 PASS");
+      } else {
          RetVal += 1;
-         LOG_ERROR("IOTest: error reading R8 array on cells FAIL");
+         LOG_ERROR("IOTest: error reading R8 array on cells frame 0 FAIL");
+      }
+      Err = IO::readArray(NewR8Tim2.data(), NCellsSize * NVertLevels, "TimeR8",
+                          InFileID, DecompCellR8, VarIDTimeR8, 1);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R8 array on cells frame 1 PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: error reading R8 array on cells frame 1 FAIL");
       }
 
       Err = IO::readArray(NewI4Edge.data(), NEdgesSize * NVertLevels, "EdgeI4",
                           InFileID, DecompEdgeI4, VarIDEdgeI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading I4 array on Edges PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I4 array on Edges FAIL");
       }
       Err = IO::readArray(NewI8Edge.data(), NEdgesSize * NVertLevels, "EdgeI8",
                           InFileID, DecompEdgeI8, VarIDEdgeI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading I8 array on Edges PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I8 array on Edges FAIL");
       }
       Err = IO::readArray(NewR4Edge.data(), NEdgesSize * NVertLevels, "EdgeR4",
                           InFileID, DecompEdgeR4, VarIDEdgeR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R4 array on Edges PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R4 array on Edges FAIL");
       }
       Err = IO::readArray(NewR8Edge.data(), NEdgesSize * NVertLevels, "EdgeR8",
                           InFileID, DecompEdgeR8, VarIDEdgeR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R8 array on Edges PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R8 array on Edges FAIL");
       }
 
       Err = IO::readArray(NewI4Vrtx.data(), NVerticesSize * NVertLevels,
                           "VrtxI4", InFileID, DecompVrtxI4, VarIDVrtxI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading I4 array on vertices PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I4 array on vertices FAIL");
       }
       Err = IO::readArray(NewI8Vrtx.data(), NVerticesSize * NVertLevels,
                           "VrtxI8", InFileID, DecompVrtxI8, VarIDVrtxI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading I8 array on vertices PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I8 array on vertices FAIL");
       }
       Err = IO::readArray(NewR4Vrtx.data(), NVerticesSize * NVertLevels,
                           "VrtxR4", InFileID, DecompVrtxR4, VarIDVrtxR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R4 array on vertices PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R4 array on vertices FAIL");
       }
       Err = IO::readArray(NewR8Vrtx.data(), NVerticesSize * NVertLevels,
                           "VrtxR8", InFileID, DecompVrtxR8, VarIDVrtxR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: reading R8 array on vertices PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R8 array on vertices FAIL");
       }
@@ -971,6 +1219,7 @@ int main(int argc, char *argv[]) {
       int Err2 = 0;
       int Err3 = 0;
       int Err4 = 0;
+      int Err5 = 0;
 
       if (NewI4Scalar != RefI4Scalar)
          Err1++;
@@ -981,34 +1230,35 @@ int main(int argc, char *argv[]) {
       if (NewR8Scalar != RefR8Scalar)
          Err4++;
       if (Err1 == 0) {
-         LOG_INFO("IOTest: read/write scalar I4 test PASS");
+         LOG_ERROR("IOTest: read/write scalar I4 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write scalar I4 test FAIL");
+         LOG_ERROR("IOTest: read/write scalar I4 test FAIL");
       }
       if (Err2 == 0) {
-         LOG_INFO("IOTest: read/write scalar I8 test PASS");
+         LOG_ERROR("IOTest: read/write scalar I8 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write scalar I8 test FAIL");
+         LOG_ERROR("IOTest: read/write scalar I8 test FAIL");
       }
       if (Err3 == 0) {
-         LOG_INFO("IOTest: read/write scalar R4 test PASS");
+         LOG_ERROR("IOTest: read/write scalar R4 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write scalar R4 test FAIL");
+         LOG_ERROR("IOTest: read/write scalar R4 test FAIL");
       }
       if (Err4 == 0) {
-         LOG_INFO("IOTest: read/write scalar R8 test PASS");
+         LOG_ERROR("IOTest: read/write scalar R8 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write scalar R8 test FAIL");
+         LOG_ERROR("IOTest: read/write scalar R8 test FAIL");
       }
 
       Err1 = 0;
       Err2 = 0;
       Err3 = 0;
       Err4 = 0;
+      Err5 = 0;
       for (int k = 0; k < NVertLevels; ++k) {
          if (NewI4Vert(k) != RefI4Vert(k))
             Err1++;
@@ -1018,36 +1268,45 @@ int main(int argc, char *argv[]) {
             Err3++;
          if (NewR8Vert(k) != RefR8Vert(k))
             Err4++;
+         if (NewR8Time(k) != RefR8Time(k))
+            Err5++;
       }
       if (Err1 == 0) {
-         LOG_INFO("IOTest: read/write vert I4 vector test PASS");
+         LOG_ERROR("IOTest: read/write vert I4 vector test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write vert I4 vector test FAIL");
+         LOG_ERROR("IOTest: read/write vert I4 vector test FAIL");
       }
       if (Err2 == 0) {
-         LOG_INFO("IOTest: read/write vert I8 vector test PASS");
+         LOG_ERROR("IOTest: read/write vert I8 vector test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write vert I8 vector test FAIL");
+         LOG_ERROR("IOTest: read/write vert I8 vector test FAIL");
       }
       if (Err3 == 0) {
-         LOG_INFO("IOTest: read/write vert R4 vector test PASS");
+         LOG_ERROR("IOTest: read/write vert R4 vector test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write vert R4 vector test FAIL");
+         LOG_ERROR("IOTest: read/write vert R4 vector test FAIL");
       }
       if (Err4 == 0) {
-         LOG_INFO("IOTest: read/write vert R8 vector test PASS");
+         LOG_ERROR("IOTest: read/write vert R8 vector test frame 0 PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write vert R8 vector test FAIL");
+         LOG_ERROR("IOTest: read/write vert R8 vector test frame 0 FAIL");
+      }
+      if (Err5 == 0) {
+         LOG_ERROR("IOTest: read/write vert R8 vector test frame 1 PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: read/write vert R8 vector test frame 1 FAIL");
       }
 
       Err1 = 0;
       Err2 = 0;
       Err3 = 0;
       Err4 = 0;
+      Err5 = 0;
       for (int Cell = 0; Cell < NCellsOwned; ++Cell) {
          for (int k = 0; k < NVertLevels; ++k) {
             if (NewI4Cell(Cell, k) != RefI4Cell(Cell, k))
@@ -1058,31 +1317,39 @@ int main(int argc, char *argv[]) {
                Err3++;
             if (NewR8Cell(Cell, k) != RefR8Cell(Cell, k))
                Err4++;
+            if (NewR8Tim2(Cell, k) != RefR8Tim2(Cell, k))
+               Err5++;
          }
       }
       if (Err1 == 0) {
-         LOG_INFO("IOTest: read/write array I4 on Cells test PASS");
+         LOG_ERROR("IOTest: read/write array I4 on Cells test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array I4 on Cells test FAIL");
+         LOG_ERROR("IOTest: read/write array I4 on Cells test FAIL");
       }
       if (Err2 == 0) {
-         LOG_INFO("IOTest: read/write array I8 on Cells test PASS");
+         LOG_ERROR("IOTest: read/write array I8 on Cells test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array I8 on Cells test FAIL");
+         LOG_ERROR("IOTest: read/write array I8 on Cells test FAIL");
       }
       if (Err3 == 0) {
-         LOG_INFO("IOTest: read/write array R4 on Cells test PASS");
+         LOG_ERROR("IOTest: read/write array R4 on Cells test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array R4 on Cells test FAIL");
+         LOG_ERROR("IOTest: read/write array R4 on Cells test FAIL");
       }
       if (Err4 == 0) {
-         LOG_INFO("IOTest: read/write array R8 on Cells test PASS");
+         LOG_ERROR("IOTest: read/write array R8 on Cells test frame 0 PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array R8 on Cells test FAIL");
+         LOG_ERROR("IOTest: read/write array R8 on Cells test frame 0 FAIL");
+      }
+      if (Err5 == 0) {
+         LOG_ERROR("IOTest: read/write array R8 on Cells test frame 1 PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: read/write array R8 on Cells test frame 1 FAIL");
       }
 
       Err1 = 0;
@@ -1102,28 +1369,28 @@ int main(int argc, char *argv[]) {
          }
       }
       if (Err1 == 0) {
-         LOG_INFO("IOTest: read/write array I4 on Edges test PASS");
+         LOG_ERROR("IOTest: read/write array I4 on Edges test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array I4 on Edges test FAIL");
+         LOG_ERROR("IOTest: read/write array I4 on Edges test FAIL");
       }
       if (Err2 == 0) {
-         LOG_INFO("IOTest: read/write array I8 on Edges test PASS");
+         LOG_ERROR("IOTest: read/write array I8 on Edges test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array I8 on Edges test FAIL");
+         LOG_ERROR("IOTest: read/write array I8 on Edges test FAIL");
       }
       if (Err3 == 0) {
-         LOG_INFO("IOTest: read/write array R4 on Edges test PASS");
+         LOG_ERROR("IOTest: read/write array R4 on Edges test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array R4 on Edges test FAIL");
+         LOG_ERROR("IOTest: read/write array R4 on Edges test FAIL");
       }
       if (Err4 == 0) {
-         LOG_INFO("IOTest: read/write array R8 on Edges test PASS");
+         LOG_ERROR("IOTest: read/write array R8 on Edges test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array R8 on Edges test FAIL");
+         LOG_ERROR("IOTest: read/write array R8 on Edges test FAIL");
       }
 
       Err1 = 0;
@@ -1143,28 +1410,28 @@ int main(int argc, char *argv[]) {
          }
       }
       if (Err1 == 0) {
-         LOG_INFO("IOTest: read/write array I4 on Vertices test PASS");
+         LOG_ERROR("IOTest: read/write array I4 on Vertices test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array I4 on Vertices test FAIL");
+         LOG_ERROR("IOTest: read/write array I4 on Vertices test FAIL");
       }
       if (Err2 == 0) {
-         LOG_INFO("IOTest: read/write array I8 on Vertices test PASS");
+         LOG_ERROR("IOTest: read/write array I8 on Vertices test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array I8 on Vertices test FAIL");
+         LOG_ERROR("IOTest: read/write array I8 on Vertices test FAIL");
       }
       if (Err3 == 0) {
-         LOG_INFO("IOTest: read/write array R4 on Vertices test PASS");
+         LOG_ERROR("IOTest: read/write array R4 on Vertices test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array R4 on Vertices test FAIL");
+         LOG_ERROR("IOTest: read/write array R4 on Vertices test FAIL");
       }
       if (Err4 == 0) {
-         LOG_INFO("IOTest: read/write array R8 on Vertices test PASS");
+         LOG_ERROR("IOTest: read/write array R8 on Vertices test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write array R8 on Vertices test FAIL");
+         LOG_ERROR("IOTest: read/write array R8 on Vertices test FAIL");
       }
 
       // Read array attributes
@@ -1180,10 +1447,10 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading var I4 metadata FAIL");
       }
       if (VarMetaI4New == VarMetaI4Ref) {
-         LOG_INFO("IOTest: read/write var metadata I4 test PASS");
+         LOG_ERROR("IOTest: read/write var metadata I4 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write var metadata I4 test FAIL");
+         LOG_ERROR("IOTest: read/write var metadata I4 test FAIL");
       }
       Err = IO::readMeta("VarMetaI8", VarMetaI8New, InFileID, VarIDCellI4);
       if (Err != 0) {
@@ -1191,10 +1458,10 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading var I8 metadata FAIL");
       }
       if (VarMetaI8New == VarMetaI8Ref) {
-         LOG_INFO("IOTest: read/write var metadata I8 test PASS");
+         LOG_ERROR("IOTest: read/write var metadata I8 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write var metadata I8 test FAIL");
+         LOG_ERROR("IOTest: read/write var metadata I8 test FAIL");
       }
       Err = IO::readMeta("VarMetaR4", VarMetaR4New, InFileID, VarIDCellI4);
       if (Err != 0) {
@@ -1202,10 +1469,10 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading var R4 metadata FAIL");
       }
       if (VarMetaR4New == VarMetaR4Ref) {
-         LOG_INFO("IOTest: read/write var metadata R4 test PASS");
+         LOG_ERROR("IOTest: read/write var metadata R4 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write var metadata R4 test FAIL");
+         LOG_ERROR("IOTest: read/write var metadata R4 test FAIL");
       }
       Err = IO::readMeta("VarMetaR8", VarMetaR8New, InFileID, VarIDCellI4);
       if (Err != 0) {
@@ -1213,10 +1480,10 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading var R8 metadata FAIL");
       }
       if (VarMetaR8New == VarMetaR8Ref) {
-         LOG_INFO("IOTest: read/write var metadata R8 test PASS");
+         LOG_ERROR("IOTest: read/write var metadata R8 test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write var metadata R8 test FAIL");
+         LOG_ERROR("IOTest: read/write var metadata R8 test FAIL");
       }
       Err =
           IO::readMeta("VarMetaDescr", VarMetaDescrNew, InFileID, VarIDCellI4);
@@ -1225,79 +1492,105 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading var string metadata FAIL");
       }
       if (VarMetaDescrNew == VarMetaDescrRef) {
-         LOG_INFO("IOTest: read/write var metadata string test PASS");
+         LOG_ERROR("IOTest: read/write var metadata string test PASS");
       } else {
          RetVal += 1;
-         LOG_INFO("IOTest: read/write var metadata string test FAIL");
+         LOG_ERROR("IOTest: read/write var metadata string test FAIL");
       }
 
       // Finished reading, close file
       Err = IO::closeFile(InFileID);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: closing input file PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error closing input file FAIL");
       }
 
       // Test destruction of Decompositions
       Err = IO::destroyDecomp(DecompCellI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp cell I4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp cell I4 FAIL");
       }
       Err = IO::destroyDecomp(DecompCellI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp cell I8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp cell I8 FAIL");
       }
       Err = IO::destroyDecomp(DecompCellR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp cell R4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp cell R4 FAIL");
       }
       Err = IO::destroyDecomp(DecompCellR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp cell R8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp cell R8 FAIL");
       }
 
       Err = IO::destroyDecomp(DecompEdgeI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp Edge I4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp Edge I4 FAIL");
       }
       Err = IO::destroyDecomp(DecompEdgeI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp Edge I8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp Edge I8 FAIL");
       }
       Err = IO::destroyDecomp(DecompEdgeR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp Edge R4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp Edge R4 FAIL");
       }
       Err = IO::destroyDecomp(DecompEdgeR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp Edge R8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp Edge R8 FAIL");
       }
 
       Err = IO::destroyDecomp(DecompVrtxI4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp Vrtx I4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp Vrtx I4 FAIL");
       }
       Err = IO::destroyDecomp(DecompVrtxI8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp Vrtx I8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp Vrtx I8 FAIL");
       }
       Err = IO::destroyDecomp(DecompVrtxR4);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp Vrtx R4 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp Vrtx R4 FAIL");
       }
       Err = IO::destroyDecomp(DecompVrtxR8);
-      if (Err != 0) {
+      if (Err == 0) {
+         LOG_ERROR("IOTest: destroying decomp Vrtx R8 PASS");
+      } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error destroying decomp Vrtx R8 FAIL");
       }
@@ -1306,7 +1599,7 @@ int main(int argc, char *argv[]) {
       Decomp::clear();
       MachEnv::removeAll();
       if (Err == 0)
-         LOG_INFO("IOTest: Successful completion");
+         LOG_ERROR("IOTest: Successful completion");
    }
    Kokkos::finalize();
    MPI_Finalize();

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -715,7 +715,8 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error writing R4Vert vector FAIL");
       }
 
-      // Write R8 arrays as two time slices
+      // Write R8 arrays as two time slices - the first frame here with
+      // the second frame written after re-open
       std::vector<int> DimLengths(1);
       DimLengths[0] = NVertLevels;
       Err = IO::writeNDVar(RefR8Vert.data(), OutFileID, VarIDR8Time, 0,
@@ -725,15 +726,6 @@ int main(int argc, char *argv[]) {
       } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R8Time vector frame 0 FAIL");
-      }
-
-      Err = IO::writeNDVar(RefR8Time.data(), OutFileID, VarIDR8Time, 1,
-                           &DimLengths);
-      if (Err == 0) {
-         LOG_ERROR("IOTest: writing R8Time vector frame 1 PASS");
-      } else {
-         RetVal += 1;
-         LOG_ERROR("IOTest: error writing R8Time vector frame 1 FAIL");
       }
 
       // Write distributed arrays
@@ -761,7 +753,8 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R4 array on cells FAIL");
       }
-      // Write R8 cell data as two time slices
+      // Write R8 cell data as two time slices - this is first frame
+      // Second frame written below
       Err = IO::writeArray(RefR8Cell.data(), NCellsSize * NVertLevels, &FillR8,
                            OutFileID, DecompCellR8, VarIDTimeR8, 0);
       if (Err == 0) {
@@ -769,15 +762,6 @@ int main(int argc, char *argv[]) {
       } else {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R8 array on cells frame 0 FAIL");
-      }
-
-      Err = IO::writeArray(RefR8Tim2.data(), NCellsSize * NVertLevels, &FillR8,
-                           OutFileID, DecompCellR8, VarIDTimeR8, 1);
-      if (Err == 0) {
-         LOG_ERROR("IOTest: writing R8 array on cells frame 1 PASS");
-      } else {
-         RetVal += 1;
-         LOG_ERROR("IOTest: error writing R8 array on cells frame 1 FAIL");
       }
 
       Err = IO::writeArray(RefI4Edge.data(), NEdgesSize * NVertLevels, &FillI4,
@@ -847,6 +831,45 @@ int main(int argc, char *argv[]) {
       }
 
       // Finished writing, close file
+      Err = IO::closeFile(OutFileID);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: closing output file PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: error closing output file FAIL");
+      }
+
+      // Re-open to write additional frames for multi-frame fields
+      // Open a file for output
+      Err = IO::openFile(OutFileID, "IOTest.nc", IO::ModeWrite, IO::FmtDefault,
+                         IO::IfExists::Append);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: file re-open PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: error re-opening file for output FAIL");
+      }
+
+      // write second frame data
+      Err = IO::writeNDVar(RefR8Time.data(), OutFileID, VarIDR8Time, 1,
+                           &DimLengths);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R8Time vector frame 1 PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: error writing R8Time vector frame 1 FAIL");
+      }
+
+      Err = IO::writeArray(RefR8Tim2.data(), NCellsSize * NVertLevels, &FillR8,
+                           OutFileID, DecompCellR8, VarIDTimeR8, 1);
+      if (Err == 0) {
+         LOG_ERROR("IOTest: writing R8 array on cells frame 1 PASS");
+      } else {
+         RetVal += 1;
+         LOG_ERROR("IOTest: error writing R8 array on cells frame 1 FAIL");
+      }
+
+      // Finished writing again, close file
       Err = IO::closeFile(OutFileID);
       if (Err == 0) {
          LOG_ERROR("IOTest: closing output file PASS");


### PR DESCRIPTION
With these changes, users can write multiple time slices of a field to a given file. This is specified through the stream input YAML configuration by adding a file frequency in addition to the data frequency.  Currently this only applies to output streams. While input multi-frame reads are supported at the base IO level, I am waiting for forcing designs to determine how best to support multiple slices in an input file.  Unit tests for reading/writing multiple slices from a file have been added for the base IO level and all unit tests pass.  I have modified the default YAML config to write 10-day high-frequency output for two months in two monthly files and verified that correct times have been written for the time field. The user and developer docs have been updated to describe how to configure and use this feature. 

Checklist
* [ ] Documentation:
  * [x] Design document has been generated and added to the docs
  * [x] User's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [ ] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
  * [ ] Polaris test suite has passed


