### PR TITLE
Fix compiler warnings

### DIFF
--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -565,8 +565,6 @@ void HorzMesh::readWeights() {
 // Read the Coriolis parameter at the cells, edges, and vertices
 void HorzMesh::readCoriolis() {
 
-   int Err;
-
    readCellArray(FCellH, "fCell");
 
    readVertexArray(FVertexH, "fVertex");

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -328,7 +328,7 @@ I4 OceanState::getNormalVelocityH(HostArray2DReal &NormVelH,
 // TimeLevel == [1:new, 0:current, -1:previous, -2:two times ago, ...]
 I4 OceanState::copyToDevice(const I4 TimeLevel) {
 
-   I4 Err = 0;
+   I4 Err;
    I4 TimeIndex;
 
    Err = getTimeIndex(TimeIndex, TimeLevel);
@@ -344,7 +344,7 @@ I4 OceanState::copyToDevice(const I4 TimeLevel) {
 // TimeLevel == [1: new, 0:current, -1:previous, -2:two times ago, ...]
 I4 OceanState::copyToHost(const I4 TimeLevel) {
 
-   I4 Err = 0;
+   I4 Err;
    I4 TimeIndex;
 
    Err = getTimeIndex(TimeIndex, TimeLevel);
@@ -360,7 +360,7 @@ I4 OceanState::copyToHost(const I4 TimeLevel) {
 // TimeLevel == [1:new, 0:current, -1:previous, -2:two times ago, ...]
 I4 OceanState::exchangeHalo(const I4 TimeLevel) {
 
-   I4 Err = 0;
+   I4 Err;
    I4 TimeIndex;
    Err = getTimeIndex(TimeIndex, TimeLevel);
 
@@ -386,7 +386,7 @@ I4 OceanState::updateTimeLevels() {
    // Update current time index for layer thickness and normal velocity
    CurTimeIndex = (CurTimeIndex + 1) % NTimeLevels;
 
-   I4 Err = 0;
+   I4 Err;
 
    // Update IOField data associations
    Err = Field::attachFieldData<Array2DReal>(NormalVelocityFldName,

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -345,7 +345,7 @@ I4 Tracers::getHostByIndex(HostArray2DReal &TracerArrayH, const I4 TimeLevel,
       return -2;
    }
 
-   I4 Err = 0;
+   I4 Err;
    I4 TimeIndex;
 
    Err          = getTimeIndex(TimeIndex, TimeLevel);
@@ -459,7 +459,7 @@ I4 Tracers::copyToDevice(const I4 TimeLevel) {
 
 I4 Tracers::copyToHost(const I4 TimeLevel) {
 
-   I4 Err = 0;
+   I4 Err;
    I4 TimeIndex;
 
    Err = getTimeIndex(TimeIndex, TimeLevel);

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -189,10 +189,9 @@ int testTendencies() {
                                        ThickTimeLevel, VelTimeLevel, Time);
 
    // check that everything got computed correctly
-   int NCellsOwned    = Mesh->NCellsOwned;
-   int NEdgesOwned    = Mesh->NEdgesOwned;
-   int NVerticesOwned = Mesh->NVerticesOwned;
-   int NTracers       = Tracers::getNumTracers();
+   int NCellsOwned = Mesh->NCellsOwned;
+   int NEdgesOwned = Mesh->NEdgesOwned;
+   int NTracers    = Tracers::getNumTracers();
 
    const Real LayerThickTendSum =
        sum(DefTendencies->LayerThicknessTend, NCellsOwned);


### PR DESCRIPTION
This PR fixes compiler warnings in `HorzMesh` (#251), `OceanState` (#252), `Tracers` (#253), and `TendenciesTest` (#254). These changes all have to do with declared/initialized variables that weren't being used.

Fixes #251, #252, #253, and #254
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Testing
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
after.


