### PR TITLE
Add vertical coordinate module

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -18,6 +18,8 @@ Omega:
     FluxTracerType: Center
   WindStress:
     InterpType: Isotropic
+  VertCoord:
+    MovementWeightType: Uniform
   Tendencies:
     ThicknessFluxTendencyEnable: true
     PVTendencyEnable: true

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -6,8 +6,6 @@ Omega:
     StartTime: 0001-01-01_00:00:00
     StopTime: 0001-01-01_02:00:00
     RunDuration: none
-  Dimension:
-    NVertLevels: 60
   Decomp:
     HaloWidth: 3
     DecompMethod: MetisKWay

--- a/components/omega/doc/design/AuxiliaryState.md
+++ b/components/omega/doc/design/AuxiliaryState.md
@@ -70,14 +70,14 @@ The constructor will be responsible for:
   * registering fields and metadata with the I/O infrastructure
 
 ```c++
-AuxiliaryState(const std::string &Name, const HorzMesh *Mesh, int NVertLevels);
+AuxiliaryState(const std::string &Name, const HorzMesh *Mesh, int NVertLayers);
 ```
 
 The create method will take the same arguments as the constructor, use it to
 create a new auxiliary state, and put it in the static map of all auxiliary
 states. It will return a pointer to the newly created state.
 ```c++
-AuxiliaryState* AuxiliaryState::create(const std::string &Name, const HorzMesh *Mesh, int NVertLevels);
+AuxiliaryState* AuxiliaryState::create(const std::string &Name, const HorzMesh *Mesh, int NVertLayers);
 ```
 
 #### 4.2.2 Initialization

--- a/components/omega/doc/design/AuxiliaryVariables.md
+++ b/components/omega/doc/design/AuxiliaryVariables.md
@@ -10,7 +10,7 @@ can often be bundled together into groups of variables that are logically
 related, or can be efficiently computed together. Each auxiliary variable group
 is implemented as a class containing array(s) storing the variable(s) and member
 functions that compute them. The member functions compute the variable (or
-variable group) over a chunk of vertical levels for a particular mesh location.
+variable group) over a chunk of vertical layers for a particular mesh location.
 There may be more than one compute function, since some groups may contain
 variables defined on different mesh elements. This approach allows flexible
 groupings of computational work within larger cell/edge/vertex loops. This type
@@ -31,7 +31,7 @@ implement a given variable (group) computation on a specific mesh location
 
 ### 2.3 Requirement: Vectorization on CPU architectures
 Auxiliary variables computations have inner loops over a chunk of vertical
-levels. The chunk size will be set to the vector length on CPU machines and 1
+layers. The chunk size will be set to the vector length on CPU machines and 1
 for GPUs. This will allow for the possibility of vectorization on CPUs.
 
 ### 2.4 Requirement: Configuration options
@@ -101,11 +101,11 @@ The constructor will be responsible for:
   * registering fields and metadata with the I/O infrastructure.
 
 ```c++
-   LayerThicknessAuxVars(const HorzMesh *mesh, int NVertLevels, const Config *Options)
+   LayerThicknessAuxVars(const HorzMesh *mesh, int NVertLayers, const Config *Options)
        : FluxLayerThickEdge("FluxLayerThickEdge", mesh->NEdgesSize,
-                            NVertLevels),
+                            NVertLayers),
          MeanLayerThickEdge("MeanLayerThickEdge", mesh->NEdgesSize,
-                            NVertLevels),
+                            NVertLayers),
          CellsOnEdge(mesh->CellsOnEdge) {
 
              std::string FluxThickTypeStr;
@@ -128,11 +128,11 @@ The constructor will be responsible for:
 
 #### 4.2.2 Compute methods
 Compute methods implement the auxiliary variables computations for a chunk of
-vertical levels at a given horizontal mesh location. The mesh location is
+vertical layers at a given horizontal mesh location. The mesh location is
 indicated in the method name. There may be more than one compute method to
 compute different groups of variables over different mesh locations. Any
 configurable computation options are handled inside the compute method. The
-inner loop over a chunk of vertical levels enables CPU vectorization.
+inner loop over a chunk of vertical layers enables CPU vectorization.
 
 ```c++
    KOKKOS_FUNCTION void

--- a/components/omega/doc/design/EOS.md
+++ b/components/omega/doc/design/EOS.md
@@ -63,7 +63,7 @@ class Eos{
     private:
        EOSType eosChoice;
        I4 NCellsAll;
-       I4 NChunks = NVertLevels / VecLength;
+       I4 NChunks = NVertLayers / VecLength;
        void computeSpecVolTEOS10Poly75t();
        void computeSpecVolLinear();
        void truncateTempSal();
@@ -106,14 +106,14 @@ The constructor will be responsible for:
   * allocating arrays
 
 ```c++
-Eos::Eos(const HorzMesh *Mesh, int NVertLevels, Config *Options);
+Eos::Eos(const HorzMesh *Mesh, int NVertLayers, Config *Options);
 ```
 
 The create method will take the same arguments as the constructor plus a name. It calls the constructor to
 create a new eos instance, and put it in the static map of all eos.
 It will return a pointer to the newly created object.
 ```c++
-Eos *Eos::create(const std::string &Name, const HorzMesh *Mesh, int NVertLevels, Config *Options);
+Eos *Eos::create(const std::string &Name, const HorzMesh *Mesh, int NVertLayers, Config *Options);
 ```
 
 #### 4.2.2 Initialization

--- a/components/omega/doc/design/Reductions.md
+++ b/components/omega/doc/design/Reductions.md
@@ -128,11 +128,11 @@ relevant MachEnv (eg defaultEnv.comm) and indxRange is a
 `std::vector` of length 2x the number of array dimensions.
 The entries of this vector will be the min, max index of
 each array dimension. So, for example an array dimensioned
-`(nCellsAll+1, nVertLevels+1)` might need to be summed over
-the `indxRange{0, nCellsOwned-1, 0, nVertLevels-1}`. Note
+`(nCellsAll+1, nVertLayers+1)` might need to be summed over
+the `indxRange{0, nCellsOwned-1, 0, nVertLayers-1}`. Note
 that the indxRange supports a constant scalar values only so
 does not support a variable index range like
-minLevelCell/maxLevelCell. That is best managed either
+minLayerCell/maxLayerCell. That is best managed either
 by masking with the sum-product interface below or
 ensuring the array has been set to zero in non-active
 entries.

--- a/components/omega/doc/design/Tendencies.md
+++ b/components/omega/doc/design/Tendencies.md
@@ -66,14 +66,14 @@ The constructor will be responsible for:
   * allocating tendency arrays
 
 ```c++
-Tendencies(const std::string &Name, const HorzMesh *Mesh, int NVertLevels, Config *Options);
+Tendencies(const std::string &Name, const HorzMesh *Mesh, int NVertLayers, Config *Options);
 ```
 
 The create method will take the same arguments as the constructor, use it to
 create a new tendencies instance, and put it in the static map of all tendencies.
 It will return a pointer to the newly created object.
 ```c++
-Tendencies* Tendencies::create(const std::string &Name, const HorzMesh *Mesh, int NVertLevels, Config *Options);
+Tendencies* Tendencies::create(const std::string &Name, const HorzMesh *Mesh, int NVertLayers, Config *Options);
 ```
 
 #### 4.2.2 Initialization

--- a/components/omega/doc/design/Tendency.md
+++ b/components/omega/doc/design/Tendency.md
@@ -3,7 +3,7 @@
 
 ## 1 Overview
 
-The tendency terms in OMEGA are implemented as functors, which define an operation over a number of vertical levels for particular a cell, edge, or vertex.
+The tendency terms in OMEGA are implemented as functors, which define an operation over a number of vertical layers for particular a cell, edge, or vertex.
 Tendency functors take information which remains constant during the forward simulation (such as `HorzMesh` and `Config`)  as constructor arguments.
 The `operator()` method is overloaded with the relevant discrete /parameterization.
 This approach allows for a modularization of the tendency terms that enables flexible groupings of work within larger cell/edge/vertex loops.
@@ -19,7 +19,7 @@ Each functor will implement a given tendency operation on a specific mesh locati
 Tendency functors take in constant data as constructor arguments, which simplifies the arguments used to call the operator method.
 
 ### 2.3 Requirement: Tendencies must allow for vectorization on CPU architectures.
-Tendency operations have inner loops over a chunk of vertical levels.
+Tendency operations have inner loops over a chunk of vertical layers.
 The chunk size will be set to the vector length on CPU machines and 1 for GPUs.
 This will allow for the possibility of vectorization on CPUs.
 
@@ -76,8 +76,8 @@ ThicknessFluxDivergenceOnCell::ThicknessFluxDivergenceOnCell(HorzMesh const *Mes
 ```
 
 #### 4.2.2 operator
-The operator method implements the tendency computation for a chunk of vertical levels at a given horizontal mesh location.
-The inner loop over a chunk of vertical levels enables CPU vectorization.
+The operator method implements the tendency computation for a chunk of vertical layers at a given horizontal mesh location.
+The inner loop over a chunk of vertical layers enables CPU vectorization.
 
 ```c++
 KOKKOS_FUNCTION void ThicknessFluxDivergenceOnCell::operator()(Array2DReal &Tend

--- a/components/omega/doc/design/VerticalMixingCoeff.md
+++ b/components/omega/doc/design/VerticalMixingCoeff.md
@@ -137,7 +137,7 @@ It is assumed that viscosity and diffusivity will be stored at cell centers. Add
 
 ```c++
 parallelFor(
-    {NCellsAll, NVertLevels}, KOKKOS_LAMBDA(int ICell, int K) {
+    {NCellsAll, NVertLayers}, KOKKOS_LAMBDA(int ICell, int K) {
 
         // Add background contribution to viscosity and diffusivity
         VertViscosity(ICell, K) = BackgroundViscosity;

--- a/components/omega/doc/devGuide/AuxiliaryState.md
+++ b/components/omega/doc/devGuide/AuxiliaryState.md
@@ -25,9 +25,9 @@ OMEGA::AuxiliaryState* DefAuxState = OMEGA::AuxiliaryState::getDefault();
 ## Creation of non-default auxiliary states
 
 A non-default auxiliary state can be created from a string `Name`, horizontal mesh `Mesh`, a number of
-vertical levels `NVertLevels`, and a number of Tracers `NTracers`:
+vertical layers `NVertLayers`, and a number of Tracers `NTracers`:
 ```c++
-OMEGA::AuxiliaryState*  NewAuxState = OMEGA::AuxiliaryState::create(Name, Mesh, NVertLevels, NTracers);
+OMEGA::AuxiliaryState*  NewAuxState = OMEGA::AuxiliaryState::create(Name, Mesh, NVertLayers, NTracers);
 ```
 For conveniece, this returns a pointer to the newly created state. Given its name, a pointer to a named auxiliary state
 can be obtained at any time by calling the static `get` method:

--- a/components/omega/doc/devGuide/AuxiliaryVariables.md
+++ b/components/omega/doc/devGuide/AuxiliaryVariables.md
@@ -28,7 +28,7 @@ class KineticAuxVars {
    Array2DReal KineticEnergyCell;
    Array2DReal VelocityDivCell;
 
-   KineticAuxVars(const HorzMesh *mesh, int NVertLevels);
+   KineticAuxVars(const HorzMesh *mesh, int NVertLayers);
    void addMetaData() const;
    void defineIOFields() const;
 

--- a/components/omega/doc/devGuide/DataTypes.md
+++ b/components/omega/doc/devGuide/DataTypes.md
@@ -42,8 +42,8 @@ Within Omega the default location for an Array should be on the device
 with a similar type HostArrayNDTT defined for arrays needed on the host.
 As an example, we can define and allocate a device and host array using:
 ```c++
-   Array3dReal Temperature("Temperature",nTimeLevels, nCells, nVertLevels);
-   HostArray3dReal TemperatureHost("Temperature",nTimeLevels, nCells, nVertLevels);
+   Array3dReal Temperature("Temperature",nTimeLevels, nCells, nVertLayers);
+   HostArray3dReal TemperatureHost("Temperature",nTimeLevels, nCells, nVertLayers);
 ```
 Alternatively, you can use the copy functions to create a host copy
 from the device or vice versa.

--- a/components/omega/doc/devGuide/Field.md
+++ b/components/omega/doc/devGuide/Field.md
@@ -24,7 +24,7 @@ int Err = Field::init();
 ```
 which primarily defines the CodeMeta and SimMeta fields for later use.
 For array fields, the appropriate Dimensions must be defined. The default
-dimensions (eg NCells, NEdges, NVertLevels) will be defined by the relevant
+dimensions (eg NCells, NEdges, NVertLayers) will be defined by the relevant
 Mesh initialization and should be done before any Fields are defined.
 See {ref}`omega-dev-dimension`.
 

--- a/components/omega/doc/devGuide/HorzOperators.md
+++ b/components/omega/doc/devGuide/HorzOperators.md
@@ -25,7 +25,7 @@ over mesh elements, for example
 ```c++
     auto mesh = OMEGA::HorzMesh::getDefault();
     DivergenceOnCell DivOnCell(mesh);
-    parallelFor({mesh->NCellsOwned, NVertLevels / VecLength}, KOKKOS_LAMBDA(int ICell, int KChunk) {
+    parallelFor({mesh->NCellsOwned, NVertLayers / VecLength}, KOKKOS_LAMBDA(int ICell, int KChunk) {
         // computes divergence of Vec for cells with indices (ICell, KChunk:KChunk+VecLength-1)
         // stores the result in DivVec
         DivOnCell(DivVec, ICell, KChunk, Vec);

--- a/components/omega/doc/devGuide/IO.md
+++ b/components/omega/doc/devGuide/IO.md
@@ -138,7 +138,7 @@ defined using:
    int Err = IO::defineDim(FileID, DimName, Length, DimID);
 ```
 where FileID is the ID of an open file, the DimName is a ``std::string``
-with the dimension name (eg NCells, NEdges, NVertices, NVertLevels or
+with the dimension name (eg NCells, NEdges, NVertices, NVertLayers or
 NTracers), length is the length of the full global array and DimID is
 the ID assigned to this dimension. Note that for reading a file, we
 supply the function:
@@ -165,14 +165,14 @@ when the IO system was initialized, but can also be set explicitly to
 is generally preferred (see [UserGuide](#omega-user-IO)). The GlobalIndx
 array describes the global location (as a zero-based offset) of each
 local array entry. This can be computed from the Omega Default Decomp
-arrays. For example, an array dimensioned (NCellsAll,NVertLevels) would
+arrays. For example, an array dimensioned (NCellsAll,NVertLayers) would
 have an offset computed using:
 ```c++
-   std::vector<int> OffsetCell(NCellsAll*NVertLevels,-1);
+   std::vector<int> OffsetCell(NCellsAll*NVertLayers,-1);
    int Add = 0;
    for (int Cell; Cell = 0; Cell < NCellsOwned){
-      for (int k; k = 0; k < NVertLevels){
-         OffsetCell[Add] = (CellIDH(Cell)-1)*NVertLevels + k;
+      for (int k; k = 0; k < NVertLayers){
+         OffsetCell[Add] = (CellIDH(Cell)-1)*NVertLayers + k;
          Add++;
       }
    }

--- a/components/omega/doc/devGuide/OceanState.md
+++ b/components/omega/doc/devGuide/OceanState.md
@@ -16,7 +16,7 @@ OceanState::create(const std::string &Name, ///< [in] Name for mesh
                    HorzMesh *Mesh,          ///< [in] Horizontal mesh
                    Decomp *MeshDecomp,      ///< [in] Decomp for Mesh
                    Halo *MeshHalo_,         ///< [in] Halo for Mesh
-                   const int NVertLevels_,  ///< [in] Number of vertical levels
+                   const int NVertLayers_,  ///< [in] Number of vertical layers
                    const int NTimeLevels_   ///< [in] Number of time levels
 );
 ```

--- a/components/omega/doc/devGuide/Reductions.md
+++ b/components/omega/doc/devGuide/Reductions.md
@@ -30,7 +30,7 @@ int globalSum(const ArrayTTDD array,
 and dimension DD ranging from 1D to 5D. The `indexRange` vector is of length
 2x the number of array dimensions: e.g. for a 2D array the min and
 max indexes for a local sum might be
-`indexRange{0, nCellsOwned-1, 0, nVertLevels-1}`. The index range vector
+`indexRange{0, nCellsOwned-1, 0, nVertLayers-1}`. The index range vector
 is an optional parameter and, when absent, local sum defaults to
 min,max indexes of the array. Computed global sum is stored
 in `Result`. Any errors from the MPI collective call are passed back

--- a/components/omega/doc/devGuide/Tendencies.md
+++ b/components/omega/doc/devGuide/Tendencies.md
@@ -27,15 +27,15 @@ tendency terms, which each store constant mesh information as private member var
 
 A non-default tendency group can be created with or without custom tendencies.
 Without custom tendencies, it is created from a string `Name`, horizontal mesh `Mesh`, number of
-vertical levels `NVertLevels`, number of tracers `NTracers`, and a configuration `Options`:
+vertical layers `NVertLayers`, number of tracers `NTracers`, and a configuration `Options`:
 ```c++
-OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, NVertLevels, NTracers, Options);
+OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, NVertLayers, NTracers, Options);
 ```
 For convenience, this returns a pointer to the newly created instance.
 To allow the user to provide custom tendencies, the `create` function can take two additional arguments
 `CustomThicknessTend` and `CustomVelocityTend`
 ```c++
-OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, NVertLevels, NTracers, Options, CustomThicknessTend, CustomVelocityTend);
+OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, NVertLayers, NTracers, Options, CustomThicknessTend, CustomVelocityTend);
 ```
 The two custom tendency arguments need to be callable objects that take a Kokkos array `Tend`, ocean state `State`,
 auxiliary state `AuxState`, two integers: `ThickTimeLevel` and `VelTimeLevel`, and time instant `Time`.

--- a/components/omega/doc/devGuide/TendencyTerms.md
+++ b/components/omega/doc/devGuide/TendencyTerms.md
@@ -22,7 +22,7 @@ contributon to the tendency for the given term. The functors are designed to be
 used inside a Kokkos parallel loop:
 ```c++
    OMEGA::parallelFor(
-       {mesh->NCellsOwned, NVertLevels}, KOKKOS_LAMBDA(int ICell, int KChunk) {
+       {mesh->NCellsOwned, NVertLayers}, KOKKOS_LAMBDA(int ICell, int KChunk) {
           ThickFluxDixOnC(ThicknessTend, ICell, KChunk, ThickFluxEdge);
        });
 ```

--- a/components/omega/doc/devGuide/Tracers.md
+++ b/components/omega/doc/devGuide/Tracers.md
@@ -53,7 +53,7 @@ All tracers are stored in a vector of 3-dimensional device and host arrays.
 ```
 
 Each device and host array in the vector has dimensions corresponding to the
-number of tracers, the number of cells in the rank, and the vertical levels.
+number of tracers, the number of cells in the rank, and the vertical layers.
 
 The host tracer array (`TracerArraysH`) is internally managed, so users
 should not directly modify it in most cases.

--- a/components/omega/doc/devGuide/VertCoord.md
+++ b/components/omega/doc/devGuide/VertCoord.md
@@ -1,0 +1,115 @@
+(omega-dev-vert-coord)=
+
+## Vertical Coordinate
+
+### Initialization
+
+The default `VertCoord` instance is  created by the `init` method, which assumes that `Decomp` has already been initialized.
+```
+Decomp::init();
+VertCoord::init();
+```
+The default instance can be retrieved by:
+```
+auto *DefVertCoord = VertCoord::getDefault();
+```
+
+Additional instances can be created by calling the `create` method.
+```
+VertCoord *VertCoord::create(const std::string &Name,  ///< [in] Name for vertical coordinate
+                             const Decomp *MeshDecomp, ///< [in] Decomp for mesh
+                             Config *Options)          ///< [in] Confiuration options
+```
+This calls the constructor and places the instance in a map that can be used to retrieve the instance by name:
+```
+auto *DefVertCoord = VertCoord::get('Name');
+```
+The constructor stores some information from `Decomp`, allocates the primary member variables that are computed by methods of the `VertCoord` class during a model timestep.
+Host mirror copies are also created, with variables appended with `H`.
+It also reads in some additional mesh information and computes the information describing the min/max location of the active vertical layers.
+Finally, it registers variables with `IOStreams` so they can be requested as output.
+
+### Variables
+
+A list of member variables along with their types and dimension sizes is below:
+
+| Variable Name | Type | Dimensions |
+| ------------- | ---- | ---------- |
+| PressureInterface | Real | NCellsSize, NVertLayersP1 |
+| PressureMid | Real | NCellsSize, NVertLayers |
+| ZInterface | Real | NCellsSize, NVertLayersP1|
+| ZMid | Real | NCellsSize, NVertLayers |
+| GeopotentialMid | Real | NCellsSize, NVertLayers |
+| LayerThicknessPStar | Real | NCellsSize, NVertLayers|
+| MinLayerCell | Integer | NCellsSize |
+| MaxLayerCell | Integer | NCellsSize |
+| MinLayerEdgeTop | Integer| NEdgesSize |
+| MaxLayerEdgeTop | Integer | NEdgesSize |
+| MinLayerEdgeBot | Integer | NEdgesSize |
+| MaxLayerEdgeBot | Integer | NEdgesSize |
+| MinLayerVertexTop | Integer | NVerticesSize |
+| MaxLayerVertexTop | Integer | NVerticesSize |
+| MinLayerVertexBot | Integer | NVerticesSize |
+| MaxLayerVertexBot | Integer | NVerticesSize |
+| VertCoordMovementWeights | Real | NCellsSize, NVertLayers |
+| RefLayerThickness | Real | NCellsSize, NVertLayers |
+| BottomDepth | Real | NCellsSize |
+
+### Removal
+
+`VertCoord` instances can be removed by name:
+```
+VertCoord.erase("Name");
+```
+or all instances can be destroyed by calling:
+```
+VertCoord.clear();
+```
+
+### Use of hierarchical parallelism
+
+The methods `computePressure` and `computeZHeight` are similar in that they use hierarchical parallelism to split the work for horizontal cells over teams of threads, with a `parallel_for`.
+This is done with a `TeamPolicy`:
+```c++
+const auto Policy = TeamPolicy(NCellsAll, OMEGA_TEAMSIZE, 1);
+```
+The `parallel_for` is then called with this policy:
+```c++
+Kokkos::parallel_for("loopName", Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+       const I4 ICell = Member.league_rank();
+     ...
+}
+```
+The cumulative sum in the vertical is computed among threads (in parallel) within in the `parallel_for` using  a `parallel_scan`.
+The `parallel_scan` is called inside the `parallel_for`:
+```c++
+Range = KMax - KMin + 1;
+Kokkos::parallel_scan(
+    TeamThreadRange(Member, Range),
+    [&](int K, Real &Accum, bool IsFinal) {
+    ...
+}
+```
+where `KMax` and `KMin` are the maximum and minimum active vertical layer indices.
+In `computeTargetThickness` an outer loop divides the horizontal cells over teams of threads as above, however, there is a nested `parallel_reduce` that computes the column sum of the reference layer thicknesses times the vertical coordinate movement weights among threads in a team:
+```c++
+Real SumWh 0= 0;
+Kokkos::parallel_reduce(
+    Kokkos::TeamThreadRange(Member, KMin, KMax + 1),
+    [=](const int K, Real &LocalWh) {
+       LocalWh += VertCoordMovementWeights(ICell, K) *
+                  RefLayerThickness(ICell, K);
+    },
+    SumWh);
+```
+also, the vertical computation of the target thicknesses are computed in a nested `parallel_for`:
+```c++
+Kokkos::parallel_for(
+    Kokkos::TeamThreadRange(Member, NChunks), [&](const int KChunk) {
+   ...
+}
+```
+This `parallel_for` iterates over vertical chunks to facilitate vectorization on CPUs within in inner `for` loop over the vector length.
+The vector length on GPUs is set to 1 to maximize parallelism.
+The `computeGeopotential` method uses hierarchical parallelism in a very similar way to `computeTargetThickness`, except that it doesn't require a column sum.
+It has an outer `parallel_for` that splits horizontal cells into teams and an inner `parallel_for` that does vertical computations in chunks.

--- a/components/omega/doc/devGuide/VertCoord.md
+++ b/components/omega/doc/devGuide/VertCoord.md
@@ -86,7 +86,7 @@ The `parallel_scan` is called inside the `parallel_for`:
 Range = KMax - KMin + 1;
 Kokkos::parallel_scan(
     TeamThreadRange(Member, Range),
-    [&](int K, Real &Accum, bool IsFinal) {
+    [=](int K, Real &Accum, bool IsFinal) {
     ...
 }
 ```
@@ -105,7 +105,7 @@ Kokkos::parallel_reduce(
 also, the vertical computation of the target thicknesses are computed in a nested `parallel_for`:
 ```c++
 Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(Member, NChunks), [&](const int KChunk) {
+    Kokkos::TeamThreadRange(Member, NChunks), [=](const int KChunk) {
    ...
 }
 ```

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -48,6 +48,7 @@ userGuide/TimeStepping
 userGuide/Reductions
 userGuide/Tracers
 userGuide/TridiagonalSolvers
+userGuide/VertCoord
 ```
 
 ```{toctree}
@@ -86,6 +87,7 @@ devGuide/TimeStepping
 devGuide/Reductions
 devGuide/Tracers
 devGuide/TridiagonalSolvers
+devGuide/VertCoord
 ```
 
 ```{toctree}

--- a/components/omega/doc/userGuide/VertCoord.md
+++ b/components/omega/doc/userGuide/VertCoord.md
@@ -1,0 +1,59 @@
+(omega-user-vert-coord)=
+
+## Vertical Coordinate
+
+### Overview
+
+Omega uses pseudo height, $\tilde{z} = \frac{p}{\rho_0 g}$,  as the vertical coordinate ([V0 governing equation document](OmegaV1GoverningEqns)).
+The pseudo height is essentially a normalized pressure coordinate, with the advantage that it has units of meters.
+The `VertCoord` class contains variables and functions relevant to keeping track of:
+ - the maximum possible number of layers in a cell, i.e. the extent of the vertical dimension (read in from the mesh file)
+ - the bottom depth of each cell (read in from the mesh file)
+ - the location of active vertical layers (used to set extents of vertical loop bounds):
+   - the max and min indices of active layers in each cell (read in from the mesh file)
+   - the max and min indices of active layers for edges and vertices at the bottom and top of the water column (computed from min/max cell layers)
+ - pressure (computed from the layer thickness and surface pressure)
+ - $z$ height (computed from the bottom depth, specific volume, and layer thickness)
+ - geopotential (computed from the z height and tidal forcing)
+ - desired vertical interface locations (computed from pressure, reference layer pseudo thickness, and user-specified weights)
+
+Multiple instances of the vertical coordinate class can be created and accessed by a unique name.
+
+### Variables
+
+| Variable Name | Description | Units |
+| ------------- | ----------- | ----- |
+| NVertLayers   | maximum number of vertical layers | - |
+| NVertLayersP1 | maximum number of vertical layers plus 1 | - |
+| PressureInterface | pressure at layer interfaces | pressure per unit area at layer interfaces | kg m/s$^2$ |
+| PressureMid | pressure at layer mid points | pressure per unit area at layer mid point | kg m/s$^2$ |
+| ZInterface | z height of layer interfaces | m |
+| ZMid | z height of layer midpoint | m |
+| GeopotentialMid | geopotential at layer mid points | m$^2$/s$^2$|
+| LayerThicknessPStar | desired layer thickness based on total perturbation from the reference thickness | - |
+| MinLayerCell | first active layer for cell | - |
+| MaxLayerCell | last active layer for cell | - |
+| MinLayerEdgeTop | min of the first active layers for cells on edge | - |
+| MaxLayerEdgeTop | min of the last active layer for cells on edge | - |
+| MinLayerEdgeBot | max of the first active layer for cells on edge | - |
+| MaxLayerEdgeBot | max of the last active layer for cells on edge | - |
+| MinLayerVertexTop | min of the first active layer for cells on vertex | - |
+| MaxLayerVertexTop | min of the last active layer for cells on vertex | - |
+| MinLayerVertexBot | max of the first active layer for cells on vertex | - |
+| MaxLayerVertexBot | max of the last active layer for cells on vertex | - |
+| VertCoordMovementWeights | weights to specify how total column thickness changes are distributed across layers | - |
+| RefLayerThickness | reference layer thickness used to distributed total column thickness changes | m |
+| BottomDepth | positive down distance from the reference geoid to the bottom | m |
+
+### Configuration options
+
+The vertical coordinate movement can be specified by the `MovementWeightType` option in the configuration file.
+```yaml
+omega:
+   VertCoord:
+      MovementWeightType: [Fixed,Uniform]
+```
+The option `Uniform` specifies that perturbations to the total pseudo-thickness of the water column is distributed evenly to all vertical layers.
+This is similar to the standard "z-star" coordinate in Boussinesq models
+The option `Fixed` means that total pseudo-thickness perturbations are confined to the top layer, while all others remain constant.
+This is similar to the traditional "z" coordinate in Boussinesq models

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -77,6 +77,13 @@ using ScratchMemSpace = ExecSpace::scratch_memory_space;
 using Kokkos::MemoryUnmanaged;
 using Kokkos::TeamThreadRange;
 
+/// team_size for hierarchical parallelism
+#ifdef OMEGA_TARGET_DEVICE
+constexpr int OMEGA_TEAMSIZE = 64;
+#else
+constexpr int OMEGA_TEAMSIZE = 1;
+#endif
+
 // Takes a functor that uses multidimensional indexing
 // and converts it into one that also accepts linear index
 template <class F, int Rank> struct LinearIdxWrapper : F {

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -7,6 +7,7 @@
 #include "HorzMesh.h"
 #include "OceanState.h"
 #include "Tracers.h"
+#include "VertCoord.h"
 #include "auxiliaryVars/KineticAuxVars.h"
 #include "auxiliaryVars/LayerThicknessAuxVars.h"
 #include "auxiliaryVars/TracerAuxVars.h"
@@ -49,7 +50,7 @@ class AuxiliaryState {
 
    // Create a non-default auxiliary state
    static AuxiliaryState *create(const std::string &Name, const HorzMesh *Mesh,
-                                 Halo *MeshHalo, int NVertLevels, int NTracers);
+                                 Halo *MeshHalo, int NVertLayers, int NTracers);
 
    /// Get the default auxiliary state
    static AuxiliaryState *getDefault();
@@ -82,7 +83,7 @@ class AuxiliaryState {
 
  private:
    AuxiliaryState(const std::string &Name, const HorzMesh *Mesh, Halo *MeshHalo,
-                  int NVertLevels, int NTracers);
+                  int NVertLayers, int NTracers);
 
    AuxiliaryState(const AuxiliaryState &) = delete;
    AuxiliaryState(AuxiliaryState &&)      = delete;

--- a/components/omega/src/ocn/CustomTendencyTerms.cpp
+++ b/components/omega/src/ocn/CustomTendencyTerms.cpp
@@ -115,7 +115,7 @@ void ManufacturedSolution::ManufacturedThicknessTendency::operator()(
    ElapsedTimeInterval.get(ElapsedTimeSec, TimeUnits::Seconds);
 
    auto *Mesh       = HorzMesh::getDefault();
-   auto NVertLevels = ThicknessTend.extent_int(1);
+   auto NVertLayers = ThicknessTend.extent_int(1);
 
    Array1DReal XCell = Mesh->XCell;
    Array1DReal YCell = Mesh->YCell;
@@ -127,7 +127,7 @@ void ManufacturedSolution::ManufacturedThicknessTendency::operator()(
    OMEGA_SCOPE(LocAngFreq, AngFreq);
 
    parallelFor(
-       {Mesh->NCellsAll, NVertLevels}, KOKKOS_LAMBDA(int ICell, int KLevel) {
+       {Mesh->NCellsAll, NVertLayers}, KOKKOS_LAMBDA(int ICell, int KLevel) {
           R8 X     = XCell(ICell);
           R8 Y     = YCell(ICell);
           R8 Phase = LocKx * X + LocKy * Y - LocAngFreq * ElapsedTimeSec;
@@ -153,7 +153,7 @@ void ManufacturedSolution::ManufacturedVelocityTendency::operator()(
    ElapsedTimeInterval.get(ElapsedTimeSec, TimeUnits::Seconds);
 
    auto *Mesh       = HorzMesh::getDefault();
-   auto NVertLevels = NormalVelTend.extent_int(1);
+   auto NVertLayers = NormalVelTend.extent_int(1);
 
    Array1DReal FEdge     = Mesh->FEdge;
    Array1DReal XEdge     = Mesh->XEdge;
@@ -176,7 +176,7 @@ void ManufacturedSolution::ManufacturedVelocityTendency::operator()(
    R8 LocKy4 = LocKy2 * LocKy2;
 
    parallelFor(
-       {Mesh->NEdgesAll, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int KLevel) {
+       {Mesh->NEdgesAll, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int KLevel) {
           R8 X = XEdge(IEdge);
           R8 Y = YEdge(IEdge);
 

--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -14,7 +14,7 @@
 namespace OMEGA {
 
 /// Constructor for Teos10Eos
-Teos10Eos::Teos10Eos(int NVertLevels) : NVertLevels(NVertLevels) {
+Teos10Eos::Teos10Eos(int NVertLayers) : NVertLayers(NVertLayers) {
    SpecVolPCoeffs = Array2DReal("SpecVolPCoeffs", 6, VecLength);
 }
 
@@ -24,15 +24,15 @@ LinearEos::LinearEos() {}
 /// Constructor for Eos
 Eos::Eos(const std::string &Name_, ///< [in] Name for eos object
          const HorzMesh *Mesh,     ///< [in] Horizontal mesh
-         int NVertLevels           ///< [in] Number of vertical levels
+         int NVertLayers           ///< [in] Number of vertical layers
          )
-    : ComputeSpecVolTeos10(NVertLevels) {
-   SpecVol = Array2DReal("SpecVol", Mesh->NCellsAll, NVertLevels);
+    : ComputeSpecVolTeos10(NVertLayers) {
+   SpecVol = Array2DReal("SpecVol", Mesh->NCellsAll, NVertLayers);
    SpecVolDisplaced =
-       Array2DReal("SpecVolDisplaced", Mesh->NCellsAll, NVertLevels);
+       Array2DReal("SpecVolDisplaced", Mesh->NCellsAll, NVertLayers);
    // Array dimension lengths
    NCellsAll = Mesh->NCellsAll;
-   NChunks   = NVertLevels / VecLength;
+   NChunks   = NVertLayers / VecLength;
    Name      = Name_;
 
    defineFields();
@@ -61,11 +61,10 @@ void Eos::init() {
 
    if (!Instance) {
       Instance = new Eos("Default", HorzMesh::getDefault(),
-                         HorzMesh::getDefault()->NVertLevels);
+                         VertCoord::getDefault()->NVertLayers);
    }
 
    Error Err; // error code
-   HorzMesh *DefHorzMesh = HorzMesh::getDefault();
 
    /// Retrieve default eos
    Eos *eos = Eos::getInstance();
@@ -110,7 +109,7 @@ void Eos::init() {
    }
 } // end init
 
-/// Compute specific volume for all cells/levels (no displacement)
+/// Compute specific volume for all cells/layers (no displacement)
 void Eos::computeSpecVol(const Array2DReal &ConservTemp,
                          const Array2DReal &AbsSalinity,
                          const Array2DReal &Pressure) {
@@ -194,7 +193,7 @@ void Eos::defineFields() {
    int NDims = 2;
    std::vector<std::string> DimNames(NDims);
    DimNames[0] = "NCells";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
 
    /// Create and register the specific volume field
    auto SpecVolField =

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -16,6 +16,7 @@
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 #include "TimeMgr.h"
+#include "VertCoord.h"
 #include <string>
 
 namespace OMEGA {
@@ -31,7 +32,7 @@ class Teos10Eos {
    Array2DReal SpecVolPCoeffs;
 
    /// constructor declaration
-   Teos10Eos(int NVertLevels);
+   Teos10Eos(int NVertLayers);
 
    //   The functor takes the full arrays of specific volume (inout),
    //   the indices ICell and KChunk, and the ocean tracers (conservative)
@@ -65,7 +66,7 @@ class Teos10Eos {
                 calcDelta(LocSpecVolPCoeffs, KVec, Pressure(ICell, K));
          } else {
             // Displacement, use the displaced pressure
-            I4 KTmp = Kokkos::min(K + KDisp, NVertLevels - 1);
+            I4 KTmp = Kokkos::min(K + KDisp, NVertLayers - 1);
             KTmp    = Kokkos::max(0, KTmp);
             SpecVol(ICell, K) =
                 calcRefProfile(Pressure(ICell, KTmp)) +
@@ -236,7 +237,7 @@ class Teos10Eos {
    }
 
  private:
-   const int NVertLevels;
+   const int NVertLayers;
 };
 
 /// Linear Equation of State
@@ -286,7 +287,7 @@ class Eos {
    std::string EosGroupName;    ///< EOS group name (for config)
    std::string Name;            ///< Name of this EOS instance
 
-   /// Compute specific volume for all cells/levels
+   /// Compute specific volume for all cells/layers
    void computeSpecVol(const Array2DReal &ConservTemp,
                        const Array2DReal &AbsSalinity,
                        const Array2DReal &Pressure);
@@ -301,7 +302,7 @@ class Eos {
 
  private:
    /// Private constructor
-   Eos(const std::string &Name, const HorzMesh *Mesh, int NVertLevels);
+   Eos(const std::string &Name, const HorzMesh *Mesh, int NVertLayers);
 
    /// Private destructor
    ~Eos();

--- a/components/omega/src/ocn/HorzMesh.h
+++ b/components/omega/src/ocn/HorzMesh.h
@@ -14,6 +14,7 @@
 #include "Decomp.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
+#include "VertCoord.h"
 
 #include <memory>
 #include <string>
@@ -68,7 +69,7 @@ class HorzMesh {
    /// Construct a new local mesh for a given decomposition
    HorzMesh(const std::string &Name, ///< [in] Name for mesh
             Decomp *Decomp,          ///< [in] Decomposition for mesh
-            I4 InNVertLevels         ///< [in] num vertical levels
+            I4 InNVertLayers         ///< [in] num vertical layers
    );
 
    // Forbid copy and move construction
@@ -80,7 +81,7 @@ class HorzMesh {
    // private function.
    void computeEdgeSign();
 
-   void setMasks(int NVertLevels);
+   void setMasks(int NVertLayers);
 
    void setMeshScaling();
 
@@ -96,7 +97,7 @@ class HorzMesh {
    // Note that all sizes are actual counts (1-based) so that loop extents
    // should always use the 0:NCellsXX-1 form.
 
-   I4 NVertLevels; ///< number of vertical levels
+   I4 NVertLayers; ///< number of vertical layers
 
    Array1DI4 NCellsHalo;      ///< num cells owned+halo for halo layer
    HostArray1DI4 NCellsHaloH; ///< num cells owned+halo for halo layer
@@ -272,7 +273,7 @@ class HorzMesh {
    /// AllHorzMeshes map
    static HorzMesh *create(const std::string &Name, ///< [in] Name for mesh
                            Decomp *Decomp,  ///< [in] Decomposition for mesh
-                           I4 InNVertLevels ///< [in] num vertival levels
+                           I4 InNVertLayers ///< [in] num vertival layers
    );
 
    /// Destructor - deallocates all memory and deletes a HorzMesh

--- a/components/omega/src/ocn/OceanFinal.cpp
+++ b/components/omega/src/ocn/OceanFinal.cpp
@@ -18,6 +18,7 @@
 #include "TimeMgr.h"
 #include "TimeStepper.h"
 #include "Tracers.h"
+#include "VertCoord.h"
 
 namespace OMEGA {
 
@@ -38,6 +39,7 @@ int ocnFinalize(const TimeInstant &CurrTime ///< [in] current sim time
    Dimension::clear();
    Field::clear();
    HorzMesh::clear();
+   VertCoord::clear();
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -25,6 +25,7 @@
 #include "TimeMgr.h"
 #include "TimeStepper.h"
 #include "Tracers.h"
+#include "VertCoord.h"
 
 #include "mpi.h"
 
@@ -89,21 +90,9 @@ int initOmegaModules(MPI_Comm Comm) {
       ABORT_ERROR("ocnInit: Error initializing default halo");
    }
 
+   VertCoord::init();
+
    HorzMesh::init();
-
-   // Create the vertical dimension - this will eventually move to
-   // a vertical mesh later
-   Config *OmegaConfig = Config::getOmegaConfig();
-   Config DimConfig("Dimension");
-   Error ConfigErr = OmegaConfig->get(DimConfig);
-   CHECK_ERROR_ABORT(ConfigErr, "ocnInit: Dimension group not found in Config");
-
-   I4 NVertLevels;
-   ConfigErr += DimConfig.get("NVertLevels", NVertLevels);
-   CHECK_ERROR_ABORT(ConfigErr,
-                     "ocnInit: NVertLevels not found in Dimension Config");
-
-   auto VertDim = OMEGA::Dimension::create("NVertLevels", NVertLevels);
 
    Tracers::init();
    AuxiliaryState::init();

--- a/components/omega/src/ocn/OceanState.h
+++ b/components/omega/src/ocn/OceanState.h
@@ -40,7 +40,7 @@ class OceanState {
    OceanState(const std::string &Name, ///< [in] Name for mesh
               HorzMesh *Mesh,          ///< [in] Horizontal mesh
               Halo *MeshHalo_,         ///< [in] Halo for Mesh
-              const int NVertLevels_,  ///< [in] Number of vertical levels
+              const int NVertLayers_,  ///< [in] Number of vertical layers
               const int NTimeLevels_   ///< [in] Number of time levels
    );
 
@@ -78,7 +78,7 @@ class OceanState {
    static const I4 MaxTimeLevels = 5; ///< Maximum number of time levels
 
    I4 NTimeLevels; ///< Number of time levels in state variable arrays
-   I4 NVertLevels; ///< Number of vertical levels in state variable arrays
+   I4 NVertLayers; ///< Number of vertical layers in state variable arrays
 
    // Prognostic variables
 
@@ -105,7 +105,7 @@ class OceanState {
    create(const std::string &Name, ///< [in] Name for mesh
           HorzMesh *Mesh,          ///< [in] Horizontal mesh
           Halo *MeshHalo,          ///< [in] Halo for Mesh
-          const int NVertLevels,   ///< [in] Number of vertical levels
+          const int NVertLayers,   ///< [in] Number of vertical layers
           const int NTimeLevels    ///< [in] Number of time levels
    );
 

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -37,6 +37,7 @@
 #include "OceanState.h"
 #include "TendencyTerms.h"
 #include "TimeMgr.h"
+#include "VertCoord.h"
 
 #include <functional>
 #include <memory>
@@ -149,7 +150,8 @@ class Tendencies {
    // Construct a new tendency object
    Tendencies(const std::string &Name, ///< [in] Name for tendencies
               const HorzMesh *Mesh,    ///< [in] Horizontal mesh
-              int NVertLevels,         ///< [in] Number of vertical levels
+              const VertCoord *VCoord, ///< [in] Vertical coordinate
+              int NVertLayers,         ///< [in] Number of vertical layers
               int NTracersIn,          ///< [in] Number of tracers
               Config *Options,         ///< [in] Configuration options
               CustomTendencyType InCustomThicknessTend,
@@ -157,7 +159,8 @@ class Tendencies {
 
    Tendencies(const std::string &Name, ///< [in] Name for tendencies
               const HorzMesh *Mesh,    ///< [in] Horizontal mesh
-              int NVertLevels,         ///< [in] Number of vertical levels
+              const VertCoord *VCoord, ///< [in] Vertical coordinate
+              int NVertLayers,         ///< [in] Number of vertical layers
               int NTracersIn,          ///< [in] Number of tracers
               Config *Options          ///< [in] Configuration options
    );
@@ -170,7 +173,7 @@ class Tendencies {
    I4 NCellsAll; ///< Number of cells including full halo
    I4 NEdgesAll; ///< Number of edges including full halo
    I4 NTracers;  ///< Number of tracers
-   I4 NChunks;   ///< Number of vertical level chunks
+   I4 NChunks;   ///< Number of vertical layer chunks
 
    // Pointer to default tendencies
    static Tendencies *DefaultTendencies;

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -14,6 +14,7 @@
 #include "HorzMesh.h"
 #include "OceanState.h"
 #include "Tracers.h"
+#include "VertCoord.h"
 
 namespace OMEGA {
 
@@ -47,9 +48,10 @@ VelocityHyperDiffOnEdge::VelocityHyperDiffOnEdge(const HorzMesh *Mesh)
 WindForcingOnEdge::WindForcingOnEdge(const HorzMesh *Mesh)
     : Enabled(false), EdgeMask(Mesh->EdgeMask) {}
 
-BottomDragOnEdge::BottomDragOnEdge(const HorzMesh *Mesh)
+BottomDragOnEdge::BottomDragOnEdge(const HorzMesh *Mesh,
+                                   const VertCoord *VCoord)
     : Enabled(false), Coeff(0), CellsOnEdge(Mesh->CellsOnEdge),
-      NVertLevels(Mesh->NVertLevels), EdgeMask(Mesh->EdgeMask) {}
+      NVertLayers(VCoord->NVertLayers), EdgeMask(Mesh->EdgeMask) {}
 
 TracerHorzAdvOnCell::TracerHorzAdvOnCell(const HorzMesh *Mesh)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -14,6 +14,7 @@
 #include "HorzMesh.h"
 #include "MachEnv.h"
 #include "OceanState.h"
+#include "VertCoord.h"
 
 #include <functional>
 #include <memory>
@@ -310,7 +311,7 @@ class BottomDragOnEdge {
    Real Coeff;
 
    /// constructor declaration
-   BottomDragOnEdge(const HorzMesh *Mesh);
+   BottomDragOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    /// The functor takes the edge index and arrays for
    /// horizontal velocity, kinetic energy,
@@ -319,7 +320,7 @@ class BottomDragOnEdge {
                                    const Array2DReal &NormalVelEdge,
                                    const Array2DReal &KECell,
                                    const Array2DReal &LayerThickEdge) const {
-      const I4 KBot = NVertLevels - 1;
+      const I4 KBot = NVertLayers - 1;
 
       const I4 JCell0 = CellsOnEdge(IEdge, 0);
       const I4 JCell1 = CellsOnEdge(IEdge, 1);
@@ -333,7 +334,7 @@ class BottomDragOnEdge {
    }
 
  private:
-   I4 NVertLevels;
+   I4 NVertLayers;
    Array2DI4 CellsOnEdge;
    Array2DReal EdgeMask;
 };

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -14,8 +14,6 @@
 #include "Logging.h"
 #include "TimeStepper.h"
 
-#include <iostream>
-
 namespace OMEGA {
 
 // Initialize static member variables
@@ -25,7 +23,7 @@ std::vector<HostArray3DReal> Tracers::TracerArraysH;
 std::map<std::string, std::pair<I4, I4>> Tracers::TracerGroups;
 std::map<std::string, I4> Tracers::TracerIndexes;
 std::map<I4, std::string> Tracers::TracerNames;
-std::vector<std::string> Tracers::TracerDimNames = {"NCells", "NVertLevels"};
+std::vector<std::string> Tracers::TracerDimNames = {"NCells", "NVertLayers"};
 
 Halo *Tracers::MeshHalo = nullptr;
 
@@ -33,7 +31,7 @@ I4 Tracers::NCellsOwned  = 0;
 I4 Tracers::NCellsAll    = 0;
 I4 Tracers::NCellsSize   = 0;
 I4 Tracers::NTimeLevels  = 0;
-I4 Tracers::NVertLevels  = 0;
+I4 Tracers::NVertLayers  = 0;
 I4 Tracers::CurTimeIndex = 0;
 I4 Tracers::NumTracers   = 0;
 
@@ -46,12 +44,13 @@ void Tracers::init() {
    Error Err;       // error code
 
    // Retrieve mesh cell/edge/vertex totals from Decomp
-   HorzMesh *DefHorzMesh = HorzMesh::getDefault();
+   HorzMesh *DefHorzMesh   = HorzMesh::getDefault();
+   VertCoord *DefVertCoord = VertCoord::getDefault();
 
    NCellsOwned = DefHorzMesh->NCellsOwned;
    NCellsAll   = DefHorzMesh->NCellsAll;
    NCellsSize  = DefHorzMesh->NCellsSize;
-   NVertLevels = DefHorzMesh->NVertLevels;
+   NVertLayers = DefVertCoord->NVertLayers;
 
    MeshHalo = Halo::getDefault();
 
@@ -117,10 +116,10 @@ void Tracers::init() {
    for (I4 TimeIndex = 0; TimeIndex < NTimeLevels; ++TimeIndex) {
       TracerArrays[TimeIndex] =
           Array3DReal("TracerTime" + std::to_string(TimeIndex), NumTracers,
-                      NCellsSize, NVertLevels);
+                      NCellsSize, NVertLayers);
       TracerArraysH[TimeIndex] =
           HostArray3DReal("TracerHTime" + std::to_string(TimeIndex), NumTracers,
-                          NCellsSize, NVertLevels);
+                          NCellsSize, NVertLayers);
    }
 
    // Define tracers
@@ -246,7 +245,7 @@ I4 Tracers::clear() {
    NCellsAll   = 0;
    NCellsSize  = 0;
    NTimeLevels = 0;
-   NVertLevels = 0;
+   NVertLayers = 0;
 
    return 0;
 }

--- a/components/omega/src/ocn/Tracers.h
+++ b/components/omega/src/ocn/Tracers.h
@@ -25,6 +25,7 @@
 #include "Decomp.h"
 #include "Field.h"
 #include "Halo.h"
+#include "VertCoord.h"
 
 namespace OMEGA {
 
@@ -34,7 +35,7 @@ class Tracers {
  private:
    static I4 NumTracers;  ///< Total number of tracers defined at intialization
    static I4 NTimeLevels; ///< Number of time levels in tracer variable arrays
-   static I4 NVertLevels; ///< Number of vertical levels in tracer arrays
+   static I4 NVertLayers; ///< Number of vertical layers in tracer arrays
    static I4 NCellsOwned; ///< Number of cells owned by this task
    static I4 NCellsAll;   ///< Total number of local cells (owned + all halo)
    static I4 NCellsSize;  ///< Array size (incl padding, bndy cell)

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -408,7 +408,7 @@ void VertCoord::computePressure(const Array2DReal &PressureInterface,
           PressureInterface(ICell, KMin) = SurfacePressure(ICell);
           Kokkos::parallel_scan(
               TeamThreadRange(Member, Range),
-              [&](int K, Real &Accum, bool IsFinal) {
+              [=](int K, Real &Accum, bool IsFinal) {
                  const I4 KLvl  = K + KMin;
                  Real Increment = Gravity * Rho0 * LayerThickness(ICell, KLvl);
                  Accum += Increment;
@@ -446,7 +446,7 @@ void VertCoord::computeZHeight(const Array2DReal &ZInterface,
           ZInterface(ICell, KMax + 1) = -BottomDepth(ICell);
           Kokkos::parallel_scan(
               TeamThreadRange(Member, Range),
-              [&](int K, Real &Accum, bool IsFinal) {
+              [=](int K, Real &Accum, bool IsFinal) {
                  const I4 KLvl = KMax - K;
                  Real DZ =
                      Rho0 * SpecVol(ICell, KLvl) * LayerThickness(ICell, KLvl);
@@ -479,7 +479,7 @@ void VertCoord::computeGeopotential(const Array2DReal &GeopotentialMid,
           const I4 KRange  = KMax - KMin + 1;
           const I4 NChunks = (KRange + VecLength - 1) / VecLength;
           Kokkos::parallel_for(
-              Kokkos::TeamThreadRange(Member, NChunks), [&](const int KChunk) {
+              Kokkos::TeamThreadRange(Member, NChunks), [=](const int KChunk) {
                  const I4 KStart = KMin + KChunk * VecLength;
                  const I4 KEnd   = KStart + VecLength;
 
@@ -540,7 +540,7 @@ void VertCoord::computeTargetThickness(
           const I4 NChunks = (KRange + VecLength - 1) / VecLength;
 
           Kokkos::parallel_for(
-              Kokkos::TeamThreadRange(Member, NChunks), [&](const int KChunk) {
+              Kokkos::TeamThreadRange(Member, NChunks), [=](const int KChunk) {
                  const I4 KStart = KMin + KChunk * VecLength;
                  const I4 KEnd   = KStart + VecLength;
 

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -41,7 +41,11 @@ VertCoord::VertCoord(const std::string &Name_, const Decomp *Decomp,
    I4 NVertLevelsID;
    Err = IO::getDimFromFile(MeshFileID, "nVertLevels", NVertLevelsID,
                             NVertLevels);
-
+   if (Err != 0) {
+      LOG_WARN("VertCoord: error reading nVertLevels from mesh file, "
+               "using NVertLevels = 1");
+      NVertLevels = 1;
+   }
    NVertLevelsP1 = NVertLevels + 1;
 
    auto VertDim = Dimension::create("NVertLevels", NVertLevels);

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -1,0 +1,384 @@
+//===-- base/VertCoord.cpp - vertical coordinate ----------------*- C++ -*-===//
+//
+//===----------------------------------------------------------------------===//
+
+#include "VertCoord.h"
+#include "Dimension.h"
+#include "IO.h"
+#include "OmegaKokkos.h"
+
+namespace OMEGA {
+
+VertCoord *VertCoord::DefaultVertCoord = nullptr;
+std::map<std::string, std::unique_ptr<VertCoord>> VertCoord::AllVertCoords;
+
+//------------------------------------------------------------------------------
+// Initialize default vertical coordinate, requires prior initialization of
+// HorzMesh.
+void VertCoord::init() {
+
+   Decomp *DefDecomp = Decomp::getDefault();
+
+   Config *OmegaConfig = Config::getOmegaConfig();
+
+   VertCoord::DefaultVertCoord = create("Default", DefDecomp, OmegaConfig);
+
+} // end init
+
+VertCoord::VertCoord(const std::string &Name_, const Decomp *Decomp,
+                     Config *Options) {
+
+   Name = Name_;
+
+   // Retrieve mesh filename from Decomp
+   MeshFileName = Decomp->MeshFileName;
+
+   // Open the mesh file for reading (assume IO has already been initialized)
+   I4 Err;
+   Err = IO::openFile(MeshFileID, MeshFileName, IO::ModeRead);
+
+   // Set NVertLevels and NVertLevelsP1 and create the vertical dimension
+   I4 NVertLevelsID;
+   Err = IO::getDimFromFile(MeshFileID, "nVertLevels", NVertLevelsID,
+                            NVertLevels);
+
+   NVertLevelsP1 = NVertLevels + 1;
+
+   auto VertDim = Dimension::create("NVertLevels", NVertLevels);
+
+   // Retrieve mesh variables from Decomp
+   NCellsOwned = Decomp->NCellsOwned;
+   NCellsAll   = Decomp->NCellsAll;
+   NCellsSize  = Decomp->NCellsSize;
+
+   NEdgesOwned = Decomp->NEdgesOwned;
+   NEdgesAll   = Decomp->NEdgesAll;
+   NEdgesSize  = Decomp->NEdgesSize;
+
+   NVerticesOwned = Decomp->NVerticesOwned;
+   NVerticesAll   = Decomp->NVerticesAll;
+   NVerticesSize  = Decomp->NVerticesSize;
+   VertexDegree   = Decomp->VertexDegree;
+
+   // Retrieve connectivity arrays from HorzMesh
+   CellsOnEdge   = Decomp->CellsOnEdge;
+   CellsOnVertex = Decomp->CellsOnVertex;
+
+   // Allocate device arrays
+   MaxLevelCell = Array1DI4("MaxLevelCell", NCellsSize);
+   MinLevelCell = Array1DI4("MinLevelCell", NCellsSize);
+   BottomDepth  = Array1DReal("BottomDepth", NCellsSize);
+
+   PressureInterface =
+       Array2DReal("PressureInterface", NCellsSize, NVertLevelsP1);
+   PressureMid = Array2DReal("PressureMid", NCellsSize, NVertLevels);
+
+   ZInterface = Array2DReal("ZInterface", NCellsSize, NVertLevelsP1);
+   ZMid       = Array2DReal("ZMid", NCellsSize, NVertLevels);
+
+   GeopotentialMid = Array2DReal("GeopotentialMid", NCellsSize, NVertLevels);
+   LayerThicknessTarget =
+       Array2DReal("LayerThicknessTarget", NCellsSize, NVertLevels);
+
+   MaxLevelCellH         = createHostMirrorCopy(MaxLevelCell);
+   MinLevelCellH         = createHostMirrorCopy(MinLevelCell);
+   BottomDepthH          = createHostMirrorCopy(BottomDepth);
+   PressureInterfaceH    = createHostMirrorCopy(PressureInterface);
+   PressureMidH          = createHostMirrorCopy(PressureMid);
+   ZInterfaceH           = createHostMirrorCopy(ZInterface);
+   ZMidH                 = createHostMirrorCopy(ZMid);
+   GeopotentialMidH      = createHostMirrorCopy(GeopotentialMid);
+   LayerThicknessTargetH = createHostMirrorCopy(LayerThicknessTarget);
+
+   readArrays(Decomp);
+
+   minMaxLevelEdge();
+   minMaxLevelVertex();
+
+} // end constructor
+
+VertCoord *VertCoord::create(const std::string &Name, const Decomp *Decomp,
+                             Config *Options) {
+   // Check to see if a VertCoord of the same name already exists and, if so,
+   // exit with an error
+   if (AllVertCoords.find(Name) != AllVertCoords.end()) {
+      LOG_ERROR("Attempted to create a VertCoord with name {} but a VertCoord "
+                "of that name already exists",
+                Name);
+      return nullptr;
+   }
+
+   // create a new VertCoord on the heap and put it in a map of unique_ptrs,
+   // which will manage its lifetime
+   auto *NewVertCoord = new VertCoord(Name, Decomp, Options);
+   AllVertCoords.emplace(Name, NewVertCoord);
+
+   return NewVertCoord;
+} // end create
+
+void VertCoord::readArrays(const Decomp *Decomp) {
+
+   I4 NDims             = 1;
+   IO::Rearranger Rearr = IO::RearrBox;
+
+   I4 CellDecompI4;
+   std::vector<I4> CellDims{Decomp->NCellsGlobal};
+   std::vector<I4> CellID(NCellsAll);
+   for (int Cell = 0; Cell < NCellsAll; ++Cell) {
+      CellID[Cell] = Decomp->CellIDH(Cell) - 1;
+   }
+   I4 DecErr = IO::createDecomp(CellDecompI4, IO::IOTypeI4, NDims, CellDims,
+                                NCellsAll, CellID, Rearr);
+   if (DecErr != 0) {
+      LOG_CRITICAL("VertCoord: error creating cell I4 IO decomposition");
+   }
+
+   HostArray1DI4 TmpArrayI4H("TmpCellArray", NCellsSize);
+   I4 ArrayID;
+   const std::string MaxNameMPAS = "maxLevelCell";
+   I4 MaxReadErr = IO::readArray(TmpArrayI4H.data(), NCellsAll, MaxNameMPAS,
+                                 MeshFileID, CellDecompI4, ArrayID);
+
+   if (MaxReadErr != 0) {
+      LOG_WARN("VertCoord: error reading maxLevelCell from mesh file, "
+               "using MaxLevelCell = NVertLevels - 1");
+      deepCopy(TmpArrayI4H, NVertLevels - 1);
+   } else {
+      for (int ICell = 0; ICell < NCellsAll; ++ICell) {
+         TmpArrayI4H(ICell) = TmpArrayI4H(ICell) - 1;
+      }
+   }
+   TmpArrayI4H(NCellsAll) = -1;
+
+   deepCopy(MaxLevelCellH, TmpArrayI4H);
+   deepCopy(MaxLevelCell, TmpArrayI4H);
+
+   const std::string MinNameMPAS = "minLevelCell";
+   I4 MinReadErr = IO::readArray(TmpArrayI4H.data(), NCellsAll, MinNameMPAS,
+                                 MeshFileID, CellDecompI4, ArrayID);
+
+   if (MinReadErr != 0) {
+      LOG_WARN("VertCoord: error reading minLevelCell from mesh file, "
+               "using MinLevelCell = 0");
+      deepCopy(TmpArrayI4H, 0);
+   } else {
+      for (int ICell = 0; ICell < NCellsAll; ++ICell) {
+         TmpArrayI4H(ICell) = TmpArrayI4H(ICell) - 1;
+      }
+   }
+   TmpArrayI4H(NCellsAll) = NVertLevelsP1;
+
+   deepCopy(MinLevelCellH, TmpArrayI4H);
+   deepCopy(MinLevelCell, TmpArrayI4H);
+
+   I4 CellDecompR8;
+   DecErr = IO::createDecomp(CellDecompR8, IO::IOTypeR8, NDims, CellDims,
+                             NCellsAll, CellID, Rearr);
+   if (DecErr != 0) {
+      LOG_CRITICAL("VertCoord: error creating cell R8 IO decomposition");
+   }
+
+   HostArray1DR8 TmpArrayR8H("TmpCellArray", NCellsSize);
+   const std::string BotNameMPAS = "bottomDepth";
+   I4 BotReadErr = IO::readArray(TmpArrayR8H.data(), NCellsAll, BotNameMPAS,
+                                 MeshFileID, CellDecompR8, ArrayID);
+   if (BotReadErr != 0) {
+      LOG_CRITICAL("VertCoord: error reading bottomDepth");
+   }
+
+   deepCopy(BottomDepthH, TmpArrayR8H);
+   deepCopy(BottomDepth, TmpArrayR8H);
+
+   DecErr = IO::destroyDecomp(CellDecompI4);
+   if (DecErr != 0) {
+      LOG_CRITICAL("VertCoord: error destroying cell I4 IO decomposition");
+   }
+   DecErr = IO::destroyDecomp(CellDecompR8);
+   if (DecErr != 0) {
+      LOG_CRITICAL("VertCoord: error destroying cell R8 IO decomposition");
+   }
+}
+
+//------------------------------------------------------------------------------
+// Destroys a local VertCoord and deallocates all arrays
+VertCoord::~VertCoord() {} // end deconstructor
+
+//------------------------------------------------------------------------------
+// Removes a VertCoord from list by name
+void VertCoord::erase(std::string InName) {
+   AllVertCoords.erase(InName); // removes the VertCoord from the list and in
+                                // the process, calls the destructor
+} // end erase
+
+//------------------------------------------------------------------------------
+// Removes all VertCoords to clean up before exit
+void VertCoord::clear() {
+
+   AllVertCoords.clear(); // removes all VertCoords from the list and in the
+                          // process, calls the destructors for each
+
+} // end clear
+
+//------------------------------------------------------------------------------
+void VertCoord::minMaxLevelEdge() {
+
+   MinLevelEdgeTop = Array1DI4("MinLevelEdgeTop", NEdgesSize);
+   MinLevelEdgeBot = Array1DI4("MinLevelEdgeBot", NEdgesSize);
+   MaxLevelEdgeTop = Array1DI4("MaxLevelEdgeTop", NEdgesSize);
+   MaxLevelEdgeBot = Array1DI4("MaxLevelEdgeBot", NEdgesSize);
+
+   OMEGA_SCOPE(LocNVertLevelsP1, NVertLevelsP1);
+   OMEGA_SCOPE(LocCellsOnEdge, CellsOnEdge);
+   OMEGA_SCOPE(LocMinLevelCell, MinLevelCell);
+   OMEGA_SCOPE(LocMaxLevelCell, MaxLevelCell);
+   OMEGA_SCOPE(LocMinLevelEdgeTop, MinLevelEdgeTop);
+   OMEGA_SCOPE(LocMinLevelEdgeBot, MinLevelEdgeBot);
+   OMEGA_SCOPE(LocMaxLevelEdgeTop, MaxLevelEdgeTop);
+   OMEGA_SCOPE(LocMaxLevelEdgeBot, MaxLevelEdgeBot);
+   parallelFor(
+       {NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
+          I4 Lvl1;
+          I4 Lvl2;
+          const I4 ICell1 = LocCellsOnEdge(IEdge, 0);
+          const I4 ICell2 = LocCellsOnEdge(IEdge, 1);
+          Lvl1            = LocMaxLevelCell(ICell1) == -1 ? LocNVertLevelsP1
+                                                          : LocMinLevelCell(ICell1);
+          Lvl2            = LocMaxLevelCell(ICell2) == -1 ? LocNVertLevelsP1
+                                                          : LocMinLevelCell(ICell2);
+          LocMinLevelEdgeTop(IEdge) = Kokkos::min(Lvl1, Lvl2);
+
+          Lvl1 = LocMaxLevelCell(ICell1) == -1 ? 0 : LocMinLevelCell(ICell1);
+          Lvl2 = LocMaxLevelCell(ICell2) == -1 ? 0 : LocMinLevelCell(ICell2);
+          LocMinLevelEdgeBot(IEdge) = Kokkos::max(Lvl1, Lvl2);
+
+          LocMaxLevelEdgeTop(IEdge) =
+              Kokkos::min(LocMaxLevelCell(ICell1), LocMaxLevelCell(ICell2));
+          LocMaxLevelEdgeBot(IEdge) =
+              Kokkos::max(LocMaxLevelCell(ICell1), LocMaxLevelCell(ICell2));
+       });
+
+   OMEGA_SCOPE(LocNEdgesAll, NEdgesAll);
+   parallelFor(
+       {1}, KOKKOS_LAMBDA(const int &) {
+          LocMinLevelEdgeTop(LocNEdgesAll) = LocNVertLevelsP1;
+          LocMinLevelEdgeBot(LocNEdgesAll) = LocNVertLevelsP1;
+          LocMaxLevelEdgeTop(LocNEdgesAll) = -1;
+          LocMaxLevelEdgeBot(LocNEdgesAll) = -1;
+       });
+
+   MinLevelEdgeTopH = createHostMirrorCopy(MinLevelEdgeTop);
+   MinLevelEdgeBotH = createHostMirrorCopy(MinLevelEdgeBot);
+   MaxLevelEdgeTopH = createHostMirrorCopy(MaxLevelEdgeTop);
+   MaxLevelEdgeBotH = createHostMirrorCopy(MaxLevelEdgeBot);
+}
+
+//------------------------------------------------------------------------------
+void VertCoord::minMaxLevelVertex() {
+
+   MinLevelVertexTop = Array1DI4("MinLevelVertexTop", NVerticesSize);
+   MinLevelVertexBot = Array1DI4("MinLevelVertexBot", NVerticesSize);
+   MaxLevelVertexTop = Array1DI4("MaxLevelVertexTop", NVerticesSize);
+   MaxLevelVertexBot = Array1DI4("MaxLevelVertexBot", NVerticesSize);
+
+   OMEGA_SCOPE(LocNVertLevelsP1, NVertLevelsP1);
+   OMEGA_SCOPE(LocVertexDegree, VertexDegree);
+   OMEGA_SCOPE(LocCellsOnVertex, CellsOnVertex);
+   OMEGA_SCOPE(LocMinLevelCell, MinLevelCell);
+   OMEGA_SCOPE(LocMaxLevelCell, MaxLevelCell);
+   OMEGA_SCOPE(LocMinLevelVertexTop, MinLevelVertexTop);
+   OMEGA_SCOPE(LocMinLevelVertexBot, MinLevelVertexBot);
+   OMEGA_SCOPE(LocMaxLevelVertexTop, MaxLevelVertexTop);
+   OMEGA_SCOPE(LocMaxLevelVertexBot, MaxLevelVertexBot);
+
+   parallelFor(
+       {NVerticesAll}, KOKKOS_LAMBDA(int IVertex) {
+          I4 Lvl;
+          I4 ICell = LocCellsOnVertex(IVertex, 0);
+          Lvl      = LocMaxLevelCell(ICell) == -1 ? 0 : LocMinLevelCell(ICell);
+          LocMinLevelVertexBot(IVertex) = Lvl;
+          for (int I = 1; I < LocVertexDegree; ++I) {
+             ICell = LocCellsOnVertex(IVertex, I);
+             Lvl   = LocMaxLevelCell(ICell) == -1 ? 0 : LocMinLevelCell(ICell);
+             LocMinLevelVertexBot(IVertex) =
+                 Kokkos::max(LocMinLevelVertexBot(IVertex), Lvl);
+          }
+
+          ICell = LocCellsOnVertex(IVertex, 0);
+          Lvl   = LocMaxLevelCell(ICell) == -1 ? LocNVertLevelsP1
+                                               : LocMinLevelCell(ICell);
+          LocMinLevelVertexTop(IVertex) = Lvl;
+          for (int I = 1; I < LocVertexDegree; ++I) {
+             ICell = LocCellsOnVertex(IVertex, I);
+             Lvl   = LocMaxLevelCell(ICell) == -1 ? LocNVertLevelsP1
+                                                  : LocMinLevelCell(ICell);
+             LocMinLevelVertexTop(IVertex) =
+                 Kokkos::min(LocMinLevelVertexTop(IVertex), Lvl);
+          }
+
+          ICell                         = LocCellsOnVertex(IVertex, 0);
+          LocMaxLevelVertexBot(IVertex) = LocMaxLevelCell(ICell);
+          for (int I = 1; I < LocVertexDegree; ++I) {
+             ICell                         = LocCellsOnVertex(IVertex, I);
+             LocMaxLevelVertexBot(IVertex) = Kokkos::max(
+                 LocMaxLevelVertexBot(IVertex), LocMaxLevelCell(ICell));
+          }
+
+          ICell                         = LocCellsOnVertex(IVertex, 0);
+          LocMaxLevelVertexTop(IVertex) = LocMaxLevelCell(ICell);
+          for (int I = 1; I < LocVertexDegree; ++I) {
+             ICell                         = LocCellsOnVertex(IVertex, I);
+             LocMaxLevelVertexTop(IVertex) = Kokkos::min(
+                 LocMaxLevelVertexTop(IVertex), LocMaxLevelCell(ICell));
+          }
+       });
+   OMEGA_SCOPE(LocNVerticesAll, NVerticesAll);
+   parallelFor(
+       {1}, KOKKOS_LAMBDA(const int &) {
+          LocMinLevelVertexTop(LocNVerticesAll) = LocNVertLevelsP1;
+          LocMinLevelVertexBot(LocNVerticesAll) = LocNVertLevelsP1;
+          LocMaxLevelVertexTop(LocNVerticesAll) = -1;
+          LocMaxLevelVertexBot(LocNVerticesAll) = -1;
+       });
+
+   MinLevelVertexTopH = createHostMirrorCopy(MinLevelVertexTop);
+   MinLevelVertexBotH = createHostMirrorCopy(MinLevelVertexBot);
+   MaxLevelVertexTopH = createHostMirrorCopy(MaxLevelVertexTop);
+   MaxLevelVertexBotH = createHostMirrorCopy(MaxLevelVertexBot);
+}
+
+//------------------------------------------------------------------------------
+void VertCoord::initMovementWeights(Config *Options) {
+
+   Error Err; // default successful error code
+
+   Config VCoordConfig("VertCoord");
+   Err += Options->get(VCoordConfig);
+   CHECK_ERROR_ABORT(Err, "VertCoord: VertCoord group not found in Config");
+
+   std::string MovementWeightType;
+   Err += VCoordConfig.get("MovementWeightType", MovementWeightType);
+   CHECK_ERROR_ABORT(Err,
+                     "VertCoord: MovementWeightType not found in VertCoord");
+
+   VertCoordMovementWeights =
+       Array1DReal("VertCoordMovementWeights", NVertLevels);
+
+   OMEGA_SCOPE(LocVertCoordMovementWeights, VertCoordMovementWeights);
+   if (MovementWeightType == "Fixed") {
+      deepCopy(VertCoordMovementWeights, 0._Real);
+      parallelFor(
+          {1}, KOKKOS_LAMBDA(const int &) {
+             LocVertCoordMovementWeights(0) = 1._Real;
+          });
+   } else if (MovementWeightType == "Uniform") {
+      deepCopy(VertCoordMovementWeights, 1._Real);
+   } else {
+      ABORT_ERROR("VertCoord: Unknown MovementWeightType requested");
+   }
+
+   VertCoordMovementWeightsH = createHostMirrorCopy(VertCoordMovementWeights);
+}
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -550,6 +550,31 @@ void VertCoord::computeTargetThickness(
        });
 }
 
+//------------------------------------------------------------------------------
+// Get default VertCoord
+VertCoord *VertCoord::getDefault() { return VertCoord::DefaultVertCoord; }
+
+//------------------------------------------------------------------------------
+// Get VertCoord by name
+VertCoord *VertCoord::get(const std::string Name ///< [in] Name of VertCoord
+) {
+
+   // look for an instance of this name
+   auto it = AllVertCoords.find(Name);
+
+   // if found, return the VertCoord pointer
+   if (it != AllVertCoords.end()) {
+      return it->second.get();
+
+      // otherwise print error and return null pointer
+   } else {
+      LOG_ERROR("VertCoord::get: Attempt to retrieve non-existant VertCoord:");
+      LOG_ERROR("{} has not been defined or has been removed", Name);
+      return nullptr;
+   }
+
+} // end get VertCoord
+
 } // end namespace OMEGA
 
 //===----------------------------------------------------------------------===//

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -95,6 +95,8 @@ VertCoord::VertCoord(const std::string &Name_, const Decomp *Decomp,
    minMaxLevelEdge();
    minMaxLevelVertex();
 
+   initMovementWeights(Options);
+
 } // end constructor
 
 VertCoord *VertCoord::create(const std::string &Name, const Decomp *Decomp,

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -78,30 +78,30 @@ class VertCoord {
    HostArray2DReal LayerThicknessTargetH;
 
    // Vertical loop bounds
-   Array1DI4 MinLevelCell;
-   Array1DI4 MaxLevelCell;
-   Array1DI4 MinLevelEdgeTop;
-   Array1DI4 MaxLevelEdgeTop;
-   Array1DI4 MinLevelEdgeBot;
-   Array1DI4 MaxLevelEdgeBot;
-   Array1DI4 MinLevelVertexTop;
-   Array1DI4 MaxLevelVertexTop;
-   Array1DI4 MinLevelVertexBot;
-   Array1DI4 MaxLevelVertexBot;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
+   Array1DI4 MinLayerEdgeTop;
+   Array1DI4 MaxLayerEdgeTop;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeBot;
+   Array1DI4 MinLayerVertexTop;
+   Array1DI4 MaxLayerVertexTop;
+   Array1DI4 MinLayerVertexBot;
+   Array1DI4 MaxLayerVertexBot;
 
-   HostArray1DI4 MinLevelCellH;
-   HostArray1DI4 MaxLevelCellH;
-   HostArray1DI4 MinLevelEdgeTopH;
-   HostArray1DI4 MaxLevelEdgeTopH;
-   HostArray1DI4 MinLevelEdgeBotH;
-   HostArray1DI4 MaxLevelEdgeBotH;
-   HostArray1DI4 MinLevelVertexTopH;
-   HostArray1DI4 MaxLevelVertexTopH;
-   HostArray1DI4 MinLevelVertexBotH;
-   HostArray1DI4 MaxLevelVertexBotH;
+   HostArray1DI4 MinLayerCellH;
+   HostArray1DI4 MaxLayerCellH;
+   HostArray1DI4 MinLayerEdgeTopH;
+   HostArray1DI4 MaxLayerEdgeTopH;
+   HostArray1DI4 MinLayerEdgeBotH;
+   HostArray1DI4 MaxLayerEdgeBotH;
+   HostArray1DI4 MinLayerVertexTopH;
+   HostArray1DI4 MaxLayerVertexTopH;
+   HostArray1DI4 MinLayerVertexBotH;
+   HostArray1DI4 MaxLayerVertexBotH;
 
-   void minMaxLevelEdge();
-   void minMaxLevelVertex();
+   void minMaxLayerEdge();
+   void minMaxLayerVertex();
 
    void initMovementWeights(Config *Options);
 

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -164,11 +164,11 @@ class VertCoord {
                             const Array1DReal &TidalPotential,
                             const Array1DReal &SelfAttractionLoading);
 
-   /// Determine mass thickness used for the p-star vertical coordinate
-   void computePStarThickness(const Array2DReal &LayerThicknessPStar,
-                              const Array2DReal &PressureInterface,
-                              const Array1DReal &VertCoordMovementWeights,
-                              const Array2DReal &RefLayerThickness);
+   /// Determine mass thickness used for the target vertical coordinate
+   void computeTargetThickness(const Array2DReal &LayerThicknessTarget,
+                               const Array2DReal &PressureInterface,
+                               const Array2DReal &RefLayerThickness,
+                               const Array1DReal &VertCoordMovementWeights);
 
 }; // end class VertCoord
 

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -59,8 +59,8 @@ class VertCoord {
    VertCoord(VertCoord &&)      = delete;
 
  public:
-   I4 NVertLevels;
-   I4 NVertLevelsP1;
+   I4 NVertLayers;
+   I4 NVertLayersP1;
 
    // Variables computed
    Array2DReal PressureInterface;

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -56,6 +56,9 @@ class VertCoord {
              Config *Options           ///< [in] configuration options
    );
 
+   /// define field metadata
+   void defineFields();
+
    /// read desired quantities from mesh file
    void readArrays(const Decomp *Decomp ///< [in] Decomp for mesh
    );
@@ -119,7 +122,17 @@ class VertCoord {
 
    HostArray1DReal BottomDepthH;
 
+   // VertCoord instance name and FieldGroup name
    std::string Name;
+   std::string GroupName;
+
+   // Field names
+   std::string PressInterfFldName;    ///< Field name for interface pressure
+   std::string PressMidFldName;       ///< Field name for midpoint pressure
+   std::string ZInterfFldName;        ///< Field name for interface Z height
+   std::string ZMidFldName;           ///< Field name for midpoint Z height
+   std::string GeopotFldName;         ///< Field name for geopotential
+   std::string LyrThickTargetFldName; ///< Field name for target thickness
 
    // methods
 

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -1,0 +1,178 @@
+#ifndef OMEGA_VERTCOORD_H
+#define OMEGA_VERTCOORD_H
+//===-- base/VertCoord.h - vertical coordinate --------------*- C++ -*-===//
+//
+/// \file
+/// \brief
+///
+///
+//
+//===----------------------------------------------------------------------===//
+
+#include "Config.h"
+#include "DataTypes.h"
+#include "Decomp.h"
+#include "Error.h"
+#include "HorzMesh.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "OmegaKokkos.h"
+
+#include <memory>
+#include <string>
+
+namespace OMEGA {
+
+class VertCoord {
+
+ private:
+   // Variables from Decomp
+   I4 NCellsOwned;
+   I4 NCellsAll;
+   I4 NCellsSize;
+   I4 NEdgesOwned;
+   I4 NEdgesAll;
+   I4 NEdgesSize;
+   I4 NVerticesOwned;
+   I4 NVerticesAll;
+   I4 NVerticesSize;
+   I4 VertexDegree;
+   Array2DI4 CellsOnEdge;
+   Array2DI4 CellsOnVertex;
+
+   std::string MeshFileName;
+   int MeshFileID;
+
+   static VertCoord *DefaultVertCoord;
+   static std::map<std::string, std::unique_ptr<VertCoord>> AllVertCoords;
+
+   // methods
+
+   void readArrays(const Decomp *MeshDecomp);
+
+   /// construct a new vertical coordinate object
+   VertCoord(const std::string &Name, const Decomp *MeshDecomp,
+             Config *Options);
+
+   // Forbid copy and move construction
+   VertCoord(const VertCoord &) = delete;
+   VertCoord(VertCoord &&)      = delete;
+
+ public:
+   I4 NVertLevels;
+   I4 NVertLevelsP1;
+
+   // Variables computed
+   Array2DReal PressureInterface;
+   Array2DReal PressureMid;
+   Array2DReal ZInterface;
+   Array2DReal ZMid;
+   Array2DReal GeopotentialMid;
+   Array2DReal LayerThicknessTarget;
+
+   HostArray2DReal PressureInterfaceH;
+   HostArray2DReal PressureMidH;
+   HostArray2DReal ZInterfaceH;
+   HostArray2DReal ZMidH;
+   HostArray2DReal GeopotentialMidH;
+   HostArray2DReal LayerThicknessTargetH;
+
+   // Vertical loop bounds
+   Array1DI4 MinLevelCell;
+   Array1DI4 MaxLevelCell;
+   Array1DI4 MinLevelEdgeTop;
+   Array1DI4 MaxLevelEdgeTop;
+   Array1DI4 MinLevelEdgeBot;
+   Array1DI4 MaxLevelEdgeBot;
+   Array1DI4 MinLevelVertexTop;
+   Array1DI4 MaxLevelVertexTop;
+   Array1DI4 MinLevelVertexBot;
+   Array1DI4 MaxLevelVertexBot;
+
+   HostArray1DI4 MinLevelCellH;
+   HostArray1DI4 MaxLevelCellH;
+   HostArray1DI4 MinLevelEdgeTopH;
+   HostArray1DI4 MaxLevelEdgeTopH;
+   HostArray1DI4 MinLevelEdgeBotH;
+   HostArray1DI4 MaxLevelEdgeBotH;
+   HostArray1DI4 MinLevelVertexTopH;
+   HostArray1DI4 MaxLevelVertexTopH;
+   HostArray1DI4 MinLevelVertexBotH;
+   HostArray1DI4 MaxLevelVertexBotH;
+
+   void minMaxLevelEdge();
+   void minMaxLevelVertex();
+
+   void initMovementWeights(Config *Options);
+
+   // p star coordinate variables
+   Array1DReal VertCoordMovementWeights;
+   Array2DReal RefLayerThickness;
+
+   HostArray1DReal VertCoordMovementWeightsH;
+   HostArray2DReal RefLayerThicknessH;
+
+   // BottomDepth read from mesh file
+   Array1DReal BottomDepth;
+
+   HostArray1DReal BottomDepthH;
+
+   std::string Name;
+
+   // methods
+
+   /// Initialize Omega vertical coordinate
+   static void init();
+
+   /// Creates a new vertical coordinate object by calling the constructor and
+   /// puts it in the AllVertCoords map
+   static VertCoord *create(const std::string &Name, const Decomp *MeshDecomp,
+                            Config *Options);
+
+   /// Destructor - deallocates all memory and deletes a VertCoord
+   ~VertCoord();
+
+   static void clear();
+
+   /// Remove a VertCoord by name
+   static void erase(std::string InName);
+
+   /// Retrieve the default VertCoord
+   static VertCoord *getDefault();
+
+   /// Retreive a VertCoord by name
+   static VertCoord *get(std::string name);
+
+   /// Sums the mass thickness times g from the top layer down, starting with
+   /// the surface pressure
+   void computePressure(const Array2DReal &PressureInterface,
+                        const Array2DReal &PressureMid,
+                        const Array2DReal &LayerThickness,
+                        const Array1DReal &SurfacePressure);
+
+   /// Sum the mass thickness time specific volume from the bottom layer up,
+   /// starting with the bottom elevation
+   void computeZHeight(const Array2DReal &ZInterface, const Array2DReal &ZMid,
+                       const Array2DReal &LayerThickness,
+                       const Array2DReal &SpecVol,
+                       const Array1DReal &BottomDepth);
+
+   /// Sum the z height times g, the tidal potential, and self attraction and
+   /// loading
+   void computeGeopotential(const Array2DReal &GeopotentialMid,
+                            const Array2DReal &ZMid,
+                            const Array1DReal &TidalPotential,
+                            const Array1DReal &SelfAttractionLoading);
+
+   /// Determine mass thickness used for the p-star vertical coordinate
+   void computePStarThickness(const Array2DReal &LayerThicknessPStar,
+                              const Array2DReal &PressureInterface,
+                              const Array1DReal &VertCoordMovementWeights,
+                              const Array2DReal &RefLayerThickness);
+
+}; // end class VertCoord
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif // defined OMEGA_VERTCOORD_H

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -1,11 +1,13 @@
 #ifndef OMEGA_VERTCOORD_H
 #define OMEGA_VERTCOORD_H
-//===-- base/VertCoord.h - vertical coordinate --------------*- C++ -*-===//
+//===-- base/VertCoord.h - vertical coordinate definitions ------*- C++ -*-===//
 //
 /// \file
-/// \brief
+/// \brief Contains the vertical mesh variables and methods for Omega
 ///
-///
+/// This header defines the VertCoord class which contains information related
+/// to the vertical coordinate, the vertical extent of the mesh, and the active
+/// vertical layers for each ocean column.
 //
 //===----------------------------------------------------------------------===//
 
@@ -48,17 +50,22 @@ class VertCoord {
 
    // methods
 
-   void readArrays(const Decomp *MeshDecomp);
-
    /// construct a new vertical coordinate object
-   VertCoord(const std::string &Name, const Decomp *MeshDecomp,
-             Config *Options);
+   VertCoord(const std::string &Name,  ///< [in] Name for new VertCoord
+             const Decomp *MeshDecomp, ///< [in] associated Decomp
+             Config *Options           ///< [in] configuration options
+   );
+
+   /// read desired quantities from mesh file
+   void readArrays(const Decomp *Decomp ///< [in] Decomp for mesh
+   );
 
    // Forbid copy and move construction
    VertCoord(const VertCoord &) = delete;
    VertCoord(VertCoord &&)      = delete;
 
  public:
+   // Vertical dimension
    I4 NVertLayers;
    I4 NVertLayersP1;
 
@@ -100,11 +107,6 @@ class VertCoord {
    HostArray1DI4 MinLayerVertexBotH;
    HostArray1DI4 MaxLayerVertexBotH;
 
-   void minMaxLayerEdge();
-   void minMaxLayerVertex();
-
-   void initMovementWeights(Config *Options);
-
    // p star coordinate variables
    Array1DReal VertCoordMovementWeights;
    Array2DReal RefLayerThickness;
@@ -126,12 +128,16 @@ class VertCoord {
 
    /// Creates a new vertical coordinate object by calling the constructor and
    /// puts it in the AllVertCoords map
-   static VertCoord *create(const std::string &Name, const Decomp *MeshDecomp,
-                            Config *Options);
+   static VertCoord *
+   create(const std::string &Name,  /// [in] name for new VertCoord
+          const Decomp *MeshDecomp, /// [in] associated Decomp
+          Config *Options           /// [in] configuration options
+   );
 
    /// Destructor - deallocates all memory and deletes a VertCoord
    ~VertCoord();
 
+   /// Deallocates arrays
    static void clear();
 
    /// Remove a VertCoord by name
@@ -143,32 +149,48 @@ class VertCoord {
    /// Retreive a VertCoord by name
    static VertCoord *get(std::string name);
 
+   // Variable initialization methods
+   void minMaxLayerEdge();
+   void minMaxLayerVertex();
+   void initMovementWeights(Config *Options ///< [in] configuration options
+   );
+
    /// Sums the mass thickness times g from the top layer down, starting with
    /// the surface pressure
-   void computePressure(const Array2DReal &PressureInterface,
-                        const Array2DReal &PressureMid,
-                        const Array2DReal &LayerThickness,
-                        const Array1DReal &SurfacePressure);
+   void computePressure(
+       const Array2DReal &PressureInterface, ///< [out] P at layer interfaces
+       const Array2DReal &PressureMid,       ///< [out] P at layer midpoints
+       const Array2DReal &LayerThickness,    ///< [in] pseudo thickness
+       const Array1DReal &SurfacePressure    ///< [in] surface pressure
+   );
 
-   /// Sum the mass thickness time specific volume from the bottom layer up,
+   /// Sum the mass thickness times specific volume from the bottom layer up,
    /// starting with the bottom elevation
-   void computeZHeight(const Array2DReal &ZInterface, const Array2DReal &ZMid,
-                       const Array2DReal &LayerThickness,
-                       const Array2DReal &SpecVol,
-                       const Array1DReal &BottomDepth);
+   void computeZHeight(
+       const Array2DReal &ZInterface,     ///< [out] Z coord at layer interfaces
+       const Array2DReal &ZMid,           ///< [out] Z coord at layer midpoints
+       const Array2DReal &LayerThickness, ///< [in] pseudo thickness
+       const Array2DReal &SpecVol,        ///< [in] specific volume
+       const Array1DReal &BottomDepth);   ///< [in] bottom depth
 
    /// Sum the z height times g, the tidal potential, and self attraction and
    /// loading
-   void computeGeopotential(const Array2DReal &GeopotentialMid,
-                            const Array2DReal &ZMid,
-                            const Array1DReal &TidalPotential,
-                            const Array1DReal &SelfAttractionLoading);
+   void computeGeopotential(
+       const Array2DReal &GeopotentialMid, ///< [out] geopotential
+       const Array2DReal &ZMid,            ///< [in] Z coord at layer midpoints
+       const Array1DReal &TidalPotential,  ///< [in] tidal potential
+       const Array1DReal
+           &SelfAttractionLoading ///< [in] self attraction and loading
+   );
 
    /// Determine mass thickness used for the target vertical coordinate
-   void computeTargetThickness(const Array2DReal &LayerThicknessTarget,
-                               const Array2DReal &PressureInterface,
-                               const Array2DReal &RefLayerThickness,
-                               const Array1DReal &VertCoordMovementWeights);
+   void computeTargetThickness(
+       const Array2DReal
+           &LayerThicknessTarget,            ///< [out] desired target thickness
+       const Array2DReal &PressureInterface, ///< [in] P at layer interfaces
+       const Array2DReal &RefLayerThickness, ///< [in] reference pseudo thicknes
+       const Array1DReal &VertCoordMovementWeights ///< [in] movement weights
+   );
 
 }; // end class VertCoord
 

--- a/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.cpp
@@ -7,11 +7,11 @@
 namespace OMEGA {
 
 KineticAuxVars::KineticAuxVars(const std::string &AuxStateSuffix,
-                               const HorzMesh *Mesh, int NVertLevels)
+                               const HorzMesh *Mesh, int NVertLayers)
     : KineticEnergyCell("KineticEnergyCell" + AuxStateSuffix, Mesh->NCellsSize,
-                        NVertLevels),
+                        NVertLayers),
       VelocityDivCell("VelocityDivCell" + AuxStateSuffix, Mesh->NCellsSize,
-                      NVertLevels),
+                      NVertLayers),
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       EdgeSignOnCell(Mesh->EdgeSignOnCell), DcEdge(Mesh->DcEdge),
       DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell) {}
@@ -36,7 +36,7 @@ void KineticAuxVars::registerFields(
 
    // Kinetic energy on cells
    DimNames[0]                 = "NCells" + DimSuffix;
-   DimNames[1]                 = "NVertLevels";
+   DimNames[1]                 = "NVertLayers";
    auto KineticEnergyCellField = Field::create(
        KineticEnergyCell.label(),                        // field name
        "kinetic energy of horizontal velocity on cells", // long name/describe

--- a/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.h
@@ -15,7 +15,7 @@ class KineticAuxVars {
    Array2DReal VelocityDivCell;
 
    KineticAuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
-                  int NVertLevels);
+                  int NVertLayers);
 
    KOKKOS_FUNCTION void
    computeVarsOnCell(int ICell, int KChunk,

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
@@ -7,12 +7,12 @@ namespace OMEGA {
 
 LayerThicknessAuxVars::LayerThicknessAuxVars(const std::string &AuxStateSuffix,
                                              const HorzMesh *Mesh,
-                                             int NVertLevels)
+                                             int NVertLayers)
     : FluxLayerThickEdge("FluxLayerThickEdge" + AuxStateSuffix,
-                         Mesh->NEdgesSize, NVertLevels),
+                         Mesh->NEdgesSize, NVertLayers),
       MeanLayerThickEdge("MeanLayerThickEdge" + AuxStateSuffix,
-                         Mesh->NEdgesSize, NVertLevels),
-      SshCell("SshCell" + AuxStateSuffix, Mesh->NCellsSize, NVertLevels),
+                         Mesh->NEdgesSize, NVertLayers),
+      SshCell("SshCell" + AuxStateSuffix, Mesh->NCellsSize, NVertLayers),
       CellsOnEdge(Mesh->CellsOnEdge), BottomDepth(Mesh->BottomDepth) {}
 
 void LayerThicknessAuxVars::registerFields(const std::string &AuxGroupName,
@@ -32,7 +32,7 @@ void LayerThicknessAuxVars::registerFields(const std::string &AuxGroupName,
    }
 
    DimNames[0] = "NEdges" + DimSuffix;
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
 
    // Flux layer thickness on edges
    auto FluxLayerThickEdgeField = Field::create(

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
@@ -20,7 +20,7 @@ class LayerThicknessAuxVars {
    FluxThickEdgeOption FluxThickEdgeChoice;
 
    LayerThicknessAuxVars(const std::string &AuxStateSuffix,
-                         const HorzMesh *Mesh, int NVertLevels);
+                         const HorzMesh *Mesh, int NVertLayers);
 
    KOKKOS_FUNCTION void
    computeVarsOnEdge(int IEdge, int KChunk, const Array2DReal &LayerThickCell,
@@ -73,7 +73,7 @@ class LayerThicknessAuxVars {
 
       /*
       Real TotalThickness = 0.0;
-      for (int K = 0; K < NVertLevels; K++) {
+      for (int K = 0; K < NVertLayers; K++) {
          TotalThickness += LayerThickCell(ICell, K);
       }
 

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
@@ -6,12 +6,12 @@
 namespace OMEGA {
 
 TracerAuxVars::TracerAuxVars(const std::string &AuxStateSuffix,
-                             const HorzMesh *Mesh, const I4 NVertLevels,
+                             const HorzMesh *Mesh, const I4 NVertLayers,
                              const I4 NTracers)
     : HTracersEdge("ThickTracersEdge" + AuxStateSuffix, NTracers,
-                   Mesh->NEdgesSize, NVertLevels),
+                   Mesh->NEdgesSize, NVertLayers),
       Del2TracersCell("Del2TracerCell" + AuxStateSuffix, NTracers,
-                      Mesh->NCellsSize, NVertLevels),
+                      Mesh->NCellsSize, NVertLayers),
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
@@ -36,7 +36,7 @@ void TracerAuxVars::registerFields(const std::string &AuxGroupName,
    // Thickness-weighted tracers on Edge
    DimNames[0]            = "NTracers";
    DimNames[1]            = "NEdges" + DimSuffix;
-   DimNames[2]            = "NVertLevels";
+   DimNames[2]            = "NVertLayers";
    auto HTracersEdgeField = Field::create(
        HTracersEdge.label(), // field name
        "thickness-weighted tracers at edges. May be centered, upwinded, or a "

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
@@ -20,7 +20,7 @@ class TracerAuxVars {
    FluxTracerEdgeOption TracersOnEdgeChoice;
 
    TracerAuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
-                 const I4 NVertLevels, const I4 NTracers);
+                 const I4 NVertLayers, const I4 NTracers);
 
    KOKKOS_FUNCTION void computeVarsOnEdge(int L, int IEdge, int KChunk,
                                           const Array2DReal &NormalVelEdge,

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
@@ -7,12 +7,12 @@
 namespace OMEGA {
 
 VelocityDel2AuxVars::VelocityDel2AuxVars(const std::string &AuxStateSuffix,
-                                         const HorzMesh *Mesh, int NVertLevels)
-    : Del2Edge("VelDel2Edge" + AuxStateSuffix, Mesh->NEdgesSize, NVertLevels),
+                                         const HorzMesh *Mesh, int NVertLayers)
+    : Del2Edge("VelDel2Edge" + AuxStateSuffix, Mesh->NEdgesSize, NVertLayers),
       Del2DivCell("VelDel2DivCell" + AuxStateSuffix, Mesh->NCellsSize,
-                  NVertLevels),
+                  NVertLayers),
       Del2RelVortVertex("VelDel2RelVortVertex" + AuxStateSuffix,
-                        Mesh->NVerticesSize, NVertLevels),
+                        Mesh->NVerticesSize, NVertLayers),
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       EdgeSignOnCell(Mesh->EdgeSignOnCell), DcEdge(Mesh->DcEdge),
       DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
@@ -30,7 +30,7 @@ void VelocityDel2AuxVars::registerFields(const std::string &AuxGroupName,
    const Real FillValue = -9.99e30;
    int NDims            = 2;
    std::vector<std::string> DimNames(NDims);
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    std::string DimSuffix;
    if (MeshName == "Default") {
       DimSuffix = "";

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
@@ -16,7 +16,7 @@ class VelocityDel2AuxVars {
    Array2DReal Del2RelVortVertex;
 
    VelocityDel2AuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
-                       int NVertLevels);
+                       int NVertLayers);
 
    KOKKOS_FUNCTION void
    computeVarsOnEdge(int IEdge, int KChunk, const Array2DReal &VelocityDivCell,

--- a/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.cpp
@@ -7,17 +7,17 @@
 namespace OMEGA {
 
 VorticityAuxVars::VorticityAuxVars(const std::string &AuxStateSuffix,
-                                   const HorzMesh *Mesh, int NVertLevels)
+                                   const HorzMesh *Mesh, int NVertLayers)
     : RelVortVertex("RelVortVertex" + AuxStateSuffix, Mesh->NVerticesSize,
-                    NVertLevels),
+                    NVertLayers),
       NormRelVortVertex("NormRelVortVertex" + AuxStateSuffix,
-                        Mesh->NVerticesSize, NVertLevels),
+                        Mesh->NVerticesSize, NVertLayers),
       NormPlanetVortVertex("NormPlanetVortVertex" + AuxStateSuffix,
-                           Mesh->NVerticesSize, NVertLevels),
+                           Mesh->NVerticesSize, NVertLayers),
       NormRelVortEdge("NormRelVortEdge" + AuxStateSuffix, Mesh->NEdgesSize,
-                      NVertLevels),
+                      NVertLayers),
       NormPlanetVortEdge("NormPlanetVortEdge" + AuxStateSuffix,
-                         Mesh->NEdgesSize, NVertLevels),
+                         Mesh->NEdgesSize, NVertLayers),
       VertexDegree(Mesh->VertexDegree), CellsOnVertex(Mesh->CellsOnVertex),
       EdgesOnVertex(Mesh->EdgesOnVertex),
       EdgeSignOnVertex(Mesh->EdgeSignOnVertex), DcEdge(Mesh->DcEdge),
@@ -42,7 +42,7 @@ void VorticityAuxVars::registerFields(const std::string &AuxGroupName,
    }
 
    DimNames[0] = "NVertices" + DimSuffix; // for first three fields
-   DimNames[1] = "NVertLevels";           // same for all fields below
+   DimNames[1] = "NVertLayers";           // same for all fields below
 
    // Relative vorticity on vertices
    auto RelVortVertexField = Field::create(

--- a/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.h
@@ -19,7 +19,7 @@ class VorticityAuxVars {
    Array2DReal NormPlanetVortEdge;
 
    VorticityAuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
-                    int NVertLevels);
+                    int NVertLayers);
 
    KOKKOS_FUNCTION void
    computeVarsOnVertex(int IVertex, int KChunk,

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -48,18 +48,18 @@ void RungeKutta4Stepper::finalizeInit() {
    if (!MeshHalo)
       LOG_CRITICAL("Invalid MeshHalo");
 
-   int NVertLevels = Tend->LayerThicknessTend.extent_int(1);
+   int NVertLayers = Tend->LayerThicknessTend.extent_int(1);
    int NTracers    = Tracers::getNumTracers();
    int NCellsSize  = Mesh->NCellsSize;
    int NTimeLevels = 1; // for provisional tracer
 
    ProvisState = OceanState::create("Provis" + Name, Mesh, MeshHalo,
-                                    NVertLevels, NTimeLevels);
+                                    NVertLayers, NTimeLevels);
    if (!ProvisState)
       LOG_CRITICAL("Error creating Provis state");
 
    ProvisTracers =
-       Array3DReal("ProvisTracers", NTracers, NCellsSize, NVertLevels);
+       Array3DReal("ProvisTracers", NTracers, NCellsSize, NVertLayers);
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -387,13 +387,13 @@ void TimeStepper::updateThicknessByTend(OceanState *State1, int TimeLevel1,
    if (Err != 0)
       ABORT_ERROR("TimeStepper updateThickness: error retrieving layer thick");
    const auto &LayerThickTend = Tend->LayerThicknessTend;
-   const int NVertLevels      = LayerThickTend.extent_int(1);
+   const int NVertLayers      = LayerThickTend.extent_int(1);
 
    R8 CoeffSeconds;
    Coeff.get(CoeffSeconds, TimeUnits::Seconds);
 
    parallelFor(
-       "updateThickByTend", {Mesh->NCellsAll, NVertLevels},
+       "updateThickByTend", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(int ICell, int K) {
           LayerThick1(ICell, K) =
               LayerThick2(ICell, K) + CoeffSeconds * LayerThickTend(ICell, K);
@@ -416,13 +416,13 @@ void TimeStepper::updateVelocityByTend(OceanState *State1, int TimeLevel1,
    if (Err != 0)
       ABORT_ERROR("TimeStepper updateVelocity: error retrieving velocity");
    const auto &NormalVelTend = Tend->NormalVelocityTend;
-   const int NVertLevels     = NormalVelTend.extent_int(1);
+   const int NVertLayers     = NormalVelTend.extent_int(1);
 
    R8 CoeffSeconds;
    Coeff.get(CoeffSeconds, TimeUnits::Seconds);
 
    parallelFor(
-       "updateVelByTend", {Mesh->NEdgesAll, NVertLevels},
+       "updateVelByTend", {Mesh->NEdgesAll, NVertLayers},
        KOKKOS_LAMBDA(int IEdge, int K) {
           NormalVel1(IEdge, K) =
               NormalVel2(IEdge, K) + CoeffSeconds * NormalVelTend(IEdge, K);
@@ -453,13 +453,13 @@ void TimeStepper::updateTracersByTend(const Array3DReal &NextTracers,
    const auto &LayerThick2 = State2->LayerThickness[TimeLevel2];
    const auto &TracerTend  = Tend->TracerTend;
    const int NTracers      = TracerTend.extent(0);
-   const int NVertLevels   = TracerTend.extent(2);
+   const int NVertLayers   = TracerTend.extent(2);
 
    R8 CoeffSeconds;
    Coeff.get(CoeffSeconds, TimeUnits::Seconds);
 
    parallelFor(
-       "updateTracersByTend", {NTracers, Mesh->NCellsAll, NVertLevels},
+       "updateTracersByTend", {NTracers, Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(int L, int ICell, int K) {
           NextTracers(L, ICell, K) =
               (CurTracers(L, ICell, K) * LayerThick2(ICell, K) +
@@ -476,10 +476,10 @@ void TimeStepper::weightTracers(const Array3DReal &NextTracers,
 
    const Array2DReal &CurThickness = CurState->LayerThickness[TimeLevel1];
    const int NTracers              = NextTracers.extent(0);
-   const int NVertLevels           = NextTracers.extent(2);
+   const int NVertLayers           = NextTracers.extent(2);
 
    parallelFor(
-       "weightTracers", {NTracers, Mesh->NCellsAll, NVertLevels},
+       "weightTracers", {NTracers, Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(int L, int ICell, int K) {
           NextTracers(L, ICell, K) =
               CurTracers(L, ICell, K) * CurThickness(ICell, K);
@@ -494,13 +494,13 @@ void TimeStepper::accumulateTracersUpdate(const Array3DReal &AccumTracer,
 
    const auto &TracerTend = Tend->TracerTend;
    const int NTracers     = TracerTend.extent(0);
-   const int NVertLevels  = TracerTend.extent(2);
+   const int NVertLayers  = TracerTend.extent(2);
 
    R8 CoeffSeconds;
    Coeff.get(CoeffSeconds, TimeUnits::Seconds);
 
    parallelFor(
-       "accumulateTracersUpdate", {NTracers, Mesh->NCellsAll, NVertLevels},
+       "accumulateTracersUpdate", {NTracers, Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(int L, int ICell, int K) {
           AccumTracer(L, ICell, K) += CoeffSeconds * TracerTend(L, ICell, K);
        });
@@ -514,10 +514,10 @@ void TimeStepper::finalizeTracersUpdate(const Array3DReal &NextTracers,
 
    const Array2DReal &NextThick = State->LayerThickness[TimeLevel];
    const int NTracers           = NextTracers.extent(0);
-   const int NVertLevels        = NextTracers.extent(2);
+   const int NVertLayers        = NextTracers.extent(2);
 
    parallelFor(
-       "finalizeTracersUpdate", {NTracers, Mesh->NCellsAll, NVertLevels},
+       "finalizeTracersUpdate", {NTracers, Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(int L, int ICell, int K) {
           NextTracers(L, ICell, K) /= NextThick(ICell, K);
        });

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -447,3 +447,14 @@ add_omega_test(
     ocn/EosTest.cpp
     "-n;2"
 )
+
+################
+# VertCoord test
+################
+
+add_omega_test(
+    VERTCOORD_TEST
+    testVertCoord.exe
+    ocn/VertCoordTest.cpp
+    "-n;8"
+)

--- a/components/omega/test/base/DataTypesTest.cpp
+++ b/components/omega/test/base/DataTypesTest.cpp
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
       // a reference host array.
 
       int NumCells    = 100;
-      int NumVertLvls = 100;
+      int NumVertLyrs = 100;
       int NumTracers  = 4;
       int NumTimeLvls = 2;
       int NumExtra    = 2;
@@ -129,17 +129,17 @@ int main(int argc, char *argv[]) {
       }
 
       // Test for 2DI4
-      Array2DI4 TstArr2DI4("TstArr2DI4", NumCells, NumVertLvls);
-      HostArray2DI4 RefArr2DI4("RefArr2DI4", NumCells, NumVertLvls);
+      Array2DI4 TstArr2DI4("TstArr2DI4", NumCells, NumVertLyrs);
+      HostArray2DI4 RefArr2DI4("RefArr2DI4", NumCells, NumVertLyrs);
 
       for (int j = 0; j < NumCells; ++j) {
-         for (int i = 0; i < NumVertLvls; ++i) {
+         for (int i = 0; i < NumVertLyrs; ++i) {
             RefArr2DI4(j, i) = i + j;
          }
       }
 
       parallelFor(
-          {NumCells, NumVertLvls},
+          {NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int j, int i) { TstArr2DI4(j, i) = i + j; });
 
       Kokkos::fence();
@@ -148,7 +148,7 @@ int main(int argc, char *argv[]) {
 
       icount = 0;
       for (int j = 0; j < NumCells; ++j) {
-         for (int i = 0; i < NumVertLvls; ++i) {
+         for (int i = 0; i < NumVertLyrs; ++i) {
             if (TstHost2DI4(j, i) != RefArr2DI4(j, i))
                ++icount;
          }
@@ -162,19 +162,19 @@ int main(int argc, char *argv[]) {
       }
 
       // Test for 3DI4
-      Array3DI4 TstArr3DI4("TstArr3DI4", NumTracers, NumCells, NumVertLvls);
-      HostArray3DI4 RefArr3DI4("RefArr3DI4", NumTracers, NumCells, NumVertLvls);
+      Array3DI4 TstArr3DI4("TstArr3DI4", NumTracers, NumCells, NumVertLyrs);
+      HostArray3DI4 RefArr3DI4("RefArr3DI4", NumTracers, NumCells, NumVertLyrs);
 
       for (int k = 0; k < NumTracers; ++k) {
          for (int j = 0; j < NumCells; ++j) {
-            for (int i = 0; i < NumVertLvls; ++i) {
+            for (int i = 0; i < NumVertLyrs; ++i) {
                RefArr3DI4(k, j, i) = i + j + k;
             }
          }
       }
 
       parallelFor(
-          {NumTracers, NumCells, NumVertLvls},
+          {NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int k, int j, int i) {
              TstArr3DI4(k, j, i) = i + j + k;
           });
@@ -186,7 +186,7 @@ int main(int argc, char *argv[]) {
       icount = 0;
       for (int k = 0; k < NumTracers; ++k) {
          for (int j = 0; j < NumCells; ++j) {
-            for (int i = 0; i < NumVertLvls; ++i) {
+            for (int i = 0; i < NumVertLyrs; ++i) {
                if (TstHost3DI4(k, j, i) != RefArr3DI4(k, j, i))
                   ++icount;
             }
@@ -202,14 +202,14 @@ int main(int argc, char *argv[]) {
 
       // Test for 4DI4
       Array4DI4 TstArr4DI4("TstArr4DI4", NumTimeLvls, NumTracers, NumCells,
-                           NumVertLvls);
+                           NumVertLyrs);
       HostArray4DI4 RefArr4DI4("RefArr4DI4", NumTimeLvls, NumTracers, NumCells,
-                               NumVertLvls);
+                               NumVertLyrs);
 
       for (int m = 0; m < NumTimeLvls; ++m) {
          for (int k = 0; k < NumTracers; ++k) {
             for (int j = 0; j < NumCells; ++j) {
-               for (int i = 0; i < NumVertLvls; ++i) {
+               for (int i = 0; i < NumVertLyrs; ++i) {
                   RefArr4DI4(m, k, j, i) = i + j + k + m;
                }
             }
@@ -217,7 +217,7 @@ int main(int argc, char *argv[]) {
       }
 
       parallelFor(
-          {NumTimeLvls, NumTracers, NumCells, NumVertLvls},
+          {NumTimeLvls, NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int m, int k, int j, int i) {
              TstArr4DI4(m, k, j, i) = i + j + k + m;
           });
@@ -230,7 +230,7 @@ int main(int argc, char *argv[]) {
       for (int m = 0; m < NumTimeLvls; ++m) {
          for (int k = 0; k < NumTracers; ++k) {
             for (int j = 0; j < NumCells; ++j) {
-               for (int i = 0; i < NumVertLvls; ++i) {
+               for (int i = 0; i < NumVertLyrs; ++i) {
                   if (TstHost4DI4(m, k, j, i) != RefArr4DI4(m, k, j, i))
                      ++icount;
                }
@@ -247,15 +247,15 @@ int main(int argc, char *argv[]) {
 
       // Test for 5DI4
       Array5DI4 TstArr5DI4("TstArr5DI4", NumExtra, NumTimeLvls, NumTracers,
-                           NumCells, NumVertLvls);
+                           NumCells, NumVertLyrs);
       HostArray5DI4 RefArr5DI4("RefArr5DI4", NumExtra, NumTimeLvls, NumTracers,
-                               NumCells, NumVertLvls);
+                               NumCells, NumVertLyrs);
 
       for (int n = 0; n < NumExtra; ++n) {
          for (int m = 0; m < NumTimeLvls; ++m) {
             for (int k = 0; k < NumTracers; ++k) {
                for (int j = 0; j < NumCells; ++j) {
-                  for (int i = 0; i < NumVertLvls; ++i) {
+                  for (int i = 0; i < NumVertLyrs; ++i) {
                      RefArr5DI4(n, m, k, j, i) = i + j + k + m + n;
                   }
                }
@@ -264,7 +264,7 @@ int main(int argc, char *argv[]) {
       }
 
       parallelFor(
-          {NumExtra, NumTimeLvls, NumTracers, NumCells, NumVertLvls},
+          {NumExtra, NumTimeLvls, NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int n, int m, int k, int j, int i) {
              TstArr5DI4(n, m, k, j, i) = i + j + k + m + n;
           });
@@ -278,7 +278,7 @@ int main(int argc, char *argv[]) {
          for (int m = 0; m < NumTimeLvls; ++m) {
             for (int k = 0; k < NumTracers; ++k) {
                for (int j = 0; j < NumCells; ++j) {
-                  for (int i = 0; i < NumVertLvls; ++i) {
+                  for (int i = 0; i < NumVertLyrs; ++i) {
                      if (TstHost5DI4(n, m, k, j, i) !=
                          RefArr5DI4(n, m, k, j, i))
                         ++icount;
@@ -323,17 +323,17 @@ int main(int argc, char *argv[]) {
       }
 
       // Test for 2DI8
-      Array2DI8 TstArr2DI8("TstArr2DI8", NumCells, NumVertLvls);
-      HostArray2DI8 RefArr2DI8("RefArr2DI8", NumCells, NumVertLvls);
+      Array2DI8 TstArr2DI8("TstArr2DI8", NumCells, NumVertLyrs);
+      HostArray2DI8 RefArr2DI8("RefArr2DI8", NumCells, NumVertLyrs);
 
       for (int j = 0; j < NumCells; ++j) {
-         for (int i = 0; i < NumVertLvls; ++i) {
+         for (int i = 0; i < NumVertLyrs; ++i) {
             RefArr2DI8(j, i) = i + j;
          }
       }
 
       parallelFor(
-          {NumCells, NumVertLvls},
+          {NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int j, int i) { TstArr2DI8(j, i) = i + j; });
 
       Kokkos::fence();
@@ -342,7 +342,7 @@ int main(int argc, char *argv[]) {
 
       icount = 0;
       for (int j = 0; j < NumCells; ++j) {
-         for (int i = 0; i < NumVertLvls; ++i) {
+         for (int i = 0; i < NumVertLyrs; ++i) {
             if (TstHost2DI8(j, i) != RefArr2DI8(j, i))
                ++icount;
          }
@@ -356,19 +356,19 @@ int main(int argc, char *argv[]) {
       }
 
       // Test for 3DI8
-      Array3DI8 TstArr3DI8("TstArr3DI8", NumTracers, NumCells, NumVertLvls);
-      HostArray3DI8 RefArr3DI8("RefArr3DI8", NumTracers, NumCells, NumVertLvls);
+      Array3DI8 TstArr3DI8("TstArr3DI8", NumTracers, NumCells, NumVertLyrs);
+      HostArray3DI8 RefArr3DI8("RefArr3DI8", NumTracers, NumCells, NumVertLyrs);
 
       for (int k = 0; k < NumTracers; ++k) {
          for (int j = 0; j < NumCells; ++j) {
-            for (int i = 0; i < NumVertLvls; ++i) {
+            for (int i = 0; i < NumVertLyrs; ++i) {
                RefArr3DI8(k, j, i) = i + j + k;
             }
          }
       }
 
       parallelFor(
-          {NumTracers, NumCells, NumVertLvls},
+          {NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int k, int j, int i) {
              TstArr3DI8(k, j, i) = i + j + k;
           });
@@ -380,7 +380,7 @@ int main(int argc, char *argv[]) {
       icount = 0;
       for (int k = 0; k < NumTracers; ++k) {
          for (int j = 0; j < NumCells; ++j) {
-            for (int i = 0; i < NumVertLvls; ++i) {
+            for (int i = 0; i < NumVertLyrs; ++i) {
                if (TstHost3DI8(k, j, i) != RefArr3DI8(k, j, i))
                   ++icount;
             }
@@ -396,14 +396,14 @@ int main(int argc, char *argv[]) {
 
       // Test for 4DI8
       Array4DI8 TstArr4DI8("TstArr4DI8", NumTimeLvls, NumTracers, NumCells,
-                           NumVertLvls);
+                           NumVertLyrs);
       HostArray4DI8 RefArr4DI8("RefArr4DI8", NumTimeLvls, NumTracers, NumCells,
-                               NumVertLvls);
+                               NumVertLyrs);
 
       for (int m = 0; m < NumTimeLvls; ++m) {
          for (int k = 0; k < NumTracers; ++k) {
             for (int j = 0; j < NumCells; ++j) {
-               for (int i = 0; i < NumVertLvls; ++i) {
+               for (int i = 0; i < NumVertLyrs; ++i) {
                   RefArr4DI8(m, k, j, i) = i + j + k + m;
                }
             }
@@ -411,7 +411,7 @@ int main(int argc, char *argv[]) {
       }
 
       parallelFor(
-          {NumTimeLvls, NumTracers, NumCells, NumVertLvls},
+          {NumTimeLvls, NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int m, int k, int j, int i) {
              TstArr4DI8(m, k, j, i) = i + j + k + m;
           });
@@ -424,7 +424,7 @@ int main(int argc, char *argv[]) {
       for (int m = 0; m < NumTimeLvls; ++m) {
          for (int k = 0; k < NumTracers; ++k) {
             for (int j = 0; j < NumCells; ++j) {
-               for (int i = 0; i < NumVertLvls; ++i) {
+               for (int i = 0; i < NumVertLyrs; ++i) {
                   if (TstHost4DI8(m, k, j, i) != RefArr4DI8(m, k, j, i))
                      ++icount;
                }
@@ -441,15 +441,15 @@ int main(int argc, char *argv[]) {
 
       // Test for 5DI8
       Array5DI8 TstArr5DI8("TstArr5DI8", NumExtra, NumTimeLvls, NumTracers,
-                           NumCells, NumVertLvls);
+                           NumCells, NumVertLyrs);
       HostArray5DI8 RefArr5DI8("RefArr5DI8", NumExtra, NumTimeLvls, NumTracers,
-                               NumCells, NumVertLvls);
+                               NumCells, NumVertLyrs);
 
       for (int n = 0; n < NumExtra; ++n) {
          for (int m = 0; m < NumTimeLvls; ++m) {
             for (int k = 0; k < NumTracers; ++k) {
                for (int j = 0; j < NumCells; ++j) {
-                  for (int i = 0; i < NumVertLvls; ++i) {
+                  for (int i = 0; i < NumVertLyrs; ++i) {
                      RefArr5DI8(n, m, k, j, i) = i + j + k + m + n;
                   }
                }
@@ -458,7 +458,7 @@ int main(int argc, char *argv[]) {
       }
 
       parallelFor(
-          {NumExtra, NumTimeLvls, NumTracers, NumCells, NumVertLvls},
+          {NumExtra, NumTimeLvls, NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int n, int m, int k, int j, int i) {
              TstArr5DI8(n, m, k, j, i) = i + j + k + m + n;
           });
@@ -472,7 +472,7 @@ int main(int argc, char *argv[]) {
          for (int m = 0; m < NumTimeLvls; ++m) {
             for (int k = 0; k < NumTracers; ++k) {
                for (int j = 0; j < NumCells; ++j) {
-                  for (int i = 0; i < NumVertLvls; ++i) {
+                  for (int i = 0; i < NumVertLyrs; ++i) {
                      if (TstHost5DI8(n, m, k, j, i) !=
                          RefArr5DI8(n, m, k, j, i))
                         ++icount;
@@ -517,17 +517,17 @@ int main(int argc, char *argv[]) {
       }
 
       // Test for 2DR4
-      Array2DR4 TstArr2DR4("TstArr2DR4", NumCells, NumVertLvls);
-      HostArray2DR4 RefArr2DR4("RefArr2DR4", NumCells, NumVertLvls);
+      Array2DR4 TstArr2DR4("TstArr2DR4", NumCells, NumVertLyrs);
+      HostArray2DR4 RefArr2DR4("RefArr2DR4", NumCells, NumVertLyrs);
 
       for (int j = 0; j < NumCells; ++j) {
-         for (int i = 0; i < NumVertLvls; ++i) {
+         for (int i = 0; i < NumVertLyrs; ++i) {
             RefArr2DR4(j, i) = i + j;
          }
       }
 
       parallelFor(
-          {NumCells, NumVertLvls},
+          {NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int j, int i) { TstArr2DR4(j, i) = i + j; });
 
       Kokkos::fence();
@@ -536,7 +536,7 @@ int main(int argc, char *argv[]) {
 
       icount = 0;
       for (int j = 0; j < NumCells; ++j) {
-         for (int i = 0; i < NumVertLvls; ++i) {
+         for (int i = 0; i < NumVertLyrs; ++i) {
             if (TstHost2DR4(j, i) != RefArr2DR4(j, i))
                ++icount;
          }
@@ -550,19 +550,19 @@ int main(int argc, char *argv[]) {
       }
 
       // Test for 3DR4
-      Array3DR4 TstArr3DR4("TstArr3DR4", NumTracers, NumCells, NumVertLvls);
-      HostArray3DR4 RefArr3DR4("RefArr3DR4", NumTracers, NumCells, NumVertLvls);
+      Array3DR4 TstArr3DR4("TstArr3DR4", NumTracers, NumCells, NumVertLyrs);
+      HostArray3DR4 RefArr3DR4("RefArr3DR4", NumTracers, NumCells, NumVertLyrs);
 
       for (int k = 0; k < NumTracers; ++k) {
          for (int j = 0; j < NumCells; ++j) {
-            for (int i = 0; i < NumVertLvls; ++i) {
+            for (int i = 0; i < NumVertLyrs; ++i) {
                RefArr3DR4(k, j, i) = i + j + k;
             }
          }
       }
 
       parallelFor(
-          {NumTracers, NumCells, NumVertLvls},
+          {NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int k, int j, int i) {
              TstArr3DR4(k, j, i) = i + j + k;
           });
@@ -574,7 +574,7 @@ int main(int argc, char *argv[]) {
       icount = 0;
       for (int k = 0; k < NumTracers; ++k) {
          for (int j = 0; j < NumCells; ++j) {
-            for (int i = 0; i < NumVertLvls; ++i) {
+            for (int i = 0; i < NumVertLyrs; ++i) {
                if (TstHost3DR4(k, j, i) != RefArr3DR4(k, j, i))
                   ++icount;
             }
@@ -590,14 +590,14 @@ int main(int argc, char *argv[]) {
 
       // Test for 4DR4
       Array4DR4 TstArr4DR4("TstArr4DR4", NumTimeLvls, NumTracers, NumCells,
-                           NumVertLvls);
+                           NumVertLyrs);
       HostArray4DR4 RefArr4DR4("RefArr4DR4", NumTimeLvls, NumTracers, NumCells,
-                               NumVertLvls);
+                               NumVertLyrs);
 
       for (int m = 0; m < NumTimeLvls; ++m) {
          for (int k = 0; k < NumTracers; ++k) {
             for (int j = 0; j < NumCells; ++j) {
-               for (int i = 0; i < NumVertLvls; ++i) {
+               for (int i = 0; i < NumVertLyrs; ++i) {
                   RefArr4DR4(m, k, j, i) = i + j + k + m;
                }
             }
@@ -605,7 +605,7 @@ int main(int argc, char *argv[]) {
       }
 
       parallelFor(
-          {NumTimeLvls, NumTracers, NumCells, NumVertLvls},
+          {NumTimeLvls, NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int m, int k, int j, int i) {
              TstArr4DR4(m, k, j, i) = i + j + k + m;
           });
@@ -618,7 +618,7 @@ int main(int argc, char *argv[]) {
       for (int m = 0; m < NumTimeLvls; ++m) {
          for (int k = 0; k < NumTracers; ++k) {
             for (int j = 0; j < NumCells; ++j) {
-               for (int i = 0; i < NumVertLvls; ++i) {
+               for (int i = 0; i < NumVertLyrs; ++i) {
                   if (TstHost4DR4(m, k, j, i) != RefArr4DR4(m, k, j, i))
                      ++icount;
                }
@@ -635,15 +635,15 @@ int main(int argc, char *argv[]) {
 
       // Test for 5DR4
       Array5DR4 TstArr5DR4("TstArr5DR4", NumExtra, NumTimeLvls, NumTracers,
-                           NumCells, NumVertLvls);
+                           NumCells, NumVertLyrs);
       HostArray5DR4 RefArr5DR4("RefArr5DR4", NumExtra, NumTimeLvls, NumTracers,
-                               NumCells, NumVertLvls);
+                               NumCells, NumVertLyrs);
 
       for (int n = 0; n < NumExtra; ++n) {
          for (int m = 0; m < NumTimeLvls; ++m) {
             for (int k = 0; k < NumTracers; ++k) {
                for (int j = 0; j < NumCells; ++j) {
-                  for (int i = 0; i < NumVertLvls; ++i) {
+                  for (int i = 0; i < NumVertLyrs; ++i) {
                      RefArr5DR4(n, m, k, j, i) = i + j + k + m + n;
                   }
                }
@@ -652,7 +652,7 @@ int main(int argc, char *argv[]) {
       }
 
       parallelFor(
-          {NumExtra, NumTimeLvls, NumTracers, NumCells, NumVertLvls},
+          {NumExtra, NumTimeLvls, NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int n, int m, int k, int j, int i) {
              TstArr5DR4(n, m, k, j, i) = i + j + k + m + n;
           });
@@ -666,7 +666,7 @@ int main(int argc, char *argv[]) {
          for (int m = 0; m < NumTimeLvls; ++m) {
             for (int k = 0; k < NumTracers; ++k) {
                for (int j = 0; j < NumCells; ++j) {
-                  for (int i = 0; i < NumVertLvls; ++i) {
+                  for (int i = 0; i < NumVertLyrs; ++i) {
                      if (TstHost5DR4(n, m, k, j, i) !=
                          RefArr5DR4(n, m, k, j, i))
                         ++icount;
@@ -711,17 +711,17 @@ int main(int argc, char *argv[]) {
       }
 
       // Test for 2DR8
-      Array2DR8 TstArr2DR8("TstArr2DR8", NumCells, NumVertLvls);
-      HostArray2DR8 RefArr2DR8("RefArr2DR8", NumCells, NumVertLvls);
+      Array2DR8 TstArr2DR8("TstArr2DR8", NumCells, NumVertLyrs);
+      HostArray2DR8 RefArr2DR8("RefArr2DR8", NumCells, NumVertLyrs);
 
       for (int j = 0; j < NumCells; ++j) {
-         for (int i = 0; i < NumVertLvls; ++i) {
+         for (int i = 0; i < NumVertLyrs; ++i) {
             RefArr2DR8(j, i) = i + j;
          }
       }
 
       parallelFor(
-          {NumCells, NumVertLvls},
+          {NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int j, int i) { TstArr2DR8(j, i) = i + j; });
 
       Kokkos::fence();
@@ -730,7 +730,7 @@ int main(int argc, char *argv[]) {
 
       icount = 0;
       for (int j = 0; j < NumCells; ++j) {
-         for (int i = 0; i < NumVertLvls; ++i) {
+         for (int i = 0; i < NumVertLyrs; ++i) {
             if (TstHost2DR8(j, i) != RefArr2DR8(j, i))
                ++icount;
          }
@@ -744,19 +744,19 @@ int main(int argc, char *argv[]) {
       }
 
       // Test for 3DR8
-      Array3DR8 TstArr3DR8("TstArr3DR8", NumTracers, NumCells, NumVertLvls);
-      HostArray3DR8 RefArr3DR8("RefArr3DR8", NumTracers, NumCells, NumVertLvls);
+      Array3DR8 TstArr3DR8("TstArr3DR8", NumTracers, NumCells, NumVertLyrs);
+      HostArray3DR8 RefArr3DR8("RefArr3DR8", NumTracers, NumCells, NumVertLyrs);
 
       for (int k = 0; k < NumTracers; ++k) {
          for (int j = 0; j < NumCells; ++j) {
-            for (int i = 0; i < NumVertLvls; ++i) {
+            for (int i = 0; i < NumVertLyrs; ++i) {
                RefArr3DR8(k, j, i) = i + j + k;
             }
          }
       }
 
       parallelFor(
-          {NumTracers, NumCells, NumVertLvls},
+          {NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int k, int j, int i) {
              TstArr3DR8(k, j, i) = i + j + k;
           });
@@ -768,7 +768,7 @@ int main(int argc, char *argv[]) {
       icount = 0;
       for (int k = 0; k < NumTracers; ++k) {
          for (int j = 0; j < NumCells; ++j) {
-            for (int i = 0; i < NumVertLvls; ++i) {
+            for (int i = 0; i < NumVertLyrs; ++i) {
                if (TstHost3DR8(k, j, i) != RefArr3DR8(k, j, i))
                   ++icount;
             }
@@ -784,14 +784,14 @@ int main(int argc, char *argv[]) {
 
       // Test for 4DR8
       Array4DR8 TstArr4DR8("TstArr4DR8", NumTimeLvls, NumTracers, NumCells,
-                           NumVertLvls);
+                           NumVertLyrs);
       HostArray4DR8 RefArr4DR8("RefArr4DR8", NumTimeLvls, NumTracers, NumCells,
-                               NumVertLvls);
+                               NumVertLyrs);
 
       for (int m = 0; m < NumTimeLvls; ++m) {
          for (int k = 0; k < NumTracers; ++k) {
             for (int j = 0; j < NumCells; ++j) {
-               for (int i = 0; i < NumVertLvls; ++i) {
+               for (int i = 0; i < NumVertLyrs; ++i) {
                   RefArr4DR8(m, k, j, i) = i + j + k + m;
                }
             }
@@ -799,7 +799,7 @@ int main(int argc, char *argv[]) {
       }
 
       parallelFor(
-          {NumTimeLvls, NumTracers, NumCells, NumVertLvls},
+          {NumTimeLvls, NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int m, int k, int j, int i) {
              TstArr4DR8(m, k, j, i) = i + j + k + m;
           });
@@ -812,7 +812,7 @@ int main(int argc, char *argv[]) {
       for (int m = 0; m < NumTimeLvls; ++m) {
          for (int k = 0; k < NumTracers; ++k) {
             for (int j = 0; j < NumCells; ++j) {
-               for (int i = 0; i < NumVertLvls; ++i) {
+               for (int i = 0; i < NumVertLyrs; ++i) {
                   if (TstHost4DR8(m, k, j, i) != RefArr4DR8(m, k, j, i))
                      ++icount;
                }
@@ -829,15 +829,15 @@ int main(int argc, char *argv[]) {
 
       // Test for 5DR8
       Array5DR8 TstArr5DR8("TstArr5DR8", NumExtra, NumTimeLvls, NumTracers,
-                           NumCells, NumVertLvls);
+                           NumCells, NumVertLyrs);
       HostArray5DR8 RefArr5DR8("RefArr5DR8", NumExtra, NumTimeLvls, NumTracers,
-                               NumCells, NumVertLvls);
+                               NumCells, NumVertLyrs);
 
       for (int n = 0; n < NumExtra; ++n) {
          for (int m = 0; m < NumTimeLvls; ++m) {
             for (int k = 0; k < NumTracers; ++k) {
                for (int j = 0; j < NumCells; ++j) {
-                  for (int i = 0; i < NumVertLvls; ++i) {
+                  for (int i = 0; i < NumVertLyrs; ++i) {
                      RefArr5DR8(n, m, k, j, i) = i + j + k + m + n;
                   }
                }
@@ -846,7 +846,7 @@ int main(int argc, char *argv[]) {
       }
 
       parallelFor(
-          {NumExtra, NumTimeLvls, NumTracers, NumCells, NumVertLvls},
+          {NumExtra, NumTimeLvls, NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int n, int m, int k, int j, int i) {
              TstArr5DR8(n, m, k, j, i) = i + j + k + m + n;
           });
@@ -860,7 +860,7 @@ int main(int argc, char *argv[]) {
          for (int m = 0; m < NumTimeLvls; ++m) {
             for (int k = 0; k < NumTracers; ++k) {
                for (int j = 0; j < NumCells; ++j) {
-                  for (int i = 0; i < NumVertLvls; ++i) {
+                  for (int i = 0; i < NumVertLyrs; ++i) {
                      if (TstHost5DR8(n, m, k, j, i) !=
                          RefArr5DR8(n, m, k, j, i))
                         ++icount;
@@ -905,17 +905,17 @@ int main(int argc, char *argv[]) {
       }
 
       // Test for 2DReal
-      Array2DReal TstArr2DReal("TstArr2DReal", NumCells, NumVertLvls);
-      HostArray2DReal RefArr2DReal("RefArr2DReal", NumCells, NumVertLvls);
+      Array2DReal TstArr2DReal("TstArr2DReal", NumCells, NumVertLyrs);
+      HostArray2DReal RefArr2DReal("RefArr2DReal", NumCells, NumVertLyrs);
 
       for (int j = 0; j < NumCells; ++j) {
-         for (int i = 0; i < NumVertLvls; ++i) {
+         for (int i = 0; i < NumVertLyrs; ++i) {
             RefArr2DReal(j, i) = i + j;
          }
       }
 
       parallelFor(
-          {NumCells, NumVertLvls},
+          {NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int j, int i) { TstArr2DReal(j, i) = i + j; });
 
       Kokkos::fence();
@@ -924,7 +924,7 @@ int main(int argc, char *argv[]) {
 
       icount = 0;
       for (int j = 0; j < NumCells; ++j) {
-         for (int i = 0; i < NumVertLvls; ++i) {
+         for (int i = 0; i < NumVertLyrs; ++i) {
             if (TstHost2DReal(j, i) != RefArr2DReal(j, i))
                ++icount;
          }
@@ -939,20 +939,20 @@ int main(int argc, char *argv[]) {
 
       // Test for 3DReal
       Array3DReal TstArr3DReal("TstArr3DReal", NumTracers, NumCells,
-                               NumVertLvls);
+                               NumVertLyrs);
       HostArray3DReal RefArr3DReal("RefArr3DReal", NumTracers, NumCells,
-                                   NumVertLvls);
+                                   NumVertLyrs);
 
       for (int k = 0; k < NumTracers; ++k) {
          for (int j = 0; j < NumCells; ++j) {
-            for (int i = 0; i < NumVertLvls; ++i) {
+            for (int i = 0; i < NumVertLyrs; ++i) {
                RefArr3DReal(k, j, i) = i + j + k;
             }
          }
       }
 
       parallelFor(
-          {NumTracers, NumCells, NumVertLvls},
+          {NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int k, int j, int i) {
              TstArr3DReal(k, j, i) = i + j + k;
           });
@@ -964,7 +964,7 @@ int main(int argc, char *argv[]) {
       icount = 0;
       for (int k = 0; k < NumTracers; ++k) {
          for (int j = 0; j < NumCells; ++j) {
-            for (int i = 0; i < NumVertLvls; ++i) {
+            for (int i = 0; i < NumVertLyrs; ++i) {
                if (TstHost3DReal(k, j, i) != RefArr3DReal(k, j, i))
                   ++icount;
             }
@@ -980,14 +980,14 @@ int main(int argc, char *argv[]) {
 
       // Test for 4DReal
       Array4DReal TstArr4DReal("TstArr4DReal", NumTimeLvls, NumTracers,
-                               NumCells, NumVertLvls);
+                               NumCells, NumVertLyrs);
       HostArray4DReal RefArr4DReal("RefArr4DReal", NumTimeLvls, NumTracers,
-                                   NumCells, NumVertLvls);
+                                   NumCells, NumVertLyrs);
 
       for (int m = 0; m < NumTimeLvls; ++m) {
          for (int k = 0; k < NumTracers; ++k) {
             for (int j = 0; j < NumCells; ++j) {
-               for (int i = 0; i < NumVertLvls; ++i) {
+               for (int i = 0; i < NumVertLyrs; ++i) {
                   RefArr4DReal(m, k, j, i) = i + j + k + m;
                }
             }
@@ -995,7 +995,7 @@ int main(int argc, char *argv[]) {
       }
 
       parallelFor(
-          {NumTimeLvls, NumTracers, NumCells, NumVertLvls},
+          {NumTimeLvls, NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int m, int k, int j, int i) {
              TstArr4DReal(m, k, j, i) = i + j + k + m;
           });
@@ -1008,7 +1008,7 @@ int main(int argc, char *argv[]) {
       for (int m = 0; m < NumTimeLvls; ++m) {
          for (int k = 0; k < NumTracers; ++k) {
             for (int j = 0; j < NumCells; ++j) {
-               for (int i = 0; i < NumVertLvls; ++i) {
+               for (int i = 0; i < NumVertLyrs; ++i) {
                   if (TstHost4DReal(m, k, j, i) != RefArr4DReal(m, k, j, i))
                      ++icount;
                }
@@ -1025,15 +1025,15 @@ int main(int argc, char *argv[]) {
 
       // Test for 5DReal
       Array5DReal TstArr5DReal("TstArr5DReal", NumExtra, NumTimeLvls,
-                               NumTracers, NumCells, NumVertLvls);
+                               NumTracers, NumCells, NumVertLyrs);
       HostArray5DReal RefArr5DReal("RefArr5DReal", NumExtra, NumTimeLvls,
-                                   NumTracers, NumCells, NumVertLvls);
+                                   NumTracers, NumCells, NumVertLyrs);
 
       for (int n = 0; n < NumExtra; ++n) {
          for (int m = 0; m < NumTimeLvls; ++m) {
             for (int k = 0; k < NumTracers; ++k) {
                for (int j = 0; j < NumCells; ++j) {
-                  for (int i = 0; i < NumVertLvls; ++i) {
+                  for (int i = 0; i < NumVertLyrs; ++i) {
                      RefArr5DReal(n, m, k, j, i) = i + j + k + m + n;
                   }
                }
@@ -1042,7 +1042,7 @@ int main(int argc, char *argv[]) {
       }
 
       parallelFor(
-          {NumExtra, NumTimeLvls, NumTracers, NumCells, NumVertLvls},
+          {NumExtra, NumTimeLvls, NumTracers, NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int n, int m, int k, int j, int i) {
              TstArr5DReal(n, m, k, j, i) = i + j + k + m + n;
           });
@@ -1056,7 +1056,7 @@ int main(int argc, char *argv[]) {
          for (int m = 0; m < NumTimeLvls; ++m) {
             for (int k = 0; k < NumTracers; ++k) {
                for (int j = 0; j < NumCells; ++j) {
-                  for (int i = 0; i < NumVertLvls; ++i) {
+                  for (int i = 0; i < NumVertLyrs; ++i) {
                      if (TstHost5DReal(n, m, k, j, i) !=
                          RefArr5DReal(n, m, k, j, i))
                         ++icount;

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -102,29 +102,29 @@ int main(int argc, char *argv[]) {
       I4 NCellsGlobal    = DefDecomp->NCellsGlobal;
       I4 NEdgesGlobal    = DefDecomp->NEdgesGlobal;
       I4 NVerticesGlobal = DefDecomp->NVerticesGlobal;
-      I4 NVertLevels     = 128;
+      I4 NVertLayers     = 128;
 
-      HostArray1DI4 RefI4Vert("RefI4Vert", NVertLevels);
-      HostArray1DI8 RefI8Vert("RefI8Vert", NVertLevels);
-      HostArray1DR4 RefR4Vert("RefR4Vert", NVertLevels);
-      HostArray1DR8 RefR8Vert("RefR8Vert", NVertLevels);
-      HostArray1DR8 RefR8Time("RefR8Time", NVertLevels);
+      HostArray1DI4 RefI4Vert("RefI4Vert", NVertLayers);
+      HostArray1DI8 RefI8Vert("RefI8Vert", NVertLayers);
+      HostArray1DR4 RefR4Vert("RefR4Vert", NVertLayers);
+      HostArray1DR8 RefR8Vert("RefR8Vert", NVertLayers);
+      HostArray1DR8 RefR8Time("RefR8Time", NVertLayers);
 
-      HostArray2DI4 RefI4Cell("RefI4Cell", NCellsSize, NVertLevels);
-      HostArray2DI8 RefI8Cell("RefI8Cell", NCellsSize, NVertLevels);
-      HostArray2DR4 RefR4Cell("RefR4Cell", NCellsSize, NVertLevels);
-      HostArray2DR8 RefR8Cell("RefR8Cell", NCellsSize, NVertLevels);
-      HostArray2DR8 RefR8Tim2("RefR8Tim2", NCellsSize, NVertLevels);
+      HostArray2DI4 RefI4Cell("RefI4Cell", NCellsSize, NVertLayers);
+      HostArray2DI8 RefI8Cell("RefI8Cell", NCellsSize, NVertLayers);
+      HostArray2DR4 RefR4Cell("RefR4Cell", NCellsSize, NVertLayers);
+      HostArray2DR8 RefR8Cell("RefR8Cell", NCellsSize, NVertLayers);
+      HostArray2DR8 RefR8Tim2("RefR8Tim2", NCellsSize, NVertLayers);
 
-      HostArray2DI4 RefI4Edge("RefI4Edge", NEdgesSize, NVertLevels);
-      HostArray2DI8 RefI8Edge("RefI8Edge", NEdgesSize, NVertLevels);
-      HostArray2DR4 RefR4Edge("RefR4Edge", NEdgesSize, NVertLevels);
-      HostArray2DR8 RefR8Edge("RefR8Edge", NEdgesSize, NVertLevels);
+      HostArray2DI4 RefI4Edge("RefI4Edge", NEdgesSize, NVertLayers);
+      HostArray2DI8 RefI8Edge("RefI8Edge", NEdgesSize, NVertLayers);
+      HostArray2DR4 RefR4Edge("RefR4Edge", NEdgesSize, NVertLayers);
+      HostArray2DR8 RefR8Edge("RefR8Edge", NEdgesSize, NVertLayers);
 
-      HostArray2DI4 RefI4Vrtx("RefI4Vrtx", NVerticesSize, NVertLevels);
-      HostArray2DI8 RefI8Vrtx("RefI8Vrtx", NVerticesSize, NVertLevels);
-      HostArray2DR4 RefR4Vrtx("RefR4Vrtx", NVerticesSize, NVertLevels);
-      HostArray2DR8 RefR8Vrtx("RefR8Vrtx", NVerticesSize, NVertLevels);
+      HostArray2DI4 RefI4Vrtx("RefI4Vrtx", NVerticesSize, NVertLayers);
+      HostArray2DI8 RefI8Vrtx("RefI8Vrtx", NVerticesSize, NVertLayers);
+      HostArray2DR4 RefR4Vrtx("RefR4Vrtx", NVerticesSize, NVertLayers);
+      HostArray2DR8 RefR8Vrtx("RefR8Vrtx", NVerticesSize, NVertLayers);
 
       HostArray1DI4 CellIDH = DefDecomp->CellIDH;
       HostArray1DI4 EdgeIDH = DefDecomp->EdgeIDH;
@@ -135,7 +135,7 @@ int main(int argc, char *argv[]) {
       I8 RefI8Scalar = -2;
       R4 RefR4Scalar = -3.1;
       R8 RefR8Scalar = -4.56789;
-      for (int K = 0; K < NVertLevels; ++K) {
+      for (int K = 0; K < NVertLayers; ++K) {
          RefI4Vert(K) = K;
          RefI8Vert(K) = K * 2;
          RefR4Vert(K) = K * 3.1;
@@ -145,43 +145,43 @@ int main(int argc, char *argv[]) {
 
       // Offset arrays - initialize to -1, corresponding to entries
       // that should not be written;
-      std::vector<int> OffsetCell(NCellsSize * NVertLevels, -1);
-      std::vector<int> OffsetEdge(NEdgesSize * NVertLevels, -1);
-      std::vector<int> OffsetVrtx(NVerticesSize * NVertLevels, -1);
+      std::vector<int> OffsetCell(NCellsSize * NVertLayers, -1);
+      std::vector<int> OffsetEdge(NEdgesSize * NVertLayers, -1);
+      std::vector<int> OffsetVrtx(NVerticesSize * NVertLayers, -1);
       for (int Cell = 0; Cell < NCellsOwned; ++Cell) {
          int GlobalCellAdd = CellIDH(Cell) - 1; // 0-based offset
-         for (int k = 0; k < NVertLevels; ++k) {
+         for (int k = 0; k < NVertLayers; ++k) {
             RefI4Cell(Cell, k)    = GlobalCellAdd * k;
             RefI8Cell(Cell, k)    = GlobalCellAdd * k * 1000000000;
             RefR4Cell(Cell, k)    = GlobalCellAdd * k * 123.45;
             RefR8Cell(Cell, k)    = GlobalCellAdd * k * 1.23456789;
             RefR8Tim2(Cell, k)    = GlobalCellAdd * k * 2.23456789;
-            int VectorAdd         = Cell * NVertLevels + k;
-            OffsetCell[VectorAdd] = GlobalCellAdd * NVertLevels + k;
+            int VectorAdd         = Cell * NVertLayers + k;
+            OffsetCell[VectorAdd] = GlobalCellAdd * NVertLayers + k;
          }
       }
 
       for (int Edge = 0; Edge < NEdgesOwned; ++Edge) {
          int GlobalEdgeAdd = EdgeIDH(Edge) - 1;
-         for (int k = 0; k < NVertLevels; ++k) {
+         for (int k = 0; k < NVertLayers; ++k) {
             RefI4Edge(Edge, k)    = GlobalEdgeAdd * k;
             RefI8Edge(Edge, k)    = GlobalEdgeAdd * k * 1000000000;
             RefR4Edge(Edge, k)    = GlobalEdgeAdd * k * 123.45;
             RefR8Edge(Edge, k)    = GlobalEdgeAdd * k * 1.23456789;
-            int VectorAdd         = Edge * NVertLevels + k;
-            OffsetEdge[VectorAdd] = GlobalEdgeAdd * NVertLevels + k;
+            int VectorAdd         = Edge * NVertLayers + k;
+            OffsetEdge[VectorAdd] = GlobalEdgeAdd * NVertLayers + k;
          }
       }
 
       for (int Vrtx = 0; Vrtx < NVerticesOwned; ++Vrtx) {
          int GlobalVrtxAdd = VrtxIDH(Vrtx) - 1;
-         for (int k = 0; k < NVertLevels; ++k) {
+         for (int k = 0; k < NVertLayers; ++k) {
             RefI4Vrtx(Vrtx, k)    = GlobalVrtxAdd * k;
             RefI8Vrtx(Vrtx, k)    = GlobalVrtxAdd * k * 1000000000;
             RefR4Vrtx(Vrtx, k)    = GlobalVrtxAdd * k * 123.45;
             RefR8Vrtx(Vrtx, k)    = GlobalVrtxAdd * k * 1.23456789;
-            int VectorAdd         = Vrtx * NVertLevels + k;
-            OffsetVrtx[VectorAdd] = GlobalVrtxAdd * NVertLevels + k;
+            int VectorAdd         = Vrtx * NVertLayers + k;
+            OffsetVrtx[VectorAdd] = GlobalVrtxAdd * NVertLayers + k;
          }
       }
 
@@ -199,12 +199,12 @@ int main(int argc, char *argv[]) {
       int DecompVrtxI8;
       int DecompVrtxR4;
       int DecompVrtxR8;
-      std::vector<int> CellDims{NCellsGlobal, NVertLevels};
-      std::vector<int> EdgeDims{NEdgesGlobal, NVertLevels};
-      std::vector<int> VrtxDims{NVerticesGlobal, NVertLevels};
-      int CellArraySize = NCellsSize * NVertLevels;
-      int EdgeArraySize = NEdgesSize * NVertLevels;
-      int VrtxArraySize = NVerticesSize * NVertLevels;
+      std::vector<int> CellDims{NCellsGlobal, NVertLayers};
+      std::vector<int> EdgeDims{NEdgesGlobal, NVertLayers};
+      std::vector<int> VrtxDims{NVerticesGlobal, NVertLayers};
+      int CellArraySize = NCellsSize * NVertLayers;
+      int EdgeArraySize = NEdgesSize * NVertLayers;
+      int VrtxArraySize = NVerticesSize * NVertLayers;
 
       Err = IO::createDecomp(DecompCellI4, IO::IOTypeI4, 2, CellDims,
                              CellArraySize, OffsetCell, IO::DefaultRearr);
@@ -319,7 +319,7 @@ int main(int argc, char *argv[]) {
       int DimVrtxID;
       int DimVertID;
       int DimTimeID; // unlimited time dim
-      Err = IO::defineDim(OutFileID, "NVertLevels", NVertLevels, DimVertID);
+      Err = IO::defineDim(OutFileID, "NVertLayers", NVertLayers, DimVertID);
       if (Err == 0) {
          LOG_ERROR("IOTest: defining vertical dimension PASS");
       } else {
@@ -715,7 +715,7 @@ int main(int argc, char *argv[]) {
       // Write R8 arrays as two time slices - the first frame here with
       // the second frame written after re-open
       std::vector<int> DimLengths(1);
-      DimLengths[0] = NVertLevels;
+      DimLengths[0] = NVertLayers;
       Err = IO::writeNDVar(RefR8Vert.data(), OutFileID, VarIDR8Time, 0,
                            &DimLengths);
       if (Err == 0) {
@@ -726,7 +726,7 @@ int main(int argc, char *argv[]) {
       }
 
       // Write distributed arrays
-      Err = IO::writeArray(RefI4Cell.data(), NCellsSize * NVertLevels, &FillI4,
+      Err = IO::writeArray(RefI4Cell.data(), NCellsSize * NVertLayers, &FillI4,
                            OutFileID, DecompCellI4, VarIDCellI4);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing I4 array on cells PASS");
@@ -734,7 +734,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I4 array on cells FAIL");
       }
-      Err = IO::writeArray(RefI8Cell.data(), NCellsSize * NVertLevels, &FillI8,
+      Err = IO::writeArray(RefI8Cell.data(), NCellsSize * NVertLayers, &FillI8,
                            OutFileID, DecompCellI8, VarIDCellI8);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing I8 array on cells PASS");
@@ -742,7 +742,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I8 array on cells FAIL");
       }
-      Err = IO::writeArray(RefR4Cell.data(), NCellsSize * NVertLevels, &FillR4,
+      Err = IO::writeArray(RefR4Cell.data(), NCellsSize * NVertLayers, &FillR4,
                            OutFileID, DecompCellR4, VarIDCellR4);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing R4 array on cells PASS");
@@ -752,7 +752,7 @@ int main(int argc, char *argv[]) {
       }
       // Write R8 cell data as two time slices - this is first frame
       // Second frame written below
-      Err = IO::writeArray(RefR8Cell.data(), NCellsSize * NVertLevels, &FillR8,
+      Err = IO::writeArray(RefR8Cell.data(), NCellsSize * NVertLayers, &FillR8,
                            OutFileID, DecompCellR8, VarIDTimeR8, 0);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing R8 array on cells frame 0 PASS");
@@ -761,7 +761,7 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error writing R8 array on cells frame 0 FAIL");
       }
 
-      Err = IO::writeArray(RefI4Edge.data(), NEdgesSize * NVertLevels, &FillI4,
+      Err = IO::writeArray(RefI4Edge.data(), NEdgesSize * NVertLayers, &FillI4,
                            OutFileID, DecompEdgeI4, VarIDEdgeI4);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing I4 array on Edges PASS");
@@ -769,7 +769,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I4 array on Edges FAIL");
       }
-      Err = IO::writeArray(RefI8Edge.data(), NEdgesSize * NVertLevels, &FillI8,
+      Err = IO::writeArray(RefI8Edge.data(), NEdgesSize * NVertLayers, &FillI8,
                            OutFileID, DecompEdgeI8, VarIDEdgeI8);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing I8 array on Edges PASS");
@@ -777,7 +777,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I8 array on Edges FAIL");
       }
-      Err = IO::writeArray(RefR4Edge.data(), NEdgesSize * NVertLevels, &FillR4,
+      Err = IO::writeArray(RefR4Edge.data(), NEdgesSize * NVertLayers, &FillR4,
                            OutFileID, DecompEdgeR4, VarIDEdgeR4);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing R4 array on Edges PASS");
@@ -785,7 +785,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R4 array on Edges FAIL");
       }
-      Err = IO::writeArray(RefR8Edge.data(), NEdgesSize * NVertLevels, &FillR8,
+      Err = IO::writeArray(RefR8Edge.data(), NEdgesSize * NVertLayers, &FillR8,
                            OutFileID, DecompEdgeR8, VarIDEdgeR8);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing R8 array on Edges PASS");
@@ -794,7 +794,7 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error writing R8 array on Edges FAIL");
       }
 
-      Err = IO::writeArray(RefI4Vrtx.data(), NVerticesSize * NVertLevels,
+      Err = IO::writeArray(RefI4Vrtx.data(), NVerticesSize * NVertLayers,
                            &FillI4, OutFileID, DecompVrtxI4, VarIDVrtxI4);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing I4 array on vertices PASS");
@@ -802,7 +802,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I4 array on vertices FAIL");
       }
-      Err = IO::writeArray(RefI8Vrtx.data(), NVerticesSize * NVertLevels,
+      Err = IO::writeArray(RefI8Vrtx.data(), NVerticesSize * NVertLayers,
                            &FillI8, OutFileID, DecompVrtxI8, VarIDVrtxI8);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing I8 array on vertices PASS");
@@ -810,7 +810,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing I8 array on vertices FAIL");
       }
-      Err = IO::writeArray(RefR4Vrtx.data(), NVerticesSize * NVertLevels,
+      Err = IO::writeArray(RefR4Vrtx.data(), NVerticesSize * NVertLayers,
                            &FillR4, OutFileID, DecompVrtxR4, VarIDVrtxR4);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing R4 array on vertices PASS");
@@ -818,7 +818,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error writing R4 array on vertices FAIL");
       }
-      Err = IO::writeArray(RefR8Vrtx.data(), NVerticesSize * NVertLevels,
+      Err = IO::writeArray(RefR8Vrtx.data(), NVerticesSize * NVertLayers,
                            &FillR8, OutFileID, DecompVrtxR8, VarIDVrtxR8);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing R8 array on vertices PASS");
@@ -857,7 +857,7 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error writing R8Time vector frame 1 FAIL");
       }
 
-      Err = IO::writeArray(RefR8Tim2.data(), NCellsSize * NVertLevels, &FillR8,
+      Err = IO::writeArray(RefR8Tim2.data(), NCellsSize * NVertLayers, &FillR8,
                            OutFileID, DecompCellR8, VarIDTimeR8, 1);
       if (Err == 0) {
          LOG_ERROR("IOTest: writing R8 array on cells frame 1 PASS");
@@ -886,11 +886,11 @@ int main(int argc, char *argv[]) {
       }
 
       // Get dimension lengths to verify read/write of dimension info
-      I4 NVertLevelsID;
-      I4 NVertLevelsNew;
-      Err = IO::getDimFromFile(InFileID, "NVertLevels", NVertLevelsID,
-                               NVertLevelsNew);
-      if (Err == 0 and NVertLevelsNew == NVertLevels) {
+      I4 NVertLayersID;
+      I4 NVertLayersNew;
+      Err = IO::getDimFromFile(InFileID, "NVertLayers", NVertLayersID,
+                               NVertLayersNew);
+      if (Err == 0 and NVertLayersNew == NVertLayers) {
          LOG_ERROR("IOTest: read/write vert dimension test PASS");
       } else {
          RetVal += 1;
@@ -1025,27 +1025,27 @@ int main(int argc, char *argv[]) {
       R4 NewR4Scalar = 0;
       R8 NewR8Scalar = 0;
 
-      HostArray1DI4 NewI4Vert("NewI4Vert", NVertLevels);
-      HostArray1DI8 NewI8Vert("NewI8Vert", NVertLevels);
-      HostArray1DR4 NewR4Vert("NewR4Vert", NVertLevels);
-      HostArray1DR8 NewR8Vert("NewR8Vert", NVertLevels);
-      HostArray1DR8 NewR8Time("NewR8Time", NVertLevels);
+      HostArray1DI4 NewI4Vert("NewI4Vert", NVertLayers);
+      HostArray1DI8 NewI8Vert("NewI8Vert", NVertLayers);
+      HostArray1DR4 NewR4Vert("NewR4Vert", NVertLayers);
+      HostArray1DR8 NewR8Vert("NewR8Vert", NVertLayers);
+      HostArray1DR8 NewR8Time("NewR8Time", NVertLayers);
 
-      HostArray2DI4 NewI4Cell("NewI4Cell", NCellsSize, NVertLevels);
-      HostArray2DI8 NewI8Cell("NewI8Cell", NCellsSize, NVertLevels);
-      HostArray2DR4 NewR4Cell("NewR4Cell", NCellsSize, NVertLevels);
-      HostArray2DR8 NewR8Cell("NewR8Cell", NCellsSize, NVertLevels);
-      HostArray2DR8 NewR8Tim2("NewR8Tim2", NCellsSize, NVertLevels);
+      HostArray2DI4 NewI4Cell("NewI4Cell", NCellsSize, NVertLayers);
+      HostArray2DI8 NewI8Cell("NewI8Cell", NCellsSize, NVertLayers);
+      HostArray2DR4 NewR4Cell("NewR4Cell", NCellsSize, NVertLayers);
+      HostArray2DR8 NewR8Cell("NewR8Cell", NCellsSize, NVertLayers);
+      HostArray2DR8 NewR8Tim2("NewR8Tim2", NCellsSize, NVertLayers);
 
-      HostArray2DI4 NewI4Edge("NewI4Edge", NEdgesSize, NVertLevels);
-      HostArray2DI8 NewI8Edge("NewI8Edge", NEdgesSize, NVertLevels);
-      HostArray2DR4 NewR4Edge("NewR4Edge", NEdgesSize, NVertLevels);
-      HostArray2DR8 NewR8Edge("NewR8Edge", NEdgesSize, NVertLevels);
+      HostArray2DI4 NewI4Edge("NewI4Edge", NEdgesSize, NVertLayers);
+      HostArray2DI8 NewI8Edge("NewI8Edge", NEdgesSize, NVertLayers);
+      HostArray2DR4 NewR4Edge("NewR4Edge", NEdgesSize, NVertLayers);
+      HostArray2DR8 NewR8Edge("NewR8Edge", NEdgesSize, NVertLayers);
 
-      HostArray2DI4 NewI4Vrtx("NewI4Vrtx", NVerticesSize, NVertLevels);
-      HostArray2DI8 NewI8Vrtx("NewI8Vrtx", NVerticesSize, NVertLevels);
-      HostArray2DR4 NewR4Vrtx("NewR4Vrtx", NVerticesSize, NVertLevels);
-      HostArray2DR8 NewR8Vrtx("NewR8Vrtx", NVerticesSize, NVertLevels);
+      HostArray2DI4 NewI4Vrtx("NewI4Vrtx", NVerticesSize, NVertLayers);
+      HostArray2DI8 NewI8Vrtx("NewI8Vrtx", NVerticesSize, NVertLayers);
+      HostArray2DR4 NewR4Vrtx("NewR4Vrtx", NVerticesSize, NVertLayers);
+      HostArray2DR8 NewR8Vrtx("NewR8Vrtx", NVerticesSize, NVertLayers);
 
       // Read non-distributed variables
       Err = IO::readNDVar(&NewI4Scalar, "ScalarI4", InFileID, VarIDScalarI4);
@@ -1123,7 +1123,7 @@ int main(int argc, char *argv[]) {
       }
 
       // Read distributed arrays
-      Err = IO::readArray(NewI4Cell.data(), NCellsSize * NVertLevels, "CellI4",
+      Err = IO::readArray(NewI4Cell.data(), NCellsSize * NVertLayers, "CellI4",
                           InFileID, DecompCellI4, VarIDCellI4);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading I4 array on cells PASS");
@@ -1131,7 +1131,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I4 array on cells FAIL");
       }
-      Err = IO::readArray(NewI8Cell.data(), NCellsSize * NVertLevels, "CellI8",
+      Err = IO::readArray(NewI8Cell.data(), NCellsSize * NVertLayers, "CellI8",
                           InFileID, DecompCellI8, VarIDCellI8);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading I8 array on cells PASS");
@@ -1139,7 +1139,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I8 array on cells FAIL");
       }
-      Err = IO::readArray(NewR4Cell.data(), NCellsSize * NVertLevels, "CellR4",
+      Err = IO::readArray(NewR4Cell.data(), NCellsSize * NVertLayers, "CellR4",
                           InFileID, DecompCellR4, VarIDCellR4);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading R4 array on cells PASS");
@@ -1148,7 +1148,7 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading R4 array on cells FAIL");
       }
       // Read R8 Cell data as two time slices
-      Err = IO::readArray(NewR8Cell.data(), NCellsSize * NVertLevels, "TimeR8",
+      Err = IO::readArray(NewR8Cell.data(), NCellsSize * NVertLayers, "TimeR8",
                           InFileID, DecompCellR8, VarIDTimeR8, 0);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading R8 array on cells frame 0 PASS");
@@ -1156,7 +1156,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R8 array on cells frame 0 FAIL");
       }
-      Err = IO::readArray(NewR8Tim2.data(), NCellsSize * NVertLevels, "TimeR8",
+      Err = IO::readArray(NewR8Tim2.data(), NCellsSize * NVertLayers, "TimeR8",
                           InFileID, DecompCellR8, VarIDTimeR8, 1);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading R8 array on cells frame 1 PASS");
@@ -1165,7 +1165,7 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading R8 array on cells frame 1 FAIL");
       }
 
-      Err = IO::readArray(NewI4Edge.data(), NEdgesSize * NVertLevels, "EdgeI4",
+      Err = IO::readArray(NewI4Edge.data(), NEdgesSize * NVertLayers, "EdgeI4",
                           InFileID, DecompEdgeI4, VarIDEdgeI4);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading I4 array on Edges PASS");
@@ -1173,7 +1173,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I4 array on Edges FAIL");
       }
-      Err = IO::readArray(NewI8Edge.data(), NEdgesSize * NVertLevels, "EdgeI8",
+      Err = IO::readArray(NewI8Edge.data(), NEdgesSize * NVertLayers, "EdgeI8",
                           InFileID, DecompEdgeI8, VarIDEdgeI8);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading I8 array on Edges PASS");
@@ -1181,7 +1181,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I8 array on Edges FAIL");
       }
-      Err = IO::readArray(NewR4Edge.data(), NEdgesSize * NVertLevels, "EdgeR4",
+      Err = IO::readArray(NewR4Edge.data(), NEdgesSize * NVertLayers, "EdgeR4",
                           InFileID, DecompEdgeR4, VarIDEdgeR4);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading R4 array on Edges PASS");
@@ -1189,7 +1189,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R4 array on Edges FAIL");
       }
-      Err = IO::readArray(NewR8Edge.data(), NEdgesSize * NVertLevels, "EdgeR8",
+      Err = IO::readArray(NewR8Edge.data(), NEdgesSize * NVertLayers, "EdgeR8",
                           InFileID, DecompEdgeR8, VarIDEdgeR8);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading R8 array on Edges PASS");
@@ -1198,7 +1198,7 @@ int main(int argc, char *argv[]) {
          LOG_ERROR("IOTest: error reading R8 array on Edges FAIL");
       }
 
-      Err = IO::readArray(NewI4Vrtx.data(), NVerticesSize * NVertLevels,
+      Err = IO::readArray(NewI4Vrtx.data(), NVerticesSize * NVertLayers,
                           "VrtxI4", InFileID, DecompVrtxI4, VarIDVrtxI4);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading I4 array on vertices PASS");
@@ -1206,7 +1206,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I4 array on vertices FAIL");
       }
-      Err = IO::readArray(NewI8Vrtx.data(), NVerticesSize * NVertLevels,
+      Err = IO::readArray(NewI8Vrtx.data(), NVerticesSize * NVertLayers,
                           "VrtxI8", InFileID, DecompVrtxI8, VarIDVrtxI8);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading I8 array on vertices PASS");
@@ -1214,7 +1214,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading I8 array on vertices FAIL");
       }
-      Err = IO::readArray(NewR4Vrtx.data(), NVerticesSize * NVertLevels,
+      Err = IO::readArray(NewR4Vrtx.data(), NVerticesSize * NVertLayers,
                           "VrtxR4", InFileID, DecompVrtxR4, VarIDVrtxR4);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading R4 array on vertices PASS");
@@ -1222,7 +1222,7 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_ERROR("IOTest: error reading R4 array on vertices FAIL");
       }
-      Err = IO::readArray(NewR8Vrtx.data(), NVerticesSize * NVertLevels,
+      Err = IO::readArray(NewR8Vrtx.data(), NVerticesSize * NVertLayers,
                           "VrtxR8", InFileID, DecompVrtxR8, VarIDVrtxR8);
       if (Err == 0) {
          LOG_ERROR("IOTest: reading R8 array on vertices PASS");
@@ -1279,7 +1279,7 @@ int main(int argc, char *argv[]) {
       Err3 = 0;
       Err4 = 0;
       Err5 = 0;
-      for (int k = 0; k < NVertLevels; ++k) {
+      for (int k = 0; k < NVertLayers; ++k) {
          if (NewI4Vert(k) != RefI4Vert(k))
             Err1++;
          if (NewI8Vert(k) != RefI8Vert(k))
@@ -1328,7 +1328,7 @@ int main(int argc, char *argv[]) {
       Err4 = 0;
       Err5 = 0;
       for (int Cell = 0; Cell < NCellsOwned; ++Cell) {
-         for (int k = 0; k < NVertLevels; ++k) {
+         for (int k = 0; k < NVertLayers; ++k) {
             if (NewI4Cell(Cell, k) != RefI4Cell(Cell, k))
                Err1++;
             if (NewI8Cell(Cell, k) != RefI8Cell(Cell, k))
@@ -1377,7 +1377,7 @@ int main(int argc, char *argv[]) {
       Err3 = 0;
       Err4 = 0;
       for (int Edge = 0; Edge < NEdgesOwned; ++Edge) {
-         for (int k = 0; k < NVertLevels; ++k) {
+         for (int k = 0; k < NVertLayers; ++k) {
             if (NewI4Edge(Edge, k) != RefI4Edge(Edge, k))
                Err1++;
             if (NewI8Edge(Edge, k) != RefI8Edge(Edge, k))
@@ -1418,7 +1418,7 @@ int main(int argc, char *argv[]) {
       Err3 = 0;
       Err4 = 0;
       for (int Vrtx = 0; Vrtx < NVerticesOwned; ++Vrtx) {
-         for (int k = 0; k < NVertLevels; ++k) {
+         for (int k = 0; k < NVertLayers; ++k) {
             if (NewI4Vrtx(Vrtx, k) != RefI4Vrtx(Vrtx, k))
                Err1++;
             if (NewI8Vrtx(Vrtx, k) != RefI8Vrtx(Vrtx, k))

--- a/components/omega/test/base/ReductionsTest.cpp
+++ b/components/omega/test/base/ReductionsTest.cpp
@@ -97,14 +97,14 @@ int main(int argc, char *argv[]) {
 
       // test SUM of I4 arrays
       int i, j, k;
-      I4 NumCells = 10, NumVertLvls = 10, c = 0;
+      I4 NumCells = 10, NumVertLyrs = 10, c = 0;
       HostArray1DI4 HostArr1DI4("HostArrD1", NumCells);
-      HostArray2DI4 HostArr2DI4("HostArrD2", NumCells, NumVertLvls);
+      HostArray2DI4 HostArr2DI4("HostArrD2", NumCells, NumVertLyrs);
       I4 Sum1DI4 = 0, Sum2DI4 = 0;
       for (i = 0; i < NumCells; i++) {
          HostArr1DI4(i) = i;
          Sum1DI4 += i;
-         for (j = 0; j < NumVertLvls; j++) {
+         for (j = 0; j < NumVertLyrs; j++) {
             HostArr2DI4(i, j) = c;
             Sum2DI4 += c;
             c++;
@@ -130,12 +130,12 @@ int main(int argc, char *argv[]) {
 
       // test SUM of I8 arrays
       HostArray1DI8 HostArr1DI8("HostArrD1I8", NumCells);
-      HostArray2DI8 HostArr2DI8("HostArrD2I8", NumCells, NumVertLvls);
+      HostArray2DI8 HostArr2DI8("HostArrD2I8", NumCells, NumVertLyrs);
       I8 Sum1DI8 = 0, Sum2DI8 = 0, c8 = 0;
       for (i = 0; i < NumCells; i++) {
          HostArr1DI8(i) = i;
          Sum1DI8 += i;
-         for (j = 0; j < NumVertLvls; j++) {
+         for (j = 0; j < NumVertLyrs; j++) {
             HostArr2DI8(i, j) = c8;
             Sum2DI8 += c8;
             c8++;
@@ -161,12 +161,12 @@ int main(int argc, char *argv[]) {
 
       // test SUM of R4 arrays
       HostArray1DR4 HostArr1DR4("HostArrD1R4", NumCells);
-      HostArray2DR4 HostArr2DR4("HostArrD2R4", NumCells, NumVertLvls);
+      HostArray2DR4 HostArr2DR4("HostArrD2R4", NumCells, NumVertLyrs);
       R4 Sum1DR4 = 0.0, Sum2DR4 = 0.0, f = 0.0;
       for (i = 0; i < NumCells; i++) {
          HostArr1DR4(i) = i + 0.00001;
          Sum1DR4 += HostArr1DR4(i);
-         for (j = 0; j < NumVertLvls; j++) {
+         for (j = 0; j < NumVertLyrs; j++) {
             HostArr2DR4(i, j) = f;
             Sum2DR4 += HostArr2DR4(i, j);
             f += 1.00001;
@@ -193,7 +193,7 @@ int main(int argc, char *argv[]) {
 
       // test SUM of R8 arrays
       HostArray1DR8 HostArr1DR8("HostArrD1R8", NumCells);
-      HostArray2DR8 HostArr2DR8("HostArrD2R8", NumCells, NumVertLvls);
+      HostArray2DR8 HostArr2DR8("HostArrD2R8", NumCells, NumVertLyrs);
       R8 Sum1DR8 = 0.0, Sum2DR8 = 0.0, d = 0.0;
       complex<double> LocalSum1D(0.0, 0.0), LocalSum2D(0.0, 0.0);
       double e, t1, t2, ai;
@@ -205,7 +205,7 @@ int main(int argc, char *argv[]) {
          e  = t1 - ai;
          t2 = ((real(LocalSum1D) - e) + (ai - (t1 - e))) + imag(LocalSum1D);
          LocalSum1D = complex<double>(t1 + t2, t2 - ((t1 + t2) - t1));
-         for (j = 0; j < NumVertLvls; j++) {
+         for (j = 0; j < NumVertLyrs; j++) {
             HostArr2DR8(i, j) = d;
             d += 1.0000000000001;
             ai = HostArr2DR8(i, j);
@@ -327,11 +327,11 @@ int main(int argc, char *argv[]) {
 
       // test SUM of I4 arrays on device
       Array1DI4 DevArr1DI4("DevArr1DI4", NumCells);
-      Array2DI4 DevArr2DI4("DevArr2DI4", NumCells, NumVertLvls);
+      Array2DI4 DevArr2DI4("DevArr2DI4", NumCells, NumVertLyrs);
 
       parallelFor({NumCells}, KOKKOS_LAMBDA(int i) { DevArr1DI4(i) = i; });
       parallelFor(
-          {NumCells, NumVertLvls},
+          {NumCells, NumVertLyrs},
           KOKKOS_LAMBDA(int i, int j) { DevArr2DI4(i, j) = i * 10 + j; });
       Kokkos::fence();
 

--- a/components/omega/test/infra/DimensionTest.cpp
+++ b/components/omega/test/infra/DimensionTest.cpp
@@ -82,9 +82,9 @@ int initDimensionTest() {
        Dimension::create("NCells", NCellsGlobal, NCellsSize, CellOffset);
    std::shared_ptr<Dimension> EdgeDim =
        Dimension::create("NEdges", NEdgesGlobal, NEdgesSize, EdgeOffset);
-   I4 NVertLevels = 100;
+   I4 NVertLayers = 100;
    std::shared_ptr<Dimension> VertDim =
-       Dimension::create("NVertLevels", NVertLevels);
+       Dimension::create("NVertLayers", NVertLayers);
 
    return Err;
 
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
       I4 NEdgesLocRef = DefDecomp->NEdgesSize;
       I4 NEdgesGlbRef = DefDecomp->NEdgesGlobal;
       I4 NEdgesOwned  = DefDecomp->NEdgesOwned;
-      I4 NVertLvlsRef = 100;
+      I4 NVertLyrsRef = 100;
 
       // Retrieve the number of defined dimensions
       I4 NDimsRef = 3;
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
       // Check to see if expected dimensions exist (and a non-existent one
       // doesn't)
       if (Dimension::exists("NCells") and Dimension::exists("NEdges") and
-          Dimension::exists("NVertLevels") and !Dimension::exists("Garbage")) {
+          Dimension::exists("NVertLayers") and !Dimension::exists("Garbage")) {
          LOG_INFO("Test dimension existence function: PASS");
       } else {
          LOG_ERROR("Test dimension existence function: FAIL");
@@ -162,19 +162,19 @@ int main(int argc, char **argv) {
          ++Err;
       }
 
-      I4 NVertLvlsGlb = Dimension::getDimLengthGlobal("NVertLevels");
-      I4 NVertLvlsLoc = Dimension::getDimLengthLocal("NVertLevels");
-      if (NVertLvlsGlb == NVertLvlsRef and NVertLvlsLoc == NVertLvlsRef) {
-         LOG_INFO("Length retrievals for NVertLevels: PASS");
+      I4 NVertLyrsGlb = Dimension::getDimLengthGlobal("NVertLayers");
+      I4 NVertLyrsLoc = Dimension::getDimLengthLocal("NVertLayers");
+      if (NVertLyrsGlb == NVertLyrsRef and NVertLyrsLoc == NVertLyrsRef) {
+         LOG_INFO("Length retrievals for NVertLayers: PASS");
       } else {
-         LOG_ERROR("Length retrievals for NVertLevels: FAIL");
+         LOG_ERROR("Length retrievals for NVertLayers: FAIL");
          ++Err;
       }
 
       // Test distributed property by name
       if (Dimension::isDistributedDim("NCells") and
           Dimension::isDistributedDim("NEdges") and
-          !Dimension::isDistributedDim("NVertLevels")) {
+          !Dimension::isDistributedDim("NVertLayers")) {
          LOG_INFO("Test distributed property by name: PASS");
       } else {
          LOG_ERROR("Test distributed property by name: FAIL");
@@ -184,7 +184,7 @@ int main(int argc, char **argv) {
       // Test get offset array by dim name
       HostArray1DI4 OffsetCell = Dimension::getDimOffset("NCells");
       HostArray1DI4 OffsetEdge = Dimension::getDimOffset("NEdges");
-      HostArray1DI4 OffsetVert = Dimension::getDimOffset("NVertLevels");
+      HostArray1DI4 OffsetVert = Dimension::getDimOffset("NVertLayers");
       I4 Count                 = 0;
       for (int N = 0; N < NCellsLocRef; ++N) {
          if (N < NCellsOwned) {
@@ -204,7 +204,7 @@ int main(int argc, char **argv) {
                ++Count;
          }
       }
-      for (int N = 0; N < NVertLvlsRef; ++N) {
+      for (int N = 0; N < NVertLyrsRef; ++N) {
          if (OffsetVert(N) != N)
             ++Count;
       }
@@ -259,12 +259,12 @@ int main(int argc, char **argv) {
             }
             if (Count == 0)
                OffsetPass = true;
-         } else if (MyName == "NVertLevels") {
-            if (LengthLoc == NVertLvlsRef and LengthGlb == NVertLvlsRef and
+         } else if (MyName == "NVertLayers") {
+            if (LengthLoc == NVertLyrsRef and LengthGlb == NVertLyrsRef and
                 !Distrib)
                ScalarPass = true;
             Count = 0;
-            for (int N = 0; N < NVertLvlsRef; ++N) {
+            for (int N = 0; N < NVertLyrsRef; ++N) {
                if (OffsetTest(N) != N)
                   ++Count;
             }

--- a/components/omega/test/infra/FieldTest.cpp
+++ b/components/omega/test/infra/FieldTest.cpp
@@ -118,16 +118,16 @@ int initFieldTest() {
        Dimension::create("NEdges", NEdgesGlobal, NEdgesSize, EdgeOffset);
    std::shared_ptr<Dimension> VrtxDim = Dimension::create(
        "NVertices", NVerticesGlobal, NVerticesSize, VrtxOffset);
-   I4 NVertLevels = 100;
+   I4 NVertLayers = 100;
    std::shared_ptr<Dimension> VertDim =
-       Dimension::create("NVertLevels", NVertLevels);
+       Dimension::create("NVertLayers", NVertLayers);
    I4 NTracers                        = 2;
    std::shared_ptr<Dimension> TrcrDim = Dimension::create("NTracers", NTracers);
    I4 NTime                           = 2;
    std::shared_ptr<Dimension> TimeDim = Dimension::create("NTime", NTime);
    I4 NStuff                          = 2;
    std::shared_ptr<Dimension> StuffDim =
-       Dimension::create("NStuff", NVertLevels);
+       Dimension::create("NStuff", NVertLayers);
 
    // Create a model clock for time info
    Calendar::init("Gregorian");
@@ -185,7 +185,7 @@ int initFieldTest() {
        Field::create("Test1DR4H", "Test 1DR4 field on host", "Units1DR4H",
                      "var_name_1DR4", 0.0, 100000.0, 999, 1, DimNames);
 
-   DimNames[0] = "NVertLevels";
+   DimNames[0] = "NVertLayers";
    auto Test1DR8H =
        Field::create("Test1DR8H", "Test 1DR8 field on host", "Units1DR8H",
                      "var_name_1DR8", 0.0, 100000.0, 999, 1, DimNames);
@@ -207,7 +207,7 @@ int initFieldTest() {
        Field::create("Test1DR4", "Test 1DR4 field on device", "Units1DR4",
                      "var_name_1DR4", 0.0, 100000.0, 999, 1, DimNames);
 
-   DimNames[0] = "NVertLevels";
+   DimNames[0] = "NVertLayers";
    auto Test1DR8 =
        Field::create("Test1DR8", "Test 1DR8 field on device", "Units1DR8",
                      "var_name_1DR8", 0.0, 100000.0, 999, 1, DimNames);
@@ -216,25 +216,25 @@ int initFieldTest() {
    DimNames.resize(2);
 
    DimNames[0] = "NCells";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    auto Test2DI4H =
        Field::create("Test2DI4H", "Test 2DI4 field on host", "Units2DI4H",
                      "var_name_2DI4", 0, 100000, 999, 2, DimNames);
 
    DimNames[0] = "NEdges";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    auto Test2DI8H =
        Field::create("Test2DI8H", "Test 2DI8 field on host", "Units2DI8H",
                      "var_name_2DI8", 0, 100000, 999, 2, DimNames);
 
    DimNames[0] = "NVertices";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    auto Test2DR4H =
        Field::create("Test2DR4H", "Test 2DR4 field on host", "Units2DR4H",
                      "var_name_2DR4", 0.0, 100000.0, 999, 2, DimNames);
 
    DimNames[0] = "NCells";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    auto Test2DR8H =
        Field::create("Test2DR8H", "Test 2DR8 field on host", "Units2DR8H",
                      "var_name_2DR8", 0.0, 100000.0, 999, 2, DimNames);
@@ -242,25 +242,25 @@ int initFieldTest() {
    // 2D Fields on device
 
    DimNames[0] = "NCells";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    auto Test2DI4 =
        Field::create("Test2DI4", "Test 2DI4 field on device", "Units2DI4",
                      "var_name_2DI4", 0, 100000, 999, 2, DimNames);
 
    DimNames[0] = "NEdges";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    auto Test2DI8 =
        Field::create("Test2DI8", "Test 2DI8 field on device", "Units2DI8",
                      "var_name_2DI8", 0, 100000, 999, 2, DimNames);
 
    DimNames[0] = "NVertices";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    auto Test2DR4 =
        Field::create("Test2DR4", "Test 2DR4 field on device", "Units2DR4",
                      "var_name_2DR4", 0.0, 100000.0, 999, 2, DimNames);
 
    DimNames[0] = "NEdges";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    auto Test2DR8 =
        Field::create("Test2DR8", "Test 2DR8 field on device", "Units2DR8",
                      "var_name_2DR8", 0.0, 100000.0, 999, 2, DimNames);
@@ -269,7 +269,7 @@ int initFieldTest() {
 
    DimNames.resize(3);
    DimNames[0] = "NCells";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    DimNames[2] = "NTracers";
    auto Test3DI4 =
        Field::create("Test3DI4", "Test 3DI4 field on device", "Units3DI4",
@@ -277,7 +277,7 @@ int initFieldTest() {
 
    DimNames.resize(4);
    DimNames[0] = "NCells";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    DimNames[2] = "NTracers";
    DimNames[3] = "NTime";
    auto Test4DI8 =
@@ -286,7 +286,7 @@ int initFieldTest() {
 
    DimNames.resize(5);
    DimNames[0] = "NCells";
-   DimNames[1] = "NVertLevels";
+   DimNames[1] = "NVertLayers";
    DimNames[2] = "NTracers";
    DimNames[3] = "NTime";
    DimNames[4] = "NStuff";
@@ -323,36 +323,36 @@ int initFieldTest() {
    HostArray1DI4 Data1DI4H("Test1DI4H", NCellsSize);
    HostArray1DI8 Data1DI8H("Test1DI8H", NEdgesSize);
    HostArray1DR4 Data1DR4H("Test1DR4H", NVerticesSize);
-   HostArray1DR8 Data1DR8H("Test1DR8H", NVertLevels);
+   HostArray1DR8 Data1DR8H("Test1DR8H", NVertLayers);
 
-   HostArray2DI4 Data2DI4H("Test2DI4H", NCellsSize, NVertLevels);
-   HostArray2DI8 Data2DI8H("Test2DI8H", NEdgesSize, NVertLevels);
-   HostArray2DR4 Data2DR4H("Test2DR4H", NVerticesSize, NVertLevels);
-   HostArray2DR8 Data2DR8H("Test2DR8H", NCellsSize, NVertLevels);
+   HostArray2DI4 Data2DI4H("Test2DI4H", NCellsSize, NVertLayers);
+   HostArray2DI8 Data2DI8H("Test2DI8H", NEdgesSize, NVertLayers);
+   HostArray2DR4 Data2DR4H("Test2DR4H", NVerticesSize, NVertLayers);
+   HostArray2DR8 Data2DR8H("Test2DR8H", NCellsSize, NVertLayers);
 
    Array1DI4 Data1DI4("Test1DI4", NCellsSize);
    Array1DI8 Data1DI8("Test1DI8", NEdgesSize);
    Array1DR4 Data1DR4("Test1DR4", NVerticesSize);
-   Array1DR8 Data1DR8("Test1DR8", NVertLevels);
+   Array1DR8 Data1DR8("Test1DR8", NVertLayers);
 
-   Array2DI4 Data2DI4("Test2DI4", NCellsSize, NVertLevels);
-   Array2DI8 Data2DI8("Test2DI8", NEdgesSize, NVertLevels);
-   Array2DR4 Data2DR4("Test2DR4", NVerticesSize, NVertLevels);
-   Array2DR8 Data2DR8("Test2DR8", NEdgesSize, NVertLevels);
+   Array2DI4 Data2DI4("Test2DI4", NCellsSize, NVertLayers);
+   Array2DI8 Data2DI8("Test2DI8", NEdgesSize, NVertLayers);
+   Array2DR4 Data2DR4("Test2DR4", NVerticesSize, NVertLayers);
+   Array2DR8 Data2DR8("Test2DR8", NEdgesSize, NVertLayers);
 
-   Array3DI4 Data3DI4("Test3DI4", NCellsSize, NVertLevels, NTracers);
-   Array4DI8 Data4DI8("Test4DI8", NCellsSize, NVertLevels, NTracers, NTime);
-   Array5DR4 Data5DR4("Test5DR4", NCellsSize, NVertLevels, NTracers, NTime,
+   Array3DI4 Data3DI4("Test3DI4", NCellsSize, NVertLayers, NTracers);
+   Array4DI8 Data4DI8("Test4DI8", NCellsSize, NVertLayers, NTracers, NTime);
+   Array5DR4 Data5DR4("Test5DR4", NCellsSize, NVertLayers, NTracers, NTime,
                       NStuff);
 
    // Host arrays vertical vector
-   for (int K = 0; K < NVertLevels; ++K) {
+   for (int K = 0; K < NVertLayers; ++K) {
       Data1DR8H(K) = RefR8 + K;
    }
    // Host arrays on cells
    for (int Cell = 0; Cell < NCellsSize; ++Cell) {
       Data1DI4H(Cell) = RefI4 + Cell;
-      for (int K = 0; K < NVertLevels; ++K) {
+      for (int K = 0; K < NVertLayers; ++K) {
          Data2DI4H(Cell, K) = RefI4 + Cell + K;
          Data2DR8H(Cell, K) = RefR8 + Cell + K;
       }
@@ -360,25 +360,25 @@ int initFieldTest() {
    // Host arrays on edges
    for (int Edge = 0; Edge < NEdgesSize; ++Edge) {
       Data1DI8H(Edge) = RefI8 + Edge;
-      for (int K = 0; K < NVertLevels; ++K) {
+      for (int K = 0; K < NVertLayers; ++K) {
          Data2DI8H(Edge, K) = RefI8 + Edge + K;
       }
    }
    // Host arrays on vertices
    for (int Vrtx = 0; Vrtx < NVerticesSize; ++Vrtx) {
       Data1DR4H(Vrtx) = RefR4 + Vrtx;
-      for (int K = 0; K < NVertLevels; ++K) {
+      for (int K = 0; K < NVertLayers; ++K) {
          Data2DR4H(Vrtx, K) = RefR4 + Vrtx + K;
       }
    }
    // Device array vertical vector
    parallelFor(
-       {NVertLevels}, KOKKOS_LAMBDA(int K) { Data1DR8(K) = RefR8 + K; });
+       {NVertLayers}, KOKKOS_LAMBDA(int K) { Data1DR8(K) = RefR8 + K; });
    // Device arrays on cells
    parallelFor(
        {NCellsSize}, KOKKOS_LAMBDA(int Cell) {
           Data1DI4(Cell) = RefI4 + Cell;
-          for (int K = 0; K < NVertLevels; ++K) {
+          for (int K = 0; K < NVertLayers; ++K) {
              Data2DI4(Cell, K) = RefI4 + Cell + K;
              for (int Trcr = 0; Trcr < NTracers; ++Trcr) {
                 Data3DI4(Cell, K, Trcr) = RefI4 + Cell + K + Trcr;
@@ -397,7 +397,7 @@ int initFieldTest() {
    parallelFor(
        {NEdgesSize}, KOKKOS_LAMBDA(int Edge) {
           Data1DI8(Edge) = RefI8 + Edge;
-          for (int K = 0; K < NVertLevels; ++K) {
+          for (int K = 0; K < NVertLayers; ++K) {
              Data2DI8(Edge, K) = RefI8 + Edge + K;
              Data2DR8(Edge, K) = RefR8 + Edge + K;
           }
@@ -406,7 +406,7 @@ int initFieldTest() {
    parallelFor(
        {NVerticesSize}, KOKKOS_LAMBDA(int Vrtx) {
           Data1DR4(Vrtx) = RefR4 + Vrtx;
-          for (int K = 0; K < NVertLevels; ++K) {
+          for (int K = 0; K < NVertLayers; ++K) {
              Data2DR4(Vrtx, K) = RefR4 + Vrtx + K;
           }
        });
@@ -488,7 +488,7 @@ int main(int argc, char **argv) {
       I4 NCellsSize     = DefDecomp->NCellsSize;
       I4 NEdgesSize     = DefDecomp->NEdgesSize;
       I4 NVerticesSize  = DefDecomp->NVerticesSize;
-      I4 NVertLevels    = 100;
+      I4 NVertLayers    = 100;
       I4 NTracers       = 2;
       I4 NTime          = 2;
       I4 NStuff         = 2;
@@ -656,7 +656,7 @@ int main(int argc, char **argv) {
       TstEval<std::string>("Retrieve dim names 5 result 1", DimNames[0],
                            "NCells", Err);
       TstEval<std::string>("Retrieve dim names 5 result 2", DimNames[1],
-                           "NVertLevels", Err);
+                           "NVertLayers", Err);
       TstEval<std::string>("Retrieve dim names 5 result 3", DimNames[2],
                            "NTracers", Err);
       TstEval<std::string>("Retrieve dim names 5 result 4", DimNames[3],
@@ -772,7 +772,7 @@ int main(int argc, char **argv) {
       // Test values for correctness
       // Host arrays vertical vector
       int DataCount1 = 0;
-      for (int K = 0; K < NVertLevels; ++K) {
+      for (int K = 0; K < NVertLayers; ++K) {
          if (Data1DR8H(K) != RefR8 + K)
             ++DataCount1;
       }
@@ -785,7 +785,7 @@ int main(int argc, char **argv) {
       for (int Cell = 0; Cell < NCellsSize; ++Cell) {
          if (Data1DI4H(Cell) != RefI4 + Cell)
             ++DataCount1;
-         for (int K = 0; K < NVertLevels; ++K) {
+         for (int K = 0; K < NVertLayers; ++K) {
             if (Data2DI4H(Cell, K) != RefI4 + Cell + K)
                ++DataCount2;
             if (Data2DR8H(Cell, K) != RefR8 + Cell + K)
@@ -802,7 +802,7 @@ int main(int argc, char **argv) {
       for (int Edge = 0; Edge < NEdgesSize; ++Edge) {
          if (Data1DI8H(Edge) != RefI8 + Edge)
             ++DataCount1;
-         for (int K = 0; K < NVertLevels; ++K) {
+         for (int K = 0; K < NVertLayers; ++K) {
             if (Data2DI8H(Edge, K) != RefI8 + Edge + K)
                ++DataCount2;
          }
@@ -816,7 +816,7 @@ int main(int argc, char **argv) {
       for (int Vrtx = 0; Vrtx < NVerticesSize; ++Vrtx) {
          if (Data1DR4H(Vrtx) != RefR4 + Vrtx)
             ++DataCount1;
-         for (int K = 0; K < NVertLevels; ++K) {
+         for (int K = 0; K < NVertLayers; ++K) {
             if (Data2DR4H(Vrtx, K) != RefR4 + Vrtx + K)
                ++DataCount2;
          }
@@ -830,7 +830,7 @@ int main(int argc, char **argv) {
 
       // Device array vertical vector
       parallelReduce(
-          {NVertLevels},
+          {NVertLayers},
           KOKKOS_LAMBDA(int K, I4 &LCount) {
              if (Data1DR8(K) != RefR8 + K)
                 ++LCount;
@@ -845,12 +845,12 @@ int main(int argc, char **argv) {
           KOKKOS_LAMBDA(int Cell, I4 &LCount) {
              if (Data1DI4(Cell) != RefI4 + Cell)
                 ++LCount;
-             for (int K = 0; K < NVertLevels; ++K) {
-                int Add2 = Cell * NVertLevels + K;
+             for (int K = 0; K < NVertLayers; ++K) {
+                int Add2 = Cell * NVertLayers + K;
                 if (Data2DI4(Cell, K) != RefI4 + Cell + K)
                    ++LCount;
                 for (int Trcr = 0; Trcr < NTracers; ++Trcr) {
-                   int Add3 = Trcr * NCellsSize * NVertLevels + Add2;
+                   int Add3 = Trcr * NCellsSize * NVertLayers + Add2;
                    if (Data3DI4(Cell, K, Trcr) != RefI4 + Cell + K + Trcr)
                       ++LCount;
                    for (int TimeLvl = 0; TimeLvl < NTime; ++TimeLvl) {
@@ -875,7 +875,7 @@ int main(int argc, char **argv) {
           KOKKOS_LAMBDA(int Edge, I4 &LCount) {
              if (Data1DI8(Edge) != RefI8 + Edge)
                 ++LCount;
-             for (int K = 0; K < NVertLevels; ++K) {
+             for (int K = 0; K < NVertLayers; ++K) {
                 if (Data2DI8(Edge, K) != RefI8 + Edge + K)
                    ++LCount;
                 if (Data2DR8(Edge, K) != RefR8 + Edge + K)
@@ -891,7 +891,7 @@ int main(int argc, char **argv) {
           KOKKOS_LAMBDA(int Vrtx, I4 &LCount) {
              if (Data1DR4(Vrtx) != RefR4 + Vrtx)
                 ++LCount;
-             for (int K = 0; K < NVertLevels; ++K) {
+             for (int K = 0; K < NVertLayers; ++K) {
                 if (Data2DR4(Vrtx, K) != RefR4 + Vrtx + K)
                    ++LCount;
              }

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -14,6 +14,7 @@
 #include "Pacer.h"
 #include "TimeStepper.h"
 #include "Tracers.h"
+#include "VertCoord.h"
 #include "mpi.h"
 
 #include <cmath>
@@ -43,7 +44,7 @@ struct TestSetup {
 };
 
 constexpr Geometry Geom   = Geometry::Spherical;
-constexpr int NVertLevels = 60;
+constexpr int NVertLayers = 60;
 
 int initState() {
    int Err = 0;
@@ -111,12 +112,11 @@ int initAuxStateTest(const std::string &mesh) {
       LOG_ERROR("AuxStateTest: error initializing default halo");
    }
 
+   VertCoord::init();
    HorzMesh::init();
    Tracers::init();
 
    const auto &Mesh = HorzMesh::getDefault();
-   // Horz dimensions created in HorzMesh
-   auto VertDim = Dimension::create("NVertLevels", NVertLevels);
 
    int StateErr = OceanState::init();
    if (StateErr != 0) {
@@ -288,6 +288,7 @@ void finalizeAuxStateTest() {
    Dimension::clear();
    TimeStepper::clear();
    HorzMesh::clear();
+   VertCoord::clear();
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -11,6 +11,7 @@
 #include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
+#include "VertCoord.h"
 #include "auxiliaryVars/KineticAuxVars.h"
 #include "auxiliaryVars/LayerThicknessAuxVars.h"
 #include "auxiliaryVars/TracerAuxVars.h"
@@ -309,7 +310,7 @@ constexpr char DefaultMeshFile[] = "OmegaSphereMesh.nc";
 using TestSetup                  = TestSetupSphere;
 #endif
 
-constexpr int NVertLevels = 16;
+constexpr int NVertLayers = 16;
 constexpr int NTracers    = 3;
 
 int initState(const Array2DReal &LayerThickCell,
@@ -349,24 +350,24 @@ int testKineticAuxVars(const Array2DReal &LayerThicknessCell,
    // Compute exact result
 
    Array2DReal ExactKineticEnergyCell("ExactKineticEnergyCell",
-                                      Mesh->NCellsOwned, NVertLevels);
+                                      Mesh->NCellsOwned, NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.kineticEnergy(X, Y); },
        ExactKineticEnergyCell, Geom, Mesh, OnCell, ExchangeHalos::No);
 
    Array2DReal ExactVelocityDivCell("ExactVelocityDivCell", Mesh->NCellsOwned,
-                                    NVertLevels);
+                                    NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.divergence(X, Y); },
        ExactVelocityDivCell, Geom, Mesh, OnCell, ExchangeHalos::No);
 
    // Compute numerical result
 
-   KineticAuxVars KineticAux("", Mesh, NVertLevels);
+   KineticAuxVars KineticAux("", Mesh, NVertLayers);
 
    parallelFor(
-       {Mesh->NCellsOwned, NVertLevels}, KOKKOS_LAMBDA(int ICell, int KLevel) {
-          KineticAux.computeVarsOnCell(ICell, KLevel, NormalVelocityEdge);
+       {Mesh->NCellsOwned, NVertLayers}, KOKKOS_LAMBDA(int ICell, int KLayer) {
+          KineticAux.computeVarsOnCell(ICell, KLayer, NormalVelocityEdge);
        });
    const auto &NumKineticEnergyCell = KineticAux.KineticEnergyCell;
    const auto &NumVelocityDivCell   = KineticAux.VelocityDivCell;
@@ -452,18 +453,18 @@ int testLayerThicknessAuxVars(const Array2DReal &LayerThickCell,
 
    // Compute exact result
 
-   Array2DReal ExactThickEdge("ExactThickEdge", Mesh->NEdgesOwned, NVertLevels);
+   Array2DReal ExactThickEdge("ExactThickEdge", Mesh->NEdgesOwned, NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.layerThickness(X, Y); },
        ExactThickEdge, Geom, Mesh, OnEdge, ExchangeHalos::No);
 
    // Compute numerical result
 
-   LayerThicknessAuxVars LayerThicknessAux("", Mesh, NVertLevels);
+   LayerThicknessAuxVars LayerThicknessAux("", Mesh, NVertLayers);
    LayerThicknessAux.FluxThickEdgeChoice = FluxThickEdgeOption::Upwind;
    parallelFor(
-       {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int KLevel) {
-          LayerThicknessAux.computeVarsOnEdge(IEdge, KLevel, LayerThickCell,
+       {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int KLayer) {
+          LayerThicknessAux.computeVarsOnEdge(IEdge, KLayer, LayerThickCell,
                                               NormalVelEdge);
        });
 
@@ -498,18 +499,18 @@ int testVorticityAuxVars(const Array2DReal &LayerThickCell,
 
    const auto Decomp = Decomp::getDefault();
    const auto Mesh   = HorzMesh::getDefault();
-   VorticityAuxVars VorticityAux("", Mesh, NVertLevels);
+   VorticityAuxVars VorticityAux("", Mesh, NVertLayers);
 
    // Compute exact results for vertex variables
 
    Array2DReal ExactRelVortVertex("ExactRelVortVertex", Mesh->NVerticesOwned,
-                                  NVertLevels);
+                                  NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.relativeVorticity(X, Y); },
        ExactRelVortVertex, Geom, Mesh, OnVertex, ExchangeHalos::No);
 
    Array2DReal ExactNormRelVortVertex("ExactNormRelVortVertex",
-                                      Mesh->NVerticesOwned, NVertLevels);
+                                      Mesh->NVerticesOwned, NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) {
           return Setup.normalizedRelativeVorticity(X, Y);
@@ -517,7 +518,7 @@ int testVorticityAuxVars(const Array2DReal &LayerThickCell,
        ExactNormRelVortVertex, Geom, Mesh, OnVertex, ExchangeHalos::No);
 
    Array2DReal ExactNormPlanetVortVertex("ExactNormPlanetVortVertex",
-                                         Mesh->NVerticesOwned, NVertLevels);
+                                         Mesh->NVerticesOwned, NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) {
           return Setup.normalizedPlanetaryVorticity(X, Y);
@@ -527,9 +528,9 @@ int testVorticityAuxVars(const Array2DReal &LayerThickCell,
    // Compute numerical results for vertex variables
 
    parallelFor(
-       {Decomp->NVerticesHaloH(0), NVertLevels},
-       KOKKOS_LAMBDA(int IVertex, int KLevel) {
-          VorticityAux.computeVarsOnVertex(IVertex, KLevel, LayerThickCell,
+       {Decomp->NVerticesHaloH(0), NVertLayers},
+       KOKKOS_LAMBDA(int IVertex, int KLayer) {
+          VorticityAux.computeVarsOnVertex(IVertex, KLayer, LayerThickCell,
                                            NormalVelEdge);
        });
 
@@ -562,7 +563,7 @@ int testVorticityAuxVars(const Array2DReal &LayerThickCell,
    // Compute exact results for edge variables
 
    Array2DReal ExactNormRelVortEdge("ExactNormRelVortEdge", Mesh->NEdgesOwned,
-                                    NVertLevels);
+                                    NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) {
           return Setup.normalizedRelativeVorticity(X, Y);
@@ -570,7 +571,7 @@ int testVorticityAuxVars(const Array2DReal &LayerThickCell,
        ExactNormRelVortEdge, Geom, Mesh, OnEdge, ExchangeHalos::No);
 
    Array2DReal ExactNormPlanetVortEdge("ExactNormPlanetVortEdge",
-                                       Mesh->NEdgesOwned, NVertLevels);
+                                       Mesh->NEdgesOwned, NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) {
           return Setup.normalizedPlanetaryVorticity(X, Y);
@@ -580,8 +581,8 @@ int testVorticityAuxVars(const Array2DReal &LayerThickCell,
    // Compute numerical results for vertex variables
 
    parallelFor(
-       {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int KLevel) {
-          VorticityAux.computeVarsOnEdge(IEdge, KLevel);
+       {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int KLayer) {
+          VorticityAux.computeVarsOnEdge(IEdge, KLayer);
        });
    const auto &NumNormRelVortEdge    = VorticityAux.NormRelVortEdge;
    const auto &NumNormPlanetVortEdge = VorticityAux.NormPlanetVortEdge;
@@ -614,25 +615,25 @@ int testVelocityDel2AuxVars(Real RTol) {
 
    const auto Decomp = Decomp::getDefault();
    const auto Mesh   = HorzMesh::getDefault();
-   VelocityDel2AuxVars VelocityDel2Aux("", Mesh, NVertLevels);
+   VelocityDel2AuxVars VelocityDel2Aux("", Mesh, NVertLayers);
 
    // Use analytical expressions to compute inputs
 
    Array2DReal ExactVelocityDivCell("ExactVelocityDivCell", Mesh->NCellsSize,
-                                    NVertLevels);
+                                    NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.divergence(X, Y); },
        ExactVelocityDivCell, Geom, Mesh, OnCell);
 
    Array2DReal ExactRelVortVertex("ExactRelVortVertex", Mesh->NVerticesSize,
-                                  NVertLevels);
+                                  NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.relativeVorticity(X, Y); },
        ExactRelVortVertex, Geom, Mesh, OnVertex);
 
    // Compute exact Del2
 
-   Array2DReal ExactDel2Edge("ExactDel2Edge", Mesh->NEdgesOwned, NVertLevels);
+   Array2DReal ExactDel2Edge("ExactDel2Edge", Mesh->NEdgesOwned, NVertLayers);
    Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
           VecField[0] = Setup.velocityDel2X(X, Y);
@@ -643,9 +644,9 @@ int testVelocityDel2AuxVars(Real RTol) {
    // Compute numerical Del2
 
    parallelFor(
-       {Decomp->NEdgesHaloH(1), NVertLevels},
-       KOKKOS_LAMBDA(int IEdge, int KLevel) {
-          VelocityDel2Aux.computeVarsOnEdge(IEdge, KLevel, ExactVelocityDivCell,
+       {Decomp->NEdgesHaloH(1), NVertLayers},
+       KOKKOS_LAMBDA(int IEdge, int KLayer) {
+          VelocityDel2Aux.computeVarsOnEdge(IEdge, KLayer, ExactVelocityDivCell,
                                             ExactRelVortVertex);
        });
    const auto &NumDel2Edge = VelocityDel2Aux.Del2Edge;
@@ -661,7 +662,7 @@ int testVelocityDel2AuxVars(Real RTol) {
    // Compute exact Del2Div
 
    Array2DReal ExactDel2DivCell("ExactDel2DivCell", Mesh->NCellsOwned,
-                                NVertLevels);
+                                NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.velocityDel2Div(X, Y); },
        ExactDel2DivCell, Geom, Mesh, OnCell, ExchangeHalos::No);
@@ -669,8 +670,8 @@ int testVelocityDel2AuxVars(Real RTol) {
    // Compute numerical Del2Div
 
    parallelFor(
-       {Mesh->NCellsOwned, NVertLevels}, KOKKOS_LAMBDA(int ICell, int KLevel) {
-          VelocityDel2Aux.computeVarsOnCell(ICell, KLevel);
+       {Mesh->NCellsOwned, NVertLayers}, KOKKOS_LAMBDA(int ICell, int KLayer) {
+          VelocityDel2Aux.computeVarsOnCell(ICell, KLayer);
        });
    const auto &NumDel2DivCell = VelocityDel2Aux.Del2DivCell;
 
@@ -685,7 +686,7 @@ int testVelocityDel2AuxVars(Real RTol) {
    // Compute exact Del2RelVort
 
    Array2DReal ExactDel2RelVortVertex("ExactDel2RelVortVertex",
-                                      Mesh->NVerticesOwned, NVertLevels);
+                                      Mesh->NVerticesOwned, NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.velocityDel2Curl(X, Y); },
        ExactDel2RelVortVertex, Geom, Mesh, OnVertex, ExchangeHalos::No);
@@ -693,9 +694,9 @@ int testVelocityDel2AuxVars(Real RTol) {
    // Compute numerical Del2RelVort
 
    parallelFor(
-       {Mesh->NVerticesOwned, NVertLevels},
-       KOKKOS_LAMBDA(int IVertex, int KLevel) {
-          VelocityDel2Aux.computeVarsOnVertex(IVertex, KLevel);
+       {Mesh->NVerticesOwned, NVertLayers},
+       KOKKOS_LAMBDA(int IVertex, int KLayer) {
+          VelocityDel2Aux.computeVarsOnVertex(IVertex, KLayer);
        });
    const auto &NumDel2RelVortVertex = VelocityDel2Aux.Del2RelVortVertex;
 
@@ -722,18 +723,18 @@ int testTracerAuxVars(const Array2DReal &LayerThickCell,
 
    const auto Mesh = HorzMesh::getDefault();
 
-   TracerAuxVars TracerAux("", Mesh, NVertLevels, NTracers);
+   TracerAuxVars TracerAux("", Mesh, NVertLayers, NTracers);
    TracerAux.TracersOnEdgeChoice = FluxTracerEdgeOption::Upwind;
 
    // Set input arrays
 
    Array3DReal TracersOnCell("TracersOnCell", NTracers, Mesh->NCellsSize,
-                             NVertLevels);
+                             NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.tracer(X, Y); },
        TracersOnCell, Geom, Mesh, OnCell);
 
-   Array2DReal LayerThickEdge("LayerThickEdge", Mesh->NEdgesSize, NVertLevels);
+   Array2DReal LayerThickEdge("LayerThickEdge", Mesh->NEdgesSize, NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.layerThickness(X, Y); },
        LayerThickEdge, Geom, Mesh, OnEdge);
@@ -741,7 +742,7 @@ int testTracerAuxVars(const Array2DReal &LayerThickCell,
    // Compute exact HTracerEdge
 
    Array3DReal ExactHTrEdge("ExactHTrEdge", NTracers, Mesh->NEdgesOwned,
-                            NVertLevels);
+                            NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.thickTracer(X, Y); },
        ExactHTrEdge, Geom, Mesh, OnEdge, ExchangeHalos::No);
@@ -749,9 +750,9 @@ int testTracerAuxVars(const Array2DReal &LayerThickCell,
    // Compute numerical HTracersEdge
 
    parallelFor(
-       {NTracers, Mesh->NEdgesOwned, NVertLevels},
-       KOKKOS_LAMBDA(int L, int IEdge, int KLevel) {
-          TracerAux.computeVarsOnEdge(L, IEdge, KLevel, NormalVelEdge,
+       {NTracers, Mesh->NEdgesOwned, NVertLayers},
+       KOKKOS_LAMBDA(int L, int IEdge, int KLayer) {
+          TracerAux.computeVarsOnEdge(L, IEdge, KLayer, NormalVelEdge,
                                       LayerThickCell, TracersOnCell);
        });
 
@@ -767,7 +768,7 @@ int testTracerAuxVars(const Array2DReal &LayerThickCell,
    // Compute exact Del2TracerCell
 
    Array3DReal ExactDel2TrCell("ExactDel2TrCell", NTracers, Mesh->NCellsOwned,
-                               NVertLevels);
+                               NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.del2Tracer(X, Y); },
        ExactDel2TrCell, Geom, Mesh, OnCell, ExchangeHalos::No);
@@ -775,9 +776,9 @@ int testTracerAuxVars(const Array2DReal &LayerThickCell,
    // Compute numerical Del2TracerCell
 
    parallelFor(
-       {NTracers, Mesh->NCellsOwned, NVertLevels},
-       KOKKOS_LAMBDA(int L, int ICell, int KLevel) {
-          TracerAux.computeVarsOnCells(L, ICell, KLevel, LayerThickEdge,
+       {NTracers, Mesh->NCellsOwned, NVertLayers},
+       KOKKOS_LAMBDA(int L, int ICell, int KLayer) {
+          TracerAux.computeVarsOnCells(L, ICell, KLayer, LayerThickEdge,
                                        TracersOnCell);
        });
 
@@ -827,6 +828,8 @@ int initAuxVarsTest(const std::string &mesh) {
       LOG_ERROR("AuxVarsTest: error initializing default halo");
    }
 
+   VertCoord::init();
+
    HorzMesh::init();
 
    return Err;
@@ -836,6 +839,7 @@ void finalizeAuxVarsTest() {
    Field::clear();
    Dimension::clear();
    HorzMesh::clear();
+   VertCoord::clear();
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();
@@ -849,8 +853,8 @@ int auxVarsTest(const std::string &mesh = DefaultMeshFile) {
 
    const auto &Mesh = HorzMesh::getDefault();
 
-   Array2DReal LayerThickCell("LayerThickCell", Mesh->NCellsSize, NVertLevels);
-   Array2DReal NormalVelEdge("NormalVelEdge", Mesh->NEdgesSize, NVertLevels);
+   Array2DReal LayerThickCell("LayerThickCell", Mesh->NCellsSize, NVertLayers);
+   Array2DReal NormalVelEdge("NormalVelEdge", Mesh->NEdgesSize, NVertLayers);
    Err += initState(LayerThickCell, NormalVelEdge, Mesh);
 
    const Real RTol = sizeof(Real) == 4 ? 1e-2 : 2e-4;

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -20,6 +20,7 @@
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
+#include "VertCoord.h"
 #include "mpi.h"
 
 #include <iostream>
@@ -60,6 +61,9 @@ int initHorzMeshTest() {
    Err = Halo::init();
    if (Err != 0)
       LOG_ERROR("HorzMeshTest: error initializing default halo");
+
+   // Initialize the vertical coordinate
+   VertCoord::init();
 
    // Initialize the default mesh
    HorzMesh::init();
@@ -771,6 +775,7 @@ int main(int argc, char *argv[]) {
       }
       // Finalize Omega objects
       HorzMesh::clear();
+      VertCoord::clear();
       Dimension::clear();
       Halo::clear();
       Decomp::clear();

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -11,6 +11,7 @@
 #include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
+#include "VertCoord.h"
 #include "mpi.h"
 
 #include <cmath>
@@ -187,10 +188,10 @@ int testDivergence(Real RTol) {
    TestSetup Setup;
 
    const auto &Mesh      = HorzMesh::getDefault();
-   const int NVertLevels = 16;
+   const int NVertLayers = 16;
 
    // Prepare operator input
-   Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLevels);
+   Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLayers);
    Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
           VecField[0] = Setup.exactVecX(X, Y);
@@ -199,16 +200,16 @@ int testDivergence(Real RTol) {
        VecEdge, EdgeComponent::Normal, Geom, Mesh);
 
    // Compute exact result
-   Array2DReal ExactDivCell("ExactDivCell", Mesh->NCellsOwned, NVertLevels);
+   Array2DReal ExactDivCell("ExactDivCell", Mesh->NCellsOwned, NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.exactDivVec(X, Y); },
        ExactDivCell, Geom, Mesh, OnCell, ExchangeHalos::No);
 
    // Compute numerical result
-   Array2DReal NumDivCell("NumDivCell", Mesh->NCellsOwned, NVertLevels);
+   Array2DReal NumDivCell("NumDivCell", Mesh->NCellsOwned, NVertLayers);
    DivergenceOnCell DivergenceCell(Mesh);
    parallelFor(
-       {Mesh->NCellsOwned, NVertLevels}, KOKKOS_LAMBDA(int ICell, int K) {
+       {Mesh->NCellsOwned, NVertLayers}, KOKKOS_LAMBDA(int ICell, int K) {
           DivergenceCell(NumDivCell, ICell, K, VecEdge);
        });
 
@@ -231,10 +232,10 @@ int testGradient(Real RTol) {
    TestSetup Setup;
 
    const auto &Mesh      = HorzMesh::getDefault();
-   const int NVertLevels = 16;
+   const int NVertLayers = 16;
 
    // Prepare operator input
-   Array2DReal ScalarCell("ScalarCell", Mesh->NCellsSize, NVertLevels);
+   Array2DReal ScalarCell("ScalarCell", Mesh->NCellsSize, NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real Coord1, Real Coord2) {
           return Setup.exactScalar(Coord1, Coord2);
@@ -242,7 +243,7 @@ int testGradient(Real RTol) {
        ScalarCell, Geom, Mesh, OnCell);
 
    // Compute exact result
-   Array2DReal ExactGradEdge("ExactGradEdge", Mesh->NEdgesOwned, NVertLevels);
+   Array2DReal ExactGradEdge("ExactGradEdge", Mesh->NEdgesOwned, NVertLayers);
    Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
           VecField[0] = Setup.exactGradScalarX(X, Y);
@@ -252,9 +253,9 @@ int testGradient(Real RTol) {
 
    // Compute numerical result
    GradientOnEdge GradientEdge(Mesh);
-   Array2DReal NumGradEdge("NumGradEdge", Mesh->NEdgesOwned, NVertLevels);
+   Array2DReal NumGradEdge("NumGradEdge", Mesh->NEdgesOwned, NVertLayers);
    parallelFor(
-       {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
+       {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int K) {
           GradientEdge(NumGradEdge, IEdge, K, ScalarCell);
        });
 
@@ -276,10 +277,10 @@ int testCurl(Real RTol) {
    int Err = 0;
    TestSetup Setup;
    const auto &Mesh      = HorzMesh::getDefault();
-   const int NVertLevels = 16;
+   const int NVertLayers = 16;
 
    // Prepare operator input
-   Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLevels);
+   Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLayers);
    Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
           VecField[0] = Setup.exactVecX(X, Y);
@@ -289,17 +290,17 @@ int testCurl(Real RTol) {
 
    // Compute exact result
    Array2DReal ExactCurlVertex("ExactCurlVertex", Mesh->NVerticesOwned,
-                               NVertLevels);
+                               NVertLayers);
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.exactCurlVec(X, Y); },
        ExactCurlVertex, Geom, Mesh, OnVertex, ExchangeHalos::No);
 
    // Compute numerical result
    Array2DReal NumCurlVertex("NumCurlVertex", Mesh->NVerticesOwned,
-                             NVertLevels);
+                             NVertLayers);
    CurlOnVertex CurlVertex(Mesh);
    parallelFor(
-       {Mesh->NVerticesOwned, NVertLevels}, KOKKOS_LAMBDA(int IVertex, int K) {
+       {Mesh->NVerticesOwned, NVertLayers}, KOKKOS_LAMBDA(int IVertex, int K) {
           CurlVertex(NumCurlVertex, IVertex, K, VecEdge);
        });
 
@@ -323,10 +324,10 @@ int testRecon(Real RTol) {
    TestSetup Setup;
 
    const auto &Mesh      = HorzMesh::getDefault();
-   const int NVertLevels = 16;
+   const int NVertLayers = 16;
 
    // Prepare operator input
-   Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLevels);
+   Array2DReal VecEdge("VecEdge", Mesh->NEdgesSize, NVertLayers);
    Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
           VecField[0] = Setup.exactVecX(X, Y);
@@ -335,7 +336,7 @@ int testRecon(Real RTol) {
        VecEdge, EdgeComponent::Normal, Geom, Mesh);
 
    // Compute exact result
-   Array2DReal ExactReconEdge("ExactReconEdge", Mesh->NEdgesOwned, NVertLevels);
+   Array2DReal ExactReconEdge("ExactReconEdge", Mesh->NEdgesOwned, NVertLayers);
 
    Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
@@ -346,10 +347,10 @@ int testRecon(Real RTol) {
        ExchangeHalos::No);
 
    // Compute numerical result
-   Array2DReal NumReconEdge("NumReconEdge", Mesh->NEdgesOwned, NVertLevels);
+   Array2DReal NumReconEdge("NumReconEdge", Mesh->NEdgesOwned, NVertLayers);
    TangentialReconOnEdge TanReconEdge(Mesh);
    parallelFor(
-       {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
+       {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int K) {
           TanReconEdge(NumReconEdge, IEdge, K, VecEdge);
        });
 
@@ -454,6 +455,8 @@ int initOperatorsTest(const std::string &MeshFile) {
       LOG_ERROR("OperatorsTest: error initializing default halo");
    }
 
+   VertCoord::init();
+
    HorzMesh::init();
 
    return Err;
@@ -461,6 +464,7 @@ int initOperatorsTest(const std::string &MeshFile) {
 
 void finalizeOperatorsTest() {
    HorzMesh::clear();
+   VertCoord::clear();
    Dimension::clear();
    Halo::clear();
    Decomp::clear();

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -124,10 +124,10 @@ int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
    }
 
    if constexpr (Array::rank == 2) {
-      const int NVertLevels = ScalarElement.extent_int(1);
+      const int NVertLayers = ScalarElement.extent_int(1);
 
       parallelFor(
-          {NElementsOwned, NVertLevels}, KOKKOS_LAMBDA(int IElement, int K) {
+          {NElementsOwned, NVertLayers}, KOKKOS_LAMBDA(int IElement, int K) {
              if (Geom == Geometry::Planar) {
                 const Real X               = XElement(IElement);
                 const Real Y               = YElement(IElement);
@@ -142,9 +142,9 @@ int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
 
    if constexpr (Array::rank == 3) {
       const int NTracers    = ScalarElement.extent_int(0);
-      const int NVertLevels = ScalarElement.extent_int(2);
+      const int NVertLayers = ScalarElement.extent_int(2);
       parallelFor(
-          {NTracers, NElementsOwned, NVertLevels},
+          {NTracers, NElementsOwned, NVertLayers},
           KOKKOS_LAMBDA(int L, int IElement, int K) {
              if (Geom == Geometry::Planar) {
                 const Real X                  = XElement(IElement);
@@ -284,9 +284,9 @@ int setVectorEdge(const Functor &Fun, const Array &VectorFieldEdge,
    }
 
    if constexpr (Array::rank == 2) {
-      const int NVertLevels = VectorFieldEdge.extent_int(1);
+      const int NVertLayers = VectorFieldEdge.extent_int(1);
       parallelFor(
-          {Mesh->NEdgesOwned, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
+          {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int K) {
              VectorFieldEdge(IEdge, K) = ProjectVector(IEdge);
           });
    }
@@ -469,16 +469,16 @@ int computeErrors(ErrorMeasures &ErrorMeasures, const Array &NumFieldElement,
           });
    }
    if constexpr (Array::rank == 2) {
-      const int NVertLevels = NumFieldElement.extent_int(1);
+      const int NVertLayers = NumFieldElement.extent_int(1);
 
-      LInfElement = Array("LInfElement", NElementsOwned, NVertLevels);
-      L2Element   = Array("L2Element", NElementsOwned, NVertLevels);
+      LInfElement = Array("LInfElement", NElementsOwned, NVertLayers);
+      L2Element   = Array("L2Element", NElementsOwned, NVertLayers);
 
-      LInfScaleElement = Array("LInfScaleElement", NElementsOwned, NVertLevels);
-      L2ScaleElement   = Array("L2ScaleElement", NElementsOwned, NVertLevels);
+      LInfScaleElement = Array("LInfScaleElement", NElementsOwned, NVertLayers);
+      L2ScaleElement   = Array("L2ScaleElement", NElementsOwned, NVertLayers);
 
       parallelFor(
-          {NElementsOwned, NVertLevels}, KOKKOS_LAMBDA(int IElement, int K) {
+          {NElementsOwned, NVertLayers}, KOKKOS_LAMBDA(int IElement, int K) {
              const Real NumValElement   = NumFieldElement(IElement, K);
              const Real ExactValElement = ExactFieldElement(IElement, K);
 
@@ -497,18 +497,18 @@ int computeErrors(ErrorMeasures &ErrorMeasures, const Array &NumFieldElement,
 
    if constexpr (Array::rank == 3) {
       const int NTracers    = NumFieldElement.extent_int(0);
-      const int NVertLevels = NumFieldElement.extent_int(2);
+      const int NVertLayers = NumFieldElement.extent_int(2);
 
-      LInfElement = Array("LInfElement", NTracers, NElementsOwned, NVertLevels);
-      L2Element   = Array("L2Element", NTracers, NElementsOwned, NVertLevels);
+      LInfElement = Array("LInfElement", NTracers, NElementsOwned, NVertLayers);
+      L2Element   = Array("L2Element", NTracers, NElementsOwned, NVertLayers);
 
       LInfScaleElement =
-          Array("LInfScaleElement", NTracers, NElementsOwned, NVertLevels);
+          Array("LInfScaleElement", NTracers, NElementsOwned, NVertLayers);
       L2ScaleElement =
-          Array("L2ScaleElement", NTracers, NElementsOwned, NVertLevels);
+          Array("L2ScaleElement", NTracers, NElementsOwned, NVertLayers);
 
       parallelFor(
-          {NTracers, NElementsOwned, NVertLevels},
+          {NTracers, NElementsOwned, NVertLayers},
           KOKKOS_LAMBDA(int L, int IElement, int K) {
              const Real NumValElement   = NumFieldElement(L, IElement, K);
              const Real ExactValElement = ExactFieldElement(L, IElement, K);

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -25,6 +25,7 @@
 #include "OmegaKokkos.h"
 #include "Pacer.h"
 #include "TimeStepper.h"
+#include "VertCoord.h"
 #include "mpi.h"
 
 #include <iostream>
@@ -83,21 +84,11 @@ int initStateTest() {
    if (Err != 0)
       LOG_ERROR("State: error initializing default halo");
 
+   // Initialize the vertical coordinate
+   VertCoord::init();
+
    // Initialize the default mesh
    HorzMesh::init();
-
-   // Get the number of vertical levels from Config
-   Config *OmegaConfig = Config::getOmegaConfig();
-   Config DimConfig("Dimension");
-   Err1 += OmegaConfig->get(DimConfig);
-   CHECK_ERROR_ABORT(Err1, "State: Dimension group not found in Config");
-
-   I4 NVertLevels;
-   Err1 += DimConfig.get("NVertLevels", NVertLevels);
-   CHECK_ERROR_ABORT(Err1, "State: NVertLevels not found in Dimension Config");
-
-   // Create vertical dimension
-   auto VertDim = Dimension::create("NVertLevels", NVertLevels);
 
    // Initialize tracers
    Tracers::init();
@@ -153,9 +144,9 @@ int checkHost(OceanState *RefState, OceanState *TstState, int RefTimeLevel,
    RefState->getLayerThicknessH(LayerThicknessHRef, RefTimeLevel);
    TstState->getLayerThicknessH(LayerThicknessHTst, TstTimeLevel);
    for (int Cell = 0; Cell < RefState->NCellsAll; Cell++) {
-      for (int Level = 0; Level < RefState->NVertLevels; Level++) {
-         if (LayerThicknessHRef(Cell, Level) !=
-             LayerThicknessHTst(Cell, Level)) {
+      for (int Layer = 0; Layer < RefState->NVertLayers; Layer++) {
+         if (LayerThicknessHRef(Cell, Layer) !=
+             LayerThicknessHTst(Cell, Layer)) {
             count++;
          }
       }
@@ -166,9 +157,9 @@ int checkHost(OceanState *RefState, OceanState *TstState, int RefTimeLevel,
    RefState->getNormalVelocityH(NormalVelocityHRef, RefTimeLevel);
    TstState->getNormalVelocityH(NormalVelocityHTst, TstTimeLevel);
    for (int Edge = 0; Edge < RefState->NEdgesAll; Edge++) {
-      for (int Level = 0; Level < RefState->NVertLevels; Level++) {
-         if (NormalVelocityHRef(Edge, Level) !=
-             NormalVelocityHTst(Edge, Level)) {
+      for (int Layer = 0; Layer < RefState->NVertLayers; Layer++) {
+         if (NormalVelocityHRef(Edge, Layer) !=
+             NormalVelocityHTst(Edge, Layer)) {
             count++;
          }
       }
@@ -188,10 +179,10 @@ int checkDevice(OceanState *RefState, OceanState *TstState, int RefTimeLevel,
    RefState->getLayerThickness(LayerThicknessRef, RefTimeLevel);
    TstState->getLayerThickness(LayerThicknessTst, TstTimeLevel);
    parallelReduce(
-       "reduce", {RefState->NCellsAll, RefState->NVertLevels},
-       KOKKOS_LAMBDA(int Cell, int Level, int &Accum) {
-          if (LayerThicknessRef(Cell, Level) !=
-              LayerThicknessTst(Cell, Level)) {
+       "reduce", {RefState->NCellsAll, RefState->NVertLayers},
+       KOKKOS_LAMBDA(int Cell, int Layer, int &Accum) {
+          if (LayerThicknessRef(Cell, Layer) !=
+              LayerThicknessTst(Cell, Layer)) {
              Accum++;
           }
        },
@@ -203,10 +194,10 @@ int checkDevice(OceanState *RefState, OceanState *TstState, int RefTimeLevel,
    RefState->getNormalVelocity(NormalVelocityRef, RefTimeLevel);
    TstState->getNormalVelocity(NormalVelocityTst, TstTimeLevel);
    parallelReduce(
-       "reduce", {RefState->NCellsAll, RefState->NVertLevels},
-       KOKKOS_LAMBDA(int Cell, int Level, int &Accum) {
-          if (NormalVelocityRef(Cell, Level) !=
-              NormalVelocityTst(Cell, Level)) {
+       "reduce", {RefState->NCellsAll, RefState->NVertLayers},
+       KOKKOS_LAMBDA(int Cell, int Layer, int &Accum) {
+          if (NormalVelocityRef(Cell, Layer) !=
+              NormalVelocityTst(Cell, Layer)) {
              Accum++;
           }
        },
@@ -245,12 +236,12 @@ int main(int argc, char *argv[]) {
 
       // Test retrieval of the default state
       OceanState *DefState = OceanState::getDefault();
-      int NVertLevels      = DefState->NVertLevels;
+      int NVertLayers      = DefState->NVertLayers;
       int NCellsAll        = DefState->NCellsAll;
       int NEdgesAll        = DefState->NEdgesAll;
       int CurTime          = 0;
       int NewTime          = 1;
-      if (DefState and NVertLevels > 0) {
+      if (DefState and NVertLayers > 0) {
          LOG_INFO("State: Default state retrieval PASS");
       } else {
          RetVal += 1;
@@ -270,8 +261,8 @@ int main(int argc, char *argv[]) {
       int Count1 = 0;
       int Count2 = 0;
       for (int Cell = 0; Cell < NCellsAll; Cell++) {
-         for (int Level = 0; Level < NVertLevels; Level++) {
-            R8 val = LayerThickHDef(Cell, Level);
+         for (int Layer = 0; Layer < NVertLayers; Layer++) {
+            R8 val = LayerThickHDef(Cell, Layer);
             if (val != 0.0)
                ++Count1;                     // check for all-zero array
             if (val < 0.0 and val > 300.0) { // out of range
@@ -292,9 +283,9 @@ int main(int argc, char *argv[]) {
 
          // Create new reference and test states with the number of time levels
          OceanState *RefState = OceanState::create(
-             "Reference", DefHorzMesh, DefHalo, NVertLevels, NTimeLevels);
+             "Reference", DefHorzMesh, DefHalo, NVertLayers, NTimeLevels);
          OceanState *TstState = OceanState::create("Test", DefHorzMesh, DefHalo,
-                                                   NVertLevels, NTimeLevels);
+                                                   NVertLayers, NTimeLevels);
 
          // Test successful creation
          if (TstState and RefState) { // true if non-null ptr
@@ -318,17 +309,17 @@ int main(int argc, char *argv[]) {
          RefState->getNormalVelocityH(NormalVelocityHRef, CurTime);
          TstState->getNormalVelocityH(NormalVelocityHTst, CurTime);
          for (int Cell = 0; Cell < NCellsAll; Cell++) {
-            for (int Level = 0; Level < NVertLevels; Level++) {
-               LayerThickHRef(Cell, Level) = LayerThickHDef(Cell, Level);
-               LayerThickHTst(Cell, Level) = LayerThickHDef(Cell, Level);
+            for (int Layer = 0; Layer < NVertLayers; Layer++) {
+               LayerThickHRef(Cell, Layer) = LayerThickHDef(Cell, Layer);
+               LayerThickHTst(Cell, Layer) = LayerThickHDef(Cell, Layer);
             }
          }
          for (int Edge = 0; Edge < NEdgesAll; Edge++) {
-            for (int Level = 0; Level < NVertLevels; Level++) {
-               NormalVelocityHRef(Edge, Level) =
-                   NormalVelocityHDef(Edge, Level);
-               NormalVelocityHTst(Edge, Level) =
-                   NormalVelocityHDef(Edge, Level);
+            for (int Layer = 0; Layer < NVertLayers; Layer++) {
+               NormalVelocityHRef(Edge, Layer) =
+                   NormalVelocityHDef(Edge, Layer);
+               NormalVelocityHTst(Edge, Layer) =
+                   NormalVelocityHDef(Edge, Layer);
             }
          }
          RefState->copyToDevice(CurTime);
@@ -341,18 +332,18 @@ int main(int argc, char *argv[]) {
          RefState->getNormalVelocityH(NormalVelocityHRef, NewTime);
          TstState->getNormalVelocityH(NormalVelocityHTst, NewTime);
          for (int Cell = 0; Cell < NCellsAll; Cell++) {
-            for (int Level = 0; Level < NVertLevels; Level++) {
-               LayerThickHRef(Cell, Level) = LayerThickHDef(Cell, Level) + 1;
-               LayerThickHTst(Cell, Level) = LayerThickHDef(Cell, Level) + 1;
+            for (int Layer = 0; Layer < NVertLayers; Layer++) {
+               LayerThickHRef(Cell, Layer) = LayerThickHDef(Cell, Layer) + 1;
+               LayerThickHTst(Cell, Layer) = LayerThickHDef(Cell, Layer) + 1;
             }
          }
 
          for (int Edge = 0; Edge < NEdgesAll; Edge++) {
-            for (int Level = 0; Level < NVertLevels; Level++) {
-               NormalVelocityHRef(Edge, Level) =
-                   NormalVelocityHDef(Edge, Level) + 1;
-               NormalVelocityHTst(Edge, Level) =
-                   NormalVelocityHDef(Edge, Level) + 1;
+            for (int Layer = 0; Layer < NVertLayers; Layer++) {
+               NormalVelocityHRef(Edge, Layer) =
+                   NormalVelocityHDef(Edge, Layer) + 1;
+               NormalVelocityHTst(Edge, Layer) =
+                   NormalVelocityHDef(Edge, Layer) + 1;
             }
          }
          RefState->copyToDevice(NewTime);
@@ -435,6 +426,7 @@ int main(int argc, char *argv[]) {
       Tendencies::clear();
       TimeStepper::clear();
       HorzMesh::clear();
+      VertCoord::clear();
       Halo::clear();
       Decomp::clear();
       MachEnv::removeAll();

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -15,6 +15,7 @@
 #include "OmegaKokkos.h"
 #include "Pacer.h"
 #include "TimeStepper.h"
+#include "VertCoord.h"
 #include "mpi.h"
 
 #include <cmath>
@@ -44,7 +45,7 @@ struct TestSetup {
 };
 
 constexpr Geometry Geom   = Geometry::Spherical;
-constexpr int NVertLevels = 60;
+constexpr int NVertLayers = 60;
 
 int initState() {
    int Err = 0;
@@ -114,12 +115,9 @@ int initTendenciesTest(const std::string &mesh) {
       LOG_ERROR("TendenciesTest: error initializing default halo");
    }
 
+   VertCoord::init();
    HorzMesh::init();
    Tracers::init();
-
-   const auto &Mesh = HorzMesh::getDefault();
-   std::shared_ptr<Dimension> VertDim =
-       Dimension::create("NVertLevels", NVertLevels);
 
    int StateErr = OceanState::init();
    if (StateErr != 0) {
@@ -149,10 +147,11 @@ int testTendencies() {
       return -1;
    }
 
-   const auto *Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
    // test creation of another tendencies
    Config *Options = Config::getOmegaConfig();
-   Tendencies::create("TestTendencies", Mesh, 12, 3, Options);
+   Tendencies::create("TestTendencies", Mesh, VCoord, 12, 3, Options);
 
    // test retrievel of another tendencies
    if (Tendencies::get("TestTendencies")) {
@@ -228,6 +227,7 @@ void finalizeTendenciesTest() {
    Dimension::clear();
    TimeStepper::clear();
    HorzMesh::clear();
+   VertCoord::clear();
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -23,6 +23,7 @@
 #include "OmegaKokkos.h"
 #include "Pacer.h"
 #include "TimeStepper.h"
+#include "VertCoord.h"
 #include "mpi.h"
 
 #include <iostream>
@@ -73,6 +74,9 @@ I4 initTracersTest() {
       return Err;
    }
 
+   // Initialize the vertical coordinate
+   VertCoord::init();
+
    // Initialize the default mesh
    HorzMesh::init();
 
@@ -118,7 +122,7 @@ int main(int argc, char *argv[]) {
       I4 NTracers    = Tracers::getNumTracers();
       I4 NCellsOwned = DefHorzMesh->NCellsOwned;
       I4 NCellsSize  = DefHorzMesh->NCellsSize;
-      I4 NVertLevels = DefHorzMesh->NVertLevels;
+      I4 NVertLayers = VertCoord::getDefault()->NVertLayers;
       I4 NTimeLevels = DefTimeStepper->getNTimeLevels();
 
       // Get group names
@@ -233,7 +237,7 @@ int main(int argc, char *argv[]) {
 
       // Reference host array of current time level
       HostArray3DReal RefHostArray =
-          HostArray3DReal("RefHostArray", NTracers, NCellsSize, NVertLevels);
+          HostArray3DReal("RefHostArray", NTracers, NCellsSize, NVertLayers);
 
       // intialize tracer elements of all time levels
       for (I4 TimeLevel = 1; TimeLevel + NTimeLevels > 1; --TimeLevel) {
@@ -248,7 +252,7 @@ int main(int argc, char *argv[]) {
 
          for (I4 Tracer = 0; Tracer < NTracers; ++Tracer) {
             for (I4 Cell = 0; Cell < NCellsSize; Cell++) {
-               for (I4 Vert = 0; Vert < NVertLevels; Vert++) {
+               for (I4 Vert = 0; Vert < NVertLayers; Vert++) {
                   TempHostArray(Tracer, Cell, Vert) =
                       RefReal + Tracer + Cell + Vert + TimeLevel;
                   if (TimeLevel == 1)
@@ -262,7 +266,7 @@ int main(int argc, char *argv[]) {
 
       // Reference device array of new time level
       Array3DReal RefArray =
-          Array3DReal("RefArray", NTracers, NCellsSize, NVertLevels);
+          Array3DReal("RefArray", NTracers, NCellsSize, NVertLayers);
 
       Err = Tracers::getAll(RefArray, 1);
       if (Err != 0) {
@@ -296,7 +300,7 @@ int main(int argc, char *argv[]) {
 
       // check if time level shift works
       parallelReduce(
-          "reduce1", {NTracers, NCellsOwned, NVertLevels},
+          "reduce1", {NTracers, NCellsOwned, NVertLayers},
           KOKKOS_LAMBDA(I4 Tracer, I4 Cell, I4 Vert, I4 & Accum) {
              if (std::abs(CurArray(Tracer, Cell, Vert) -
                           RefArray(Tracer, Cell, Vert)) > 1e-9) {
@@ -331,7 +335,7 @@ int main(int argc, char *argv[]) {
          count = -1;
 
          parallelReduce(
-             "reduce2", {NCellsOwned, NVertLevels},
+             "reduce2", {NCellsOwned, NVertLayers},
              KOKKOS_LAMBDA(I4 Cell, I4 Vert, I4 & Accum) {
                 if (std::abs(CurTracer(Cell, Vert) -
                              (RefReal + Tracer + Cell + Vert + 1)) > 1e-9) {
@@ -362,7 +366,7 @@ int main(int argc, char *argv[]) {
          count = -1;
 
          parallelReduce(
-             "reduce3", {NCellsOwned, NVertLevels},
+             "reduce3", {NCellsOwned, NVertLayers},
              KOKKOS_LAMBDA(I4 Cell, I4 Vert, I4 & Accum) {
                 if (std::abs(RefFieldData(Cell, Vert) -
                              TestFieldData(Cell, Vert)) > 1e-9) {
@@ -398,7 +402,7 @@ int main(int argc, char *argv[]) {
          count = -1;
 
          parallelReduce(
-             "reduce4", {NCellsOwned, NVertLevels},
+             "reduce4", {NCellsOwned, NVertLayers},
              KOKKOS_LAMBDA(I4 Cell, I4 Vert, I4 & Accum) {
                 if (std::abs(RefFieldData(Cell, Vert) -
                              TestFieldData(Cell, Vert)) > 1e-9) {
@@ -428,7 +432,7 @@ int main(int argc, char *argv[]) {
       count = -1;
 
       parallelReduce(
-          "reduce5", {NCellsOwned, NVertLevels},
+          "reduce5", {NCellsOwned, NVertLayers},
           KOKKOS_LAMBDA(I4 Cell, I4 Vert, I4 & Accum) {
              if (std::abs(SaltTracerByName(Cell, Vert) -
                           SaltTracerByIndexVar(Cell, Vert)) > 1e-9) {
@@ -463,7 +467,7 @@ int main(int argc, char *argv[]) {
          }
 
          for (I4 Cell = 0; Cell < NCellsOwned; Cell++) {
-            for (I4 Vert = 0; Vert < NVertLevels; Vert++) {
+            for (I4 Vert = 0; Vert < NVertLayers; Vert++) {
                if (std::abs(RefHostArray(Tracer, Cell, Vert) -
                             TestHostArray(Cell, Vert)) > 1e-9)
                   ++count;
@@ -483,6 +487,7 @@ int main(int argc, char *argv[]) {
       Tracers::clear();
       TimeStepper::clear();
       HorzMesh::clear();
+      VertCoord::clear();
       Halo::clear();
       Decomp::clear();
       MachEnv::removeAll();

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -1,0 +1,606 @@
+//===-- Test driver for OMEGA Vertical Coordinate ----------------*- C++ -*-===/
+//
+/// \file
+/// \brief Test driver for OMEGA VertCoord class
+///
+///
+//
+//===-----------------------------------------------------------------------===/
+
+#include "VertCoord.h"
+#include "DataTypes.h"
+#include "Decomp.h"
+#include "Dimension.h"
+#include "Error.h"
+#include "Halo.h"
+#include "HorzMesh.h"
+#include "IO.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "OmegaKokkos.h"
+#include "Pacer.h"
+#include "mpi.h"
+
+#include <algorithm>
+#include <iostream>
+
+using namespace OMEGA;
+
+int initVertCoordTest() {
+
+   int Err = 0;
+
+   MachEnv::init(MPI_COMM_WORLD);
+   MachEnv *DefEnv  = MachEnv::getDefault();
+   MPI_Comm DefComm = DefEnv->getComm();
+
+   // Initialize the Logging system
+   initLogging(DefEnv);
+
+   // Open config file
+   Config("Omega");
+   Config::readAll("omega.yml");
+
+   // Initialize the IO system
+   Err = IO::init(DefComm);
+   if (Err != 0)
+      LOG_ERROR("VertCoordTest: error initializing parallel IO");
+
+   // Create the default decomposition (initializes the decomposition)
+   Decomp::init();
+
+   // Initialize the default halo
+   Err = Halo::init();
+   if (Err != 0)
+      LOG_ERROR("VertCoordTest: error initializing default halo");
+
+   // Initialize the vertical coordinate
+   VertCoord::init();
+
+   // Initialize the default mesh
+   HorzMesh::init();
+
+   return Err;
+} // end initVertCoordTest
+
+//------------------------------------------------------------------------------
+// The test driver for VertCoord test
+//
+int main(int argc, char *argv[]) {
+
+   int RetVal = 0;
+
+   // Initialize the global MPI environment
+   MPI_Init(&argc, &argv);
+   Kokkos::initialize();
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
+   {
+      int Err = initVertCoordTest();
+      if (Err != 0)
+         LOG_CRITICAL("VertCoordTest: Error initializing");
+
+      auto *DefVertCoord = VertCoord::getDefault();
+      auto *DefMesh      = HorzMesh::getDefault();
+
+      I4 NCellsSize    = DefMesh->NCellsSize;
+      I4 NCellsAll     = DefMesh->NCellsAll;
+      I4 NEdgesAll     = DefMesh->NEdgesAll;
+      I4 NVerticesAll  = DefMesh->NVerticesAll;
+      I4 VertexDegree  = DefMesh->VertexDegree;
+      I4 NVertLayers   = DefVertCoord->NVertLayers;
+      I4 NVertLayersP1 = DefVertCoord->NVertLayersP1;
+
+      // Tests for computePressure
+
+      Array2DReal LayerThickness("LayerThickness", NCellsSize, NVertLayers);
+      Array1DReal SurfacePressure("SurfacePressure", NCellsSize);
+
+      auto &PressInterf = DefVertCoord->PressureInterface;
+      auto &PressMid    = DefVertCoord->PressureMid;
+
+      /// Initialize layer thickness and surface pressure so that resulting
+      /// interface pressure is the number of layers above plus one
+      Real Gravity = 9.80616_Real;
+      Real Rho0    = 1035._Real;
+      parallelFor(
+          {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+             SurfacePressure(ICell) = 1.0_Real;
+             for (int K = 0; K < NVertLayers; K++) {
+                LayerThickness(ICell, K) = 1.0_Real / (Gravity * Rho0);
+             }
+          });
+      Kokkos::fence();
+
+      /// Call function and get host copies of outputs
+      DefVertCoord->computePressure(PressInterf, PressMid, LayerThickness,
+                                    SurfacePressure);
+      auto PressInterfH = createHostMirrorCopy(PressInterf);
+      auto PressMidH    = createHostMirrorCopy(PressMid);
+
+      /// Check results
+      Err = 0;
+      for (int ICell = 0; ICell < NCellsAll; ICell++) {
+         for (int K = DefVertCoord->MinLayerCellH(ICell);
+              K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
+            // Interface pressure at layer K should be K+1
+            Real Expected = K + 1;
+            Real Diff     = std::abs(PressInterfH(ICell, K) - Expected);
+            if (Diff > 1e-10) {
+               Err += 1;
+            }
+            // Mid pressures at layer K should be K+1.5
+            Expected = K + 1.5;
+            Diff     = std::abs(PressMidH(ICell, K) - Expected);
+            if (Diff > 1e-10) {
+               Err += Err + 1;
+            }
+         }
+      }
+
+      /// Determine test pass/fail
+      if (Err == 0) {
+         LOG_INFO(
+             "VertCoordTest: computePressure with uniform LayerThickness PASS");
+      } else {
+         LOG_INFO(
+             "VertCoordTest: computePressure with uniform LayerThickness FAIL");
+         RetVal += 1;
+      }
+
+      /// Initialize layer thickness and surface pressure so that the resulting
+      /// interface pressure is (K+1)*K/2 + the cell number
+      parallelFor(
+          {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+             SurfacePressure(ICell) = 1.0_Real * ICell;
+             for (int K = 0; K < NVertLayers; K++) {
+                LayerThickness(ICell, K) = (K + 1.0_Real) / (Gravity * Rho0);
+             }
+          });
+      Kokkos::fence();
+
+      /// Call functions and get host copy of output
+      DefVertCoord->computePressure(PressInterf, PressMid, LayerThickness,
+                                    SurfacePressure);
+      auto PressInterfH2 = createHostMirrorCopy(PressInterf);
+
+      /// Check results
+      Err = 0;
+      for (int ICell = 0; ICell < NCellsAll; ICell++) {
+         for (int K = DefVertCoord->MinLayerCellH(ICell);
+              K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
+            /// Interface pressure should be (K+1)*K/2 + the cell number
+            Real Expected = ((K + 1.0_Real) * K) / 2.0_Real + ICell;
+            Real Diff     = std::abs(PressInterfH2(ICell, K) - Expected);
+            if (Diff > 1e-10) {
+               Err += 1;
+            }
+         }
+      }
+
+      /// Determine test pass/fail
+      if (Err == 0) {
+         LOG_INFO("VertCoordTest: computePressure with non-uniform "
+                  "LayerThickness PASS");
+      } else {
+         LOG_INFO("VertCoordTest: computePressure with non-uniform "
+                  "LayerThickness FAIL");
+         RetVal += 1;
+      }
+
+      // Tests for computeZHeight
+
+      Array2DReal SpecVol("SpecVol", NCellsSize, NVertLayers);
+      Array1DReal BottomDepth("BottomDepth", NCellsSize);
+      Array1DReal MaxLyrCellReal("MaxLyrCellReal", NCellsSize);
+      deepCopy(MaxLyrCellReal, DefVertCoord->MaxLayerCell);
+
+      auto &ZInterf  = DefVertCoord->ZInterface;
+      auto &ZMid     = DefVertCoord->ZMid;
+      auto &BotDepth = DefVertCoord->BottomDepth;
+
+      /// Initialize bottom depth, layer thickness and specific volume so that
+      /// the resulting interface z value is the negative layer number
+      parallelFor(
+          {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+             BotDepth(ICell) = MaxLyrCellReal(ICell) + 1.0_Real;
+             for (int K = 0; K < NVertLayers; K++) {
+                LayerThickness(ICell, K) = (ICell + 1.0_Real) / Rho0;
+                SpecVol(ICell, K)        = 1.0_Real / (ICell + 1.0_Real);
+             }
+          });
+      Kokkos::fence();
+
+      /// Call functions and get host copy of output
+      DefVertCoord->computeZHeight(ZInterf, ZMid, LayerThickness, SpecVol,
+                                   BotDepth);
+      auto ZInterfH = createHostMirrorCopy(ZInterf);
+      auto ZMidH    = createHostMirrorCopy(ZMid);
+
+      /// Check results
+      Err = 0;
+      for (int ICell = 0; ICell < NCellsAll; ICell++) {
+         for (int K = DefVertCoord->MinLayerCellH(ICell);
+              K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
+            /// Z value at interface K should be -K
+            Real Expected = -K;
+            Real Diff     = std::abs(ZInterfH(ICell, K) - Expected);
+            if (Diff > 1e-10) {
+               Err += 1;
+            }
+            /// Z value at mid point of layer K should be -(K + .5)
+            Expected = -K - 0.5;
+            Diff     = std::abs(ZMidH(ICell, K) - Expected);
+            if (Diff > 1e-10) {
+               Err += 1;
+            }
+         }
+      }
+
+      /// Determine test pass/fail
+      if (Err == 0) {
+         LOG_INFO(
+             "VertCoordTest: computeZHeight with uniform LayerThickness PASS");
+      } else {
+         LOG_INFO(
+             "VertCoordTest: computeZHeight with uniform LayerThickness FAIL");
+         RetVal += 1;
+      }
+
+      /// Initialize bottom depth, layer thickness and specific volume so that
+      /// the resulting interface z value is -(K+1)*K/2
+      parallelFor(
+          {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+             BotDepth(ICell) = (MaxLyrCellReal(ICell) + 2) *
+                               (MaxLyrCellReal(ICell) + 1) / 2.0_Real;
+             for (int K = 0; K < NVertLayers; K++) {
+                LayerThickness(ICell, K) = (K + 1) / Rho0;
+                SpecVol(ICell, K)        = 1.0_Real;
+             }
+          });
+      Kokkos::fence();
+
+      /// Call functions and get host copy of output
+      DefVertCoord->computeZHeight(ZInterf, ZMid, LayerThickness, SpecVol,
+                                   BotDepth);
+      auto ZInterfH2 = createHostMirrorCopy(ZInterf);
+
+      /// Check results
+      Err = 0;
+      for (int ICell = 0; ICell < NCellsAll; ICell++) {
+         for (int K = DefVertCoord->MinLayerCellH(ICell);
+              K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
+            /// Z value at interface should be -(K+1)*K/2
+            Real Expected = -((K + 1.0_Real) * K) / 2.0_Real;
+            Real Diff     = std::abs(ZInterfH2(ICell, K) - Expected);
+            if (Diff > 1e-10) {
+               Err += 1;
+            }
+         }
+      }
+
+      /// Determine test pass/fail
+      if (Err == 0) {
+         LOG_INFO("VertCoordTest: computeZHeight with non-uniform "
+                  "LayerThickness PASS");
+      } else {
+         LOG_INFO("VertCoordTest: computeZHeight with non-uniform "
+                  "LayerThickness FAIL");
+         RetVal += 1;
+      }
+
+      // Tests for computeGeopotential
+      Array2DReal GeopotentialMid("GeopotentialMid", NCellsSize, NVertLayers);
+      Array1DReal TidalPotential("TidalPotential", NCellsSize);
+      Array1DReal SelfAttractionLoading("SelfAttractionLoading", NCellsSize);
+
+      /// Initialize z mid, tidal potential and SAL so that the resulting
+      /// geopotential is the cell number + layer number
+      parallelFor(
+          {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+             TidalPotential(ICell)        = ICell;
+             SelfAttractionLoading(ICell) = -ICell;
+             for (int K = 0; K < NVertLayers; K++) {
+                ZMid(ICell, K) = (ICell + K) / Gravity;
+             }
+          });
+      Kokkos::fence();
+
+      /// Call functions and get host copy of output
+      DefVertCoord->computeGeopotential(GeopotentialMid, ZMid, TidalPotential,
+                                        SelfAttractionLoading);
+      auto GeopotentialMidH = createHostMirrorCopy(GeopotentialMid);
+
+      /// Check results
+      Err = 0;
+      for (int ICell = 0; ICell < NCellsAll; ICell++) {
+         for (int K = DefVertCoord->MinLayerCellH(ICell);
+              K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
+            /// Geopotential should be cell number + layer number
+            Real Expected = ICell + K;
+            Real Diff     = std::abs(GeopotentialMidH(ICell, K) - Expected);
+            if (Diff > 1e-10) {
+               Err += 1;
+            }
+         }
+      }
+
+      /// Determine test pass/fail
+      if (Err == 0) {
+         LOG_INFO("VertCoordTest: computeGeopotential PASS");
+      } else {
+         LOG_INFO("VertCoordTest: computeGeopotential FAIL");
+         RetVal += 1;
+      }
+
+      // Tests for computeTargetThickness
+      Array2DReal LayerThicknessTarget("LayerThicknessTarget", NCellsSize,
+                                       NVertLayers);
+      Array2DReal RefLayerThickness("RefLayerThickness", NCellsSize,
+                                    NVertLayers);
+
+      /// Initialize surface pressure, vertical coord weights, ref layer
+      /// thickness, and layer thickness so that the resulting target thickness
+      /// is 2 (perturbation is evenly distributed amoung layers)
+      parallelFor(
+          {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+             SurfacePressure(ICell) = 0.0;
+             for (int K = 0; K < NVertLayers; K++) {
+                RefLayerThickness(ICell, K) = 1.0;
+                LayerThickness(ICell, K)    = 2.0;
+             }
+          });
+      Kokkos::fence();
+
+      auto &MovementWgts = DefVertCoord->VertCoordMovementWeights;
+
+      /// Call functions and get host copy of output
+      DefVertCoord->computePressure(PressInterf, PressMid, LayerThickness,
+                                    SurfacePressure);
+      DefVertCoord->computeTargetThickness(LayerThicknessTarget, PressInterf,
+                                           RefLayerThickness, MovementWgts);
+      auto LayerThicknessTargetH = createHostMirrorCopy(LayerThicknessTarget);
+
+      /// Check results
+      Err = 0;
+      for (int ICell = 0; ICell < NCellsAll; ICell++) {
+         for (int K = DefVertCoord->MinLayerCellH(ICell);
+              K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
+            /// target thickness should be 2
+            Real Expected = 2.0;
+            Real Diff = std::abs(LayerThicknessTargetH(ICell, K) - Expected);
+            if (Diff > 1e-10) {
+               Err += 1;
+            }
+         }
+      }
+
+      /// Determine test pass/fail
+      if (Err == 0) {
+         LOG_INFO("VertCoordTest: computeTargetThickness with uniform "
+                  "distribution PASS");
+      } else {
+         LOG_INFO("VertCoordTest: computeTargetThickness with uniform "
+                  "distribution FAIL");
+         RetVal += 1;
+      }
+
+      /// Intialize surface pressure, vertical coord weights, ref layer
+      /// thickness, and layer thickness so that the resulting target thickness
+      /// is the max number of layers + 2 in the top layer and 1 elsewhere
+      /// (perturbation is distributed to top layer only)
+      parallelFor(
+          {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+             SurfacePressure(ICell) = 0.0;
+             for (int K = 0; K < NVertLayers; K++) {
+                RefLayerThickness(ICell, K) = 1.0;
+                LayerThickness(ICell, K)    = 2.0;
+             }
+          });
+      parallelFor(
+          {NVertLayers}, KOKKOS_LAMBDA(int K) { MovementWgts(K) = 0.0; });
+      parallelFor({1}, KOKKOS_LAMBDA(const int &) { MovementWgts(0) = 1.0; });
+      Kokkos::fence();
+
+      /// Call functions and get host copy of output
+      DefVertCoord->computePressure(PressInterf, PressMid, LayerThickness,
+                                    SurfacePressure);
+      DefVertCoord->computeTargetThickness(LayerThicknessTarget, PressInterf,
+                                           RefLayerThickness, MovementWgts);
+      auto LayerThicknessTargetH2 = createHostMirrorCopy(LayerThicknessTarget);
+      Err                         = 0;
+
+      /// Check results
+      for (int ICell = 0; ICell < NCellsAll; ICell++) {
+         for (int K = DefVertCoord->MinLayerCellH(ICell);
+              K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
+            Real Expected;
+            if (K == 0) {
+               /// target thickness is number of layers + 2 in top layer
+               Expected = DefVertCoord->MaxLayerCellH(ICell) + 2;
+            } else {
+               /// target thickness is 1 in all other layer
+               Expected = 1.0;
+            }
+            Real Diff = std::abs(LayerThicknessTargetH2(ICell, K) - Expected);
+            if (Diff > 1e-10) {
+               LOG_INFO("LayerThicknessTargetH({},{}) = {}, {}", ICell, K,
+                        LayerThicknessTargetH2(ICell, K), Expected);
+               Err += 1;
+            }
+         }
+      }
+
+      /// Determine test pass/fail
+      if (Err == 0) {
+         LOG_INFO("VertCoordTest: computeTargetThickness with top only "
+                  "distribution PASS");
+      } else {
+         LOG_INFO("VertCoordTest: computeTargetThickness with top only "
+                  "distribution FAIL");
+         RetVal += 1;
+      }
+
+      // Tests for minMaxLayerEdge
+
+      /// Initialize min/max number of cell layers such that
+      /// the cellsOnEdge information can be used to determine min/max layer
+      /// edge
+      const auto &LocMinLayerCell = DefVertCoord->MinLayerCell;
+      const auto &LocMaxLayerCell = DefVertCoord->MaxLayerCell;
+      parallelFor(
+          {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+             LocMinLayerCell(ICell) = -2 * ICell;
+             LocMaxLayerCell(ICell) = 2 * ICell;
+          });
+      Kokkos::fence();
+
+      /// Call function, outputs are member variables of class
+      DefVertCoord->minMaxLayerEdge();
+
+      /// Check results
+      Err = 0;
+      for (int IEdge = 0; IEdge < NEdgesAll; IEdge++) {
+         I4 Expected;
+         I4 Count = 0;
+
+         /// Skip edges on boundary
+         if ((DefMesh->CellsOnEdgeH(IEdge, 1) == NCellsAll) ||
+             (DefMesh->CellsOnEdgeH(IEdge, 0) == NCellsAll)) {
+            continue;
+         }
+
+         /// MinLayerEdgeTop is the min of the min cell values on edge
+         Expected  = std::min(-2 * DefMesh->CellsOnEdgeH(IEdge, 0),
+                              -2 * DefMesh->CellsOnEdgeH(IEdge, 1));
+         Real Diff = std::abs(DefVertCoord->MinLayerEdgeTopH(IEdge) - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+         /// MinLayerEdgeBot is the max of the min cell values on edge
+         Expected = std::max(-2 * DefMesh->CellsOnEdgeH(IEdge, 0),
+                             -2 * DefMesh->CellsOnEdgeH(IEdge, 1));
+         Diff     = std::abs(DefVertCoord->MinLayerEdgeBotH(IEdge) - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+         /// MaxLayerEdgeTop is the min of the max cell values on edge
+         Expected = std::min(2 * DefMesh->CellsOnEdgeH(IEdge, 0),
+                             2 * DefMesh->CellsOnEdgeH(IEdge, 1));
+         Diff     = std::abs(DefVertCoord->MaxLayerEdgeTopH(IEdge) - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+         /// MaxLayerEdgeBot is the max of the max cell values on edge
+         Expected = std::max(2 * DefMesh->CellsOnEdgeH(IEdge, 0),
+                             2 * DefMesh->CellsOnEdgeH(IEdge, 1));
+         Diff     = std::abs(DefVertCoord->MaxLayerEdgeBotH(IEdge) - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+      }
+
+      /// Determine test pass/fail
+      if (Err == 0) {
+         LOG_INFO("VertCoordTest: minMaxLayerEdge PASS");
+      } else {
+         LOG_INFO("VertCoordTest: minMaxLayerEdge FAIL");
+         RetVal += 1;
+      }
+
+      // Tests for minMaxLayerVertex
+
+      /// Use MinLayerCell, MaxLayerCell values initialized in previous test
+      /// CellsOnVertex information can be used to determine min/max layer
+      /// vertex
+
+      /// Call function, outputs are member variables of class
+      DefVertCoord->minMaxLayerVertex();
+
+      /// Check results
+      Err = 0;
+      for (int IVertex = 0; IVertex < NVerticesAll; IVertex++) {
+
+         /// Skip vertices on boundary
+         I4 Boundary = 0;
+         for (int I = 0; I < VertexDegree; I++) {
+            if (DefMesh->CellsOnVertexH(IVertex, I) == NCellsAll) {
+               Boundary += 1;
+            }
+         }
+         if (Boundary > 0) {
+            continue;
+         }
+
+         /// MinLayerVertexTop is the min of the min cell values on vertex
+         I4 Expected = 1e7;
+         for (int I = 0; I < VertexDegree; I++) {
+            Expected =
+                std::min(Expected, -2 * DefMesh->CellsOnVertexH(IVertex, I));
+         }
+         Real Diff =
+             std::abs(DefVertCoord->MinLayerVertexTopH(IVertex) - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+
+         /// MinLayerVertexBot is the max of the min cell values on vertex
+         Expected = -1e7;
+         for (int I = 0; I < VertexDegree; I++) {
+            Expected =
+                std::max(Expected, -2 * DefMesh->CellsOnVertexH(IVertex, I));
+         }
+         Diff = std::abs(DefVertCoord->MinLayerVertexBotH(IVertex) - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+
+         /// MaxLayerVertexTop is the min of the max cell values on vertex
+         Expected = 1e7;
+         for (int I = 0; I < VertexDegree; I++) {
+            Expected =
+                std::min(Expected, 2 * DefMesh->CellsOnVertexH(IVertex, I));
+         }
+         Diff = std::abs(DefVertCoord->MaxLayerVertexTopH(IVertex) - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+
+         /// MaxLayerVertexBot is the max of the max cell values on vertex
+         Expected = -1e7;
+         for (int I = 0; I < VertexDegree; I++) {
+            Expected =
+                std::max(Expected, 2 * DefMesh->CellsOnVertexH(IVertex, I));
+         }
+         Diff = std::abs(DefVertCoord->MaxLayerVertexBotH(IVertex) - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+      }
+
+      /// Determine test pass/fail
+      if (Err == 0) {
+         LOG_INFO("VertCoordTest: minMaxLayerVertex PASS");
+      } else {
+         LOG_INFO("VertCoordTest: minMaxLayerVertex FAIL");
+         RetVal += 1;
+      }
+
+      // Finalize Omega objects
+      HorzMesh::clear();
+      VertCoord::clear();
+      Dimension::clear();
+      Halo::clear();
+      Decomp::clear();
+      MachEnv::removeAll();
+   }
+   Kokkos::finalize();
+   MPI_Finalize();
+
+   if (RetVal >= 256)
+      RetVal = 255;
+
+   return RetVal;
+
+} // end of main
+//===-----------------------------------------------------------------------===/

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -32,6 +32,7 @@
 #include "TendencyTerms.h"
 #include "TimeMgr.h"
 #include "Tracers.h"
+#include "VertCoord.h"
 #include "mpi.h"
 
 #include <cmath>
@@ -42,8 +43,8 @@ using namespace OMEGA;
 
 // Geometry doesn't matter for this test
 constexpr Geometry Geom = Geometry::Planar;
-// Only one vertical level is needed
-constexpr int NVertLevels = 1;
+// Only one vertical layer is needed
+constexpr int NVertLayers = 1;
 
 // Custom tendency for normal velocity
 // du/dt = -coeff * u
@@ -59,14 +60,14 @@ struct DecayVelocityTendency {
                    int VelTimeLevel, TimeInstant Time) const {
 
       auto *Mesh       = HorzMesh::getDefault();
-      auto NVertLevels = NormalVelTend.extent_int(1);
+      auto NVertLayers = NormalVelTend.extent_int(1);
       Array2DReal NormalVelEdge;
       State->getNormalVelocity(NormalVelEdge, VelTimeLevel);
 
       OMEGA_SCOPE(LocCoeff, Coeff);
 
       parallelFor(
-          {Mesh->NEdgesAll, NVertLevels}, KOKKOS_LAMBDA(int IEdge, int K) {
+          {Mesh->NEdgesAll, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int K) {
              NormalVelTend(IEdge, K) -= LocCoeff * NormalVelEdge(IEdge, K);
           });
    }
@@ -102,7 +103,7 @@ int createExactSolution(Real TimeEnd) {
    Err = Tracers::getAll(TracerArray, 0);
 
    auto *ExactState =
-       OceanState::create("Exact", DefMesh, DefHalo, NVertLevels, 1);
+       OceanState::create("Exact", DefMesh, DefHalo, NVertLayers, 1);
 
    Array2DReal LayerThickCell;
    Array2DReal NormalVelEdge;
@@ -156,17 +157,6 @@ int initTimeStepperTest(const std::string &mesh) {
    Config("Omega");
    Config::readAll("omega.yml");
 
-   // Reset NVertLevels to 1 regardless of config value
-   Config *OmegaConfig = Config::getOmegaConfig();
-   Config DimConfig("Dimension");
-   Err1 = OmegaConfig->get(DimConfig);
-   CHECK_ERROR_ABORT(Err1, "TimeStepperTest: Dimension group not in Config");
-
-   DimConfig.set("NVertLevels", NVertLevels);
-
-   // Horz dimensions will be created in HorzMesh
-   auto VertDim = Dimension::create("NVertLevels", NVertLevels);
-
    // Note that the default time stepper is not used in subsequent tests
    // but is initialized here because the number of time levels is needed
    // to initialize the Tracers. If a later timestepper test uses more time
@@ -187,6 +177,14 @@ int initTimeStepperTest(const std::string &mesh) {
       LOG_ERROR("TimeStepperTest: error initializing default halo");
    }
 
+   // Initialize the vertical coordinate and reset NVertLayers to 1
+   VertCoord::init();
+   auto *DefVertCoord        = VertCoord::getDefault();
+   DefVertCoord->NVertLayers = 1;
+   Dimension::destroy("NVertLayers");
+   std::shared_ptr<Dimension> VertDim =
+       Dimension::create("NVertLayers", NVertLayers);
+
    HorzMesh::init();
    Tracers::init();
    AuxiliaryState::init();
@@ -202,7 +200,7 @@ int initTimeStepperTest(const std::string &mesh) {
 
    // Non-default init
    // Creating non-default state and auxiliary state to use only one vertical
-   // level
+   // layer
 
    auto *DefMesh = HorzMesh::getDefault();
    auto *DefHalo = Halo::getDefault();
@@ -210,15 +208,16 @@ int initTimeStepperTest(const std::string &mesh) {
    int NTracers          = Tracers::getNumTracers();
    const int NTimeLevels = 2;
    auto *TestOceanState  = OceanState::create("TestState", DefMesh, DefHalo,
-                                              NVertLevels, NTimeLevels);
+                                              NVertLayers, NTimeLevels);
    if (!TestOceanState) {
       Err++;
       LOG_ERROR("TimeStepperTest: error creating test state");
    }
 
    auto *TestAuxState = AuxiliaryState::create("TestAuxState", DefMesh, DefHalo,
-                                               NVertLevels, NTracers);
+                                               NVertLayers, NTracers);
 
+   Config *OmegaConfig = Config::getOmegaConfig();
    TestAuxState->readConfigOptions(OmegaConfig);
 
    if (!TestAuxState) {
@@ -230,7 +229,7 @@ int initTimeStepperTest(const std::string &mesh) {
 
    // Creating non-default tendencies with custom velocity tendencies
    auto *TestTendencies = Tendencies::create(
-       "TestTendencies", DefMesh, NVertLevels, NTracers, &Options,
+       "TestTendencies", DefMesh, DefVertCoord, NVertLayers, NTracers, &Options,
        Tendencies::CustomTendencyType{}, DecayVelocityTendency{});
    if (!TestTendencies) {
       Err++;
@@ -293,6 +292,7 @@ void finalizeTimeStepperTest() {
    Dimension::clear();
    Field::clear();
    HorzMesh::clear();
+   VertCoord::clear();
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

Add the `VertCoord` class to Omega, which consists of:
- methods for computing pressure, z height, geopotential, and desired vertical interface locations (p-star type coordinate) throughout the domain
- container for min and max indices defining range of active vertical layers (`MinLayerCell`, `MaxLayerCell`, etc.)
- `NVertLevels` is renamed to `NVertLayers`, and primarily stored in the `VertCoord` class. This dimension is removed from the default config file, and is now read from the mesh file.

Add the constant `OMEGA_TEAMSIZE` to OmegaKokkos.h for hierarchical parallelism, with value defined based on build architecture (GPU vs CPU)

Ran ctests successfully on Frontier (CPU & GPU), pm-cpu, pm-gpu, and chrysalis

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Testing
  * [x] CTest unit tests for new features have been added per the approved design. 
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


