### PR TITLE
Add tridiagonal solvers

### DIFF
--- a/components/omega/doc/conf.py
+++ b/components/omega/doc/conf.py
@@ -74,7 +74,7 @@ myst_enable_extensions = [
     'dollarmath'
 ]
 myst_number_code_blocks = ["typescript"]
-myst_heading_anchors = 2
+myst_heading_anchors = 3
 myst_footnote_transition = True
 myst_dmath_double_inline = True
 myst_enable_checkboxes = True

--- a/components/omega/doc/devGuide/TridiagonalSolvers.md
+++ b/components/omega/doc/devGuide/TridiagonalSolvers.md
@@ -1,0 +1,216 @@
+(omega-dev-tridiagonal)=
+
+# Tridiagonal Solvers
+
+Omega provides batched solvers for tridiagonal systems of equations.
+Here, batched means that many systems of the same size need to be solved at the same time.
+Typically, this is because one system needs to be solved per ocean column.
+In addition to providing solvers for general tridiagonal systems,
+specialized solvers for diffusion-type systems with better stability
+properties are available.
+To obtain portable performance, different solution algorithms are utilized
+on CPUs and GPUs.
+The solvers implement the same user interface for CPUs and GPUs, so users
+should be able to ignore which algorithm is used.
+Two type aliases are provided that resolve to the optimal solver for a given
+architecture:
+- `TriDiagSolver` for general systems
+- `TriDiagDiffSolver` for diffusion-type systems
+
+## Representations of tridiagonal systems
+
+### General tridiagonal system
+A general tridiagonal system is represented by three vectors
+`DL`, `D`, `DU`, representing the lower, main, and upper diagonal, respectively, and a right-hand-side vector `X`
+$$
+(DL)_i Y_{i - 1} + D_i Y_i + (DU)_i Y_{i + 1} = X_i.
+$$
+
+### Diffusion-type tridiagonal system
+
+A diffusion-type system is represented by two vectors `G` and `H`, and a right-hand-side vector `X`. It has the form
+$$
+-G_{i - 1} Y_{i - 1} + (G_{i - 1} + G_i + H_i) Y_i - G_{i} Y_{i + 1} = X_i.
+$$
+
+## Using tridiagonal solvers
+
+There are two main ways to use Omega batched tridiagonal solvers:
+- Create global arrays storing the coefficients of all systems and call the top-level `solve` method
+- Use a team-level solver inside a parallel loop using Kokkos team policy
+
+While the first method is simpler, for computational performance it is better to use
+the second method. This is because the second method allows one to define a system, solve it,
+and do some post-processing of the solution in one parallel loop.
+With the first method this would require multiple parallel loops, and allocation of storage
+for the coefficients of all systems, which are typically no longer needed after the solution is obtained.
+
+### Top-level method
+
+To solve `NBatch` systems of size `NRow` using the general solver
+four arrays `DL`, `D`, `DU`, and `X` need to be defined.
+All arrays are of size (`NBatch`, `NRow`) and contain the
+coefficients for each of the systems.
+```c++
+Array2DReal DL("DL", NBatch, NRow); // DL(n, :) = lower diagonal of system n
+Array2DReal D("D", NBatch, NRow);   // D(n, :)  = main diagonal of system n
+Array2DReal DU("DU", NBatch, NRow); // DU(n, :) = upper diagonal of system n
+Array2DReal X("X", NBatch, NRow);   // X(n, :)  = rhs of system n
+```
+Once these arrays are filled with the coefficients, to solve the systems the
+static `TriDiagSolver:solve` method is called
+```
+TriDiagSolver::solve(DL, D, DU, X);
+```
+After this call, the rhs array `X` contains the solution.
+
+Solving diffusion-type systems is similar, except the input arrays contain coefficients in the
+form presented [above](#diffusion-type-tridiagonal-system)
+and the static `TriDiagDiffSolver::solve` method is called
+```c++
+Array2DReal G("G", NBatch, NRow); // G(n, :) = coefficients G_i of system n
+Array2DReal H("H", NBatch, NRow); // H(n, :) = coefficients H_i of system n
+Array2DReal X("X", NBatch, NRow); // X(n, :) = rhs of system n
+
+// fill G, H, X
+
+TriDiagDiffSolver::solve(G, H, X);
+```
+
+### Team-level method
+
+Note: since the steps to use the team-level general and specialized solvers are similar,
+this subsection first shows how to use the general solver.
+At the end, an example of using the specialized solver is presented.
+
+The team-level solvers need to be used inside a parallel loop using Kokkos team
+policy. To create a team policy for solving `NBatch` systems of size `NRow`
+the static member function `makeTeamPolicy` is used
+```c++
+TeamPolicy Policy = TridDiagSolver::makeTeamPolicy(NBatch, NRow);
+```
+Every team of threads except the last is responsible for solving `VecLength` systems.
+Since the total number of systems likely doesn't evenly divide `VecLength`, the last
+team solves fewer than `VecLength` systems. Hence, it is necessary to handle that with
+if statements.
+
+Typically, the parallel loop consists of three main parts:
+- defining the system
+- solving the system
+- using the solution
+
+At the beginning of the loop, temporary scratch storage for the coefficients of `VecLength` systems
+needs to be allocated.
+This is done by creating a `TriDiagScratch` struct, which contains
+four member arrays `DL`, `D`, `DU`, and `X` of size (`NRow`, `VecLength`).
+Note that, contrary to the global arrays approach, the system dimension comes first.
+
+These arrays need to be filled with the coefficients of `VecLength` systems solved by the team.
+This is done in a parallel loop over system size (using `TeamThreadRange`)
+and a serial loop over `VecLength`.
+Overall, the code that defines the systems coefficients looks typically like this:
+```c++
+parallel_for(Policy, KOKKOS_LAMBDA (TeamMember &member) {
+   // create scratch data
+   TriDiagScratch Scratch(Member, NRow);
+
+   int IStart = Member.league_rank() * VecLength;
+
+   // define the systems coefficients
+   parallel_for(TeamThreadRange(Member, NRow), [=] (int K) {
+      for (int IVec = 0; IVec < VecLength; ++IVec) {
+         const int I = IStart + IVec;
+         // handle last team having fewer systems
+         if (I < NBatch) {
+            Scratch.DL(K, IVec) = ...;
+            Scratch.D(K, IVec)  = ...;
+            Scratch.DU(K, IVec) = ...;
+            Scratch.X(K, IVec)  = ...;
+         }
+      }
+      ...
+   });
+```
+To perform a team-level solve a different overload of the static member function `TridDiagSolver::solve`
+needs to be called.
+This overload takes the team member `Member` and the filled scratch struct `Scratch`.
+This call needs to be surrounded by barriers to ensure that the
+parallel loop setting the coefficients has finished and to make the computed solution available to all threads.
+```c++
+parallel_for(Policy, KOKKOS_LAMBDA (TeamMember &member) {
+   // previous code
+
+   // solve the system
+   Member.team_barrier();
+   TridDiagSolver::solve(Member, Scratch);
+   Member.team_barrier();
+
+   ...
+});
+```
+After the call to `solve` the solution is available in `Scratch.X`. It can be manipulated further or simply stored.
+```cpp
+parallel_for(Policy, KOKKOS_LAMBDA (TeamMember &member) {
+   // previous code
+
+   // multiply the solution by 2 (just an example)
+   parallel_for(TeamThreadRange(Member, NRow), [=] (int K) {
+      for (int IVec = 0; IVec < VecLength; ++IVec) {
+        Scratch.X(K, IVec) *= 2;
+      }
+   });
+
+   Member.team_barrier();
+
+   // store the solution
+   parallel_for(TeamThreadRange(Member, NRow), [=] (int K) {
+      for (int IVec = 0; IVec < VecLength; ++IVec) {
+         const int I = IStart + IVec;
+         // handle last team having fewer systems
+         if (I < NBatch) {
+            X(I, K) = Scratch.X(K, IVec);
+         }
+      }
+   });
+});
+```
+The team-level specialized diffusion solver can be used similarly, the only substantial difference is in the form
+of the coefficients. A minimal complete example of using it is shown below.
+```cpp
+// create team policy
+TeamPolicy Policy = TridDiagDiffSolver::makeTeamPolicy(NBatch, NRow);
+
+parallel_for(Policy, KOKKOS_LAMBDA (TeamMember &member) {
+   // create scratch data
+   TriDiagDiffScratch Scratch(Member, NRow);
+
+   int IStart = Member.league_rank() * VecLength;
+
+   // define the systems coefficients
+   parallel_for(TeamThreadRange(Member, NRow), [=] (int K) {
+      for (int IVec = 0; IVec < VecLength; ++IVec) {
+         const int I = IStart + IVec;
+         // handle last team having fewer systems
+         if (I < NBatch) {
+            Scratch.G(K, IVec) = ...;
+            Scratch.H(K, IVec)  = ...;
+            Scratch.X(K, IVec)  = ...;
+         }
+      }
+
+   // solve the system
+   Member.team_barrier();
+   TridDiagDiffSolver::solve(Member, Scratch);
+   Member.team_barrier();
+
+   // store the solution
+   parallel_for(TeamThreadRange(Member, NRow), [=] (int K) {
+      for (int IVec = 0; IVec < VecLength; ++IVec) {
+         const int I = IStart + IVec;
+         // handle last team having fewer systems
+         if (I < NBatch) {
+            X(I, K) = Scratch.X(K, IVec);
+         }
+      }
+   });
+});

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -80,6 +80,7 @@ devGuide/TimeMgr
 devGuide/TimeStepping
 devGuide/Reductions
 devGuide/Tracers
+devGuide/TridiagonalSolvers
 ```
 
 ```{toctree}

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -45,6 +45,7 @@ userGuide/TimeMgr
 userGuide/TimeStepping
 userGuide/Reductions
 userGuide/Tracers
+userGuide/TridiagonalSolvers
 ```
 
 ```{toctree}

--- a/components/omega/doc/userGuide/TridiagonalSolvers.md
+++ b/components/omega/doc/userGuide/TridiagonalSolvers.md
@@ -1,0 +1,13 @@
+(omega-user-tridiagonal)=
+
+## Tridiagonal Solvers
+
+OMEGA provides two types of solvers for solving many tridiagonal systems of equations
+in one go:
+- `TriDiagSolver` for general tridiagonal systems
+- `TriDiagDiffSolver` for diffusion-type tridiagonal systems
+
+Different solver algorithms are used on CPU and GPU platforms.
+The optimal solver algorithm for a given platform is chosen automatically.
+There are no user-configurable parameters.
+The [dev guide](#omega-dev-tridiagonal) provides instructions on how to use the solvers.

--- a/components/omega/src/base/TriDiagSolvers.h
+++ b/components/omega/src/base/TriDiagSolvers.h
@@ -1,0 +1,488 @@
+#ifndef OMEGA_TRIDIAGONAL_H
+#define OMEGA_TRIDIAGONAL_H
+//===-- base/TriDiagSolvers.h - tridiagonal solvers --------*- C++ -*-===//
+//
+/// \file
+/// \brief Contains solvers for tridiagonal systems of equations
+///
+/// Batched Thomas and Parallel Cyclic Reduction (PCR) algorithms are
+/// implemented for use on CPU and GPU platforms, respectively. Specialized
+/// variants of both algorithms for diffusion-type systems, with better
+/// stability, are also available.
+//
+//===----------------------------------------------------------------------===//
+
+#include "DataTypes.h"
+#include "MachEnv.h"
+#include "OmegaKokkos.h"
+
+namespace OMEGA {
+
+// Forward declaration of different solver types
+struct ThomasSolver;
+struct PCRSolver;
+struct ThomasDiffusionSolver;
+struct PCRDiffusionSolver;
+
+#ifdef OMEGA_TARGET_DEVICE
+// On GPUs we use the Parallel Cyclic Reduction algorithm
+using TriDiagSolver     = PCRSolver;
+using TriDiagDiffSolver = PCRDiffusionSolver;
+#else
+// On CPUs we use the Thomas algorithm
+using TriDiagSolver     = ThomasSolver;
+using TriDiagDiffSolver = ThomasDiffusionSolver;
+#endif
+
+// Type of real array of size (NRow, VecLength) in the scratch memory space
+using TriDiagScratchArray = Kokkos::View<Real *[VecLength], MemLayout,
+                                         ScratchMemSpace, MemoryUnmanaged>;
+
+// Scratch data for general tridiagonal solver
+struct TriDiagScratch {
+   TriDiagScratchArray DL; // lower diagonal
+   TriDiagScratchArray D;  // main diagonal
+   TriDiagScratchArray DU; // upper diagonal
+   TriDiagScratchArray X; // rhs on input, contains solution after calling solve
+
+   // Constructor takes team member and system size
+   KOKKOS_FUNCTION TriDiagScratch(const TeamMember &Member, int NRow)
+       : DL(Member.team_scratch(0), NRow), D(Member.team_scratch(0), NRow),
+         DU(Member.team_scratch(0), NRow), X(Member.team_scratch(0), NRow) {}
+};
+
+// Thomas algorithm solver for general tridiagonal systems
+struct ThomasSolver {
+
+   // Create a Kokkos team policy for solving NBatch systems of size NRow
+   // and set scratch size
+   static TeamPolicy makeTeamPolicy(int NBatch, int NRow) {
+      TeamPolicy Policy((NBatch + VecLength - 1) / VecLength, 1, 1);
+      Policy.set_scratch_size(
+          0, Kokkos::PerTeam(4 * NRow * VecLength * sizeof(Real)));
+      return Policy;
+   }
+
+   // Solve the system defined in the scratch data argument `Scratch`
+   // This a team-level function that needs to be called inside a
+   // parallel loop using TeamPolicy, hence it has a team member argument
+   static void KOKKOS_FUNCTION solve(const TeamMember &Member,
+                                     const TriDiagScratch &Scratch) {
+      const int NRow = Scratch.X.extent_int(0);
+
+      for (int K = 1; K < NRow; ++K) {
+         for (int IVec = 0; IVec < VecLength; ++IVec) {
+            const Real W = Scratch.DL(K, IVec) / Scratch.D(K - 1, IVec);
+            Scratch.D(K, IVec) -= W * Scratch.DU(K - 1, IVec);
+            Scratch.X(K, IVec) -= W * Scratch.X(K - 1, IVec);
+         }
+      }
+
+      for (int IVec = 0; IVec < VecLength; ++IVec) {
+         Scratch.X(NRow - 1, IVec) /= Scratch.D(NRow - 1, IVec);
+      }
+
+      for (int K = NRow - 2; K >= 0; --K) {
+         for (int IVec = 0; IVec < VecLength; ++IVec) {
+            Scratch.X(K, IVec) =
+                (Scratch.X(K, IVec) -
+                 Scratch.DU(K, IVec) * Scratch.X(K + 1, IVec)) /
+                Scratch.D(K, IVec);
+         }
+      }
+   }
+
+   // Solve the system stored in the arrays DL, D, DU, and X
+   // This function should be called outside of a parallel region
+   static void solve(const Array2DReal &DL, const Array2DReal &D,
+                     const Array2DReal &DU, const Array2DReal &X) {
+
+      const int NBatch = X.extent_int(0);
+      const int NRow   = X.extent_int(1);
+
+      TeamPolicy Policy = makeTeamPolicy(NBatch, NRow);
+
+      Kokkos::parallel_for(
+          Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+             const int IStart = Member.league_rank() * VecLength;
+
+             TriDiagScratch Scratch(Member, NRow);
+
+             for (int K = 0; K < NRow; ++K) {
+                for (int IVec = 0; IVec < VecLength; ++IVec) {
+                   const int I = IStart + IVec;
+                   if (I < NBatch) {
+                      Scratch.DL(K, IVec) = DL(I, K);
+                      Scratch.D(K, IVec)  = D(I, K);
+                      Scratch.DU(K, IVec) = DU(I, K);
+                      Scratch.X(K, IVec)  = X(I, K);
+                   }
+                }
+             }
+
+             solve(Member, Scratch);
+
+             for (int IVec = 0; IVec < VecLength; ++IVec) {
+                for (int K = 0; K < NRow; ++K) {
+                   const int I = IStart + IVec;
+                   if (I < NBatch) {
+                      X(I, K) = Scratch.X(K, IVec);
+                   }
+                }
+             }
+          });
+   }
+};
+
+// Parallel Cyclic Reduction solver for general tridiagonal systems
+struct PCRSolver {
+
+   // Create a Kokkos team policy for solving NBatch systems of size NRow
+   // and set scratch size
+   static TeamPolicy makeTeamPolicy(int NBatch, int NRow) {
+      TeamPolicy Policy(NBatch, NRow, 1);
+      Policy.set_scratch_size(
+          0, Kokkos::PerTeam(4 * NRow * VecLength * sizeof(Real)));
+      return Policy;
+   }
+
+   // Solve the system defined in the scratch data argument `Scratch`
+   // This a team-level function that needs to be called inside a
+   // parallel loop using TeamPolicy, hence it has a team member argument
+   static void KOKKOS_FUNCTION solve(const TeamMember &Member,
+                                     const TriDiagScratch &Scratch) {
+      const int NRow = Scratch.X.extent_int(0);
+
+      // Row index = Thread index
+      const int K = Member.team_rank();
+
+      // Number of reduction levels
+      const int NLevels = Kokkos::ceil(Kokkos::log2(NRow));
+
+      // Perform NLevels of parallel cyclic reduction
+      for (int Lev = 1; Lev < NLevels; ++Lev) {
+
+         const int Stride     = 1 << Lev;
+         const int HalfStride = 1 << (Lev - 1);
+
+         int Kmh = K - HalfStride;
+         Kmh     = Kmh < 0 ? 0 : Kmh;
+         int Kph = K + HalfStride;
+         Kph     = Kph >= NRow ? NRow - 1 : Kph;
+
+         const Real alpha = -Scratch.DL(K, 0) / Scratch.D(Kmh, 0);
+         const Real gamma = -Scratch.DU(K, 0) / Scratch.D(Kph, 0);
+
+         // Compute new system coefficients
+         const Real NewD = Scratch.D(K, 0) + alpha * Scratch.DU(Kmh, 0) +
+                           gamma * Scratch.DL(Kph, 0);
+         const Real NewX = Scratch.X(K, 0) + alpha * Scratch.X(Kmh, 0) +
+                           gamma * Scratch.X(Kph, 0);
+         const Real NewDL = alpha * Scratch.DL(Kmh, 0);
+         const Real NewDU = gamma * Scratch.DU(Kph, 0);
+
+         Member.team_barrier();
+
+         // Store new system coefficients
+         Scratch.D(K, 0)  = NewD;
+         Scratch.X(K, 0)  = NewX;
+         Scratch.DL(K, 0) = NewDL;
+         Scratch.DU(K, 0) = NewDU;
+
+         Member.team_barrier();
+      }
+
+      const int Stride = 1 << (NLevels - 1);
+
+      // Need to solve 2x2 system
+      if (K + Stride < NRow || K - Stride >= 0) {
+         // The result is two values so only half of threads do work
+         if (K < NRow / 2) {
+            const Real Det = Scratch.D(K, 0) * Scratch.D(K + Stride, 0) -
+                             Scratch.DL(K + Stride, 0) * Scratch.DU(K, 0);
+            const Real Xk   = Scratch.X(K, 0);
+            const Real Xkps = Scratch.X(K + Stride, 0);
+            Scratch.X(K, 0) =
+                (Scratch.D(K + Stride, 0) * Xk - Scratch.DU(K, 0) * Xkps) / Det;
+            Scratch.X(K + Stride, 0) =
+                (-Scratch.DL(K + Stride, 0) * Xk + Scratch.D(K, 0) * Xkps) /
+                Det;
+         }
+      } else { // 1x1 system -> direct solution
+         Scratch.X(K, 0) /= Scratch.D(K, 0);
+      }
+   }
+
+   // Solve the system stored in the arrays DL, D, DU, and X
+   // This function should be called outside of a parallel region
+   static void solve(const Array2DReal &DL, const Array2DReal &D,
+                     const Array2DReal &DU, const Array2DReal &X) {
+
+      const int NBatch  = X.extent_int(0);
+      const int NRow    = X.extent_int(1);
+      TeamPolicy Policy = makeTeamPolicy(NBatch, NRow);
+
+      Kokkos::parallel_for(
+          Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+             const int I = Member.league_rank();
+             const int K = Member.team_rank();
+
+             TriDiagScratch Scratch(Member, NRow);
+
+             Scratch.DL(K, 0) = DL(I, K);
+             Scratch.D(K, 0)  = D(I, K);
+             Scratch.DU(K, 0) = DU(I, K);
+             Scratch.X(K, 0)  = X(I, K);
+
+             Member.team_barrier();
+
+             solve(Member, Scratch);
+
+             Member.team_barrier();
+
+             X(I, K) = Scratch.X(K, 0);
+          });
+   }
+};
+
+// Scratch data for diffuson-type tridiagonal solver
+// System is asumed to be of the form:
+// -G(i) * x_{i-1} + (H(i) + G(i) + G(i+1)) * x_i - G(i+1) * x_{i+1} = y_i
+struct TriDiagDiffScratch {
+   TriDiagScratchArray G; // G above
+   TriDiagScratchArray H; // H above
+   TriDiagScratchArray X; // rhs on input, contains solution after calling solve
+   TriDiagScratchArray Alpha; // internal workspace
+
+   KOKKOS_FUNCTION TriDiagDiffScratch(const TeamMember &Member, int NRow)
+       : G(Member.team_scratch(0), NRow), H(Member.team_scratch(0), NRow),
+         X(Member.team_scratch(0), NRow), Alpha(Member.team_scratch(0), NRow) {}
+};
+
+// Thomas algorithm solver for diffusion-type tridiagonal systems
+struct ThomasDiffusionSolver {
+
+   // Create a Kokkos team policy for solving NBatch systems of size NRow
+   // and set scratch size
+   static TeamPolicy makeTeamPolicy(int NBatch, int NRow) {
+      TeamPolicy Policy((NBatch + VecLength - 1) / VecLength, 1, 1);
+      Policy.set_scratch_size(
+          0, Kokkos::PerTeam(4 * NRow * VecLength * sizeof(Real)));
+      return Policy;
+   }
+
+   // Solve the system defined in the scratch data argument `Scratch`
+   // This a team-level function that needs to be called inside a
+   // parallel loop using TeamPolicy, hence it has a team member argument
+   static void KOKKOS_FUNCTION solve(const TeamMember &Member,
+                                     const TriDiagDiffScratch &Scratch) {
+      const int NRow = Scratch.X.extent_int(0);
+
+      for (int IVec = 0; IVec < VecLength; ++IVec) {
+         Scratch.Alpha(0, IVec) = 0;
+      }
+
+      for (int K = 1; K < NRow; ++K) {
+         for (int IVec = 0; IVec < VecLength; ++IVec) {
+            Scratch.Alpha(K, IVec) =
+                Scratch.G(K - 1, IVec) *
+                (Scratch.H(K - 1, IVec) + Scratch.Alpha(K - 1, IVec)) /
+                (Scratch.H(K - 1, IVec) + Scratch.Alpha(K - 1, IVec) +
+                 Scratch.G(K - 1, IVec));
+         }
+      }
+
+      for (int IVec = 0; IVec < VecLength; ++IVec) {
+         Scratch.H(0, IVec) += Scratch.G(0, IVec);
+      }
+
+      for (int K = 1; K < NRow; ++K) {
+         for (int IVec = 0; IVec < VecLength; ++IVec) {
+            const Real AddH = Scratch.Alpha(K, IVec) + Scratch.G(K, IVec);
+
+            Scratch.H(K, IVec) += AddH;
+            Scratch.X(K, IVec) += Scratch.G(K - 1, IVec) /
+                                  Scratch.H(K - 1, IVec) *
+                                  Scratch.X(K - 1, IVec);
+         }
+      }
+
+      for (int IVec = 0; IVec < VecLength; ++IVec) {
+         Scratch.X(NRow - 1, IVec) /= Scratch.H(NRow - 1, IVec);
+      }
+
+      for (int K = NRow - 2; K >= 0; --K) {
+         for (int IVec = 0; IVec < VecLength; ++IVec) {
+            Scratch.X(K, IVec) = (Scratch.X(K, IVec) +
+                                  Scratch.G(K, IVec) * Scratch.X(K + 1, IVec)) /
+                                 Scratch.H(K, IVec);
+         }
+      }
+   }
+
+   // Solve the system stored in the arrays G, H, and X
+   // This function should be called outside of a parallel region
+   static void solve(const Array2DReal &G, const Array2DReal &H,
+                     const Array2DReal &X) {
+      const int NBatch = X.extent_int(0);
+      const int NRow   = X.extent_int(1);
+
+      TeamPolicy Policy = makeTeamPolicy(NBatch, NRow);
+
+      Kokkos::parallel_for(
+          Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+             const int IStart = Member.league_rank() * VecLength;
+
+             TriDiagDiffScratch Scratch(Member, NRow);
+
+             for (int K = 0; K < NRow; ++K) {
+                for (int IVec = 0; IVec < VecLength; ++IVec) {
+                   const int I = IStart + IVec;
+                   if (I < NBatch) {
+                      Scratch.G(K, IVec) = G(I, K);
+                      Scratch.H(K, IVec) = H(I, K);
+                      Scratch.X(K, IVec) = X(I, K);
+                   }
+                }
+             }
+
+             solve(Member, Scratch);
+
+             for (int IVec = 0; IVec < VecLength; ++IVec) {
+                for (int K = 0; K < NRow; ++K) {
+                   const int I = IStart + IVec;
+                   if (I < NBatch) {
+                      X(I, K) = Scratch.X(K, IVec);
+                   }
+                }
+             }
+          });
+   }
+};
+
+// Parallel Cyclic Reduction solver for diffusion-type tridiagonal systems
+struct PCRDiffusionSolver {
+
+   // Create a Kokkos team policy for solving NBatch systems of size NRow
+   // and set scratch size
+   static TeamPolicy makeTeamPolicy(int NBatch, int NRow) {
+      TeamPolicy Policy(NBatch, NRow, 1);
+      Policy.set_scratch_size(
+          0, Kokkos::PerTeam(4 * NRow * VecLength * sizeof(Real)));
+      return Policy;
+   }
+
+   // Solve the system defined in the scratch data argument `Scratch`
+   // This a team-level function that needs to be called inside a
+   // parallel loop using TeamPolicy, hence it has a team member argument
+   static void KOKKOS_FUNCTION solve(const TeamMember &Member,
+                                     const TriDiagDiffScratch &Scratch) {
+      const int NRow = Scratch.X.extent_int(0);
+
+      // Row index = Thread index
+      const int K = Member.team_rank();
+
+      // Number of reduction levels
+      const int NLevels = Kokkos::ceil(Kokkos::log2(NRow));
+
+      // Perform NLevels of parallel cyclic reduction
+      for (int Lev = 1; Lev < NLevels; ++Lev) {
+
+         const int Stride     = 1 << Lev;
+         const int HalfStride = 1 << (Lev - 1);
+
+         int Kmh         = K - HalfStride;
+         const Real Gkmh = Kmh < 0 ? 0 : Scratch.G(Kmh, 0);
+         Kmh             = Kmh < 0 ? 0 : Kmh;
+
+         const int Kms   = K - Stride;
+         const Real Gkms = Kms < 0 ? 0 : Scratch.G(Kms, 0);
+
+         int Kph = K + HalfStride;
+         Kph     = Kph >= NRow ? NRow - 1 : Kph;
+
+         const Real Alpha = Gkmh / (Scratch.H(Kmh, 0) + Gkms + Gkmh);
+         const Real Beta =
+             Scratch.G(K, 0) /
+             (Scratch.H(Kph, 0) + Scratch.G(K, 0) + Scratch.G(Kph, 0));
+
+         // Compute new system coefficients
+         const Real NewG = Scratch.G(Kph, 0) * Beta;
+         const Real NewX = Scratch.X(K, 0) + Alpha * Scratch.X(Kmh, 0) +
+                           Beta * Scratch.X(Kph, 0);
+         const Real NewH = Scratch.H(K, 0) + Alpha * Scratch.H(Kmh, 0) +
+                           Beta * Scratch.H(Kph, 0);
+
+         Member.team_barrier();
+
+         // Store new system coefficients
+         Scratch.H(K, 0) = NewH;
+         Scratch.G(K, 0) = NewG;
+         Scratch.X(K, 0) = NewX;
+
+         Member.team_barrier();
+      }
+
+      const int Stride = 1 << (NLevels - 1);
+
+      // Need to solve 2x2 system
+      if (K + Stride < NRow || K - Stride >= 0) {
+         // The result is two values so only half of threads do work
+         if (K < NRow / 2) {
+            const int Kms   = K - Stride;
+            const Real Gkms = Kms < 0 ? 0 : Scratch.G(Kms, 0);
+
+            const Real Dk   = Scratch.H(K, 0) + Gkms + Scratch.G(K, 0);
+            const Real Dkps = Scratch.H(K + Stride, 0) + Scratch.G(K, 0) +
+                              Scratch.G(K + Stride, 0);
+            const Real DUk   = -Scratch.G(K, 0);
+            const Real DLkps = -Scratch.G(K, 0);
+
+            const Real Det = Dk * Dkps - DLkps * DUk;
+
+            const Real Xk   = Scratch.X(K, 0);
+            const Real Xkps = Scratch.X(K + Stride, 0);
+
+            Scratch.X(K, 0)          = (Dkps * Xk - DUk * Xkps) / Det;
+            Scratch.X(K + Stride, 0) = (-DLkps * Xk + Dk * Xkps) / Det;
+         }
+
+      } else { // 1x1 system -> direct solution
+         int Kms         = K - Stride;
+         const Real Gkms = Kms < 0 ? 0 : Scratch.G(Kms, 0);
+         Scratch.X(K, 0) /= (Scratch.H(K, 0) + Gkms + Scratch.G(K, 0));
+      }
+   }
+
+   // Solve the system stored in the arrays G, H, and X
+   // This function should be called outside of a parallel region
+   static void solve(const Array2DReal &G, const Array2DReal &H,
+                     const Array2DReal &X) {
+      const int NBatch = X.extent_int(0);
+      const int NRow   = X.extent_int(1);
+
+      TeamPolicy Policy = makeTeamPolicy(NBatch, NRow);
+      Kokkos::parallel_for(
+          Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+             const int I = Member.league_rank();
+             const int K = Member.team_rank();
+
+             TriDiagDiffScratch Scratch(Member, NRow);
+
+             Scratch.G(K, 0) = G(I, K);
+             Scratch.H(K, 0) = H(I, K);
+             Scratch.X(K, 0) = X(I, K);
+
+             Member.team_barrier();
+
+             solve(Member, Scratch);
+
+             Member.team_barrier();
+
+             X(I, K) = Scratch.X(K, 0);
+          });
+   }
+};
+
+} // namespace OMEGA
+#endif

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -71,6 +71,11 @@ template <class T> struct ArrayRank {
 
 using ExecSpace     = MemSpace::execution_space;
 using HostExecSpace = HostMemSpace::execution_space;
+using TeamPolicy      = Kokkos::TeamPolicy<ExecSpace>;
+using TeamMember      = TeamPolicy::member_type;
+using ScratchMemSpace = ExecSpace::scratch_memory_space;
+using Kokkos::MemoryUnmanaged;
+using Kokkos::TeamThreadRange;
 
 // Takes a functor that uses multidimensional indexing
 // and converts it into one that also accepts linear index

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -405,3 +405,14 @@ add_omega_test(
     ocn/TracersTest.cpp
     "-n;8"
 )
+
+##########################
+# Tridiagonal solvers test
+##########################
+
+add_omega_test(
+    TRIDIAGSOLVERS_TEST
+    testTriDiagSolvers.exe
+    base/TriDiagSolversTest.cpp
+    "-n;1"
+)

--- a/components/omega/test/base/TriDiagSolversTest.cpp
+++ b/components/omega/test/base/TriDiagSolversTest.cpp
@@ -1,0 +1,623 @@
+#include "TriDiagSolvers.h"
+#include "../ocn/OceanTestCommon.h"
+
+using namespace OMEGA;
+
+void initTridiagonalTest() {
+   int Err = 0;
+
+   MachEnv::init(MPI_COMM_WORLD);
+   MachEnv *DefEnv  = MachEnv::getDefault();
+   MPI_Comm DefComm = DefEnv->getComm();
+
+   initLogging(DefEnv);
+}
+
+int testCorrectness(int NBatch, int NRow) {
+
+   Array2DReal DL("DL", NBatch, NRow);
+   Array2DReal D("D", NBatch, NRow);
+   Array2DReal DU("DU", NBatch, NRow);
+   Array2DReal X("X", NBatch, NRow);
+
+   // Create prescribed tridiagonal matrix A = (DL, D, DU) and prescribed vector
+   // X
+   parallelFor(
+       {NBatch, NRow}, KOKKOS_LAMBDA(int I, int K) {
+          X(I, K) = 0.1 * K + 0.3 * (I % 12);
+
+          DL(I, K) = K == 0 ? 0 : 1 + 0.1 * (I % 3) + 0.2 * (K % 7);
+          D(I, K)  = 4 + 0.2 * (I % 11) + 0.1 * (K % 5);
+          DU(I, K) = K == NRow - 1 ? 0 : 1 + 0.05 * (I % 5) - 0.1 * (K % 11);
+       });
+
+   // compute A X
+   Array2DReal AX("AX", NBatch, NRow);
+   parallelFor(
+       {NBatch, NRow}, KOKKOS_LAMBDA(int I, int K) {
+          AX(I, K) = D(I, K) * X(I, K);
+          if (K > 0) {
+             AX(I, K) += DL(I, K) * X(I, K - 1);
+          }
+          if (K < NRow - 1) {
+             AX(I, K) += DU(I, K) * X(I, K + 1);
+          }
+       });
+
+   // Solve the system A Y = AX
+   // The solution Y is stored in AX
+   TriDiagSolver::solve(DL, D, DU, AX);
+
+   // Check that Y is very close to the initial vector X
+   Real Error;
+   parallelReduce(
+       {NBatch, NRow},
+       KOKKOS_LAMBDA(int I, int K, Real &Accum) {
+          Accum = Kokkos::max(Accum, Kokkos::abs(X(I, K) - AX(I, K)));
+       },
+       Kokkos::Max<Real>(Error));
+
+   if (Error > 1e-12) {
+      LOG_ERROR(
+          "TridiagonalSolver: Correctness for (NBatch, NRow) = ({}, {}) FAIL",
+          NBatch, NRow);
+      return 1;
+   }
+   return 0;
+}
+
+int testDiffusionCorrectness(int NBatch, int NRow) {
+
+   Array2DReal G("G", NBatch, NRow);
+   Array2DReal H("H", NBatch, NRow);
+   Array2DReal X("X", NBatch, NRow);
+
+   // Create prescribed tridiagonal matrix for a diffusion problem
+   // using the parametrization A = (G, H) and prescribed vector X
+   parallelFor(
+       {NBatch, NRow}, KOKKOS_LAMBDA(int I, int K) {
+          X(I, K) = 0.1 * K + 0.3 * (I % 12);
+          G(I, K) = K == NRow - 1 ? 0 : 1 + 0.1 * (I % 3) + 0.2 * (K % 7);
+          H(I, K) = 4 + 0.2 * (I % 11) + 0.1 * (K % 5);
+       });
+
+   // compute A X
+   Array2DReal AX("AX", NBatch, NRow);
+   parallelFor(
+       {NBatch, NRow}, KOKKOS_LAMBDA(int I, int K) {
+          const Real DL = K == 0 ? 0 : -G(I, K - 1);
+          const Real DU = -G(I, K);
+          const Real D  = H(I, K) - DL - DU;
+
+          AX(I, K) = D * X(I, K);
+          if (K > 0) {
+             AX(I, K) += DL * X(I, K - 1);
+          }
+          if (K < NRow - 1) {
+             AX(I, K) += DU * X(I, K + 1);
+          }
+       });
+
+   // Solve the system A Y = AX
+   // The solution Y is stored in AX
+   TriDiagDiffSolver::solve(G, H, AX);
+
+   // Check that Y is very close to the initial vector X
+   Real Error;
+   parallelReduce(
+       {NBatch, NRow},
+       KOKKOS_LAMBDA(int I, int K, Real &Accum) {
+          Accum = Kokkos::max(Accum, Kokkos::abs(X(I, K) - AX(I, K)));
+       },
+       Kokkos::Max<Real>(Error));
+
+   if (Error > 1e-12) {
+      LOG_ERROR("TridiagonalSolver: Diffusion correctness for (NBatch, NRow) = "
+                "({}, {}) FAIL",
+                NBatch, NRow);
+      return 1;
+   }
+   return 0;
+}
+
+KOKKOS_FUNCTION Real manufacturedSolution(Real X, Real T) {
+   return Kokkos::cos(X) * Kokkos::sin(T);
+}
+
+KOKKOS_FUNCTION Real manufacturedDiffusivity(Real X, Real T) {
+   return 2 + Kokkos::sin(X);
+}
+
+KOKKOS_FUNCTION Real manufacturedForcing(Real X, Real T) {
+   using Kokkos::cos;
+   using Kokkos::sin;
+   return (2 * sin(T) * sin(X) + 2 * sin(T) + cos(T)) * cos(X);
+}
+
+Real runDiffManufactured(int NCells) {
+   // Setup a 1D manufactured solution diffusion problem using NCells
+
+   const int NVertices = NCells + 1;
+
+   const Real TimeEnd  = 1;
+   const Real TimeStep = 0.001 / (NCells / 100);
+
+   const int NSteps = std::ceil(TimeEnd / TimeStep);
+
+   Array1DReal XVertex("XVertex", NVertices);
+   Array1DReal Diffusivity("Diffusivity", NVertices);
+   parallelFor(
+       {NVertices}, KOKKOS_LAMBDA(int IVertex) {
+          const Real XVertexUni = IVertex * (1._Real / NCells);
+          // A simple transformation to make grid spacing non-uniform
+          XVertex(IVertex)     = Kokkos::tanh(5 * XVertexUni);
+          Diffusivity(IVertex) = manufacturedDiffusivity(XVertex(IVertex), 0);
+       });
+
+   Array1DReal XCell("XCell", NCells);
+   Array1DReal LayerThick("LayerThick", NCells);
+   Array1DReal U("U", NCells);
+
+   // Create initial condition
+   parallelFor(
+       {NCells}, KOKKOS_LAMBDA(int ICell) {
+          XCell(ICell)      = (XVertex(ICell + 1) + XVertex(ICell)) / 2;
+          LayerThick(ICell) = XVertex(ICell + 1) - XVertex(ICell);
+          U(ICell)          = manufacturedSolution(XCell(ICell), 0);
+       });
+
+   TeamPolicy Policy = TriDiagDiffSolver::makeTeamPolicy(1, NCells);
+
+   // Integrate in time with backward Euler
+   for (int Step = 0; Step < NSteps; ++Step) {
+      const Real Time     = Step * TimeStep;
+      const Real TimeNext = (Step + 1) * TimeStep;
+
+      Kokkos::parallel_for(
+          Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+             TriDiagDiffScratch Scratch(Member, NCells);
+
+             // Setup the system to be solved
+             Kokkos::parallel_for(
+                 TeamThreadRange(Member, NCells), [=](int ICell) {
+                    for (int IVec = 0; IVec < VecLength; ++IVec) {
+
+                       // Forcing term from the manufactured solution
+                       const Real F =
+                           manufacturedForcing(XCell(ICell), TimeNext);
+
+                       Scratch.H(ICell, IVec) = LayerThick(ICell);
+
+                       if (ICell == NCells - 1) {
+                          // Boundary condition
+                          const Real XBnd = XVertex(ICell + 1);
+                          const Real BoundaryCoeff =
+                              -(2 + Kokkos::sin(XBnd)) * Kokkos::tan(XBnd);
+                          Scratch.H(ICell, IVec) -= TimeStep * BoundaryCoeff;
+                          Scratch.G(ICell, IVec) = 0;
+                       } else {
+                          const Real AvgLayerThick =
+                              (LayerThick(ICell + 1) + LayerThick(ICell)) / 2;
+                          Scratch.G(ICell, IVec) =
+                              Diffusivity(ICell + 1) * TimeStep / AvgLayerThick;
+                       }
+                       // RHS
+                       Scratch.X(ICell, IVec) =
+                           LayerThick(ICell) * (U(ICell) + TimeStep * F);
+                    }
+                 });
+
+             // Solve the system
+             Member.team_barrier();
+             TriDiagDiffSolver::solve(Member, Scratch);
+             Member.team_barrier();
+
+             // Store the solution
+             Kokkos::parallel_for(
+                 TeamThreadRange(Member, NCells),
+                 [=](int ICell) { U(ICell) = Scratch.X(ICell, 0); });
+          });
+   }
+
+   // Compute L2 error
+   Real L2Error;
+   parallelReduce(
+       {NCells},
+       KOKKOS_LAMBDA(int ICell, Real &Accum) {
+          const Real UExact = manufacturedSolution(XCell(ICell), TimeEnd);
+          const Real DU     = U(ICell) - UExact;
+          Accum += LayerThick(ICell) * DU * DU;
+       },
+       L2Error);
+
+   L2Error = Kokkos::sqrt(L2Error);
+
+   return L2Error;
+}
+
+int testDiffusionManufactured() {
+   int Err = 0;
+
+   // Compute L2 error with 100 cells
+   int NCells          = 100;
+   const Real L2Err100 = runDiffManufactured(NCells);
+
+   // Compute L2 error with 200 cells
+   NCells *= 2;
+   const Real L2Err200 = runDiffManufactured(NCells);
+
+   const Real L2Rate = std::log2(L2Err100 / L2Err200);
+
+   // Check convergence rate
+   if (std::abs(L2Rate - 2) > 0.1) {
+      Err += 1;
+      LOG_ERROR("TridiagonalSolver: Wrong conv rate for manufactured solution, "
+                "rate = {}",
+                L2Rate);
+   }
+
+   // Check error magnitude
+   const Real MaxL2Err = 2e-5;
+   if (L2Err200 > MaxL2Err) {
+      Err += 1;
+      LOG_ERROR("TridiagonalSolver: Too large error for manufactured solution, "
+                "error = {}, max error = {}",
+                L2Err200, MaxL2Err);
+   }
+
+   return Err;
+}
+
+Real runDiffusionStability(bool UseGeneralSolver, Real DiffValue) {
+   // Setup a 1D diffusion problem with discontinuous diffusivity
+
+   const int NCells    = 100;
+   const int NVertices = NCells + 1;
+
+   const Real TimeEnd  = 100;
+   const Real TimeStep = 1;
+
+   const int NSteps = std::ceil(TimeEnd / TimeStep);
+
+   // Problem domain is [0, 1]
+   const Real DX = 1.0 / NCells;
+
+   // Create discontinuous diffusivity with DiffValue in [0.3, 0.7] else 0
+   Array1DReal XVertex("XVertex", NVertices);
+   Array1DReal Diffusivity("Diffusivity", NVertices);
+   parallelFor(
+       {NVertices}, KOKKOS_LAMBDA(int IVertex) {
+          XVertex(IVertex) = IVertex * DX;
+          Diffusivity(IVertex) =
+              Kokkos::abs(XVertex(IVertex) - 0.5) < 0.2 ? DiffValue : 0;
+       });
+
+   Array1DReal XCell("XCell", NCells);
+   Array1DReal LayerThick("LayerThick", NCells);
+   Array1DReal U("U", NCells);
+
+   // Create initial condition
+   parallelFor(
+       {NCells}, KOKKOS_LAMBDA(int ICell) {
+          XCell(ICell)      = ICell * DX + DX / 2;
+          LayerThick(ICell) = DX;
+          const Real Tmp    = XCell(ICell) - 0.5_Real;
+          U(ICell)          = Kokkos::exp(-Tmp * Tmp);
+       });
+
+   // Compute initial condition norm
+   Real NormInit;
+   parallelReduce(
+       {NCells},
+       KOKKOS_LAMBDA(int ICell, Real &Accum) {
+          Accum += LayerThick(ICell) * U(ICell) * U(ICell);
+       },
+       NormInit);
+   NormInit = std::sqrt(NormInit);
+
+   // Time integration using backward Euler
+   for (int Step = 0; Step < NSteps; ++Step) {
+
+      if (UseGeneralSolver) {
+         TeamPolicy Policy = TriDiagSolver::makeTeamPolicy(1, NCells);
+
+         Kokkos::parallel_for(
+             Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+                TriDiagScratch Scratch(Member, NCells);
+
+                // Setup the system to be solved in the form expected by the
+                // general tridiagonal solver
+                Kokkos::parallel_for(
+                    TeamThreadRange(Member, NCells), [=](int ICell) {
+                       for (int IVec = 0; IVec < VecLength; ++IVec) {
+
+                          if (ICell < NCells - 1) {
+                             const Real AvgLayerThick =
+                                 (LayerThick(ICell + 1) + LayerThick(ICell)) /
+                                 2;
+                             Scratch.DU(ICell, IVec) = -Diffusivity(ICell + 1) *
+                                                       TimeStep / AvgLayerThick;
+                          } else {
+                             Scratch.DU(ICell, IVec) = 0;
+                          }
+
+                          if (ICell > 0) {
+                             const Real AvgLayerThick =
+                                 (LayerThick(ICell) + LayerThick(ICell - 1)) /
+                                 2;
+                             Scratch.DL(ICell, IVec) =
+                                 -Diffusivity(ICell) * TimeStep / AvgLayerThick;
+                          } else {
+                             Scratch.DL(ICell, IVec) = 0;
+                          }
+
+                          Scratch.D(ICell, IVec) = LayerThick(ICell) -
+                                                   Scratch.DU(ICell, IVec) -
+                                                   Scratch.DL(ICell, IVec);
+
+                          Scratch.X(ICell, IVec) = LayerThick(ICell) * U(ICell);
+                       }
+                    });
+
+                // Solve the system
+                Member.team_barrier();
+                TriDiagSolver::solve(Member, Scratch);
+                Member.team_barrier();
+
+                // Save the solution
+                Kokkos::parallel_for(
+                    TeamThreadRange(Member, NCells),
+                    [=](int ICell) { U(ICell) = Scratch.X(ICell, 0); });
+             });
+      } else {
+         TeamPolicy Policy = TriDiagDiffSolver::makeTeamPolicy(1, NCells);
+
+         Kokkos::parallel_for(
+             Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+                TriDiagDiffScratch Scratch(Member, NCells);
+
+                // Setup the system to be solved in the form expected by the
+                // specialized diffusion tridiagonal solver
+                Kokkos::parallel_for(
+                    TeamThreadRange(Member, NCells), [=](int ICell) {
+                       for (int IVec = 0; IVec < VecLength; ++IVec) {
+
+                          Scratch.H(ICell, IVec) = LayerThick(ICell);
+
+                          if (ICell < NCells - 1) {
+                             const Real AvgLayerThick =
+                                 (LayerThick(ICell + 1) + LayerThick(ICell)) /
+                                 2;
+                             Scratch.G(ICell, IVec) = Diffusivity(ICell + 1) *
+                                                      TimeStep / AvgLayerThick;
+                          } else {
+                             Scratch.G(ICell, IVec) = 0;
+                          }
+
+                          Scratch.X(ICell, IVec) = LayerThick(ICell) * U(ICell);
+                       }
+                    });
+
+                // Solve the system
+                Member.team_barrier();
+                TriDiagDiffSolver::solve(Member, Scratch);
+                Member.team_barrier();
+
+                // Store the solution
+                Kokkos::parallel_for(
+                    TeamThreadRange(Member, NCells),
+                    [=](int ICell) { U(ICell) = Scratch.X(ICell, 0); });
+             });
+      }
+   }
+
+   // Compute the solution norm
+   Real Norm;
+   parallelReduce(
+       {NCells},
+       KOKKOS_LAMBDA(int ICell, Real &Accum) {
+          Accum += LayerThick(ICell) * U(ICell) * U(ICell);
+       },
+       Norm);
+   Norm = std::sqrt(Norm);
+
+   // Return normalized change in the norm
+   return (Norm - NormInit) / NormInit;
+}
+
+int testDiffusionStability() {
+   int Err = 0;
+
+   bool UseGeneralSolver;
+
+   // First check small change in diffusivity
+   // Both general and specialized solver should work
+   // and result in similar change in norms
+   const Real SmallDiffValue = 1e2;
+
+   UseGeneralSolver = true;
+   const Real NormGeneralSmallDiff =
+       runDiffusionStability(UseGeneralSolver, SmallDiffValue);
+
+   UseGeneralSolver = false;
+   const Real NormCustomSmallDiff =
+       runDiffusionStability(UseGeneralSolver, SmallDiffValue);
+
+   if (!isApprox(NormGeneralSmallDiff, NormCustomSmallDiff, 1e-3)) {
+      Err += 1;
+      LOG_ERROR("TridiagonalSolver: Different norms");
+   }
+
+   // Now check abrupt change in diffusivity
+   // General solver is expected to fail (produce NaNs)
+   // Specialized solver is expected to work
+   const Real LargeDiffValue = 1e14;
+
+   UseGeneralSolver = true;
+   const Real NormGeneralLargeDiff =
+       runDiffusionStability(UseGeneralSolver, LargeDiffValue);
+
+   if (!std::isnan(NormGeneralLargeDiff)) {
+      Err += 1;
+      LOG_ERROR("TridiagonalSolver: Expected general solver to fail");
+   }
+
+   UseGeneralSolver = false;
+   const Real NormCustomLargeDiff =
+       runDiffusionStability(UseGeneralSolver, LargeDiffValue);
+
+   if (std::isnan(NormCustomLargeDiff)) {
+      Err += 1;
+      LOG_ERROR("TridiagonalSolver: Expected custom solver to pass");
+   }
+
+   return Err;
+}
+
+int tridiagonalTest() {
+   int Err = 0;
+
+   initTridiagonalTest();
+
+   LOG_INFO("----- Tridiagonal Unit Test -----");
+
+   for (int NBatch : {1, 2, 4, 5, 11, 33, 102}) {
+      for (int NRow : {3, 4, 5, 6, 11, 17, 64, 100}) {
+         Err += testCorrectness(NBatch, NRow);
+         Err += testDiffusionCorrectness(NBatch, NRow);
+      }
+   }
+
+   Err += testDiffusionManufactured();
+
+   Err += testDiffusionStability();
+
+   if (Err == 0) {
+      LOG_INFO("TridiagonalTest: Successful completion");
+   }
+
+   return Err;
+}
+
+void testPerformance(int NBatch, int NRow, int NRep) {
+
+   Array2DReal DL("DL", NBatch, NRow);
+   Array2DReal D("D", NBatch, NRow);
+   Array2DReal DU("DU", NBatch, NRow);
+   Array2DReal X("X", NBatch, NRow);
+
+   parallelFor(
+       {NBatch, NRow}, KOKKOS_LAMBDA(int I, int K) {
+          X(I, K) = 0.1 * K + 0.3 * (I % 12);
+
+          DL(I, K) = K == 0 ? 0 : 1 + 0.1 * (I % 3) + 0.2 * (K % 7);
+          D(I, K)  = 4 + 0.2 * (I % 11) + 0.1 * (K % 5);
+          DU(I, K) = K == NRow - 1 ? 0 : 1 + 0.05 * (I % 5) - 0.1 * (K % 11);
+       });
+
+   // Warmup
+   TriDiagSolver::solve(DL, D, DU, X);
+
+   Kokkos::fence();
+   Kokkos::Timer Timer;
+   for (int Rep = 0; Rep < NRep; ++Rep) {
+      TriDiagSolver::solve(DL, D, DU, X);
+   }
+   Kokkos::fence();
+   double TimeSeconds = Timer.seconds();
+
+   double NSolvesPerSec = NRep * NBatch / TimeSeconds;
+   double NBytes        = 5 * NRep * NBatch * NRow * sizeof(Real);
+   double Bandwidth     = NBytes / 1e9 / TimeSeconds;
+
+   printf("%12d %12d %18.2f %18e\n", NRow, NBatch, Bandwidth, NSolvesPerSec);
+}
+
+void testDiffusionPerformance(int NBatch, int NRow, int NRep) {
+
+   Array2DReal G("G", NBatch, NRow);
+   Array2DReal H("H", NBatch, NRow);
+   Array2DReal X("X", NBatch, NRow);
+
+   parallelFor(
+       {NBatch, NRow}, KOKKOS_LAMBDA(int I, int K) {
+          X(I, K) = 0.1 * K + 0.3 * (I % 12);
+          G(I, K) = K == NRow - 1 ? 0 : 1 + 0.1 * (I % 3) + 0.2 * (K % 7);
+          H(I, K) = 4 + 0.2 * (I % 11) + 0.1 * (K % 5);
+       });
+
+   // Warmup
+   TriDiagDiffSolver::solve(G, H, X);
+
+   Kokkos::fence();
+   Kokkos::Timer Timer;
+   for (int Rep = 0; Rep < NRep; ++Rep) {
+      TriDiagDiffSolver::solve(G, H, X);
+   }
+   Kokkos::fence();
+   double TimeSeconds = Timer.seconds();
+
+   double NSolvesPerSec = NRep * NBatch / TimeSeconds;
+   double NBytes        = 4 * NRep * NBatch * NRow * sizeof(Real);
+   double Bandwidth     = NBytes / 1e9 / TimeSeconds;
+
+   printf("%12d %12d %18.2f %18e\n", NRow, NBatch, Bandwidth, NSolvesPerSec);
+}
+
+int tridiagonalPerfTest() {
+   initTridiagonalTest();
+
+   const int NRows[] = {64};
+#ifdef OMEGA_TARGET_DEVICE
+   const int NBatches[] = {500, 1000, 5000, 10000};
+   const int NWork      = 120 * 500 * 64;
+#else
+   const int NBatches[] = {100, 200, 400};
+   const int NWork      = 40 * 100 * 64;
+#endif
+
+   printf("General solver performance\n");
+   printf("%12s %12s %18s %18s\n", "NRow", "NBatch", "Bandwidth [GB/s]",
+          "NSolvesPerSec");
+   for (int NRow : NRows) {
+      for (int NBatch : NBatches) {
+         const int NRep = NWork / (NBatch * NRow);
+         testPerformance(NBatch, NRow, NRep);
+      }
+   }
+
+   printf("Diffusion solver performance\n");
+   printf("%12s %12s %18s %18s\n", "NRow", "NBatch", "Bandwidth [GB/s]",
+          "NSolvesPerSec");
+   for (int NRow : NRows) {
+      for (int NBatch : NBatches) {
+         const int NRep = NWork / (NBatch * NRow);
+         testDiffusionPerformance(NBatch, NRow, NRep);
+      }
+   }
+
+   return 0;
+}
+
+int main(int argc, char *argv[]) {
+
+   int RetVal = 0;
+
+   MPI_Init(&argc, &argv);
+   Kokkos::initialize(argc, argv);
+
+   if (argc > 1 && std::string(argv[1]) == std::string("--perf")) {
+      RetVal += tridiagonalPerfTest();
+   } else {
+      RetVal += tridiagonalTest();
+   }
+
+   Kokkos::finalize();
+   MPI_Finalize();
+
+   if (RetVal >= 256)
+      RetVal = 255;
+
+   return RetVal;
+
+} // end of main


### PR DESCRIPTION
This PR adds four solvers for tridiagonal systems based on the following algorithms:
- Thomas algorithm for general tridiagonal systems on CPUs
- PCR algorithm for general tridiagonal systems on GPUs
- Thomas algorithm for diffusion systems with improved stability properties on CPUs
- PCR algorithm for diffusion systems with improved stability properties on GPUs

together with tests.

See the design doc PR (#166) for more information.

Checklist
* [x] Documentation:
  * [x] Design document has been generated and added to the docs
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
