### PR TITLE
Add more infrastructure for timing

### DIFF
--- a/components/omega/OmegaBuild.cmake
+++ b/components/omega/OmegaBuild.cmake
@@ -29,6 +29,7 @@ macro(common)
   option(OMEGA_DEBUG "Turn on error message throwing (default OFF)." OFF)
   option(OMEGA_LOG_FLUSH "Turn on unbuffered logging (default OFF)." OFF)
   option(OMEGA_TEST_CDASH "Turn on CDash support (default ON)." ON)
+  option(OMEGA_EXTERNAL_PROF "Integration of Omega timers with external profiling tools (default OFF)." OFF)
 
   if("${OMEGA_BUILD_TYPE}" STREQUAL "Debug" OR "${OMEGA_BUILD_TYPE}" STREQUAL "DEBUG")
     set(OMEGA_DEBUG ON)

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -3,6 +3,7 @@ Omega:
     Level: 2
     AutoFence: true
     TimingBarriers: false
+    PrintAllRanks: false
   TimeIntegration:
     CalendarType: No Leap
     TimeStepper: Forward-Backward

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -1,4 +1,8 @@
 Omega:
+  Timing:
+    Level: 2
+    AutoFence: true
+    TimingBarriers: false
   TimeIntegration:
     CalendarType: No Leap
     TimeStepper: Forward-Backward

--- a/components/omega/doc/devGuide/Timing.md
+++ b/components/omega/doc/devGuide/Timing.md
@@ -1,0 +1,96 @@
+(omega-dev-timing)=
+
+# Timing
+
+The timing infrastructure builds upon the E3SM Pacer library for wall clock timing.
+Pacer integrates, whenever possible, platform-specific marker APIs.
+
+# Initialization
+
+To initialize the Pacer library call
+```c++
+Pacer::initialize(Comm);
+```
+where `Comm` is an MPI communicator.
+
+# Writing-out timing data
+
+To write out timing data call
+```c++
+Pacer::print(FilePrefix, PrintAllRanks);
+```
+where `FilePrefix` is the prefix for all output files and an optional argument `PrintAllRanks` determines
+if all MPI ranks should print their data.
+
+# Finalization
+
+To finalize the Pacer library call
+```c++
+Pacer::finalize();
+```
+
+# Basic timer use
+
+To time a region of code enclose it with calls to `Pacer::start` and `Pacer::stop` functions, like so
+```c++
+Pacer::start(Name, Level);
+// region of code to be timed
+Pacer::stop(Name, Level);
+```
+These functions take a string `Name` and a non-negative integer `Level`.
+The added timer will be active only if the timing level set in the config file is greater or equal to `Level`.
+
+# Advanced timing functions
+
+## Conditional MPI barriers
+
+Properly timing MPI communication might require inserting MPI barriers. It might be desirable
+to remove those barriers in production runs. Pacer provides a function
+```c++
+Pacer::timingBarrier(TimerName, Level, Comm)
+```
+which adds an MPI barrier and puts a timer around it using the communicator `Comm`.
+Whether barriers added by this function are actually called can be controlled by the following functions
+```c++
+  Pacer::enableTimingBarriers();
+  Pacer::disableTimingBarriers();
+```
+
+## Adding parent prefixes
+
+It might be desirable to add a prefix to a group of timers based on their parent timer.
+To enable this Pacer provides the `addParentPrefix()` and `removeParentPrefix()` functions.
+For example, the following call sequence
+```c++
+Pacer::start("Parent", 0);
+Pacer::addParentPrefix();
+
+Pacer::start("Child", 0);
+Pacer::stop("Child", 0);
+
+Pacer::removeParentPrefix();
+Pacer::start("Parent", 0);
+```
+results in output where the "Child" timer shows up as "Parent:Child" in the output files.
+This is useful when timers are added inside general purpose routines, that are called
+from many places in the code, such as halo exchange.
+
+## Disabling timers
+
+It might be desirable programmatically disable or enable timing. To allow that, Pacer provides
+the `disableTimers()` and `enableTimers()` functions. In the following call sequence
+```c++
+Pacer::disableTiming();
+
+Pacer::start("Timer1", 0);
+Pacer::stop("Timer1", 0);
+
+Pacer::enableTiming();
+
+Pacer::start("Timer2", 0);
+Pacer::stop("Timer2", 0);
+```
+`Timer1` is not timed while `Timer2` is. This is useful mainly when done conditionally.
+For example, the first call to some function takes much longer than subsequent calls,
+and having a detailed timing breakdown of the first call is not important. In that case,
+it might be desirable to have a separate timer for the first call with its child timers disabled.

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -49,6 +49,7 @@ userGuide/Reductions
 userGuide/Tracers
 userGuide/TridiagonalSolvers
 userGuide/VertCoord
+userGuide/Timing
 ```
 
 ```{toctree}
@@ -88,6 +89,7 @@ devGuide/Reductions
 devGuide/Tracers
 devGuide/TridiagonalSolvers
 devGuide/VertCoord
+devGuide/Timing
 ```
 
 ```{toctree}

--- a/components/omega/doc/userGuide/Timing.md
+++ b/components/omega/doc/userGuide/Timing.md
@@ -1,0 +1,51 @@
+(omega-user-timing)=
+
+# Timing
+
+Omega uses the Pacer library for timing the code and incorporates timers around
+various parts of the code.
+
+By default, the timing output is written to two files: `omega.summary` and `omega.timing0`.
+The `omega.summary` file presents accumulated timing statistics across all MPI ranks.
+The `omega.timing.0` show timing result only from the first rank.
+
+There are four parameters that are set by the user in the input configuration
+file that control the timing behavior. These are:
+```yaml
+Timing:
+   Level: 2
+   AutoFence: true
+   TimingBarriers: false
+   PrintAllRanks: false
+```
+The `Level` parameter is a non-negative integer that determines the granularity of timers.
+Increasing it will turn on more timers.
+Having more timers provides more detailed information, but it also comes with increased overhead,
+and may be counter-productive if a high-level look at model performance is sufficient.
+
+The `Autofence` Boolean option determines if Kokkos fences are automatically added before every timer call.
+This option **needs** to be true for accurate timing using Omega timers on GPU-based systems.
+However, there are circumstances when turning off automatic fences is useful.
+The main use case is using external profiling tools.
+Another one is measuring the overhead of automatic synchronization for very high timing levels.
+
+The `TimingLevel` Boolean option determines if MPI barriers are added before or after certain timers.
+Adding barriers may be necessary to properly measure communication time, but it can add top much overhead in
+production runs.
+
+The `PrintAllRanks` Boolean option determines if all ranks should print their timing information. If this
+option is set to `true` the output will include additional files `omega.timing.i` with the
+timing data from rank `i`.
+
+## Integration with external profiling tools
+
+External profilers often include APIs to mark regions of code for detailed profiling.
+On some platforms, Omega timers automatically add these annotations.
+Currently, this is only implemented on systems with NVIDIA GPUs using NVTX.
+
+This allows, for example, to use the Nsight Compute kernel profiler to obtain
+detailed kernel information for all kernels enclosed in the `Tend:computeVelocityTendencies`
+Omega timer.
+```bash
+mpirun -np 1 ncu --nvtx --nvtx-include "Tend:computeVelocityTendencies/" omega.exe
+```

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -104,6 +104,13 @@ if (NOT TARGET pacer)
         PRIVATE
         PACER_HAVE_KOKKOS=1
      )
+    if (OMEGA_EXTERNAL_PROF)
+      target_compile_definitions(
+          pacer
+          PRIVATE
+          PACER_ADD_RANGES=1
+      )
+    endif()
 endif()
 
 # Add the parmetis and related libraries

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -94,9 +94,16 @@ if (NOT TARGET pacer)
 
     target_link_libraries(
         pacer
-        PUBLIC
+        PRIVATE
         gptl
+        Kokkos::kokkos
     )
+
+    target_compile_definitions(
+        pacer
+        PRIVATE
+        PACER_HAVE_KOKKOS=1
+     )
 endif()
 
 # Add the parmetis and related libraries

--- a/components/omega/src/base/Halo.cpp
+++ b/components/omega/src/base/Halo.cpp
@@ -279,6 +279,10 @@ Halo *Halo::get(const std::string Name // name of Halo to retrieve
 } // end Halo get
 
 //------------------------------------------------------------------------------
+// Get communicator for a Halo object
+MPI_Comm Halo::getComm() const { return MyComm; }
+
+//------------------------------------------------------------------------------
 // Sets Halo class members NeighborList, NNghbr, SendFlags, and RecvFlags during
 // Halo construction
 

--- a/components/omega/src/base/Halo.h
+++ b/components/omega/src/base/Halo.h
@@ -770,7 +770,9 @@ class Halo {
                          MeshElement ThisElem // index space Array is defined on
    ) {
       // Add more context for timers in this function
-      Pacer::addParentPrefix();
+      // BUG: fails when there is no parent timer
+      // Uncomment after fixing in Pacer
+      // Pacer::addParentPrefix();
 
       I4 IErr{0}; // error code
 
@@ -905,7 +907,9 @@ class Halo {
       MPI_Waitall(SendReqs.size(), SendReqs.data(), MPI_STATUS_IGNORE);
       Pacer::stop("Halo:waitSends", 4);
 
-      Pacer::removeParentPrefix();
+      // BUG: fails when there is no parent timer
+      // Uncomment after fixing in Pacer
+      // Pacer::removeParentPrefix();
 
       return IErr;
    } // end exchangeFullArrayHalo

--- a/components/omega/src/base/Halo.h
+++ b/components/omega/src/base/Halo.h
@@ -277,6 +277,9 @@ class Halo {
    /// Retrieves a pointer to a Halo object by Name
    static Halo *get(std::string Name);
 
+   /// Retrieves MPI communicator from a Halo object
+   MPI_Comm getComm() const;
+
    /// Buffer pack specialized function templates for supported Kokkos array
    /// ranks. Select out the proper elements from the input Array to send to a
    /// neighboring task and pack them into the proper send buffer for

--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -25,11 +25,11 @@ int main(int argc, char **argv) {
    Pacer::initialize(MPI_COMM_WORLD);
    Pacer::setPrefix("Omega:");
 
-   Pacer::start("Init");
+   Pacer::start("Init", 0);
    ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD);
    if (ErrCurr != 0)
       LOG_ERROR("Error initializing OMEGA");
-   Pacer::stop("Init");
+   Pacer::stop("Init", 0);
 
    // Get time information
    OMEGA::TimeStepper *DefStepper = OMEGA::TimeStepper::getDefault();
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
    OMEGA::Clock *ModelClock       = DefStepper->getClock();
    OMEGA::TimeInstant CurrTime    = ModelClock->getCurrentTime();
 
-   Pacer::start("RunLoop");
+   Pacer::start("RunLoop", 0);
    while (ErrCurr == 0 && !(EndAlarm->isRinging())) {
 
       ErrCurr = OMEGA::ocnRun(CurrTime);
@@ -45,13 +45,13 @@ int main(int argc, char **argv) {
       if (ErrCurr != 0)
          LOG_ERROR("Error advancing Omega run interval");
    }
-   Pacer::stop("RunLoop");
+   Pacer::stop("RunLoop", 0);
 
-   Pacer::start("Finalize");
+   Pacer::start("Finalize", 0);
    ErrFinalize = OMEGA::ocnFinalize(CurrTime);
    if (ErrFinalize != 0)
       LOG_ERROR("Error finalizing OMEGA");
-   Pacer::stop("Finalize");
+   Pacer::stop("Finalize", 0);
 
    ErrAll = abs(ErrCurr) + abs(ErrFinalize);
    if (ErrAll == 0) {

--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
       LOG_ERROR("OMEGA terminating due to error");
    }
 
-   Pacer::print("omega");
+   Pacer::print("omega", OMEGA::printTimingAllRanks());
    Pacer::finalize();
 
    Kokkos::finalize();

--- a/components/omega/src/infra/Config.cpp
+++ b/components/omega/src/infra/Config.cpp
@@ -86,7 +86,7 @@ void Config::readAll(const std::string &ConfigFile // [in] input YAML file
 ) {
 
    // Start a timer for config file reads
-   Pacer::start("ConfigReadAll");
+   Pacer::start("ConfigReadAll", 0);
 
    // Now give the full config the omega name and extract the
    // top-level omega node from the Root.
@@ -104,7 +104,7 @@ void Config::readAll(const std::string &ConfigFile // [in] input YAML file
       MPI_Barrier(ConfigComm);
    }
 
-   Pacer::stop("ConfigReadAll");
+   Pacer::stop("ConfigReadAll", 0);
    return;
 
 } // end Config::readAll

--- a/components/omega/src/infra/Error.h
+++ b/components/omega/src/infra/Error.h
@@ -215,7 +215,7 @@ Error::Error(ErrorCode ErrCode,        // [in] error code to assign
 /// It is only active for debug builds.
 #ifdef OMEGA_DEBUG
 #define OMEGA_ASSERT(_Condition, _ErrMsg, ...) \
-   if (!_Condition) {                          \
+   if (!(_Condition)) {                        \
       LOG_CRITICAL(_ErrMsg, ##__VA_ARGS__);    \
       cpptrace::generate_trace().print();      \
       OMEGA::Error::abort();                   \
@@ -227,7 +227,7 @@ Error::Error(ErrorCode ErrCode,        // [in] error code to assign
 /// This macro checks for a required condition and exits if not met
 /// It is always evaluated (unlike ASSERT for debug builds)
 #define OMEGA_REQUIRE(_Condition, _ErrMsg, ...) \
-   if (!_Condition) {                           \
+   if (!(_Condition)) {                         \
       LOG_CRITICAL(_ErrMsg, ##__VA_ARGS__);     \
       cpptrace::generate_trace().print();       \
       OMEGA::Error::abort();                    \

--- a/components/omega/src/ocn/OceanDriver.h
+++ b/components/omega/src/ocn/OceanDriver.h
@@ -18,6 +18,9 @@
 
 namespace OMEGA {
 
+/// Should timing info be printed from all ranks
+bool printTimingAllRanks();
+
 /// Read the config file and call all the inidividual initialization routines
 /// for each Omega module
 int ocnInit(MPI_Comm Comm);

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -32,6 +32,16 @@
 
 namespace OMEGA {
 
+namespace Timing {
+// Flag to determine if timing info should be printed from all ranks
+// Set by ocnInit. Access outside of this file is provided by
+// the printAllRanks() function below
+static bool PrintAllRanks = false;
+} // namespace Timing
+
+// Accessor function for the Timing::PrintAllRanks flag
+bool printTimingAllRanks() { return Timing::PrintAllRanks; }
+
 // Read timing configuration and set Pacer options
 static void readTimingConfig() {
    Error Err;
@@ -60,6 +70,9 @@ static void readTimingConfig() {
    if (TimingBarriers) {
       Pacer::enableTimingBarriers();
    }
+
+   Err += TimingConfig.get("PrintAllRanks", Timing::PrintAllRanks);
+   CHECK_ERROR_ABORT(Err, "Timing: PrintAllRanks not found in TimingConfig");
 }
 
 int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -32,6 +32,7 @@
 
 namespace OMEGA {
 
+// Read timing configuration and set Pacer options
 static void readTimingConfig() {
    Error Err;
 

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -21,6 +21,7 @@
 #include "MachEnv.h"
 #include "OceanDriver.h"
 #include "OceanState.h"
+#include "Pacer.h"
 #include "Tendencies.h"
 #include "TimeMgr.h"
 #include "TimeStepper.h"
@@ -30,6 +31,35 @@
 #include "mpi.h"
 
 namespace OMEGA {
+
+static void readTimingConfig() {
+   Error Err;
+
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config TimingConfig("Timing");
+   Err += OmegaConfig->get(TimingConfig);
+   CHECK_ERROR_ABORT(Err, "Timing: Timing group not found in Config");
+
+   int TimingLevel;
+   Err += TimingConfig.get("Level", TimingLevel);
+   CHECK_ERROR_ABORT(Err, "Timing: Level not found in TimingConfig");
+   OMEGA_REQUIRE(TimingLevel >= 0, "Invalid timing level {} < 0", TimingLevel);
+   Pacer::setTimingLevel(TimingLevel);
+
+   bool AutoFence;
+   Err += TimingConfig.get("AutoFence", AutoFence);
+   CHECK_ERROR_ABORT(Err, "Timing: AutoFence not found in TimingConfig");
+   if (AutoFence) {
+      Pacer::enableAutoFence();
+   }
+
+   bool TimingBarriers;
+   Err += TimingConfig.get("TimingBarriers", TimingBarriers);
+   CHECK_ERROR_ABORT(Err, "Timing: TimingBarriers not found in TimingConfig");
+   if (TimingBarriers) {
+      Pacer::enableTimingBarriers();
+   }
+}
 
 int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
 ) {
@@ -47,6 +77,8 @@ int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
    Config("Omega");
    Config::readAll("omega.yml");
    Config *OmegaConfig = Config::getOmegaConfig();
+
+   readTimingConfig();
 
    // initialize remaining Omega modules
    Err = initOmegaModules(Comm);

--- a/components/omega/src/ocn/OceanRun.cpp
+++ b/components/omega/src/ocn/OceanRun.cpp
@@ -42,7 +42,20 @@ int ocnRun(TimeInstant &CurrTime ///< [inout] current sim time
       // call forcing routines, anything needed pre-timestep
 
       // do forward time step
-      DefTimeStepper->doStep(DefOceanState, SimTime);
+      // first call to doStep can sometimes take very long
+      // we want to time it separately and disable child timers
+      // for that timer
+      if (IStep == 1) {
+         Pacer::start("Stepper:firstDoStep", 1);
+         Pacer::disableTiming();
+         DefTimeStepper->doStep(DefOceanState, SimTime);
+         Pacer::enableTiming();
+         Pacer::stop("Stepper:firstDoStep", 1);
+      } else {
+         Pacer::start("Stepper:doStep", 1);
+         DefTimeStepper->doStep(DefOceanState, SimTime);
+         Pacer::stop("Stepper:doStep", 1);
+      }
 
       // write restart file/output, anything needed post-timestep
 

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -5,6 +5,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ForwardBackwardStepper.h"
+#include "Pacer.h"
 
 namespace OMEGA {
 
@@ -68,8 +69,12 @@ void ForwardBackwardStepper::doStep(
 
    // Update time levels (New -> Old) of prognostic variables with halo
    // exchanges
+   const MPI_Comm Comm = MeshHalo->getComm();
+   Pacer::timingBarrier("ForwardBackward:haloExchBarrier", 3, Comm);
+   Pacer::start("ForwardBackward:haloExch", 3);
    State->updateTimeLevels();
    Tracers::updateTimeLevels();
+   Pacer::stop("ForwardBackward:haloExch", 3);
 
    // Advance the clock and update the simulation time
    StepClock->advance();

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -5,6 +5,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "RungeKutta2Stepper.h"
+#include "Pacer.h"
 
 namespace OMEGA {
 
@@ -59,8 +60,12 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
 
    // Update time levels (New -> Old) of prognostic variables with halo
    // exchanges
+   const MPI_Comm Comm = MeshHalo->getComm();
+   Pacer::timingBarrier("RK2:haloExch", 3, Comm);
+   Pacer::start("RK2:haloExch", 3);
    State->updateTimeLevels();
    Tracers::updateTimeLevels();
+   Pacer::stop("RK2:haloExch", 3);
 
    // Advance the clock and update the simulation time
    StepClock->advance();

--- a/components/omega/test/base/DataTypesTest.cpp
+++ b/components/omega/test/base/DataTypesTest.cpp
@@ -955,6 +955,7 @@ int main(int argc, char *argv[]) {
       // MPI_Status status;
    }
    LOG_INFO("------ DataTypes Unit Tests Successful ------");
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -144,6 +144,7 @@ int main(int argc, char *argv[]) {
       if (RetVal == 0)
          LOG_INFO("---- DecompTest: Successful completion ----");
    }
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/base/HaloTest.cpp
+++ b/components/omega/test/base/HaloTest.cpp
@@ -582,6 +582,7 @@ int main(int argc, char *argv[]) {
          LOG_INFO("HaloTest: Failed");
       }
    }
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -729,6 +729,7 @@ int main(int argc, char *argv[]) {
 
       LOG_INFO("IOTest: Successful completion");
    }
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/base/ReductionsTest.cpp
+++ b/components/omega/test/base/ReductionsTest.cpp
@@ -371,6 +371,7 @@ int main(int argc, char *argv[]) {
       printf("Global sum device A1DR4: %s (exp,act=%.10f,%.10f)\n", res, expR4,
              MyResR4);
    }
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/drivers/StandaloneDriverTest.cpp
+++ b/components/omega/test/drivers/StandaloneDriverTest.cpp
@@ -72,7 +72,7 @@ int main(int argc, char *argv[]) {
       LOG_INFO("DriverTest: Successful completion");
    }
 
-   Pacer::print("omega_driver_test");
+   Pacer::print("omega_driver_test", OMEGA::printTimingAllRanks());
    Pacer::finalize();
 
    Kokkos::finalize();

--- a/components/omega/test/drivers/StandaloneDriverTest.cpp
+++ b/components/omega/test/drivers/StandaloneDriverTest.cpp
@@ -32,14 +32,14 @@ int main(int argc, char *argv[]) {
    Pacer::initialize(MPI_COMM_WORLD);
    Pacer::setPrefix("Omega:");
 
-   Pacer::start("Init");
+   Pacer::start("Init", 0);
    ErrCurr = OMEGA::ocnInit(MPI_COMM_WORLD);
    if (ErrCurr == 0) {
       LOG_INFO("DriverTest: Omega initialize PASS");
    } else {
       LOG_INFO("DriverTest: Omega initialize FAIL");
    }
-   Pacer::stop("Init");
+   Pacer::stop("Init", 0);
 
    // Time management objects
    OMEGA::TimeStepper *DefStepper = OMEGA::TimeStepper::getDefault();
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
    OMEGA::Alarm *EndAlarm         = DefStepper->getEndAlarm();
    OMEGA::TimeInstant CurrTime    = ModelClock->getCurrentTime();
 
-   Pacer::start("RunLoop");
+   Pacer::start("RunLoop", 0);
    if (ErrCurr == 0) {
       ErrCurr = OMEGA::ocnRun(CurrTime);
    }
@@ -56,16 +56,16 @@ int main(int argc, char *argv[]) {
    } else {
       LOG_INFO("DriverTest: Omega model run FAIL");
    }
-   Pacer::stop("RunLoop");
+   Pacer::stop("RunLoop", 0);
 
-   Pacer::start("Finalize");
+   Pacer::start("Finalize", 0);
    ErrFinalize = OMEGA::ocnFinalize(CurrTime);
    if (ErrFinalize == 0) {
       LOG_INFO("DriverTest: Omega finalize PASS");
    } else {
       LOG_INFO("DriverTest: Omega finalize FAIL");
    }
-   Pacer::stop("Finalize");
+   Pacer::stop("Finalize", 0);
 
    ErrAll = abs(ErrCurr) + abs(ErrFinalize);
    if (ErrAll == 0) {

--- a/components/omega/test/infra/ConfigTest.cpp
+++ b/components/omega/test/infra/ConfigTest.cpp
@@ -699,6 +699,7 @@ int main(int argc, char *argv[]) {
    CHECK_ERROR(Err, "Config: expected error retrieving removed config - PASS");
 
    // Finalize environments
+   Pacer::finalize();
    MPI_Finalize();
 
    return 0; // successful completion

--- a/components/omega/test/infra/DimensionTest.cpp
+++ b/components/omega/test/infra/DimensionTest.cpp
@@ -269,6 +269,7 @@ int main(int argc, char **argv) {
    LOG_INFO("------ Dimension unit tests successful ------");
    // Clean up environments
    Decomp::clear();
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/infra/FieldTest.cpp
+++ b/components/omega/test/infra/FieldTest.cpp
@@ -888,6 +888,7 @@ int main(int argc, char **argv) {
    // Clean up environments
    Dimension::clear();
    Decomp::clear();
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -240,6 +240,7 @@ int main(int argc, char **argv) {
    Dimension::clear();
    Halo::clear();
    Decomp::clear();
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -320,6 +320,7 @@ int main(int argc, char *argv[]) {
 
    RetVal += auxStateTest();
 
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -892,6 +892,7 @@ int main(int argc, char *argv[]) {
 
    RetVal += auxVarsTest();
 
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -361,6 +361,7 @@ int main(int argc, char *argv[]) {
    RetVal += eosTest();
 
    Eos::destroyInstance();
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -783,6 +783,7 @@ int main(int argc, char *argv[]) {
       if (Err == 0)
          LOG_INFO("HorzMeshTest: Successful completion");
    }
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -499,6 +499,7 @@ int main(int argc, char *argv[]) {
 
    RetVal += operatorsTest();
 
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -425,6 +425,7 @@ int main(int argc, char *argv[]) {
       if (RetVal == 0)
          LOG_INFO("State: Successful completion");
    }
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -262,6 +262,7 @@ int main(int argc, char *argv[]) {
 
    RetVal += tendenciesTest();
 
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -1096,6 +1096,7 @@ int main(int argc, char *argv[]) {
 
    RetErr = tendencyTermsTest();
 
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -493,6 +493,7 @@ int main(int argc, char *argv[]) {
       if (RetVal == 0)
          LOG_INFO("Tracers: Successful completion");
    }
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -596,6 +596,7 @@ int main(int argc, char *argv[]) {
       Decomp::clear();
       MachEnv::removeAll();
    }
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -409,6 +409,7 @@ int main(int argc, char *argv[]) {
 
    RetVal += timeStepperTest();
 
+   Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
Adds a new module for timing under `infra/`. This module build upon the Pacer library, but extends it
with support for specifying timing levels and automatically adding Kokkos fences. It also includes more advanced
timer options that are useful in special circumstances. Finally, it adds integration with NVTX ranges on NVIDIA GPUs for profiling with vendor-specific tools.

To show how all of this can be used, new timers have been added in the `AuxiliaryState` and `Tendencies` modules.

The existing timers in `Decomp` still need to be converted to the new API, but I wanted to gather feedback before making changes there. 

For details on what was added and how to use it see the user and developer docs:
- User:  https://portal.nersc.gov/project/e3sm/mwarusz/timing/html/userGuide/Timing.html
- Developer: https://portal.nersc.gov/project/e3sm/mwarusz/timing/html/devGuide/Timing.html


<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.



<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


