### PR TITLE
Add Pacer initialization to ocean tests

### DIFF
--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -7,10 +7,9 @@
 #include "DataTypes.h"
 #include "OceanState.h"
 #include "OmegaKokkos.h"
+#include "Pacer.h"
 #include "TimeMgr.h"
 #include "TimeStepper.h"
-
-#include "Pacer.h"
 #include <mpi.h>
 
 #include <iostream>

--- a/components/omega/test/base/DataTypesTest.cpp
+++ b/components/omega/test/base/DataTypesTest.cpp
@@ -17,6 +17,7 @@
 #include "DataTypes.h"
 #include "OmegaKokkos.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 using namespace OMEGA;
 
@@ -27,6 +28,8 @@ int main(int argc, char *argv[]) {
    // initialize environments
    MPI_Init(&argc, &argv);
    Kokkos::initialize();
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
    {
 
       // declare variables of each supported type

--- a/components/omega/test/base/DataTypesTest.cpp
+++ b/components/omega/test/base/DataTypesTest.cpp
@@ -16,8 +16,8 @@
 
 #include "DataTypes.h"
 #include "OmegaKokkos.h"
-#include "mpi.h"
 #include "Pacer.h"
+#include "mpi.h"
 
 using namespace OMEGA;
 

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -18,6 +18,7 @@
 #include "Logging.h"
 #include "MachEnv.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 #include <iostream>
 
@@ -70,6 +71,8 @@ int main(int argc, char *argv[]) {
    // Initialize the global MPI environment
    MPI_Init(&argc, &argv);
    Kokkos::initialize();
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
    {
       // Call initialization routine to create the default decomposition
       int Err = initDecompTest();

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -17,8 +17,8 @@
 #include "IO.h"
 #include "Logging.h"
 #include "MachEnv.h"
-#include "mpi.h"
 #include "Pacer.h"
+#include "mpi.h"
 
 #include <iostream>
 

--- a/components/omega/test/base/HaloTest.cpp
+++ b/components/omega/test/base/HaloTest.cpp
@@ -22,8 +22,8 @@
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
-#include "mpi.h"
 #include "Pacer.h"
+#include "mpi.h"
 
 using namespace OMEGA;
 

--- a/components/omega/test/base/HaloTest.cpp
+++ b/components/omega/test/base/HaloTest.cpp
@@ -23,6 +23,7 @@
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 using namespace OMEGA;
 
@@ -160,6 +161,8 @@ int main(int argc, char *argv[]) {
    // Initialize global MPI environment and Kokkos
    MPI_Init(&argc, &argv);
    Kokkos::initialize();
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
    {
 
       // Call Halo test initialization routine

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -16,6 +16,7 @@
 #include "Logging.h"
 #include "MachEnv.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 #include <iostream>
 
@@ -72,6 +73,8 @@ int main(int argc, char *argv[]) {
    // Initialize the global MPI environment
    MPI_Init(&argc, &argv);
    Kokkos::initialize();
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
    {
       // Call initialization routine to create the default decomposition
       // and initialize the parallel IO library

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -15,8 +15,8 @@
 #include "Decomp.h"
 #include "Logging.h"
 #include "MachEnv.h"
-#include "mpi.h"
 #include "Pacer.h"
+#include "mpi.h"
 
 #include <iostream>
 

--- a/components/omega/test/base/ReductionsTest.cpp
+++ b/components/omega/test/base/ReductionsTest.cpp
@@ -13,8 +13,8 @@
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
-#include "Reductions.h"
 #include "Pacer.h"
+#include "Reductions.h"
 
 using namespace OMEGA;
 

--- a/components/omega/test/base/ReductionsTest.cpp
+++ b/components/omega/test/base/ReductionsTest.cpp
@@ -14,6 +14,7 @@
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 #include "Reductions.h"
+#include "Pacer.h"
 
 using namespace OMEGA;
 
@@ -24,6 +25,8 @@ int main(int argc, char *argv[]) {
    // Initialize the global MPI environment
    MPI_Init(&argc, &argv);
    Kokkos::initialize();
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
    {
 
       // Create reference values based on MPI_COMM_WORLD

--- a/components/omega/test/drivers/StandaloneDriverTest.cpp
+++ b/components/omega/test/drivers/StandaloneDriverTest.cpp
@@ -13,10 +13,9 @@
 
 #include "OceanDriver.h"
 #include "OmegaKokkos.h"
+#include "Pacer.h"
 #include "TimeMgr.h"
 #include "TimeStepper.h"
-
-#include "Pacer.h"
 #include <mpi.h>
 
 //------------------------------------------------------------------------------

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -22,11 +22,11 @@
 #include "MachEnv.h"
 #include "OceanState.h"
 #include "OmegaKokkos.h"
+#include "Pacer.h"
 #include "TimeMgr.h"
 #include "TimeStepper.h"
 #include "Tracers.h"
 #include "mpi.h"
-#include "Pacer.h"
 #include <chrono>
 #include <thread>
 #include <vector>

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -26,6 +26,7 @@
 #include "TimeStepper.h"
 #include "Tracers.h"
 #include "mpi.h"
+#include "Pacer.h"
 #include <chrono>
 #include <thread>
 #include <vector>
@@ -174,6 +175,8 @@ int main(int argc, char **argv) {
    // Initialize the global MPI and Kokkos environments
    MPI_Init(&argc, &argv);
    Kokkos::initialize();
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
    {
 
       Clock *ModelClock = nullptr;

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -14,6 +14,7 @@
 #include "TimeStepper.h"
 #include "Tracers.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 #include <cmath>
 #include <iomanip>
@@ -342,6 +343,8 @@ int main(int argc, char *argv[]) {
 
    MPI_Init(&argc, &argv);
    Kokkos::initialize(argc, argv);
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
 
    RetVal += auxStateTest();
 

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -11,10 +11,10 @@
 #include "MachEnv.h"
 #include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
+#include "Pacer.h"
 #include "TimeStepper.h"
 #include "Tracers.h"
 #include "mpi.h"
-#include "Pacer.h"
 
 #include <cmath>
 #include <iomanip>

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -10,13 +10,13 @@
 #include "MachEnv.h"
 #include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
+#include "Pacer.h"
 #include "auxiliaryVars/KineticAuxVars.h"
 #include "auxiliaryVars/LayerThicknessAuxVars.h"
 #include "auxiliaryVars/TracerAuxVars.h"
 #include "auxiliaryVars/VelocityDel2AuxVars.h"
 #include "auxiliaryVars/VorticityAuxVars.h"
 #include "mpi.h"
-#include "Pacer.h"
 
 #include <cmath>
 #include <iomanip>

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -16,6 +16,7 @@
 #include "auxiliaryVars/VelocityDel2AuxVars.h"
 #include "auxiliaryVars/VorticityAuxVars.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 #include <cmath>
 #include <iomanip>
@@ -848,6 +849,8 @@ int main(int argc, char *argv[]) {
 
    MPI_Init(&argc, &argv);
    Kokkos::initialize(argc, argv);
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
 
    RetVal += auxVarsTest();
 

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -19,6 +19,7 @@
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 #include <iostream>
 
@@ -147,6 +148,8 @@ int main(int argc, char *argv[]) {
    // Initialize the global MPI environment
    MPI_Init(&argc, &argv);
    Kokkos::initialize();
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
    {
 
       OMEGA::R8 tol = 1e-6;

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -18,8 +18,8 @@
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
-#include "mpi.h"
 #include "Pacer.h"
+#include "mpi.h"
 
 #include <iostream>
 

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -11,6 +11,7 @@
 #include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 #include <cmath>
 
@@ -440,6 +441,8 @@ int main(int argc, char *argv[]) {
 
    MPI_Init(&argc, &argv);
    Kokkos::initialize(argc, argv);
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
 
    RetVal += operatorsTest();
 

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -10,8 +10,8 @@
 #include "MachEnv.h"
 #include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
-#include "mpi.h"
 #include "Pacer.h"
+#include "mpi.h"
 
 #include <cmath>
 

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -22,9 +22,9 @@
 #include "MachEnv.h"
 #include "OceanState.h"
 #include "OmegaKokkos.h"
+#include "Pacer.h"
 #include "TimeStepper.h"
 #include "mpi.h"
-#include "Pacer.h"
 
 #include <iostream>
 

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -24,6 +24,7 @@
 #include "OmegaKokkos.h"
 #include "TimeStepper.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 #include <iostream>
 
@@ -258,6 +259,8 @@ int main(int argc, char *argv[]) {
    // Initialize the global MPI environment
    MPI_Init(&argc, &argv);
    Kokkos::initialize();
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
    {
 
       // Call initialization routine to create default state and other

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -12,9 +12,9 @@
 #include "MachEnv.h"
 #include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
+#include "Pacer.h"
 #include "TimeStepper.h"
 #include "mpi.h"
-#include "Pacer.h"
 
 #include <cmath>
 #include <iomanip>

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -14,6 +14,7 @@
 #include "OmegaKokkos.h"
 #include "TimeStepper.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 #include <cmath>
 #include <iomanip>
@@ -286,6 +287,8 @@ int main(int argc, char *argv[]) {
 
    MPI_Init(&argc, &argv);
    Kokkos::initialize(argc, argv);
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
 
    RetVal += tendenciesTest();
 

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -24,8 +24,8 @@
 #include "Logging.h"
 #include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
-#include "mpi.h"
 #include "Pacer.h"
+#include "mpi.h"
 
 #include <cmath>
 

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -25,6 +25,7 @@
 #include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 #include <cmath>
 
@@ -913,6 +914,8 @@ int main(int argc, char *argv[]) {
 
    MPI_Init(&argc, &argv);
    Kokkos::initialize(argc, argv);
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
 
    RetErr = tendencyTermsTest();
 

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -20,9 +20,9 @@
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
+#include "Pacer.h"
 #include "TimeStepper.h"
 #include "mpi.h"
-#include "Pacer.h"
 
 #include <iostream>
 

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -22,6 +22,7 @@
 #include "OmegaKokkos.h"
 #include "TimeStepper.h"
 #include "mpi.h"
+#include "Pacer.h"
 
 #include <iostream>
 
@@ -105,6 +106,8 @@ int main(int argc, char *argv[]) {
    // Initialize the global MPI environment
    MPI_Init(&argc, &argv);
    Kokkos::initialize();
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
    {
 
       // Call initialization routine


### PR DESCRIPTION
Pacer initialization was missing on most ocean tests, resulting in messages `[ERROR] Pacer: Not initialized.` and failure of eight tests.