### PR TITLE
Cleanup of DataTypes and MachEnv

### DIFF
--- a/components/omega/doc/devGuide/DataTypes.md
+++ b/components/omega/doc/devGuide/DataTypes.md
@@ -5,11 +5,11 @@
 Omega supports all standard data types and uses some additional defined
 types to guarantee a specific level of precision. In particular, we
 define I4, I8, R4 and R8 types for 4-byte (32-bit) and 8-byte (64-bit)
-integer and floating point variables. Note that these exist in the
-Omega namespace so use the scoped form OMEGA::I4, etc.
+integer and floating point variables.
 In addition, we define a Real data type that is, by default,
 double precision (8 bytes/64-bit) but if the code is built with a
-`-DOMEGA_SINGLE_PRECISION` (see insert link to build system) preprocessor flag,
+`-DOMEGA_SINGLE_PRECISION` preprocessor flag
+(see [build system documentation](#omega-dev-cmake-build)),
 the default Real becomes single precision (4-byte/32-bit). For floating
 point variables, developers should use this Real type instead of the
 specific R4 or R8 forms unless the specific form is required
@@ -37,8 +37,8 @@ alias array types of the form `ArrayNDTT` where N is the dimension of
 the array and TT is the data type (I4, I8, R4, R8 or Real) corresponding
 to the types described above. The dimension refers to the number of
 ranks in the array and not the physical dimension. Although Kokkos
-supports Fortran ordering, we will use C ordering for array indices.
-Within Omega the default location for an Array should be on the device
+supports Fortran ordering, we use C ordering for array indices.
+Within Omega, the default location for an Array should be on the device
 with a similar type HostArrayNDTT defined for arrays needed on the host.
 As an example, we can define and allocate a device and host array using:
 ```c++
@@ -50,7 +50,14 @@ from the device or vice versa.
 ```c++
    auto TemperatureHost = OMEGA::createHostMirrorCopy(Temperature);
 ```
-Finally, the arrays can be deallocated explicity using the class
+Note that MirrorCopy will perform a deep copy on creation, but will not
+automatically synchronize the copies during later computations. The
+synchronization must be performed manually after any changes to host or
+device arrays using a deepCopy call:
+```c++
+   deepCopy(destinationArray, sourceArray);
+```
+Finally, arrays can be deallocated explicity using the class
 deallocate method, eg `Temperature.deallocate();` or if they are local
 to a routine, they will be automatically deallocated when they fall out
 of scope on exit. More details on Kokkos arrays are available in the Kokkos

--- a/components/omega/doc/devGuide/MachEnv.md
+++ b/components/omega/doc/devGuide/MachEnv.md
@@ -9,11 +9,11 @@ if threaded, vector length for CPUs, and GPU and node information as
 needed. Multiple environments can be defined to support running portions
 of the model on subsets of tasks.
 
-On model initiation, the initialization routine `OMEGA::MachEnv::init()`
+On model initiation, the initialization routine `MachEnv::init()`
 is called to set up the default MachEnv, which can be retrieved at
 any time using:
 ```c++
-OMEGA::MachEnv DefEnv = OMEGA::MachEnv::getDefault();
+MachEnv DefEnv = MachEnv::getDefault();
 ```
 that returns a pointer to the default environment.
 Once an environment has been retrieved, the individual data members
@@ -27,12 +27,12 @@ are retrieved using various get functions:
 There is also a logical function `isMasterTask` that can be used
 for work that should only be done on the master task. By default,
 the master task is defined as task 0 in the environment, but if
-the master task is overloaded, there is a `setMasterTask` that can
-redefine any other task in the group as the master.
+the master task is overloaded, there is a `setMasterTask(TaskID)`
+that can redefine any other task in the group as the master.
 
 If Omega has been built with OpenMP threading, a `getNumThreads`
 function is available; it returns 1 if threading is not on.
-The MachEnv also has a public parameter `OMEGA::VecLength` that can
+The MachEnv also has a public parameter `VecLength` that can
 be used to tune the vector length for CPU architectures. For
 GPU builds, this VecLength is set to 1.
 
@@ -40,9 +40,9 @@ As noted previously, additional environments can be defined for
 subsets of a parent environment. There are three constructor
 interfaces for creating an environment:
 ```c++
-  OMEGA::MachEnv MyNewEnv(Name, ParentEnv, NewSize);
-  OMEGA::MachEnv MyNewEnv(Name, ParentEnv, NewSize, Begin, Stride);
-  OMEGA::MachEnv MyNewEnv(Name, ParentEnv, NewSize, Tasks);
+  MachEnv MyNewEnv(Name, ParentEnv, NewSize);
+  MachEnv MyNewEnv(Name, ParentEnv, NewSize, Begin, Stride);
+  MachEnv MyNewEnv(Name, ParentEnv, NewSize, Tasks);
 ```
 An optional additional argument exists for all three that can supply an
 alternative task to use as the Master Task for message passing. If not
@@ -53,10 +53,10 @@ environment from a strided set of tasks starting at the `Begin` Task
 (eg all odd tasks would have Begin=1 and Stride=2). The final
 interface creates a subset containing the selected tasks stored in
 a vector `Tasks`. Each new environment is given a `Name` and can be
-retrieved by name using `OMEGA::MachEnv::get(Name)`. Once retrieved,
+retrieved by name using `MachEnv::get(Name)`. Once retrieved,
 the other get functions listed above are used to get each data member.
 Because the new environments are subsets of the default environment, one
-additional function `OMEGA::MachEnv::isMember()` is provided so that
+additional function `MachEnv::isMember()` is provided so that
 non-member tasks can be excluded from calculations. The retrieval functions
 call from non-member tasks will return invalid values. Finally, there is
 a `removeEnv(Name)` function that can delete any individual defined

--- a/components/omega/src/base/MachEnv.h
+++ b/components/omega/src/base/MachEnv.h
@@ -185,7 +185,7 @@ class MachEnv {
    /// can be set here to a different task if the master task has
    /// become over-burdened by work or memory (eg in coupled mode when
    /// all components are using the same master).
-   int setMasterTask(const int TaskID ///< [in] new task to use as master
+   void setMasterTask(const int TaskID ///< [in] new task to use as master
    );
 
    /// Prints all members of a MachEnv (typically for debugging)

--- a/components/omega/test/base/DataTypesTest.cpp
+++ b/components/omega/test/base/DataTypesTest.cpp
@@ -12,9 +12,10 @@
 //
 //===-----------------------------------------------------------------------===/
 
-#include <iostream>
-
 #include "DataTypes.h"
+#include "Error.h"
+#include "Logging.h"
+#include "MachEnv.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
 #include "mpi.h"
@@ -23,73 +24,50 @@ using namespace OMEGA;
 
 int main(int argc, char *argv[]) {
 
-   int RetVal = 0;
-
    // initialize environments
    MPI_Init(&argc, &argv);
    Kokkos::initialize();
    Pacer::initialize(MPI_COMM_WORLD);
    Pacer::setPrefix("Omega:");
+
+   // These are needed to set up logging for output
+   MachEnv::init(MPI_COMM_WORLD);
+   MachEnv *DefEnv = MachEnv::getDefault();
+   initLogging(DefEnv);
+   LOG_INFO("------ DataTypes Unit Tests ------");
+
    {
       int SizeTmp = 0;
 
       // Check expected size (in bytes) for data types
       SizeTmp = sizeof(I4);
-      if (SizeTmp == 4)
-         std::cout << "Size of I4: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Size of I4: FAIL " << SizeTmp << std::endl;
-      }
+      if (SizeTmp != 4)
+         ABORT_ERROR("DataTypesTest: FAIL Size of I4 ({}) is not 4", SizeTmp);
 
       SizeTmp = sizeof(I8);
-      if (SizeTmp == 8)
-         std::cout << "Size of I8: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Size of I8: FAIL " << SizeTmp << std::endl;
-      }
+      if (SizeTmp != 8)
+         ABORT_ERROR("DataTypesTest: FAIL Size of I8 ({}) is not 8", SizeTmp);
 
       SizeTmp = sizeof(R4);
-      if (SizeTmp == 4)
-         std::cout << "Size of R4: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Size of R4: FAIL " << SizeTmp << std::endl;
-      }
+      if (SizeTmp != 4)
+         ABORT_ERROR("DataTypesTest: FAIL Size of R4 ({}) is not 4", SizeTmp);
 
       SizeTmp = sizeof(R8);
-      if (SizeTmp == 8)
-         std::cout << "Size of R8: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Size of R8: FAIL " << SizeTmp << std::endl;
-      }
+      if (SizeTmp != 8)
+         ABORT_ERROR("DataTypesTest: FAIL Size of R8 ({}) is not 8", SizeTmp);
 
       SizeTmp = sizeof(Real);
 #ifdef SINGLE_PRECISION
-      if (SizeTmp == 4)
-         std::cout << "Size of Real is 4: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Size of Real is 4: FAIL " << SizeTmp << std::endl;
-      }
+      if (SizeTmp != 4)
+         ABORT_ERROR("DataTypesTest: FAIL Size of Real ({}) is not 4", SizeTmp);
 #else
-      if (SizeTmp == 8)
-         std::cout << "Size of Real is 8: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Size of Real is 8: FAIL " << SizeTmp << std::endl;
-      }
+      if (SizeTmp != 8)
+         ABORT_ERROR("DataTypesTest: FAIL Size of Real ({}) is not 8", SizeTmp);
 #endif
 
       SizeTmp = sizeof(1._Real);
-      if (SizeTmp == sizeof(Real))
-         std::cout << "Size of Real literal: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Size of Real literal: FAIL " << SizeTmp << std::endl;
-      }
+      if (SizeTmp != sizeof(Real))
+         ABORT_ERROR("DataTypesTest: Size of Real literal: FAIL");
 
       // Test creation of device arrays and copying to/from host
       // by initializing on the device, copying to host and comparing with
@@ -121,12 +99,8 @@ int main(int argc, char *argv[]) {
             ++icount;
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 1DI4 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 1DI4 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 1DI4 test: FAIL");
 
       // Test for 2DI4
       Array2DI4 TstArr2DI4("TstArr2DI4", NumCells, NumVertLvls);
@@ -154,12 +128,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 2DI4 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 2DI4 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 2DI4 test: FAIL");
 
       // Test for 3DI4
       Array3DI4 TstArr3DI4("TstArr3DI4", NumTracers, NumCells, NumVertLvls);
@@ -193,12 +163,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 3DI4 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 3DI4 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 3DI4 test: FAIL");
 
       // Test for 4DI4
       Array4DI4 TstArr4DI4("TstArr4DI4", NumTimeLvls, NumTracers, NumCells,
@@ -238,12 +204,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 4DI4 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 4DI4 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 4DI4 test: FAIL");
 
       // Test for 5DI4
       Array5DI4 TstArr5DI4("TstArr5DI4", NumExtra, NumTimeLvls, NumTracers,
@@ -288,12 +250,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 5DI4 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 5DI4 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 5DI4 test: FAIL");
 
       // Test for 1DI8
       Array1DI8 TstArr1DI8("TstArr1DI8", NumCells);
@@ -315,12 +273,8 @@ int main(int argc, char *argv[]) {
             ++icount;
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 1DI8 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 1DI8 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 1DI8 test: FAIL");
 
       // Test for 2DI8
       Array2DI8 TstArr2DI8("TstArr2DI8", NumCells, NumVertLvls);
@@ -348,12 +302,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 2DI8 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 2DI8 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 2DI8 test: FAIL");
 
       // Test for 3DI8
       Array3DI8 TstArr3DI8("TstArr3DI8", NumTracers, NumCells, NumVertLvls);
@@ -387,12 +337,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 3DI8 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 3DI8 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 3DI8 test: FAIL");
 
       // Test for 4DI8
       Array4DI8 TstArr4DI8("TstArr4DI8", NumTimeLvls, NumTracers, NumCells,
@@ -432,12 +378,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 4DI8 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 4DI8 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 4DI8 test: FAIL");
 
       // Test for 5DI8
       Array5DI8 TstArr5DI8("TstArr5DI8", NumExtra, NumTimeLvls, NumTracers,
@@ -482,12 +424,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 5DI8 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 5DI8 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 5DI8 test: FAIL");
 
       // Test for 1DR4
       Array1DR4 TstArr1DR4("TstArr1DR4", NumCells);
@@ -509,12 +447,8 @@ int main(int argc, char *argv[]) {
             ++icount;
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 1DR4 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 1DR4 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 1DR4 test: FAIL");
 
       // Test for 2DR4
       Array2DR4 TstArr2DR4("TstArr2DR4", NumCells, NumVertLvls);
@@ -542,12 +476,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 2DR4 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 2DR4 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 2DR4 test: FAIL");
 
       // Test for 3DR4
       Array3DR4 TstArr3DR4("TstArr3DR4", NumTracers, NumCells, NumVertLvls);
@@ -581,12 +511,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 3DR4 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 3DR4 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 3DR4 test: FAIL");
 
       // Test for 4DR4
       Array4DR4 TstArr4DR4("TstArr4DR4", NumTimeLvls, NumTracers, NumCells,
@@ -626,12 +552,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 4DR4 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 4DR4 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 4DR4 test: FAIL");
 
       // Test for 5DR4
       Array5DR4 TstArr5DR4("TstArr5DR4", NumExtra, NumTimeLvls, NumTracers,
@@ -676,12 +598,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 5DR4 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 5DR4 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 5DR4 test: FAIL");
 
       // Test for 1DR8
       Array1DR8 TstArr1DR8("TstArr1DR8", NumCells);
@@ -703,12 +621,8 @@ int main(int argc, char *argv[]) {
             ++icount;
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 1DR8 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 1DR8 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 1DR8 test: FAIL");
 
       // Test for 2DR8
       Array2DR8 TstArr2DR8("TstArr2DR8", NumCells, NumVertLvls);
@@ -736,12 +650,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 2DR8 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 2DR8 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 2DR8 test: FAIL");
 
       // Test for 3DR8
       Array3DR8 TstArr3DR8("TstArr3DR8", NumTracers, NumCells, NumVertLvls);
@@ -775,12 +685,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 3DR8 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 3DR8 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 3DR8 test: FAIL");
 
       // Test for 4DR8
       Array4DR8 TstArr4DR8("TstArr4DR8", NumTimeLvls, NumTracers, NumCells,
@@ -820,12 +726,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 4DR8 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 4DR8 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 4DR8 test: FAIL");
 
       // Test for 5DR8
       Array5DR8 TstArr5DR8("TstArr5DR8", NumExtra, NumTimeLvls, NumTracers,
@@ -870,12 +772,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 5DR8 test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 5DR8 test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 5DR8 test: FAIL");
 
       // Test for 1DReal
       Array1DReal TstArr1DReal("TstArr1DReal", NumCells);
@@ -897,12 +795,8 @@ int main(int argc, char *argv[]) {
             ++icount;
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 1DReal test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 1DReal test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 1DReal test: FAIL");
 
       // Test for 2DReal
       Array2DReal TstArr2DReal("TstArr2DReal", NumCells, NumVertLvls);
@@ -930,12 +824,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 2DReal test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 2DReal test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 2DReal test: FAIL");
 
       // Test for 3DReal
       Array3DReal TstArr3DReal("TstArr3DReal", NumTracers, NumCells,
@@ -971,12 +861,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 3DReal test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 3DReal test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 3DReal test: FAIL");
 
       // Test for 4DReal
       Array4DReal TstArr4DReal("TstArr4DReal", NumTimeLvls, NumTracers,
@@ -1016,12 +902,8 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 4DReal test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 4DReal test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 4DReal test: FAIL");
 
       // Test for 5DReal
       Array5DReal TstArr5DReal("TstArr5DReal", NumExtra, NumTimeLvls,
@@ -1066,23 +948,17 @@ int main(int argc, char *argv[]) {
          }
       }
 
-      if (icount == 0)
-         std::cout << "Kokkos 5DReal test: PASS" << std::endl;
-      else {
-         RetVal += 1;
-         std::cout << "Kokkos 5DReal test: FAIL" << std::endl;
-      }
+      if (icount != 0)
+         ABORT_ERROR("DataTypesTest: Kokkos 5DReal test: FAIL");
 
       // finalize environments
       // MPI_Status status;
    }
+   LOG_INFO("------ DataTypes Unit Tests Successful ------");
    Kokkos::finalize();
    MPI_Finalize();
 
-   if (RetVal >= 256)
-      RetVal = 255;
-
-   return RetVal;
+   return 0; // if we made it here, return successfully
 
 } // end of main
 //===-----------------------------------------------------------------------===/


### PR DESCRIPTION
Some minor cleanup of the DataTypes and MachEnv code
  - removed one return code in favor of abort
  - reduced messages in unit tests
  - fixed and updated documentation

Passes CTest on chrysalis, frontier cpu/gpu

Checklist
* [x] Documentation:
  * [x] User's Guide has been updated
  * [x] Developer's Guide has been updated
BuildDocs.html) and changes look as expected
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
after.


