### PR TITLE
Add a scale factor for the divergence term in the velocity Del4 operator

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -25,6 +25,7 @@ Omega:
     ViscDel2: 1.0e3
     VelHyperDiffTendencyEnable: true
     ViscDel4: 1.2e11
+    DivFactor: 1.0
     TracerHorzAdvTendencyEnable: true
     TracerDiffTendencyEnable: true
     EddyDiff2: 10.0

--- a/components/omega/doc/userGuide/TendencyTerms.md
+++ b/components/omega/doc/userGuide/TendencyTerms.md
@@ -39,6 +39,7 @@ the currently available tendency terms:
 | | ViscDel2 | horizontal viscosity
 | VelocityHyperDiffOnEdge | VelHyperDiffTendencyEnable | enable/disable term
 | | ViscDel4 | horizontal biharmonic mixing coefficient for normal velocity
+| | DivFactor | scale factor for the divergence term
 | TracerHorzAdvOnCell | TracerHorzAdvTendencyEnable | enable/disable term
 | TracerDiffOnCell | TracerDiffTendencyEnable | enable/disable term
 | | EddyDiff2 | horizontal diffusion coefficient

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -196,6 +196,13 @@ int Tendencies::readTendConfig(Config *TendConfig ///< [in] Tendencies subconfig
       return ViscDel4Err;
    }
 
+   I4 DivFactorErr =
+       TendConfig->get("DivFactor", this->VelocityHyperDiff.DivFactor);
+   if (DivFactorErr != 0 && this->VelocityHyperDiff.Enabled) {
+      LOG_CRITICAL("Tendencies: DivFactor not found in TendConfig");
+      return DivFactorErr;
+   }
+
    I4 TrHAdvErr = TendConfig->get("TracerHorzAdvTendencyEnable",
                                   this->TracerHorzAdv.Enabled);
    if (TrHAdvErr != 0) {

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -228,6 +228,7 @@ class VelocityHyperDiffOnEdge {
    bool Enabled;
 
    Real ViscDel4;
+   Real DivFactor;
 
    /// Constructor declaration
    VelocityHyperDiffOnEdge(const HorzMesh *Mesh);
@@ -252,7 +253,8 @@ class VelocityHyperDiffOnEdge {
       for (int KVec = 0; KVec < VecLength; ++KVec) {
          const I4 K = KStart + KVec;
          const Real Del2U =
-             ((Del2DivCell(ICell1, K) - Del2DivCell(ICell0, K)) * DcEdgeInv -
+             (DivFactor * (Del2DivCell(ICell1, K) - Del2DivCell(ICell0, K)) *
+                  DcEdgeInv -
               (Del2RVortVertex(IVertex1, K) - Del2RVortVertex(IVertex0, K)) *
                   DvEdgeInv);
 

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -590,6 +590,10 @@ int testVelHyperDiff(int NVertLevels, Real RTol) {
    if (Err != 0) {
       LOG_CRITICAL("Tendencies: ViscDel4 not found in TendConfig");
    }
+   Err = TendConfig.get("DivFactor", VelHyperDiffOnE.DivFactor);
+   if (Err != 0) {
+      LOG_CRITICAL("Tendencies: DivFactor not found in TendConfig");
+   }
    const Real ViscDel4 = VelHyperDiffOnE.ViscDel4;
 
    // Compute exact result


### PR DESCRIPTION
This PR adds a scale factor, `DivFactor`, for the divergence term in the velocity hyper diffusion operator. 
- The default value of `DivFactor` is set to 1.0 and is specified in `config/Default.yml`.
- A section for reading `DivFactor` is added to the unit test of the velocity hyper diffusion operator.
- User's guide has been updated to include a description of `DivFactor` in `userGuide/TendencyTerms.md`.

Passed unit tests on Frontier (CPU & GPU).

Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [ ] Unit tests have passed.