### PR TITLE
Update Polaris version and fix dependencies

### DIFF
--- a/components/omega/dev-conda.txt
+++ b/components/omega/dev-conda.txt
@@ -25,7 +25,6 @@ mypy
 sphinx
 sphinx_rtd_theme
 myst-parser
-sphinx-multiversion
 rst-to-myst
 
 # CF-compliance

--- a/components/omega/doc/conf.py
+++ b/components/omega/doc/conf.py
@@ -36,7 +36,6 @@ language = "en"
 extensions = [
     "myst_parser",
     "sphinx_rtd_theme",
-    "sphinx_multiversion",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",

--- a/components/omega/doc/devGuide/QuickStart.md
+++ b/components/omega/doc/devGuide/QuickStart.md
@@ -199,36 +199,36 @@ ctest log file located at `$BUILD_DIR/Testing/Temporary/LastTest.log`.
 The following table shows locations for Metis and Parmetis libraries on
 supported E3SM machines. The pattern is:
 ```
-<polaris_base>/<machine>/spack/dev_polaris_0_7_0_<compiler>_<mpi>/var/spack/environments/dev_polaris_0_7_0_<compiler>_<mpi>/.spack-env/view
+<polaris_base>/<machine>/spack/dev_polaris_0_8_0_<compiler>_<mpi>/var/spack/environments/dev_polaris_0_8_0_<compiler>_<mpi>/.spack-env/view
 ```
 
 ```{eval-rst}
 +--------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Machine      | Compiler         | Parmetis path                                                                                                                                                             |
 +==============+==================+===========================================================================================================================================================================+
-| chicoma-cpu  | gnu              | /usr/projects/e3sm/polaris/chicoma-cpu/spack/dev_polaris_0_7_0_gnu_mpich/var/spack/environments/dev_polaris_0_7_0_gnu_mpich/.spack-env/view                               |
+| chicoma-cpu  | gnu              | /usr/projects/e3sm/polaris/chicoma-cpu/spack/dev_polaris_0_8_0_gnu_mpich/var/spack/environments/dev_polaris_0_8_0_gnu_mpich/.spack-env/view                               |
 +--------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| chrysalis    | intel            | /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_0_7_0_intel_openmpi/var/spack/environments/dev_polaris_0_7_0_intel_openmpi/.spack-env/view                         |
+| chrysalis    | intel            | /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_0_8_0_intel_openmpi/var/spack/environments/dev_polaris_0_8_0_intel_openmpi/.spack-env/view                         |
 |              +------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | gnu              | /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_0_7_0_gnu_openmpi/var/spack/environments/dev_polaris_0_7_0_gnu_openmpi/.spack-env/view                             |
+|              | gnu              | /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_0_8_0_gnu_openmpi/var/spack/environments/dev_polaris_0_8_0_gnu_openmpi/.spack-env/view                             |
 +--------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| frontier     | craygnu          | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_7_0_craygnu_mpich/var/spack/environments/dev_polaris_0_7_0_craygnu_mpich/.spack-env/view                   |
+| frontier     | craygnu          | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_8_0_craygnu_mpich/var/spack/environments/dev_polaris_0_8_0_craygnu_mpich/.spack-env/view                   |
 |              +------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | craygnu-mphipcc  | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_7_0_craygnu-mphipcc_mpich/var/spack/environments/dev_polaris_0_7_0_craygnu-mphipcc_mpich/.spack-env/view   |
+|              | craygnu-mphipcc  | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_8_0_craygnu-mphipcc_mpich/var/spack/environments/dev_polaris_0_8_0_craygnu-mphipcc_mpich/.spack-env/view   |
 |              +------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | craycray         | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_7_0_craycray_mpich/var/spack/environments/dev_polaris_0_7_0_craycray_mpich/.spack-env/view                 |
+|              | craycray         | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_8_0_craycray_mpich/var/spack/environments/dev_polaris_0_8_0_craycray_mpich/.spack-env/view                 |
 |              +------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | craycray-mphipcc | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_7_0_craycray-mphipcc_mpich/var/spack/environments/dev_polaris_0_7_0_craycray-mphipcc_mpich/.spack-env/view |
+|              | craycray-mphipcc | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_8_0_craycray-mphipcc_mpich/var/spack/environments/dev_polaris_0_8_0_craycray-mphipcc_mpich/.spack-env/view |
 +              +------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | crayamd          | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_7_0_crayamd_mpich/var/spack/environments/dev_polaris_0_7_0_crayamd_mpich/.spack-env/view                   |
+|              | crayamd          | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_8_0_crayamd_mpich/var/spack/environments/dev_polaris_0_8_0_crayamd_mpich/.spack-env/view                   |
 |              +------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | crayamd-mphipcc  | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_7_0_crayamd-mphipcc_mpich/var/spack/environments/dev_polaris_0_7_0_crayamd-mphipcc_mpich/.spack-env/view   |
+|              | crayamd-mphipcc  | /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_0_8_0_crayamd-mphipcc_mpich/var/spack/environments/dev_polaris_0_8_0_crayamd-mphipcc_mpich/.spack-env/view   |
 +--------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| pm-cpu       | gnu              | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_7_0_gnu_mpich/var/spack/environments/dev_polaris_0_7_0_gnu_mpich/.spack-env/view                       |
+| pm-cpu       | gnu              | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_8_0_gnu_mpich/var/spack/environments/dev_polaris_0_8_0_gnu_mpich/.spack-env/view                       |
 |              +------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              | intel            | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_7_0_intel_mpich/var/spack/environments/dev_polaris_0_7_0_intel_mpich/.spack-env/view                   |
+|              | intel            | /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_8_0_intel_mpich/var/spack/environments/dev_polaris_0_8_0_intel_mpich/.spack-env/view                   |
 +--------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| pm-gpu       | gnugpu           | /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_0_7_0_gnugpu_mpich/var/spack/environments/dev_polaris_0_7_0_gnugpu_mpich/.spack-env/view                 |
+| pm-gpu       | gnugpu           | /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_0_8_0_gnugpu_mpich/var/spack/environments/dev_polaris_0_8_0_gnugpu_mpich/.spack-env/view                 |
 +--------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
In this PR I updated the polaris version listed in the docs from 0.7.0 to 0.8.0.

I also fixed an issue where the omega dependencies incorrectly listed `sphinx-multiversion` despite it not being used for the documentation.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


