### PR TITLE
Use memcpy instead of reinterpret_cast in halo exchange

### DIFF
--- a/components/omega/src/base/Halo.h
+++ b/components/omega/src/base/Halo.h
@@ -24,6 +24,7 @@
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 #include "mpi.h"
+#include <cstring>
 #include <memory>
 #include <numeric>
 #include <type_traits>
@@ -285,6 +286,7 @@ class Halo {
    packBuffer(const T &Array,      // 1D Kokkos array of any type
               const I4 CurNeighbor // current neighbor
    ) {
+      using ValType = typename T::non_const_value_type;
 
       OMEGA_SCOPE(LocList, Neighbors[CurNeighbor].SendLists[CurElem]);
       OMEGA_SCOPE(LocNeighbor, Neighbors[CurNeighbor]);
@@ -297,8 +299,9 @@ class Halo {
          OMEGA_SCOPE(LocBuff, Neighbors[CurNeighbor].SendBuffer);
          parallelFor(
              {LocList.NTot}, KOKKOS_LAMBDA(int IExch) {
-                auto Val       = Array(LocIndex(IExch));
-                const R8 RVal  = reinterpret_cast<R8 &>(Val);
+                const ValType Val = Array(LocIndex(IExch));
+                R8 RVal;
+                memcpy(&RVal, &Val, sizeof(ValType));
                 LocBuff(IExch) = RVal;
              });
       } else {
@@ -306,7 +309,9 @@ class Halo {
          expandBuffer(LocNeighbor.SendBufferH, BufferSize);
          OMEGA_SCOPE(LocBuffH, Neighbors[CurNeighbor].SendBufferH);
          for (int IExch = 0; IExch < LocList.NTot; ++IExch) {
-            const R8 RVal   = reinterpret_cast<R8 &>(Array(LocIndexH(IExch)));
+            const ValType Val = Array(LocIndexH(IExch));
+            R8 RVal;
+            memcpy(&RVal, &Val, sizeof(ValType));
             LocBuffH(IExch) = RVal;
          }
       }
@@ -317,6 +322,8 @@ class Halo {
    packBuffer(const T &Array,      // 2D Kokkos array of any type
               const I4 CurNeighbor // current neighbor
    ) {
+
+      using ValType = typename T::non_const_value_type;
 
       OMEGA_SCOPE(LocList, Neighbors[CurNeighbor].SendLists[CurElem]);
       OMEGA_SCOPE(LocNeighbor, Neighbors[CurNeighbor]);
@@ -332,8 +339,9 @@ class Halo {
 
          parallelFor(
              {LocList.NTot, NJ}, KOKKOS_LAMBDA(int IExch, int J) {
-                auto Val       = Array(LocIndex(IExch), J);
-                const R8 RVal  = reinterpret_cast<R8 &>(Val);
+                const ValType Val = Array(LocIndex(IExch), J);
+                R8 RVal;
+                memcpy(&RVal, &Val, sizeof(ValType));
                 const I4 IBuff = IExch * NJ + J;
                 LocBuff(IBuff) = RVal;
              });
@@ -343,9 +351,10 @@ class Halo {
          OMEGA_SCOPE(LocBuffH, Neighbors[CurNeighbor].SendBufferH);
          for (int IExch = 0; IExch < LocList.NTot; ++IExch) {
             for (int J = 0; J < NJ; ++J) {
-               const I4 IBuff = IExch * NJ + J;
-               const R8 RVal =
-                   reinterpret_cast<R8 &>(Array(LocIndexH(IExch), J));
+               const I4 IBuff    = IExch * NJ + J;
+               const ValType Val = Array(LocIndexH(IExch), J);
+               R8 RVal;
+               memcpy(&RVal, &Val, sizeof(ValType));
                LocBuffH(IBuff) = RVal;
             }
          }
@@ -357,6 +366,8 @@ class Halo {
    packBuffer(const T &Array,      // 3D Kokkos array of any type
               const I4 CurNeighbor // current neighbor
    ) {
+
+      using ValType = typename T::non_const_value_type;
 
       OMEGA_SCOPE(LocList, Neighbors[CurNeighbor].SendLists[CurElem]);
       OMEGA_SCOPE(LocNeighbor, Neighbors[CurNeighbor]);
@@ -374,8 +385,9 @@ class Halo {
 
          parallelFor(
              {NK, NTotList, NJ}, KOKKOS_LAMBDA(int K, int IExch, int J) {
-                auto Val       = Array(K, LocIndex(IExch), J);
-                const R8 RVal  = reinterpret_cast<R8 &>(Val);
+                const ValType Val = Array(K, LocIndex(IExch), J);
+                R8 RVal;
+                memcpy(&RVal, &Val, sizeof(ValType));
                 const I4 IBuff = (K * NTotList + IExch) * NJ + J;
                 LocBuff(IBuff) = RVal;
              });
@@ -386,9 +398,10 @@ class Halo {
          for (int K = 0; K < NK; ++K) {
             for (int IExch = 0; IExch < LocList.NTot; ++IExch) {
                for (int J = 0; J < NJ; ++J) {
-                  const I4 IBuff = (K * LocList.NTot + IExch) * NJ + J;
-                  const R8 RVal =
-                      reinterpret_cast<R8 &>(Array(K, LocIndexH(IExch), J));
+                  const I4 IBuff    = (K * LocList.NTot + IExch) * NJ + J;
+                  const ValType Val = Array(K, LocIndexH(IExch), J);
+                  R8 RVal;
+                  memcpy(&RVal, &Val, sizeof(ValType));
                   LocBuffH(IBuff) = RVal;
                }
             }
@@ -401,6 +414,8 @@ class Halo {
    packBuffer(const T &Array,      // 4D Kokkos array of any type
               const I4 CurNeighbor // current neighbor
    ) {
+
+      using ValType = typename T::non_const_value_type;
 
       OMEGA_SCOPE(LocList, Neighbors[CurNeighbor].SendLists[CurElem]);
       OMEGA_SCOPE(LocNeighbor, Neighbors[CurNeighbor]);
@@ -420,8 +435,9 @@ class Halo {
          parallelFor(
              {NL, NK, NTotList, NJ},
              KOKKOS_LAMBDA(int L, int K, int IExch, int J) {
-                auto Val       = Array(L, K, LocIndex(IExch), J);
-                const R8 RVal  = reinterpret_cast<R8 &>(Val);
+                const ValType Val = Array(L, K, LocIndex(IExch), J);
+                R8 RVal;
+                memcpy(&RVal, &Val, sizeof(ValType));
                 const I4 IBuff = ((L * NK + K) * NTotList + IExch) * NJ + J;
                 LocBuff(IBuff) = RVal;
              });
@@ -435,8 +451,9 @@ class Halo {
                   for (int J = 0; J < NJ; ++J) {
                      const I4 IBuff =
                          ((L * NK + K) * NTotList + IExch) * NJ + J;
-                     const R8 RVal = reinterpret_cast<R8 &>(
-                         Array(L, K, LocIndexH(IExch), J));
+                     const ValType Val = Array(L, K, LocIndexH(IExch), J);
+                     R8 RVal;
+                     memcpy(&RVal, &Val, sizeof(ValType));
                      LocBuffH(IBuff) = RVal;
                   }
                }
@@ -450,6 +467,8 @@ class Halo {
    packBuffer(const T &Array,      // 5D Kokkos array of any type
               const I4 CurNeighbor // current neighbor
    ) {
+
+      using ValType = typename T::non_const_value_type;
 
       OMEGA_SCOPE(LocList, Neighbors[CurNeighbor].SendLists[CurElem]);
       OMEGA_SCOPE(LocNeighbor, Neighbors[CurNeighbor]);
@@ -470,8 +489,9 @@ class Halo {
          parallelFor(
              {NM, NL, NK, NTotList, NJ},
              KOKKOS_LAMBDA(int M, int L, int K, int IExch, int J) {
-                auto Val      = Array(M, L, K, LocIndex(IExch), J);
-                const R8 RVal = reinterpret_cast<R8 &>(Val);
+                const ValType Val = Array(M, L, K, LocIndex(IExch), J);
+                R8 RVal;
+                memcpy(&RVal, &Val, sizeof(ValType));
                 const I4 IBuff =
                     (((M * NL + L) * NK + K) * NTotList + IExch) * NJ + J;
                 LocBuff(IBuff) = RVal;
@@ -488,8 +508,9 @@ class Halo {
                         const I4 IBuff =
                             (((M * NL + L) * NK + K) * NTotList + IExch) * NJ +
                             J;
-                        const R8 RVal = reinterpret_cast<R8 &>(
-                            Array(M, L, K, LocIndexH(IExch), J));
+                        const ValType Val = Array(M, L, K, LocIndexH(IExch), J);
+                        R8 RVal;
+                        memcpy(&RVal, &Val, sizeof(ValType));
                         LocBuffH(IBuff) = RVal;
                      }
                   }
@@ -520,14 +541,20 @@ class Halo {
          parallelFor(
              {LocList.NTot}, KOKKOS_LAMBDA(int IExch) {
                 const I4 IArr = LocIndex(IExch);
-                Array(IArr)   = reinterpret_cast<ValType &>(LocBuff(IExch));
+                const R8 RVal = LocBuff(IExch);
+                ValType Val;
+                memcpy(&Val, &RVal, sizeof(ValType));
+                Array(IArr) = Val;
              });
       } else {
          OMEGA_SCOPE(LocIndexH, LocList.IndexH);
          OMEGA_SCOPE(LocBuffH, Neighbors[CurNeighbor].RecvBufferH);
          for (int IExch = 0; IExch < LocList.NTot; ++IExch) {
             const I4 IArr = LocIndexH(IExch);
-            Array(IArr)   = reinterpret_cast<ValType &>(LocBuffH(IExch));
+            const R8 RVal = LocBuffH(IExch);
+            ValType Val;
+            memcpy(&Val, &RVal, sizeof(ValType));
+            Array(IArr) = Val;
          }
       }
    }
@@ -553,7 +580,10 @@ class Halo {
              {LocList.NTot, NJ}, KOKKOS_LAMBDA(int IExch, int J) {
                 const I4 IBuff = IExch * NJ + J;
                 const I4 IArr  = LocIndex(IExch);
-                Array(IArr, J) = reinterpret_cast<ValType &>(LocBuff(IBuff));
+                const R8 RVal  = LocBuff(IBuff);
+                ValType Val;
+                memcpy(&Val, &RVal, sizeof(ValType));
+                Array(IArr, J) = Val;
              });
       } else {
          OMEGA_SCOPE(LocIndexH, LocList.IndexH);
@@ -562,7 +592,10 @@ class Halo {
             for (int J = 0; J < NJ; ++J) {
                const I4 IBuff = IExch * NJ + J;
                const I4 IArr  = LocIndexH(IExch);
-               Array(IArr, J) = reinterpret_cast<ValType &>(LocBuffH(IBuff));
+               const R8 RVal  = LocBuffH(IBuff);
+               ValType Val;
+               memcpy(&Val, &RVal, sizeof(ValType));
+               Array(IArr, J) = Val;
             }
          }
       }
@@ -590,9 +623,12 @@ class Halo {
 
          parallelFor(
              {NK, NTotList, NJ}, KOKKOS_LAMBDA(int K, int IExch, int J) {
-                const I4 IBuff    = (K * NTotList + IExch) * NJ + J;
-                const I4 IArr     = LocIndex(IExch);
-                Array(K, IArr, J) = reinterpret_cast<ValType &>(LocBuff(IBuff));
+                const I4 IBuff = (K * NTotList + IExch) * NJ + J;
+                const I4 IArr  = LocIndex(IExch);
+                const R8 RVal  = LocBuff(IBuff);
+                ValType Val;
+                memcpy(&Val, &RVal, sizeof(ValType));
+                Array(K, IArr, J) = Val;
              });
       } else {
          OMEGA_SCOPE(LocIndexH, LocList.IndexH);
@@ -602,8 +638,10 @@ class Halo {
                for (int J = 0; J < NJ; ++J) {
                   const I4 IBuff = (K * LocList.NTot + IExch) * NJ + J;
                   const I4 IArr  = LocIndexH(IExch);
-                  Array(K, IArr, J) =
-                      reinterpret_cast<ValType &>(LocBuffH(IBuff));
+                  const R8 RVal  = LocBuffH(IBuff);
+                  ValType Val;
+                  memcpy(&Val, &RVal, sizeof(ValType));
+                  Array(K, IArr, J) = Val;
                }
             }
          }
@@ -636,8 +674,10 @@ class Halo {
              KOKKOS_LAMBDA(int L, int K, int IExch, int J) {
                 const I4 IBuff = ((L * NK + K) * NTotList + IExch) * NJ + J;
                 const I4 IArr  = LocIndex(IExch);
-                Array(L, K, IArr, J) =
-                    reinterpret_cast<ValType &>(LocBuff(IBuff));
+                const R8 RVal  = LocBuff(IBuff);
+                ValType Val;
+                memcpy(&Val, &RVal, sizeof(ValType));
+                Array(L, K, IArr, J) = Val;
              });
       } else {
          OMEGA_SCOPE(LocIndexH, LocList.IndexH);
@@ -649,8 +689,10 @@ class Halo {
                      const I4 IBuff =
                          ((L * NK + K) * NTotList + IExch) * NJ + J;
                      const I4 IArr = LocIndexH(IExch);
-                     Array(L, K, IArr, J) =
-                         reinterpret_cast<ValType &>(LocBuffH(IBuff));
+                     const R8 RVal = LocBuffH(IBuff);
+                     ValType Val;
+                     memcpy(&Val, &RVal, sizeof(ValType));
+                     Array(L, K, IArr, J) = Val;
                   }
                }
             }
@@ -686,8 +728,10 @@ class Halo {
                 const I4 IBuff =
                     (((M * NL + L) * NK + K) * NTotList + IExch) * NJ + J;
                 const I4 IArr = LocIndex(IExch);
-                Array(M, L, K, IArr, J) =
-                    reinterpret_cast<ValType &>(LocBuff(IBuff));
+                const R8 RVal = LocBuff(IBuff);
+                ValType Val;
+                memcpy(&Val, &RVal, sizeof(ValType));
+                Array(M, L, K, IArr, J) = Val;
              });
       } else {
          OMEGA_SCOPE(LocIndexH, LocList.IndexH);
@@ -701,8 +745,10 @@ class Halo {
                             (((M * NL + L) * NK + K) * NTotList + IExch) * NJ +
                             J;
                         const I4 IArr = LocIndexH(IExch);
-                        Array(M, L, K, IArr, J) =
-                            reinterpret_cast<ValType &>(LocBuffH(IBuff));
+                        const R8 RVal = LocBuffH(IBuff);
+                        ValType Val;
+                        memcpy(&Val, &RVal, sizeof(ValType));
+                        Array(M, L, K, IArr, J) = Val;
                      }
                   }
                }


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

This PR removes the use of `reinterpret_cast` in halo packing and unpacking routines, replacing it with `memcpy`. Using  `reinterpret_cast` for byte-level conversions between types of different size is invalid, and even for types of the same size it is not strictly correct. I have verified that using `memcpy` in these functions doesn't affect their performance.

This PR fixes  the`HALO_TEST` and `TEND_PLANE_SINGLE_PRECISION_TEST` failures on pm-cpu reported in #207.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Testing
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

fixes #207