### PR TITLE
Fix MachEnv vector length test

### DIFF
--- a/components/omega/test/base/MachEnvTest.cpp
+++ b/components/omega/test/base/MachEnvTest.cpp
@@ -488,13 +488,11 @@ int main(int argc, char *argv[]) {
    // Test setting of compile-time vector length
 
 #ifdef OMEGA_VECTOR_LENGTH
-   if (OMEGA::VecLength == 16)
+   if (OMEGA::VecLength == OMEGA_VECTOR_LENGTH)
       std::cout << "MPI vector length test: PASS" << std::endl;
    else {
       RetVal += 1;
       std::cout << "MPI vector length test: FAIL" << std::endl;
-      std::cout << "Was test driver built with -D OMEGA_VECTOR_LENGTH=16 ?"
-                << std::endl;
    }
 #endif
 


### PR DESCRIPTION
This PR fixes MachEnv vector length test broken by #195.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
* [x] Testing
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


