### PR TITLE
Reduce error messages from IOStream

### DIFF
--- a/components/omega/doc/devGuide/IOStreams.md
+++ b/components/omega/doc/devGuide/IOStreams.md
@@ -40,7 +40,7 @@ been defined and the relevant data arrays have been attached to Fields and
 are available to access.  At the end of a simulation, IOStreams must be
 finalized using
 ```c++
-   int Err = IOStream::finalize(ModelClock);
+   IOStream::finalize(ModelClock);
 ```
 so that any final writes can take place for the OnShutdown streams and to
 deallocate all defined streams and arrays. If a stream needs to be removed
@@ -52,7 +52,7 @@ before that time, an erase function is provided:
 For most output streams, we provide a writeAll interface that should be placed
 at an appropriate time during the time step loop:
 ```c++
-   int Err = IOStream::writeAll(ModelClock);
+   IOStream::writeAll(ModelClock);
 ```
 This function checks each write stream and writes the file if it is time, based
 on a time manager alarm that is defined during initialization for each stream
@@ -60,18 +60,21 @@ based on the time frequency in the streams configuration. After writing the
 file, the alarm is reset for the next write time. If a file must be written
 outside of this routine, a single-stream write can take place using:
 ```c++
-   int Err = IOStream::write(StreamName, ModelClock);
+   IOStream::write(StreamName, ModelClock);
 ```
 
 Reading files (eg for initialization, restart or forcing) does not often
 take place all at once, so no readAll interface is provided. Instead, each
 input stream is read using:
 ```c++
-   int Err = IOStream::read(StreamName, ModelClock, ReqMetadata);
+   Error Err = IOStream::read(StreamName, ModelClock, ReqMetadata);
 ```
-where ReqMetadata is a variable of type Metadata (defined in Field but
+The returned error code typically means that a field in the stream could
+not be found in the input file - most other errors abort immediately. The
+calling routine is then responsible for deciding what action to take.
+The ReqMetadata argument is a variable of type Metadata (defined in Field but
 essentially a ``std::map<std::string, std::any>`` for the name/value pair).
-This variable should incude the names of global metadata that are desired
+This variable should include the names of global metadata that are desired
 from the input file. For example, if a time string is needed to verify the
 input file corresponds to a desired time, the required metadata can be
 initialized with

--- a/components/omega/src/infra/IOStream.h
+++ b/components/omega/src/infra/IOStream.h
@@ -150,21 +150,21 @@ class IOStream {
    /// options in the input model configuration. This routine is called by
    /// the IOStreams initialize function. It requires an initialized model
    /// clock so that stream alarm can be attached to this clock during creation.
-   static int create(const std::string &StreamName, ///< [in] name of stream
-                     Config &StreamConfig, ///< [in] stream configuration
-                     Clock *&ModelClock    ///< [inout] Omega model clock
+   static void create(const std::string &StreamName, ///< [in] name of stream
+                      Config &StreamConfig, ///< [in] stream configuration
+                      Clock *&ModelClock    ///< [inout] Omega model clock
    );
 
-   /// Define all dimensions used. Returns an error code as well as a map
-   /// of dimension names to defined dimension IDs.
-   int defineAllDims(
+   /// Define all dimensions used. Returns a map of dimension names to defined
+   /// dimension IDs.
+   void defineAllDims(
        int FileID, ///< [in] id assigned to the IO file
        std::map<std::string, int> &AllDimIDs ///< [out] dim name, assigned ID
    );
 
    /// Computes the parallel decomposition (offsets) for a field.
    /// Needed for parallel I/O
-   int computeDecomp(
+   void computeDecomp(
        std::shared_ptr<Field> FieldPtr, ///< [in] field
        int &DecompID, ///< [out] ID assigned to the defined decomposition
        I4 &LocalSize, ///< [out] size of the local array for this field
@@ -180,7 +180,7 @@ class IOStream {
 
    /// Private function that performs most of the stream read - called by the
    /// public read method
-   int readStream(
+   Error readStream(
        const Clock *ModelClock, ///< [in] Model clock for alarms, time stamp
        Metadata &ReqMetadata, ///< [inout] global metadata to extract from file
        bool ForceRead = false ///< [in] Optional: read even if not time
@@ -202,7 +202,7 @@ class IOStream {
 
    /// Write a field's data array, performing any manipulations to reduce
    /// precision or move data between host and device
-   int
+   void
    writeFieldData(std::shared_ptr<Field> FieldPtr, ///< [in] field to write
                   int FileID,  ///< [in] id assigned to open file
                   int FieldID, ///< [in] id assigned to the field
@@ -211,7 +211,7 @@ class IOStream {
 
    /// Read a field's data array, performing any manipulations to reduce
    /// precision or move data between host and device
-   int
+   Error
    readFieldData(std::shared_ptr<Field> FieldPtr, ///< [in] field to read
                  int FileID, ///< [in] id assigned to open file
                  std::map<std::string, int> &AllDimIDs, ///< [in] dimension IDs
@@ -249,26 +249,19 @@ class IOStream {
 
  public:
    //---------------------------------------------------------------------------
-   /// Return codes - these will be removed once Error Handler is completed
-
-   static constexpr int Success{0}; ///< Successful read/write completion
-   static constexpr int Skipped{1}; ///< Normal early return (eg if not time)
-   static constexpr int Fail{2};    ///< Fail
-
-   //---------------------------------------------------------------------------
    /// Default empty constructor
    IOStream();
 
    //---------------------------------------------------------------------------
    /// Creates all streams defined in the input configuration file. This does
    /// not validate the contents of the streams since the relevant Fields
-   /// may not have been defined yet. Returns an error code.
+   /// may not have been defined yet.
    static void init(Clock *&ModelClock ///< [inout] Omega model clock
    );
 
    //---------------------------------------------------------------------------
    /// Performs a final write of any streams that have the OnShutdown option and
-   /// then removes all streams to clean up. Returns an error code.
+   /// then removes all streams to clean up.
    static void
    finalize(const Clock *ModelClock ///< [in] Model clock needed for time stamps
    );
@@ -314,11 +307,11 @@ class IOStream {
    static bool validateAll();
 
    //---------------------------------------------------------------------------
-   /// Reads a stream if it is time. Returns an error code.
-   static int read(const std::string &StreamName, ///< [in] Name of stream
-                   const Clock *ModelClock, ///< [in] Model clock for time info
-                   Metadata &ReqMetadata, ///< [inout] Metadata desired in file
-                   bool ForceRead = false ///< [in] opt: read even if not time
+   /// Reads a stream if it is time.
+   static Error read(const std::string &StreamName, ///< [in] Name of stream
+                     const Clock *ModelClock, ///< [in] Model clock w time info
+                     Metadata &ReqMetadata,   ///< [inout] Metadata desired
+                     bool ForceRead = false ///< [in] opt: read even if not time
    );
 
    //---------------------------------------------------------------------------

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -118,8 +118,8 @@ int initOmegaModules(MPI_Comm Comm) {
    std::string SimTimeStr          = " "; // create SimulationTime metadata
    std::shared_ptr<Field> SimField = Field::get(SimMeta);
    SimField->addMetadata("SimulationTime", SimTimeStr);
-   int Err1 = IOStream::Success;
-   int Err2 = IOStream::Success;
+   Error Err1;
+   Error Err2;
 
    // read from initial state if this is starting a new simulation
    Metadata ReqMeta; // no requested metadata for initial state
@@ -132,7 +132,7 @@ int initOmegaModules(MPI_Comm Comm) {
 
    // One of the above two streams must be successful to initialize the
    // state and other fields used in the model
-   if (Err1 != IOStream::Success and Err2 != IOStream::Success) {
+   if (Err1.isFail() and Err2.isFail()) {
       ABORT_ERROR("Error initializing ocean variables from input streams");
    }
 

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -35,7 +35,7 @@ using namespace OMEGA;
 // The initialization routine for State testing. It calls various
 // init routines, including the creation of the default decomposition.
 
-int initStateTest() {
+void initStateTest() {
 
    int Err = 0;
    Error Err1;
@@ -75,7 +75,7 @@ int initStateTest() {
    // Initialize the default halo
    Err = Halo::init();
    if (Err != 0)
-      LOG_ERROR("State: error initializing default halo");
+      ABORT_ERROR("State: error initializing default halo");
 
    // Initialize the default mesh
    HorzMesh::init();
@@ -107,26 +107,19 @@ int initStateTest() {
 
    // Create a default ocean state
    Err = OceanState::init();
-   if (Err != 0) {
-      LOG_CRITICAL("ocnInit: Error initializing default state");
-      return Err;
-   }
+   if (Err != 0)
+      ABORT_ERROR("ocnInit: Error initializing default state");
 
    // Now that all fields have been defined, validate all the streams
    // contents
    bool StreamsValid = IOStream::validateAll();
-   if (!StreamsValid) {
-      LOG_CRITICAL("ocnInit: Error validating IO Streams");
-      return Err;
-   }
+   if (!StreamsValid)
+      ABORT_ERROR("ocnInit: Error validating IO Streams");
 
    // Read the state variables from the initial state stream
    Metadata ReqMeta; // no global metadata needed for init state read
-   Err = IOStream::read("InitialState", ModelClock, ReqMeta);
-   if (Err != IOStream::Success) {
-      LOG_CRITICAL("ocnInit: Error reading initial state from stream");
-      return Err;
-   }
+   Err1 = IOStream::read("InitialState", ModelClock, ReqMeta);
+   CHECK_ERROR_ABORT(Err1, "ocnInit: Error reading initial state from stream");
 
    // Finish initialization of initial state by filling halos and copying
    // to host. Current time level is zero.
@@ -134,7 +127,7 @@ int initStateTest() {
    DefState->exchangeHalo(0);
    DefState->copyToHost(0);
 
-   return Err;
+   return;
 }
 
 // Check for differences between layer thickness and normal velocity host arrays
@@ -226,9 +219,7 @@ int main(int argc, char *argv[]) {
 
       // Call initialization routine to create default state and other
       // quantities
-      int Err = initStateTest();
-      if (Err != 0)
-         LOG_CRITICAL("State: Error initializing");
+      initStateTest();
 
       // Get default mesh, halo and time data
       HorzMesh *DefHorzMesh   = HorzMesh::getDefault();


### PR DESCRIPTION
Reduces error messages and replaces most return codes in favor of immediate abort in IOStream routines. The exception is the read function which returns an error when fields are not found to support cases in which some fields may not be required. Developer guide has been updated to reflect the new interfaces and to document the read behavior.

Passes CTest on Frontier cpu/gpu.  Includes changes cherry-picked from #285 so final merge should wait for that PR merge and subsequent rebase.

Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.


