### PR TITLE
Add tests and developer docs for Kokkos wrappers

### DIFF
--- a/components/omega/doc/devGuide/ParallelLoops.md
+++ b/components/omega/doc/devGuide/ParallelLoops.md
@@ -1,0 +1,76 @@
+(omega-dev-parallel-loops)=
+
+# Parallel loops
+
+Omega adopts the Kokkos programming model to express on-node parallelism. To provide
+simplified syntax for the most frequently used computational patterns, Omega provides
+wrappers funtions that internally handle creating and setting-up Kokkos policies.
+
+## Flat multi-dimensional parallelism
+
+### parallelFor
+
+To perform parallel iteration over a multi-dimensional index range Omega provides the
+`parallelFor` wrapper. For example, the following code shows how to set every element of
+a 3D array in parallel.
+```c++
+   Array3DReal A("A", N1, N2, N3);
+   parallelFor(
+       {N1, N2, N3},
+       KOKKOS_LAMBDA(int J1, int J2, int J3) {
+          A(J1, J2, J3) = J1 + J2 + J3;
+       });
+```
+Ranges with up to five dimensions are supported.
+Optionally, a label can be provided as the first argument of `parallelFor`.
+```c++
+   parallelFor("Set A",
+       {N1, N2, N3},
+       KOKKOS_LAMBDA(int J1, int J2, int J3) {
+          A(J1, J2, J3) = J1 + J2 + J3;
+       });
+```
+Adding labels can result in more informative messages when
+Kokkos debug variables are defined.
+
+### parallelReduce
+
+To perform parallel reductions over a multi-dimensional index range the
+`parallelReduce` wrapper is available. The following code sums
+every element of `A`.
+```c++
+   Real SumA;
+   parallelReduce(
+       {N1, N2, N3},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, Real &Accum) {
+          Accum += A(J1, J2, J3);
+       },
+       SumA);
+```
+Note the presence of an accumulator variable `Accum` in the `KOKKOS_LAMBDA` arguments.
+You can use `parallelReduce` to perform other types of reductions.
+As an example, the following snippet finds the maximum of `A`.
+```c++
+   Real MaxA;
+   parallelReduce(
+       {N1, N2, N3},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, Real &Accum) {
+          Accum = Kokkos::max(Accum, A(J1, J2, J3));
+       },
+       Kokkos::Max<Real>(MaxA));
+```
+To perform reductions that are not sums, in addition to modifying the lambda body,
+the final reduction variable needs to be cast to the appropriate type. In the above example,
+`MaxA` is cast to `Kokkos::Max<Real>` to perform a max reduction.
+The `parallelReduce` wrapper supports performing multiple reduction at the same time.
+You can compute `SumA` and `MaxA` in one pass over the data:
+```c++
+   parallelReduce(
+       {N1, N2, N3},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, Real &AccumSum, Real &AccumMax) {
+          AccumSum += A(J1, J2, J3);
+          AccumMax = Kokkos::max(AccumMax, A(J1, J2, J3));
+       },
+       SumA, Kokkos::Max<Real>(MaxA));
+```
+Similarly to `parallelFor`, `parallelReduce` supports labels and up to five dimensions.

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -62,6 +62,7 @@ devGuide/Linting
 devGuide/Docs
 devGuide/BuildDocs
 devGuide/DataTypes
+devGuide/ParallelLoops
 devGuide/MachEnv
 devGuide/Config
 devGuide/Driver

--- a/components/omega/test/infra/OmegaKokkosTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosTest.cpp
@@ -3,106 +3,553 @@
 /// \file
 /// \brief Test driver for OMEGA Kokkos
 ///
-/// This driver tests the OmegaKokkos capabilities.
-/// The code is based on Kokkos Tutorial
+/// This driver tests the Omega wrappers of Kokkos capabilities.
 ///
 //
 //===-----------------------------------------------------------------------===/
 
-#include <iostream>
-
 #include "OmegaKokkos.h"
+#include "Error.h"
+#include "Logging.h"
+#include "MachEnv.h"
+
+#include "mpi.h"
+#include <limits>
 
 using namespace OMEGA;
 
-int main(int argc, char **argv) {
-
-   int RetVal  = 0;
-   int N       = 4096;
-   int M       = 1024;
-   int nrepeat = 100;
-
-   try {
-
-      Kokkos::initialize(argc, argv);
-      {
-
-         // Allocate y, x vectors and Matrix A on device.
-         Array1DR8 y("y", N);
-         Array1DR8 x("x", M);
-         Array2DR8 A("A", N, M);
-
-         deepCopy(y, 1);
-         deepCopy(x, 1);
-         deepCopy(A, 1);
-
-         // Timer products.
-         Kokkos::Timer timer;
-
-         for (int repeat = 0; repeat < nrepeat; repeat++) {
-
-            // Application: <y,Ax> = y^T*A*x
-            double result = 0;
-
-            parallelReduce(
-                "yAx", {N},
-                KOKKOS_LAMBDA(int j, double &update) {
-                   double temp2 = 0;
-
-                   for (int i = 0; i < M; ++i) {
-                      temp2 += A(j, i) * x(i);
-                   }
-
-                   update += y(j) * temp2;
-                },
-                result);
-
-            // Output result.
-            if (repeat == (nrepeat - 1)) {
-               std::cout << "  Computed result for " << N << " x " << M
-                         << " is " << result << std::endl;
-            }
-
-            const double solution = (double)N * (double)M;
-
-            if (result != solution) {
-               std::cout << "  FAIL: result( " << result << " ) != solution( "
-                         << solution << " )" << std::endl;
-               RetVal += 1;
-            }
-
-            // Calculate time.
-            double time = timer.seconds();
-
-            // Calculate bandwidth.
-            // Each matrix A row (each of length M) is read once.
-            // The x vector (of length M) is read N times.
-            // The y vector (of length N) is read once.
-            // double Gbytes = 1.0e-9 * double( sizeof(double) * ( 2 * M * N + N
-            // ) );
-            double Gbytes = 1.0e-9 * double(sizeof(double) * (M + M * N + N));
-
-            // Print results (problem size, time and bandwidth in GB/s).
-            std::cout << "  N( " << N << " ) M( " << M << " ) nrepeat ( "
-                      << nrepeat << " ) problem( " << Gbytes * 1000
-                      << " MB ) time( " << time << " s ) bandwidth( "
-                      << Gbytes * nrepeat / time << " GB/s )" << std::endl;
-         }
-
-         std::cout << "OmegaKokkos test: PASS" << std::endl;
+template <class Array> bool hostArraysEqual(const Array &A, const Array &B) {
+   bool Equal = true;
+   for (size_t I = 0; I < A.span(); I++) {
+      if (A.data()[I] != B.data()[I]) {
+         Equal = false;
+         break;
       }
-      Kokkos::finalize();
+   }
+   return Equal;
+}
 
-   } catch (const std::exception &Ex) {
-      std::cout << Ex.what() << ": FAIL" << std::endl;
-      RetVal += 1;
-   } catch (...) {
-      std::cout << "Unknown: FAIL" << std::endl;
-      RetVal += 1;
+static KOKKOS_FUNCTION int f1(int J1, int N1) { return -N1 / 4 + J1; }
+
+static KOKKOS_FUNCTION int f2(int J1, int J2, int N1, int N2) {
+   return -(N1 * N2) / 4 + J1 + N1 * J2;
+}
+
+static KOKKOS_FUNCTION int f3(int J1, int J2, int J3, int N1, int N2, int N3) {
+   return -(N1 * N2 * N3) / 4 + J1 + N1 * (J2 + N2 * J3);
+}
+
+static KOKKOS_FUNCTION int f4(int J1, int J2, int J3, int J4, int N1, int N2,
+                              int N3, int N4) {
+   return -(N1 * N2 * N3 * N4) / 4 + J1 + N1 * (J2 + N2 * (J3 + N3 * J4));
+}
+
+static KOKKOS_FUNCTION int f5(int J1, int J2, int J3, int J4, int J5, int N1,
+                              int N2, int N3, int N4, int N5) {
+   return -(N1 * N2 * N3 * N4 * N5) / 4 + J1 +
+          N1 * (J2 + N2 * (J3 + N3 * (J4 + N4 * J5)));
+}
+
+Error testParallelFor1D() {
+   Error Err;
+
+   const int N1 = 127;
+
+   HostArray1DI4 RefAH("RefA1H", N1);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      RefAH(J1) = f1(J1, N1);
    }
 
-   if (RetVal >= 256)
-      RetVal = 255;
+   Array1DI4 A("A1", N1);
+   parallelFor({N1}, KOKKOS_LAMBDA(int J1) { A(J1) = f1(J1, N1); });
 
-   return RetVal;
+   auto AH = createHostMirrorCopy(A);
+
+   if (!hostArraysEqual(AH, RefAH)) {
+      Err += Error(ErrorCode::Fail, "parallelFor 1D FAIL");
+   }
+
+   return Err;
+}
+
+Error testParallelReduce1D() {
+   Error Err;
+
+   const int N1 = 129;
+
+   I4 RefSum = 0;
+   I4 RefMax = std::numeric_limits<I4>::min();
+
+   for (int J1 = 0; J1 < N1; ++J1) {
+      RefSum += f1(J1, N1);
+      RefMax = std::max(RefMax, f1(J1, N1));
+   }
+
+   // Test simple sum reduction
+   I4 Sum1;
+   parallelReduce(
+       {N1}, KOKKOS_LAMBDA(int J1, I4 &Accum) { Accum += f1(J1, N1); }, Sum1);
+
+   if (Sum1 != RefSum) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 1D sum FAIL");
+   }
+
+   // Test simple max reduction
+   I4 Max1;
+   parallelReduce(
+       {N1},
+       KOKKOS_LAMBDA(int J1, I4 &Accum) {
+          Accum = Kokkos::max(Accum, f1(J1, N1));
+       },
+       Kokkos::Max<I4>(Max1));
+
+   if (Max1 != RefMax) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 1D max FAIL");
+   }
+
+   // Test doing both reductions together
+   I4 Sum2, Max2;
+   parallelReduce(
+       {N1},
+       KOKKOS_LAMBDA(int J1, I4 &SumAccum, I4 &MaxAccum) {
+          SumAccum += f1(J1, N1);
+          MaxAccum = Kokkos::max(MaxAccum, f1(J1, N1));
+       },
+       Sum2, Kokkos::Max<I4>(Max2));
+
+   if (Sum2 != RefSum || Max2 != RefMax) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 1D sum+max FAIL");
+   }
+
+   return Err;
+}
+
+Error testParallelFor2D() {
+   Error Err;
+
+   const int N1 = 63;
+   const int N2 = 31;
+
+   HostArray2DI4 RefAH("RefA2H", N1, N2);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         RefAH(J1, J2) = f2(J1, J2, N1, N2);
+      }
+   }
+
+   Array2DI4 A("A2", N1, N2);
+   parallelFor(
+       {N1, N2},
+       KOKKOS_LAMBDA(int J1, int J2) { A(J1, J2) = f2(J1, J2, N1, N2); });
+
+   auto AH = createHostMirrorCopy(A);
+
+   if (!hostArraysEqual(AH, RefAH)) {
+      Err += Error(ErrorCode::Fail, "parallelFor 2D FAIL");
+   }
+
+   return Err;
+}
+
+Error testParallelReduce2D() {
+   Error Err;
+
+   const int N1 = 33;
+   const int N2 = 65;
+
+   I4 RefSum = 0;
+   I4 RefMax = std::numeric_limits<I4>::min();
+
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         RefSum += f2(J1, J2, N1, N2);
+         RefMax = std::max(RefMax, f2(J1, J2, N1, N2));
+      }
+   }
+
+   // Test simple sum reduction
+   I4 Sum1;
+   parallelReduce(
+       {N1, N2},
+       KOKKOS_LAMBDA(int J1, int J2, I4 &Accum) {
+          Accum += f2(J1, J2, N1, N2);
+       },
+       Sum1);
+
+   if (Sum1 != RefSum) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 2D sum FAIL");
+   }
+
+   // Test simple max reduction
+   I4 Max1;
+   parallelReduce(
+       {N1, N2},
+       KOKKOS_LAMBDA(int J1, int J2, I4 &Accum) {
+          Accum = Kokkos::max(Accum, f2(J1, J2, N1, N2));
+       },
+       Kokkos::Max<I4>(Max1));
+
+   if (Max1 != RefMax) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 2D max FAIL");
+   }
+
+   // Test doing both reductions together
+   I4 Sum2, Max2;
+   parallelReduce(
+       {N1, N2},
+       KOKKOS_LAMBDA(int J1, int J2, I4 &SumAccum, I4 &MaxAccum) {
+          SumAccum += f2(J1, J2, N1, N2);
+          MaxAccum = Kokkos::max(MaxAccum, f2(J1, J2, N1, N2));
+       },
+       Sum2, Kokkos::Max<I4>(Max2));
+
+   if (Sum2 != RefSum || Max2 != RefMax) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 2D sum+max FAIL");
+   }
+
+   return Err;
+}
+
+Error testParallelFor3D() {
+   Error Err;
+
+   const int N1 = 2;
+   const int N2 = 100;
+   const int N3 = 60;
+
+   HostArray3DI4 RefAH("RefA3H", N1, N2, N3);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         for (int J3 = 0; J3 < N3; ++J3) {
+            RefAH(J1, J2, J3) = f3(J1, J2, J3, N1, N2, N3);
+         }
+      }
+   }
+
+   Array3DI4 A("A3", N1, N2, N3);
+   parallelFor(
+       {N1, N2, N3}, KOKKOS_LAMBDA(int J1, int J2, int J3) {
+          A(J1, J2, J3) = f3(J1, J2, J3, N1, N2, N3);
+       });
+
+   auto AH = createHostMirrorCopy(A);
+
+   if (!hostArraysEqual(AH, RefAH)) {
+      Err += Error(ErrorCode::Fail, "parallelFor 3D FAIL");
+   }
+
+   return Err;
+}
+
+Error testParallelReduce3D() {
+   Error Err;
+
+   const int N1 = 10;
+   const int N2 = 1;
+   const int N3 = 60;
+
+   I4 RefSum = 0;
+   I4 RefMax = std::numeric_limits<I4>::min();
+
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         for (int J3 = 0; J3 < N3; ++J3) {
+            RefSum += f3(J1, J2, J3, N1, N2, N3);
+            RefMax = std::max(RefMax, f3(J1, J2, J3, N1, N2, N3));
+         }
+      }
+   }
+
+   // Test simple sum reduction
+   I4 Sum1;
+   parallelReduce(
+       {N1, N2, N3},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, I4 &Accum) {
+          Accum += f3(J1, J2, J3, N1, N2, N3);
+       },
+       Sum1);
+
+   if (Sum1 != RefSum) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 3D sum FAIL");
+   }
+
+   // Test simple max reduction
+   I4 Max1;
+   parallelReduce(
+       {N1, N2, N3},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, I4 &Accum) {
+          Accum = Kokkos::max(Accum, f3(J1, J2, J3, N1, N2, N3));
+       },
+       Kokkos::Max<I4>(Max1));
+
+   if (Max1 != RefMax) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 3D max FAIL");
+   }
+
+   // Test doing both reductions together
+   I4 Sum2, Max2;
+   parallelReduce(
+       {N1, N2, N3},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, I4 &SumAccum, I4 &MaxAccum) {
+          SumAccum += f3(J1, J2, J3, N1, N2, N3);
+          MaxAccum = Kokkos::max(MaxAccum, f3(J1, J2, J3, N1, N2, N3));
+       },
+       Sum2, Kokkos::Max<I4>(Max2));
+
+   if (Sum2 != RefSum || Max2 != RefMax) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 3D sum+max FAIL");
+   }
+
+   return Err;
+}
+
+Error testParallelFor4D() {
+   Error Err;
+
+   const int N1 = 2;
+   const int N2 = 4;
+   const int N3 = 8;
+   const int N4 = 16;
+
+   HostArray4DI4 RefAH("RefA4H", N1, N2, N3, N4);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         for (int J3 = 0; J3 < N3; ++J3) {
+            for (int J4 = 0; J4 < N4; ++J4) {
+               RefAH(J1, J2, J3, J4) = f4(J1, J2, J3, J4, N1, N2, N3, N4);
+            }
+         }
+      }
+   }
+
+   Array4DI4 A("A4", N1, N2, N3, N4);
+   parallelFor(
+       {N1, N2, N3, N4}, KOKKOS_LAMBDA(int J1, int J2, int J3, int J4) {
+          A(J1, J2, J3, J4) = f4(J1, J2, J3, J4, N1, N2, N3, N4);
+       });
+
+   auto AH = createHostMirrorCopy(A);
+
+   if (!hostArraysEqual(AH, RefAH)) {
+      Err += Error(ErrorCode::Fail, "parallelFor 4D FAIL");
+   }
+
+   return Err;
+}
+
+Error testParallelReduce4D() {
+   Error Err;
+
+   const int N1 = 3;
+   const int N2 = 5;
+   const int N3 = 7;
+   const int N4 = 11;
+
+   I4 RefSum = 0;
+   I4 RefMax = std::numeric_limits<I4>::min();
+
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         for (int J3 = 0; J3 < N3; ++J3) {
+            for (int J4 = 0; J4 < N4; ++J4) {
+               RefSum += f4(J1, J2, J3, J4, N1, N2, N3, N4);
+               RefMax = std::max(RefMax, f4(J1, J2, J3, J4, N1, N2, N3, N4));
+            }
+         }
+      }
+   }
+
+   // Test simple sum reduction
+   I4 Sum1;
+   parallelReduce(
+       {N1, N2, N3, N4},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, int J4, I4 &Accum) {
+          Accum += f4(J1, J2, J3, J4, N1, N2, N3, N4);
+       },
+       Sum1);
+
+   if (Sum1 != RefSum) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 4D sum FAIL");
+   }
+
+   // Test simple max reduction
+   I4 Max1;
+   parallelReduce(
+       {N1, N2, N3, N4},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, int J4, I4 &Accum) {
+          Accum = Kokkos::max(Accum, f4(J1, J2, J3, J4, N1, N2, N3, N4));
+       },
+       Kokkos::Max<I4>(Max1));
+
+   if (Max1 != RefMax) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 4D max FAIL");
+   }
+
+   // Test doing both reductions together
+   I4 Sum2, Max2;
+   parallelReduce(
+       {N1, N2, N3, N4},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, int J4, I4 &SumAccum,
+                     I4 &MaxAccum) {
+          SumAccum += f4(J1, J2, J3, J4, N1, N2, N3, N4);
+          MaxAccum = Kokkos::max(MaxAccum, f4(J1, J2, J3, J4, N1, N2, N3, N4));
+       },
+       Sum2, Kokkos::Max<I4>(Max2));
+
+   if (Sum2 != RefSum || Max2 != RefMax) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 4D sum+max FAIL");
+   }
+
+   return Err;
+}
+
+Error testParallelFor5D() {
+   Error Err;
+
+   const int N1 = 33;
+   const int N2 = 1;
+   const int N3 = 3;
+   const int N4 = 2;
+   const int N5 = 129;
+
+   HostArray5DI4 RefAH("RefA5H", N1, N2, N3, N4, N5);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         for (int J3 = 0; J3 < N3; ++J3) {
+            for (int J4 = 0; J4 < N4; ++J4) {
+               for (int J5 = 0; J5 < N5; ++J5) {
+                  RefAH(J1, J2, J3, J4, J5) =
+                      f5(J1, J2, J3, J4, J5, N1, N2, N3, N4, N5);
+               }
+            }
+         }
+      }
+   }
+
+   Array5DI4 A("A5", N1, N2, N3, N4, N5);
+   parallelFor(
+       {N1, N2, N3, N4, N5},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, int J4, int J5) {
+          A(J1, J2, J3, J4, J5) = f5(J1, J2, J3, J4, J5, N1, N2, N3, N4, N5);
+       });
+
+   auto AH = createHostMirrorCopy(A);
+
+   if (!hostArraysEqual(AH, RefAH)) {
+      Err += Error(ErrorCode::Fail, "parallelFor 5D FAIL");
+   }
+
+   return Err;
+}
+
+Error testParallelReduce5D() {
+   Error Err;
+
+   const int N1 = 2;
+   const int N2 = 31;
+   const int N3 = 1;
+   const int N4 = 127;
+   const int N5 = 3;
+
+   I4 RefSum = 0;
+   I4 RefMax = std::numeric_limits<I4>::min();
+
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         for (int J3 = 0; J3 < N3; ++J3) {
+            for (int J4 = 0; J4 < N4; ++J4) {
+               for (int J5 = 0; J5 < N5; ++J5) {
+                  RefSum += f5(J1, J2, J3, J4, J5, N1, N2, N3, N4, N5);
+                  RefMax = std::max(RefMax,
+                                    f5(J1, J2, J3, J4, J5, N1, N2, N3, N4, N5));
+               }
+            }
+         }
+      }
+   }
+
+   // Test simple sum reduction
+   I4 Sum1;
+   parallelReduce(
+       {N1, N2, N3, N4, N5},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, int J4, int J5, I4 &Accum) {
+          Accum += f5(J1, J2, J3, J4, J5, N1, N2, N3, N4, N5);
+       },
+       Sum1);
+
+   if (Sum1 != RefSum) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 5D sum FAIL");
+   }
+
+   // Test simple max reduction
+   I4 Max1;
+   parallelReduce(
+       {N1, N2, N3, N4, N5},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, int J4, int J5, I4 &Accum) {
+          Accum =
+              Kokkos::max(Accum, f5(J1, J2, J3, J4, J5, N1, N2, N3, N4, N5));
+       },
+       Kokkos::Max<I4>(Max1));
+
+   if (Max1 != RefMax) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 5D max FAIL");
+   }
+
+   // Test doing both reductions together
+   I4 Sum2, Max2;
+   parallelReduce(
+       {N1, N2, N3, N4, N5},
+       KOKKOS_LAMBDA(int J1, int J2, int J3, int J4, int J5, I4 &SumAccum,
+                     I4 &MaxAccum) {
+          SumAccum += f5(J1, J2, J3, J4, J5, N1, N2, N3, N4, N5);
+          MaxAccum =
+              Kokkos::max(MaxAccum, f5(J1, J2, J3, J4, J5, N1, N2, N3, N4, N5));
+       },
+       Sum2, Kokkos::Max<I4>(Max2));
+
+   if (Sum2 != RefSum || Max2 != RefMax) {
+      Err += Error(ErrorCode::Fail, "parallelReduce 5D sum+max FAIL");
+   }
+
+   return Err;
+}
+
+int main(int argc, char **argv) {
+   Error Err;
+
+   MPI_Init(&argc, &argv);
+   MachEnv::init(MPI_COMM_WORLD);
+   MachEnv *DefEnv = MachEnv::getDefault();
+   initLogging(DefEnv);
+
+   try {
+      Kokkos::initialize(argc, argv);
+      {
+         Err += testParallelFor1D();
+         Err += testParallelReduce1D();
+
+         Err += testParallelFor2D();
+         Err += testParallelReduce2D();
+
+         Err += testParallelFor3D();
+         Err += testParallelReduce3D();
+
+         Err += testParallelFor4D();
+         Err += testParallelReduce4D();
+
+         Err += testParallelFor5D();
+         Err += testParallelReduce5D();
+      }
+      Kokkos::finalize();
+   } catch (const std::exception &Ex) {
+      Err += Error(ErrorCode::Fail, Ex.what() + std::string(": FAIL"));
+   } catch (...) {
+      Err += Error(ErrorCode::Fail, "Unknown: FAIL");
+   }
+
+   CHECK_ERROR_ABORT(Err, "Kokkos Wrappers Unit Tests FAIL");
+
+   MPI_Finalize();
+
+   return 0;
 }


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
This PR adds tests for `paralleFor` and `parallelReduce` and adds documentation of these functions to developer docs. The new docs can be browsed here: https://portal.nersc.gov/project/e3sm/mwarusz/kokkos/html/devGuide/ParallelLoops.html.

Since we have been discussing adding more wrappers for hierarchical parallelism, I thought it would be good to start by adding some tests for the existing Kokkos wrappers. The current wrappers no longer map straightforwardly to Kokkos constructs and should be tested. The plan is to write similar tests for the proposed wrappers. Additionally, I wrote some docs that can be expanded when we add hierarchical parallelism.


<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [ ] Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] CTest unit tests for new features have been added per the approved design.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


