### PR TITLE
removes or fixes several unused variables or expressions

### DIFF
--- a/components/omega/src/infra/Config.cpp
+++ b/components/omega/src/infra/Config.cpp
@@ -485,7 +485,6 @@ Error Config::get(const std::string &VarName,    // [in] name of variable to get
                   std::vector<std::string> &List // [out] string list retrieved
 ) {
    Error Err; // success error code
-   int VecSize = 0;
 
    // Extract variable from config
    // First check if it exists and verify that it is a sequence node

--- a/components/omega/src/infra/Dimension.cpp
+++ b/components/omega/src/infra/Dimension.cpp
@@ -14,6 +14,7 @@
 
 #include "Dimension.h"
 #include "DataTypes.h"
+#include "Error.h"
 #include "Logging.h"
 #include "OmegaKokkos.h"
 #include <map>
@@ -246,16 +247,15 @@ HostArray1DI4
 Dimension::getDimOffset(const std::string &Name // [in] name of dimension
 ) {
 
-   // Make sure dimension exists
-   if (exists(Name)) {
-      std::shared_ptr<Dimension> ThisDim = AllDims[Name];
-      return ThisDim->Offset;
+   // Abort if the dimension does not exist
+   if (!exists(Name))
+      ABORT_ERROR("Cannot get offset array for dimension {}: "
+                  "dimension does not exist or has not been defined",
+                  Name);
 
-   } else {
-      LOG_ERROR("Cannot get offset array for dimension {}: "
-                "dimension does not exist or has not been defined",
-                Name);
-   }
+   // Retrieve offset
+   std::shared_ptr<Dimension> ThisDim = AllDims[Name];
+   return ThisDim->Offset;
 
 } // end getDimOffset
 

--- a/components/omega/src/infra/Error.h
+++ b/components/omega/src/infra/Error.h
@@ -135,7 +135,7 @@ Error::Error(ErrorCode ErrCode, // [in] error code to assign
 
    // Strip pathname from file argument
    std::string Filename;
-   int Pos = FileWPath.find_last_of("\\/");
+   auto Pos = FileWPath.find_last_of("\\/");
    if (Pos != std::string::npos) {
       Filename = FileWPath.substr(Pos + 1);
    } else {

--- a/components/omega/src/infra/Field.cpp
+++ b/components/omega/src/infra/Field.cpp
@@ -54,10 +54,10 @@ int Field::init(const Clock *ModelClock // [in] default model clock
    std::string UnitString   = "seconds since " + StartTimeStr;
    CalendarKind CalKind     = Calendar::getKind();
    std::string CalName      = CalendarCFName[CalKind];
-   std::vector<std::string> DimNames; // empty dim names vector
+   std::vector<std::string> DimNamesTmp; // empty dim names vector
    std::shared_ptr<Field> TimeField =
        create("time", "time", UnitString, "time", 0.0, 1.e20, -9.99e30, 0,
-              DimNames, true, true);
+              DimNamesTmp, true, true);
    TimeField->addMetadata("calendar", CalName);
 
    return Err;
@@ -110,9 +110,6 @@ Field::create(const std::string &FieldName,   // [in] Name of variable/field
    // Add field name to the instance (also added as metadata below)
    ThisField->FldName = FieldName;
 
-   // Create empty metadata map: (name, value) pairs
-   ThisField->FieldMeta;
-
    // Add standard metadata. For some CF standard attributes, we
    // also duplicate the metadata under the CF standard attribute name
    ThisField->FieldMeta["Name"]          = FieldName;
@@ -145,7 +142,6 @@ Field::create(const std::string &FieldName,   // [in] Name of variable/field
    // Also determine whether this is a distributed field - true if any of
    // the dimensions are distributed.
    ThisField->Distributed = false;
-   ThisField->DimNames;
    if (NumDims > 0) {
       ThisField->DimNames.resize(NumDims);
       for (int I = 0; I < NumDims; ++I) {
@@ -191,14 +187,8 @@ Field::create(const std::string &FieldName // [in] Name of field
    // Field name
    ThisField->FldName = FieldName;
 
-   // Metadata (name, value) pairs for descriptive metadata
-   ThisField->FieldMeta;
-
-   /// Number of dimensions is 0 for this field
+   // Number of dimensions is 0 for this field
    ThisField->NDims = 0;
-
-   // Dimension name vector is empty
-   ThisField->DimNames;
 
    // Initialize to Unknown or null - no data is attached
    ThisField->DataType  = ArrayDataType::Unknown;

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -909,6 +909,7 @@ int IOStream::writeFieldMeta(
 
       } else if (MetaVal.type() == typeid(bool)) {
          bool MetaValBool = std::any_cast<bool>(MetaVal);
+         // bool is coerced to int in write
          Err = IO::writeMeta(MetaName, MetaValBool, FileID, FieldID);
 
       } else if (MetaVal.type() == typeid(std::string)) {
@@ -1696,15 +1697,23 @@ int IOStream::readFieldData(
    case ArrayDataType::I4:
       DataI4.resize(LocSize);
       DataPtr = DataI4.data();
+      break;
    case ArrayDataType::I8:
       DataI8.resize(LocSize);
       DataPtr = DataI8.data();
+      break;
    case ArrayDataType::R4:
       DataR4.resize(LocSize);
       DataPtr = DataR4.data();
+      break;
    case ArrayDataType::R8:
       DataR8.resize(LocSize);
       DataPtr = DataR8.data();
+      break;
+   case ArrayDataType::Unknown:
+      ABORT_ERROR("Unknown data array type");
+   default:
+      ABORT_ERROR("Invalid data array type");
    }
 
    // read data into vector
@@ -2388,6 +2397,15 @@ int IOStream::readStream(
       } else if (MetaTmp.type() == typeid(R4)) {
          ErrRead = IO::readMeta(MetaName, MetaValR4, InFileID, IO::GlobalID);
          ReqMetadata[MetaName] = MetaValR4;
+      } else if (MetaTmp.type() == typeid(bool)) {
+         // bool must be read as int
+         ErrRead = IO::readMeta(MetaName, MetaValI4, InFileID, IO::GlobalID);
+         if (MetaValI4 == 0) {
+            MetaValBool = false;
+         } else {
+            MetaValBool = true;
+         }
+         ReqMetadata[MetaName] = MetaValBool;
       } else if (MetaTmp.type() == typeid(std::string)) {
          ErrRead = IO::readMeta(MetaName, MetaValStr, InFileID, IO::GlobalID);
          ReqMetadata[MetaName] = MetaValStr;

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -114,6 +114,10 @@ TimeStepper *TimeStepper::create(
       NewTimeStepper =
           new RungeKutta2Stepper(InName, InStartTime, InStopTime, InTimeStep);
       break;
+   case TimeStepperType::Invalid:
+      ABORT_ERROR("Invalid time stepping method");
+   default:
+      ABORT_ERROR("Unknown time stepping method");
    }
 
    // Attach data pointers
@@ -161,6 +165,10 @@ TimeStepper *TimeStepper::create(
       NewTimeStepper =
           new RungeKutta2Stepper(InName, InStartTime, InStopTime, InTimeStep);
       break;
+   case TimeStepperType::Invalid:
+      ABORT_ERROR("Invalid time stepping method");
+   default:
+      ABORT_ERROR("Unknown time stepping method");
    }
 
    // Store instance

--- a/components/omega/test/base/MachEnvTest.cpp
+++ b/components/omega/test/base/MachEnvTest.cpp
@@ -69,12 +69,6 @@ int main(int argc, char *argv[]) {
    MPI_Comm_rank(MPI_COMM_WORLD, &WorldTask);
    MPI_Comm_size(MPI_COMM_WORLD, &WorldSize);
    int WorldMaster = 0;
-   bool IsWorldMaster;
-   if (WorldTask == WorldMaster) {
-      IsWorldMaster = true;
-   } else {
-      IsWorldMaster = false;
-   }
 
    // The subset environments create 4-task sub-environments so
    // make sure the unit test is run with at least 8 to adequately

--- a/components/omega/test/infra/FieldTest.cpp
+++ b/components/omega/test/infra/FieldTest.cpp
@@ -850,8 +850,6 @@ int main(int argc, char **argv) {
                    if (Data3DI4(Cell, K, Trcr) != RefI4 + Cell + K + Trcr)
                       ++LCount;
                    for (int TimeLvl = 0; TimeLvl < NTime; ++TimeLvl) {
-                      int Add4 =
-                          TimeLvl * NTracers * NCellsSize * NVertLevels + Add3;
                       if (Data4DI8(Cell, K, Trcr, TimeLvl) !=
                           RefI8 + Cell + K + Trcr + TimeLvl)
                          ++LCount;

--- a/components/omega/test/infra/FieldTest.cpp
+++ b/components/omega/test/infra/FieldTest.cpp
@@ -782,8 +782,6 @@ int main(int argc, char **argv) {
          if (Data1DI4H(Cell) != RefI4 + Cell)
             ++DataCount1;
          for (int K = 0; K < NVertLevels; ++K) {
-            I4 I4Ref = RefI4 + Cell + K;
-            R8 R8Ref = RefR8 + Cell + K;
             if (Data2DI4H(Cell, K) != RefI4 + Cell + K)
                ++DataCount2;
             if (Data2DR8H(Cell, K) != RefR8 + Cell + K)
@@ -858,9 +856,6 @@ int main(int argc, char **argv) {
                           RefI8 + Cell + K + Trcr + TimeLvl)
                          ++LCount;
                       for (int Stf = 0; Stf < NStuff; ++Stf) {
-                         int Add5 =
-                             Stf * NTime * NTracers * NCellsSize * NVertLevels +
-                             Add4;
                          if (Data5DR4(Cell, K, Trcr, TimeLvl, Stf) !=
                              RefR4 + Cell + K + Trcr + TimeLvl + Stf)
                             ++LCount;
@@ -879,7 +874,6 @@ int main(int argc, char **argv) {
              if (Data1DI8(Edge) != RefI8 + Edge)
                 ++LCount;
              for (int K = 0; K < NVertLevels; ++K) {
-                int Add = Edge * NVertLevels + K;
                 if (Data2DI8(Edge, K) != RefI8 + Edge + K)
                    ++LCount;
                 if (Data2DR8(Edge, K) != RefR8 + Edge + K)
@@ -896,7 +890,6 @@ int main(int argc, char **argv) {
              if (Data1DR4(Vrtx) != RefR4 + Vrtx)
                 ++LCount;
              for (int K = 0; K < NVertLevels; ++K) {
-                int Add = Vrtx * NVertLevels + K;
                 if (Data2DR4(Vrtx, K) != RefR4 + Vrtx + K)
                    ++LCount;
              }

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -35,14 +35,6 @@
 using namespace OMEGA;
 
 //------------------------------------------------------------------------------
-// Set some constant reference values for simplicity
-const I4 RefI4           = 3;
-const I8 RefI8           = 400000000;
-const R4 RefR4           = 5.1;
-const R8 RefR8           = 6.123456789;
-const std::string RefStr = "Reference String";
-
-//------------------------------------------------------------------------------
 // A simple test evaluation function
 template <typename T>
 void TestEval(const std::string &TestName, T TestVal, T ExpectVal, int &Error) {
@@ -106,7 +98,6 @@ int initIOStreamTest(Clock *&ModelClock // Model clock
    // Initialize HorzMesh - this should read Mesh stream
    HorzMesh::init();
    HorzMesh *DefMesh = HorzMesh::getDefault();
-   I4 NCellsSize     = DefMesh->NCellsSize;
 
    // Set vertical levels and time levels
    I4 NVertLevels = 60;


### PR DESCRIPTION
 Fixes many unused variables and expressions and a missing default switch clause that were found via compiler warnings.

CTests pass on Frontier with both gnu and amd on cpu, gpu.  @grnydawn should verify this fixes the compiler messages since my build did not include those flags.

* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

fixes #237, fixes #240, fixes #242 , fixes #243, fixes #246, fixes #247, fixes #248, fixes #249, fixes #259, fixes #260, fixes #261

