### PR TITLE
Omega/boundary edge masks

### DIFF
--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -635,12 +635,17 @@ void HorzMesh::setMasks(int NVertLevels) {
 
    EdgeMask = Array2DReal("EdgeMask", NEdgesSize, NVertLevels);
 
-   OMEGA_SCOPE(O_EdgeMask, EdgeMask);
+   OMEGA_SCOPE(LocEdgeMask, EdgeMask);
+   OMEGA_SCOPE(LocCellsOnEdge, CellsOnEdge);
 
+   deepCopy(EdgeMask, 1.0);
    parallelFor(
-       {NEdgesAll}, KOKKOS_LAMBDA(int Edge) {
-          for (int K = 0; K < NVertLevels; ++K) {
-             O_EdgeMask(Edge, K) = 1.0;
+       {NEdgesAll, NVertLevels}, KOKKOS_LAMBDA(int Edge, int K) {
+          const I4 Cell1 = LocCellsOnEdge(Edge, 0);
+          const I4 Cell2 = LocCellsOnEdge(Edge, 1);
+          if (!(Cell1 >= 0 and Cell1 < NCellsAll) or
+              !(Cell2 >= 0 and Cell2 < NCellsAll)) {
+             LocEdgeMask(Edge, K) = 1.0;
           }
        });
 

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -221,8 +221,9 @@ Tendencies::Tendencies(const std::string &Name, ///< [in] Name for tendencies
                        CustomTendencyType InCustomVelocityTend)
     : ThicknessFluxDiv(Mesh), PotientialVortHAdv(Mesh), KEGrad(Mesh),
       SSHGrad(Mesh), VelocityDiffusion(Mesh), VelocityHyperDiff(Mesh),
-      BottomDrag(Mesh), TracerHorzAdv(Mesh), TracerDiffusion(Mesh),
-      TracerHyperDiff(Mesh), CustomThicknessTend(InCustomThicknessTend),
+      WindForcing(Mesh), BottomDrag(Mesh), TracerHorzAdv(Mesh),
+      TracerDiffusion(Mesh), TracerHyperDiff(Mesh),
+      CustomThicknessTend(InCustomThicknessTend),
       CustomVelocityTend(InCustomVelocityTend) {
 
    // Tendency arrays

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -24,13 +24,15 @@ ThicknessFluxDivOnCell::ThicknessFluxDivOnCell(const HorzMesh *Mesh)
 
 PotentialVortHAdvOnEdge::PotentialVortHAdvOnEdge(const HorzMesh *Mesh)
     : NEdgesOnEdge(Mesh->NEdgesOnEdge), EdgesOnEdge(Mesh->EdgesOnEdge),
-      WeightsOnEdge(Mesh->WeightsOnEdge) {}
+      WeightsOnEdge(Mesh->WeightsOnEdge), EdgeMask(Mesh->EdgeMask) {}
 
 KEGradOnEdge::KEGradOnEdge(const HorzMesh *Mesh)
-    : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge) {}
+    : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge),
+      EdgeMask(Mesh->EdgeMask) {}
 
 SSHGradOnEdge::SSHGradOnEdge(const HorzMesh *Mesh)
-    : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge) {}
+    : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge),
+      EdgeMask(Mesh->EdgeMask) {}
 
 VelocityDiffusionOnEdge::VelocityDiffusionOnEdge(const HorzMesh *Mesh)
     : CellsOnEdge(Mesh->CellsOnEdge), VerticesOnEdge(Mesh->VerticesOnEdge),
@@ -42,26 +44,30 @@ VelocityHyperDiffOnEdge::VelocityHyperDiffOnEdge(const HorzMesh *Mesh)
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge),
       MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(Mesh->EdgeMask) {}
 
+WindForcingOnEdge::WindForcingOnEdge(const HorzMesh *Mesh)
+    : EdgeMask(Mesh->EdgeMask) {}
+
 BottomDragOnEdge::BottomDragOnEdge(const HorzMesh *Mesh)
     : Enabled(false), Coeff(0), CellsOnEdge(Mesh->CellsOnEdge),
-      NVertLevels(Mesh->NVertLevels) {}
+      NVertLevels(Mesh->NVertLevels), EdgeMask(Mesh->EdgeMask) {}
 
 TracerHorzAdvOnCell::TracerHorzAdvOnCell(const HorzMesh *Mesh)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
-      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell) {}
+      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell), EdgeMask(Mesh->EdgeMask) {
+}
 
 TracerDiffOnCell::TracerDiffOnCell(const HorzMesh *Mesh)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
       DvEdge(Mesh->DvEdge), DcEdge(Mesh->DcEdge), AreaCell(Mesh->AreaCell),
-      MeshScalingDel2(Mesh->MeshScalingDel2) {}
+      MeshScalingDel2(Mesh->MeshScalingDel2), EdgeMask(Mesh->EdgeMask) {}
 
 TracerHyperDiffOnCell::TracerHyperDiffOnCell(const HorzMesh *Mesh)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
       DvEdge(Mesh->DvEdge), DcEdge(Mesh->DcEdge), AreaCell(Mesh->AreaCell),
-      MeshScalingDel4(Mesh->MeshScalingDel4) {}
+      MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(Mesh->EdgeMask) {}
 
 } // end namespace OMEGA
 

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
@@ -14,7 +14,8 @@ TracerAuxVars::TracerAuxVars(const std::string &AuxStateSuffix,
                       Mesh->NCellsSize, NVertLevels),
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
-      DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell) {}
+      DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
+      EdgeMask(Mesh->EdgeMask) {}
 
 void TracerAuxVars::registerFields(const std::string &AuxGroupName,
                                    const std::string &MeshName) const {

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
@@ -79,7 +79,8 @@ class TracerAuxVars {
          for (int KVec = 0; KVec < VecLength; ++KVec) {
             const int K           = KStart + KVec;
             const Real TracerGrad = TrCell(L, JCell1, K) - TrCell(L, JCell0, K);
-            Del2TrCellTmp[KVec] -= EdgeSignOnCell(ICell, J) * DvDcEdge *
+            Del2TrCellTmp[KVec] -= EdgeMask(JEdge, K) *
+                                   EdgeSignOnCell(ICell, J) * DvDcEdge *
                                    LayerThickEdgeMean(JEdge, K) * TracerGrad;
          }
       }
@@ -101,6 +102,7 @@ class TracerAuxVars {
    Array1DReal DcEdge;
    Array1DReal DvEdge;
    Array1DReal AreaCell;
+   Array2DReal EdgeMask;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
@@ -17,7 +17,7 @@ VelocityDel2AuxVars::VelocityDel2AuxVars(const std::string &AuxStateSuffix,
       EdgeSignOnCell(Mesh->EdgeSignOnCell), DcEdge(Mesh->DcEdge),
       DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
       EdgesOnVertex(Mesh->EdgesOnVertex), CellsOnEdge(Mesh->CellsOnEdge),
-      VerticesOnEdge(Mesh->VerticesOnEdge),
+      VerticesOnEdge(Mesh->VerticesOnEdge), EdgeMask(Mesh->EdgeMask),
       EdgeSignOnVertex(Mesh->EdgeSignOnVertex),
       AreaTriangle(Mesh->AreaTriangle), VertexDegree(Mesh->VertexDegree) {}
 

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
@@ -40,7 +40,7 @@ class VelocityDel2AuxVars {
          const Real CurlVort =
              -(RelVortVertex(JVertex1, K) - RelVortVertex(JVertex0, K)) *
              InvDvEdge;
-         Del2Edge(IEdge, K) = GradDiv + CurlVort;
+         Del2Edge(IEdge, K) = EdgeMask(IEdge, K) * GradDiv + CurlVort;
       }
    }
 
@@ -104,6 +104,7 @@ class VelocityDel2AuxVars {
    Array2DI4 VerticesOnEdge;
    Array2DReal EdgeSignOnVertex;
    Array1DReal AreaTriangle;
+   Array2DReal EdgeMask;
    I4 VertexDegree;
 };
 

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -736,7 +736,7 @@ int testWindForcing(int NVertLevels) {
    // Compute numerical result
    Array2DReal NumWindForcing("NumWindForcing", Mesh->NEdgesOwned, NVertLevels);
 
-   WindForcingOnEdge WindForcingOnE;
+   WindForcingOnEdge WindForcingOnE(Mesh);
    WindForcingOnE.SaltWaterDensity = SaltWaterDensity;
 
    parallelFor(


### PR DESCRIPTION
This PR allows Omega to properly run on meshes with boundary edges.

Updates the initialization of the HorzMesh member array EdgeMask to set values on boundary edges equal to 0, and adds EdgeMask to tendency terms and auxiliary variables to nullify computations on boundary edges. Some of these changes will likely be temporary, to be replaced by setting KMin and KMax ranges to skip over computations on boundary edges similar to how many boundaries are handled in MPAS.

Ran ctest successfully on pm-cpu (intel), pm-gpu (gnu), frontier cpu (craycray), and frontier gpu (craycray-mphipcc). Changes introduced in this PR produced successful results for the barotropic gyre and global wind-forced tests in the comments of #219

Checklist
* [x] Testing
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.