### PR TITLE
Adds redirection and modifies info Logging in Omega

### DIFF
--- a/components/omega/src/infra/Logging.cpp
+++ b/components/omega/src/infra/Logging.cpp
@@ -1,13 +1,16 @@
 //===-- infra/Logging.cpp - Implements Omega Logging functions --*- C++ -*-===//
 //
 /// \file
-/// \brief implements Omega logging functions
+/// \brief Implements Omega logging functions
 ///
-/// This implements Omega logging initialization.
+/// This implements Omega logging initialization and includes some utility
+/// functions for formatting message prefixes.
 //
 //===----------------------------------------------------------------------===//
 #include "Logging.h"
 #include "MachEnv.h"
+#include <cstdio>
+#include <fstream>
 #include <iostream>
 #include <spdlog/sinks/basic_file_sink.h>
 
@@ -16,26 +19,40 @@
 
 namespace OMEGA {
 
-// Function to pack log message
-std::string _PackLogMsg(const char *file, int line, const std::string &msg) {
+//------------------------------------------------------------------------------
+// Utility function to create a log message with prefix
+std::string
+_PackLogMsg(const char *file, //[in] file from where log called (cpp __FILE__)
+            int line,         //[in] src code line where called (cpp __LINE__)
+            const std::string &msg //[in] message text
+) {
 
-   // check if MachEnv is initialized
+   // find position after path where filename starts
    std::string path(file);
    size_t pos = path.find_last_of("\\/");
    if (pos != std::string::npos) {
       return "[" + path.substr(pos + 1) + ":" + std::to_string(line) + "] " +
              msg;
    }
+   // add prefix of form [file:line] to message string
    return "[" + path + ":" + std::to_string(line) + "] " + msg;
 }
 
-std::vector<int> splitTasks(const std::string &str, const OMEGA::I4 NumTasks) {
+//------------------------------------------------------------------------------
+// Utility function to determine which tasks perform logging based on
+// input variable string containing lists of tasks or other options
+std::vector<int>
+splitTasks(const std::string &str,  //[in] option for which tasks should write
+           const OMEGA::I4 NumTasks //[in] total number of tasks
+) {
+
    std::vector<int> Tasks;
    std::stringstream ss(str);
    std::string Task;
    int Start, Stop;
    char Dash;
 
+   // If all tasks should write, create the explicit list of all tasks
    if (str == "ALL") {
       for (int i = 0; i < NumTasks; ++i) {
          Tasks.push_back(i);
@@ -43,11 +60,13 @@ std::vector<int> splitTasks(const std::string &str, const OMEGA::I4 NumTasks) {
       return Tasks;
    }
 
+   // Parse the task string. If there is a single task, extract the task id.
+   // If there is a range (beg:end), create a list with that range
    while (std::getline(ss, Task, ':')) {
       std::istringstream iss(Task);
       iss >> Start;
 
-      if (iss.eof()) {
+      if (iss.eof()) { // no range found, so extract single task
          Tasks.push_back(Start);
 
       } else {
@@ -60,6 +79,7 @@ std::vector<int> splitTasks(const std::string &str, const OMEGA::I4 NumTasks) {
       }
    }
 
+   // Default to all tasks if a -1 task found in list
    if (std::find(Tasks.begin(), Tasks.end(), -1) != Tasks.end()) {
       Tasks.clear();
       for (int i = 0; i < NumTasks; ++i) {
@@ -70,15 +90,20 @@ std::vector<int> splitTasks(const std::string &str, const OMEGA::I4 NumTasks) {
    return Tasks;
 }
 
-// return code: 1->enabled, 0->disabled, negative values->errors
-int initLogging(const OMEGA::MachEnv *DefEnv,
-                std::shared_ptr<spdlog::logger> Logger) {
+//------------------------------------------------------------------------------
+// Initialize logging for case of a pre-defined custom logger
+// Return code: 1->enabled, 0->disabled, negative values->errors
+int initLogging(
+    const OMEGA::MachEnv *DefEnv,          // [in] MachEnv for MPI task info
+    std::shared_ptr<spdlog::logger> Logger // [in] custom logger to use
+) {
 
    int RetVal = 0;
 
    OMEGA::I4 TaskId   = DefEnv->getMyTask();
    OMEGA::I4 NumTasks = DefEnv->getNumTasks();
 
+   // determine which tasks will write log files
    std::vector<int> Tasks =
        splitTasks(_OMEGA_TOSTRING(OMEGA_LOG_TASKS), NumTasks);
 
@@ -87,9 +112,12 @@ int initLogging(const OMEGA::MachEnv *DefEnv,
 
       spdlog::set_default_logger(Logger);
 
+      // set prefix format - here n is logger name, l is level and v is msg txt
       spdlog::set_pattern("[%n %l] %v");
+      // set default log level
       spdlog::set_level(
           static_cast<spdlog::level::level_enum>(SPDLOG_ACTIVE_LEVEL));
+      // flush output buffers for levels above warn
       spdlog::flush_on(spdlog::level::warn);
 
       RetVal = 1; // log enabled
@@ -102,14 +130,21 @@ int initLogging(const OMEGA::MachEnv *DefEnv,
    return RetVal;
 }
 
+//------------------------------------------------------------------------------
+// Initialize logging for a default logger and provide log file name
 // return code: 1->enabled, 0->disabled, negative values->errors
-int initLogging(const OMEGA::MachEnv *DefEnv, std::string const &LogFilePath) {
+int initLogging(
+    const OMEGA::MachEnv *DefEnv,  //[in] default environment for MPI info
+    std::string const &LogFilePath //[in] log file name with path
+) {
 
    int RetVal = 0;
 
    OMEGA::I4 TaskId   = DefEnv->getMyTask();
    OMEGA::I4 NumTasks = DefEnv->getNumTasks();
+   std::string NewLogFilePath;
 
+   // Determine which tasks will write log files
    std::vector<int> Tasks =
        splitTasks(_OMEGA_TOSTRING(OMEGA_LOG_TASKS), NumTasks);
 
@@ -119,23 +154,28 @@ int initLogging(const OMEGA::MachEnv *DefEnv, std::string const &LogFilePath) {
       try {
          std::size_t dotPos = LogFilePath.find_last_of('.');
 
+         // create log file name/path and set default (*) logger
          if (Tasks.size() > 1 && dotPos != std::string::npos) {
-            auto NewLogFilePath = LogFilePath.substr(0, dotPos) + "_" +
-                                  std::to_string(TaskId) +
-                                  LogFilePath.substr(dotPos);
-            spdlog::set_default_logger(
-                spdlog::basic_logger_mt("*", NewLogFilePath));
+            NewLogFilePath = LogFilePath.substr(0, dotPos) + "_" +
+                             std::to_string(TaskId) +
+                             LogFilePath.substr(dotPos);
          } else {
-            spdlog::set_default_logger(
-                spdlog::basic_logger_mt("*", LogFilePath));
+            NewLogFilePath = LogFilePath;
          }
 
-         spdlog::set_pattern("[%n %l] %v");
+         // Create default logger
+         spdlog::set_default_logger(
+             spdlog::basic_logger_mt("*", NewLogFilePath));
+
+         // Set the prefix for all messages l is log level and v is msg txt
+         spdlog::set_pattern("[%l] %v");
+         // Set the default log level based on cpp input
          spdlog::set_level(
              static_cast<spdlog::level::level_enum>(SPDLOG_ACTIVE_LEVEL));
+         // Flush the message buffer for all messages above warning level
          spdlog::flush_on(spdlog::level::warn);
 
-         RetVal = 1; // log enalbed
+         RetVal = 1; // log enabled
 
       } catch (spdlog::spdlog_ex const &Ex) {
          std::cout << "Log init failed: " << Ex.what() << std::endl;
@@ -147,7 +187,18 @@ int initLogging(const OMEGA::MachEnv *DefEnv, std::string const &LogFilePath) {
       RetVal = 0; // log disabled
    }
 
+   // If logging is successful, also redirect stdout and stderr to log file
+   if (RetVal == 1) {
+      // Open an output filestream to the new log file defined above
+      LogFileStream.open(NewLogFilePath, std::ios::app);
+
+      // Set the stdout and stderr buffers to the file streambuffer
+      std::cout.rdbuf(LogFileStream.rdbuf());
+      std::cerr.rdbuf(LogFileStream.rdbuf());
+   }
+
    return RetVal;
 }
 
 } // namespace OMEGA
+//===----------------------------------------------------------------------===//

--- a/components/omega/src/infra/Logging.h
+++ b/components/omega/src/infra/Logging.h
@@ -10,14 +10,26 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// \def OMEGA_LOG_LEVEL
+/// Preprocessor variable that determines at which level log messages will be
+/// written. All levels higher than the requested level will be written.
+/// Default is the info level which will write all info, warning, error and
+/// critical messages. The levels are:
+///   TRACE (0)
+///   DEBUG (1)
+///   INFO (2)
+///   WARN (3)
+///   ERROR (4)
+///   CRITICAL (5)
 #if defined(OMEGA_LOG_LEVEL)
 #define SPDLOG_ACTIVE_LEVEL OMEGA_LOG_LEVEL
 #else
-// default level: info(2)
 #define SPDLOG_ACTIVE_LEVEL 2
 #endif
 
 #include "DataTypes.h"
+#include <fstream>
+#include <iostream>
 #include <spdlog/spdlog.h>
 #include <string>
 
@@ -30,64 +42,136 @@
 #define _LOG_FLUSH (void)0
 #endif
 
+/// \def LOG_TRACE(msg, ...)
+/// Macro that writes a Log message when the TRACE or higher logging level is
+/// enabled. The trace label, together with the filename and line number from
+/// which the /// macro is called is pre-pended to the msg.
 #define LOG_TRACE(msg, ...)                                                   \
    spdlog::trace(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
    _LOG_FLUSH
+
+/// \def LOG_DEBUG(msg, ...)
+/// Macro that writes a Log message when the DEBUG or higher logging level is
+/// enabled. The debug label, together with the filename and line number from
+/// which the macro is called is pre-pended to the msg.
 #define LOG_DEBUG(msg, ...)                                                   \
    spdlog::debug(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
    _LOG_FLUSH
-#define LOG_INFO(msg, ...)                                                   \
-   spdlog::info(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+
+/// \def LOG_INFO(msg, ...)
+/// Macro that writes a Log message when the INFO or higher logging level is
+/// enabled. This is typically the default logging level. Unlike the other
+/// macros, the message is written as provided with no additional prefix.
+/// This should be used for general informational messages.
+#define LOG_INFO(msg, ...)           \
+   spdlog::info(msg, ##__VA_ARGS__); \
    _LOG_FLUSH
+
+/// \def LOG_WARN(msg, ...)
+/// Macro that writes a Log message when the WARN or higher logging level is
+/// enabled. The warn label, together with the filename and line number from
+/// which the macro is called is pre-pended to the msg.
 #define LOG_WARN(msg, ...)                                                   \
    spdlog::warn(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
    _LOG_FLUSH
+
+// original: define LOG_WARN(msg, ...)                                                   \
+   spdlog::warn(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+   _LOG_FLUSH
+
+/// \def LOG_ERROR(msg, ...)
+/// Macro that writes a Log message when the ERROR or higher logging level is
+/// enabled. The error label, together with the filename and line number from
+/// which the macro is called is pre-pended to the msg.
 #define LOG_ERROR(msg, ...)                                                   \
    spdlog::error(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
    _LOG_FLUSH
+
+/// \def LOG_CRITICAL(msg, ...)
+/// Macro that writes a Log message when the CRITICAL or higher logging level is
+/// enabled. The critical label, together with the filename and line number from
+/// which the macro is called is pre-pended to the msg.
 #define LOG_CRITICAL(msg, ...)                                   \
    spdlog::critical(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), \
                     ##__VA_ARGS__);                              \
    _LOG_FLUSH
 
+/// \def LOGGER_TRACE(logger, msg, ...)
+/// Macro similar to LOG_TRACE but for a custom input logger.
 #define LOGGER_TRACE(logger, msg, ...)                                        \
    logger->trace(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
    _LOG_FLUSH
+
+/// \def LOGGER_DEBUG(logger, msg, ...)
+/// Macro similar to LOG_DEBUG but for a custom input logger.
 #define LOGGER_DEBUG(logger, msg, ...)                                        \
    logger->debug(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
    _LOG_FLUSH
+
+/// \def LOGGER_INFO(logger, msg, ...)
+/// Macro similar to LOG_INFO but for a custom input logger.
 #define LOGGER_INFO(logger, msg, ...)                                        \
    logger->info(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
    _LOG_FLUSH
+
+/// \def LOGGER_WARN(logger, msg, ...)
+/// Macro similar to LOG_WARN but for a custom input logger.
 #define LOGGER_WARN(logger, msg, ...)                                        \
    logger->warn(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
    _LOG_FLUSH
+
+/// \def LOGGER_ERROR(logger, msg, ...)
+/// Macro similar to LOG_ERROR but for a custom input logger.
 #define LOGGER_ERROR(logger, msg, ...)                                        \
    logger->error(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
    _LOG_FLUSH
+
+/// \def LOGGER_CRITICAL(logger, msg, ...)
+/// Macro similar to LOG_CRITICAL but for a custom input logger.
 #define LOGGER_CRITICAL(logger, msg, ...)                        \
    logger->critical(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), \
                     ##__VA_ARGS__);                              \
    _LOG_FLUSH
 
+/// \def OMEGA_LOG_TASKS
+/// A preprocessor variable that defines which tasks will be writing messages.
+/// The default is to write a single log from task 0. If other tasks (or ALL)
+/// are provided, log messages will be written to a corresponding log file with
+/// the task number appended to the log file name.
 #ifndef OMEGA_LOG_TASKS
 #define OMEGA_LOG_TASKS 0
 #endif
 
 namespace OMEGA {
 
+// To prevent some circular dependencies between MachEnv and Logging
 class MachEnv;
 
-const std::string OmegaDefaultLogfile = "omega.log";
+// Public variables used for logging
+const std::string OmegaDefaultLogfile = "omega.log"; ///< Default log filename
+static std::ofstream LogFileStream;                  ///< Default log iostream
 
-int initLogging(const OMEGA::MachEnv *DefEnv,
-                std::shared_ptr<spdlog::logger> Logger);
+/// Initializes Omega logging, including setting up which tasks will log
+/// and add redirection of stdout/stderr to log file
+int initLogging(
+    const OMEGA::MachEnv *DefEnv, ///< [in] MachEnv with MPI task info
+    std::string const &LogFilePath = OmegaDefaultLogfile ///< [in] file name
+);
 
-int initLogging(const OMEGA::MachEnv *DefEnv,
-                std::string const &LogFilePath = OmegaDefaultLogfile);
+/// Alternative Logging initialization using a pre-defined custom Logger
+int initLogging(
+    const OMEGA::MachEnv *DefEnv,          ///< [in] MachEnv with MPI task info
+    std::shared_ptr<spdlog::logger> Logger ///< [in] Logger to use
+);
 
-std::string _PackLogMsg(const char *file, int line, const std::string &msg);
+/// Utility function to create a log message with prefix
+std::string
+_PackLogMsg(const char *file, ///< [in] file where log called (cpp __FILE__)
+            int line,         ///< [in] src code line where log (cpp __LINE__)
+            const std::string &msg ///< [in] message text
+);
 
 } // namespace OMEGA
 
+//===----------------------------------------------------------------------===//
 #endif // OMEGA_LOG_H


### PR DESCRIPTION
Modifies Omega logging facility to:
  - redirect stdout and stderr to default log file to catch TPL and any other stray msgs
  - remove routine/line number prefix from Info-level log messages, retains for all other log levels (would also like to remove the [info] prefix but that turns out to be more difficult)
  - some cleanup and added comments, including some doxygen-formatted comments for eventual interface docs

Passes unit tests on Chrysalis/Intel and Frontier gnu gpu/cpu.

Checklist
* [x] Testing
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

