### PR TITLE
 Allow setting vector length through cmake 

### DIFF
--- a/components/omega/OmegaBuild.cmake
+++ b/components/omega/OmegaBuild.cmake
@@ -38,6 +38,8 @@ macro(common)
     set(OMEGA_LINK_OPTIONS "")
   endif()
 
+  set(OMEGA_VECTOR_LENGTH 1 CACHE STRING "Omega vector length")
+
 endmacro()
 
 macro(run_bash_command command outvar)

--- a/components/omega/doc/devGuide/CMakeBuild.md
+++ b/components/omega/doc/devGuide/CMakeBuild.md
@@ -68,6 +68,7 @@ OMEGA_TILE_LENGTH: a length of one "side" of a Kokkos tile. 64 is a default valu
 OMEGA_LOG_LEVEL: a default logging level. "OMEGA_LOG_INFO" is a default value.
 OMEGA_LOG_FLUSH: turn on the unbuffered logging. "OFF" is a default value.
 OMEGA_LOG_TASKS: set the tasks that generate log file. "0" is a default value.
+OMEGA_VECTOR_LENGTH: Vector length used for blocking inner loops for vectorization. "1" is a default value.
 ```
 
 E3SM-specific variables

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -21,6 +21,7 @@ target_compile_definitions(
     OmegaLibFlags
     INTERFACE
     OMEGA_ARCH=${OMEGA_ARCH}
+    OMEGA_VECTOR_LENGTH=${OMEGA_VECTOR_LENGTH}
 )
 
 if(OMEGA_SINGLE_PRECISION)

--- a/components/omega/src/base/MachEnv.h
+++ b/components/omega/src/base/MachEnv.h
@@ -29,11 +29,7 @@ namespace OMEGA {
 // blocking the inner loops. This should be set to an appropriate
 // length (typically 32, 64, 128) for CPU-only builds, but set to one for
 // GPU builds to maximize parallelism instead.
-#ifdef OMEGA_VECTOR_LENGTH
 constexpr int VecLength = OMEGA_VECTOR_LENGTH;
-#else
-constexpr int VecLength = 1;
-#endif
 
 /// The MachEnv class is a container that holds information on
 /// the message passing, threading and node environment.


### PR DESCRIPTION
This is a small PR that exposes the `OMEGA_VECTOR_LENGTH` configuration option to Omega CMake build system.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


