### PR TITLE
Add checkbox for CMake warnings to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Please add a description of what is accomplished in the PR here at the top:
 -->
 
 <!--
-Below are a few things we ask you or your reviewers to kindly check. 
+Below are a few things we ask you or your reviewers to kindly check.
 ***Remove checks that are not relevant by deleting the line(s) below.***
 -->
 Checklist
@@ -12,9 +12,11 @@ Checklist
   * [ ] User's Guide has been updated
   * [ ] Developer's Guide has been updated
   * [ ] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
+* [ ] Building
+  * [ ] CMake build does not produce any new warnings from changes in this PR
 * [ ] Testing
   * [ ] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
-  * [ ] CTest unit tests for new features have been added per the approved design. 
+  * [ ] CTest unit tests for new features have been added per the approved design.
   * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
   * [ ] Unit tests have passed. Please provide a relevant CDash build entry for verification.
   * [ ] Polaris test suite has passed


### PR DESCRIPTION
Developers must assert that their development does not add any new warnings during the CMake build.