### PR TITLE
fixes behavior of OMEGA_ASSERT and OMEGA_REQUIRE

### DIFF
--- a/components/omega/doc/devGuide/Error.md
+++ b/components/omega/doc/devGuide/Error.md
@@ -31,10 +31,11 @@ macros:
 OMEGA_ASSERT(Condition, Message, addition args for message);
 OMEGA_REQUIRE(Condition, Message, addition args for message);
 ```
-These emulate the behavior of the C++ assert function.  The `ASSERT` macro
-is only evaluated in debug builds while the `REQUIRE` macro is always
-evaluated. These have identical behavior to the critical error macro, but
-take the additional boolean argument of the condition to be checked.
+These emulate the behavior of the C++ assert function in which the condition
+is checked and a critical error is thrown if the condition is not met (false).
+The `ASSERT` macro is only evaluated in debug builds while the `REQUIRE`
+macro is always evaluated. These have identical behavior to the critical error
+macro, but take the additional boolean argument of the condition to be checked.
 
 The remaining macros operate on or with an Error class that contains an error
 code and an error message. These can be used as a return code, as in:

--- a/components/omega/src/infra/Error.h
+++ b/components/omega/src/infra/Error.h
@@ -213,7 +213,7 @@ Error::Error(ErrorCode ErrCode,        // [in] error code to assign
 /// It is only active for debug builds.
 #ifdef OMEGA_DEBUG
 #define OMEGA_ASSERT(_Condition, _ErrMsg, ...) \
-   if (_Condition) {                           \
+   if (!_Condition) {                          \
       LOG_CRITICAL(_ErrMsg, ##__VA_ARGS__);    \
       cpptrace::generate_trace().print();      \
       OMEGA::Error::abort();                   \
@@ -225,7 +225,7 @@ Error::Error(ErrorCode ErrCode,        // [in] error code to assign
 /// This macro checks for a required condition and exits if not met
 /// It is always evaluated (unlike ASSERT for debug builds)
 #define OMEGA_REQUIRE(_Condition, _ErrMsg, ...) \
-   if (_Condition) {                            \
+   if (!_Condition) {                           \
       LOG_CRITICAL(_ErrMsg, ##__VA_ARGS__);     \
       cpptrace::generate_trace().print();       \
       OMEGA::Error::abort();                    \

--- a/components/omega/test/infra/ErrorTest.cpp
+++ b/components/omega/test/infra/ErrorTest.cpp
@@ -59,11 +59,11 @@ void passError2(Error &Err) {
    // Alternative critical failure tests
    // CHECK_ERROR_ABORT(Err, "Expected critical error with args: {} {} {}",
    //                   MsgArgStr, MsgArgInt, MsgArgReal);
-   // OMEGA_REQUIRE(!Err.isSuccess(),
+   // OMEGA_REQUIRE(Err.isSuccess(),
    //               "Expected Error with args: {} {} {}", MsgArgStr, MsgArgInt,
    //                MsgArgReal);
    // This one requires a debug build
-   // OMEGA_ASSERT(!Err.isSuccess(),
+   // OMEGA_ASSERT(Err.isSuccess(),
    //              "Expected Error with args: {} {} {}", MsgArgStr, MsgArgInt,
    //              MsgArgReal);
 }


### PR DESCRIPTION
The initial commit of the Error handler and Error unit test was mistakenly coded to abort on the assert condition being true (as if checking an error condition). This change fixes the behavior so it aborts on failure (false) as is expected with the C++ assert function that they are meant to mimic.

Passes all ctest tests.

Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

