### PR TITLE
Add wrappers for Kokkos hierarchical parallelism

### DIFF
--- a/components/omega/doc/devGuide/ParallelLoops.md
+++ b/components/omega/doc/devGuide/ParallelLoops.md
@@ -62,7 +62,7 @@ As an example, the following snippet finds the maximum of `A`.
 To perform reductions that are not sums, in addition to modifying the lambda body,
 the final reduction variable needs to be cast to the appropriate type. In the above example,
 `MaxA` is cast to `Kokkos::Max<Real>` to perform a max reduction.
-The `parallelReduce` wrapper supports performing multiple reduction at the same time.
+The `parallelReduce` wrapper supports performing multiple reductions at the same time.
 You can compute `SumA` and `MaxA` in one pass over the data:
 ```c++
    parallelReduce(
@@ -73,6 +73,9 @@ You can compute `SumA` and `MaxA` in one pass over the data:
        },
        SumA, Kokkos::Max<Real>(MaxA));
 ```
+There is no limit to how many reductions can be done at the same time.
+It is usually beneficial for performance to group a small number (2-8) of simple
+reductions together.
 Similarly to `parallelFor`, `parallelReduce` supports labels and up to five dimensions.
 
 ## Hierarchical parallelism
@@ -194,6 +197,17 @@ a 3D array in parallel using hierarchical parallelism.
     });
 ```
 Labels are not supported by `parallelForInner` and only one-dimensional index range can be used.
+The inner loop range can depend on the outer loop index. For example, to set the elements below the main
+diagonal of a square matrix one can do:
+```c++
+   Array2DReal M("M", N, N);
+   parallelForOuter(
+       {N}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+        parallelForInner(Team, J1, INNER_LAMBDA(Int J2) {
+          M(J1, J2) = J1 + J2;
+        });
+    });
+```
 
 ### parallelReduceInner
 To launch inner parallel reductions Omega provides the `parallelReduceInner` wrapper.
@@ -248,8 +262,8 @@ be done as follows.
        });
 ```
 This example computes partial sums up to and including `A(J1, J2, J3)` because the accumulator is updated
-before the if statement. That is, it performs an inclusive scan. To compute an exclusive scan
-simply move the addition after the if statement.
+before the `if` statement. That is, it performs an inclusive scan. To compute an exclusive scan
+simply move the addition after the `if` statement.
 ```c++
   Real FinalScanValue;
   parallelScanInner(Team, N1, INNER_LAMBDA(Int J3, Real &Accum, bool IsFinal) {

--- a/components/omega/doc/devGuide/ParallelLoops.md
+++ b/components/omega/doc/devGuide/ParallelLoops.md
@@ -74,3 +74,192 @@ You can compute `SumA` and `MaxA` in one pass over the data:
        SumA, Kokkos::Max<Real>(MaxA));
 ```
 Similarly to `parallelFor`, `parallelReduce` supports labels and up to five dimensions.
+
+## Hierarchical parallelism
+
+A more flexible alternative to flat parallelism is hierarchical parallelism.
+In general, Kokkos supports a three-level parallelism hierarchy of
+- teams of a league
+- threads of a team
+- vector lanes of a thread
+
+In Omega, we simplify this design to a two-level hierarchy (outer and inner) that naturally
+corresponds to the  model parallelism in the horizontal and vertical dimensions.
+The outer level of parallelism in Omega corresponds to parallelism over Kokkos teams,
+whereas the inner level may be a combination of parallelism over team threads and thread vector lanes.
+The simplest example of a hierarchical parallel loop using Omega wrappers looks as follows
+```c++
+   parallelForOuter(
+       {NCells},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+           parallelForInner(Team, NVertLayers, INNER_LAMBDA (int KLayer) {
+               // Inner body
+           });
+   });
+```
+Note the appearance of a variable named `Team` of type `TeamMember` in the outer lambda
+argument list. This variable handles launching of inner loops and team synchronization.
+The flexibility of hierarchical parallelism comes from:
+- the possibility of the inner loop range to depend on the outer index
+- the option to use different patterns at the outer and inner levels
+- the option to have multiple parallel loops at the inner level
+
+The following outer iteration patterns are supported in Omega:
+- `parallelForOuter`
+- `parallelReduceOuter`
+
+The following inner iteration patterns are supported in Omega:
+- `parallelForInner`
+- `parallelReduceInner`
+- `parallelScanInner`
+
+To provide even more flexibility, the outer loops support iterating over a multi-dimensional range.
+Currently, the inner loops are limited to one dimension.
+
+### INNER_LAMBDA
+
+When using hierarchical parallelism the outer loop lambda has to be annotated with `KOKKOS_LAMBDA` to
+be device accessible. In the inner lambda it must be possible to obtain correct results using capture by value (`[=]`).
+However, in some cases, better performance might be possible by using
+capture by reference (`[&]`). For that reason, Omega provides the
+`INNER_LAMBDA` macro that expends to the best performing capture clause depending on the chosen
+architecture.
+
+### teamBarrier
+
+When multiple parallel inner loops are present within one outer loop, synchronization within
+a thread team might be necessary. Omega provides the `teamBarrier` function that
+synchronizes the threads in a team, which can be called as follows.
+```c++
+teamBarrier(Team);
+```
+This function may only be called at the outer level and needs to be called by every thread in a team.
+Failure to follow these rules might result in deadlocks.
+
+### Kokkos::single
+
+When using hierarchical parallelism, it might be necessary to restrict execution to just one thread of a team.
+To do that Kokkos provides the `single` function. To execute a statement once per team with a single thread do
+```c++
+  Kokkos::single(PerTeam(Team), [=](){
+      // executed once per team (by one of the team threads)
+  });
+```
+
+### parallelForOuter
+To start outer iterations over a multidimensional index range the `parallelForOuter` wrapper is available.
+A call to `parallelForOuter` might look as follows.
+```c++
+   parallelForOuter(
+       {N1},
+       KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+           // launch inner loops here
+       });
+```
+Labels and multi-dimensional iteration ranges of up to five dimensions are supported by `parallelForOuter`.
+
+
+### parallelReduceOuter
+To start outer reductions over a multi-dimensional index range the `parallelReduceOuter` wrapper is available.
+A call to `parallelReduceOuter` might look as follows.
+```c++
+   Real OuterSum;
+   parallelReduceOuter(
+       {N1},
+       KOKKOS_LAMBDA(int J1, const TeamMember &Team, Real &Accum) {
+           Real InnerContribution;
+           // compute InnerContribution
+           Kokkos::single(PerTeam(Team), [&](){
+               Accum += InnerContribution;
+           });
+       }, OuterSum);
+```
+Note how in this example the addition of `InnerContribution` is done inside `Kokkos::single`
+with just one thread from a team. This shows how to add one contribution per team to the total sum.
+The reduction accumulator comes after the team member variable in the lambda argument list.
+Labels and multi-dimensional iteration ranges of up to five dimensions are supported in `parallelReduceOuter`.
+Different types of reductions (min, max) and multiple reducers are also supported.
+
+### parallelForInner
+To launch inner parallel iterations Omega provides the
+`parallelForInner` wrapper. For example, the following code shows how to set every element of
+a 3D array in parallel using hierarchical parallelism.
+```c++
+   Array3DReal A("A", N1, N2, N3);
+   parallelForOuter(
+       {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
+        parallelForInner(Team, N3, INNER_LAMBDA(Int J3) {
+          A(J1, J2, J3) = J1 + J2 + J3;
+        });
+    });
+```
+Labels are not supported by `parallelForInner` and only one-dimensional index range can be used.
+
+### parallelReduceInner
+To launch inner parallel reductions Omega provides the `parallelReduceInner` wrapper.
+For example, computing sums along the third dimension of a 3D array in parallel and storing them
+in a 2D array might be done as follows.
+```c++
+   Array3DReal A("A", N1, N2, N3);
+   Array2DReal B("B", N1, N2);
+   parallelForOuter(
+       {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
+        Real SumD3;
+        parallelReduceInner(Team, N3, INNER_LAMBDA(Int J3, Real &Accum) {
+            Accum += A(J1, J2, J3);
+        }, SumD3);
+        B(J1, J2) = SumD3;
+    });
+```
+Labels are not supported by `parallelReduceInner` and only one-dimensional index range can be used.
+Different types of reductions (min, max) and multiple reducers are supported.
+For example, to additionally compute and store maxima along the third dimension of A do
+```c++
+   Array2DReal C("C", N1, N2);
+   parallelForOuter(
+       {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
+        Real SumD3, MaxD3;
+        parallelReduceInner(Team, N3, INNER_LAMBDA(Int J3, Real &AccumSum, Real &AccumMax) {
+            AccumSum += A(J1, J2, J3);
+            AccumMax = Kokkos::Max(AccumMax, A(J1, J2, J3));
+        }, SumN3, MaxN3);
+        B(J1, J2) = SumD3;
+        C(J1, J2) = MaxD3;
+    });
+```
+Inner reductions are collective operations within a team. This means that the reduction results
+are available to every thread of a team, without any need for synchronization
+
+### parallelScanInner
+To launch inner parallel scans Omega provides the `parallelScanInner` wrapper.
+For example, computing prefix sums (partial sums) along the third dimension of a 3D array might
+be done as follows.
+```c++
+   Array3DReal A("A", N1, N2, N3);
+   Array3DReal D("D", N1, N2, N3);
+   parallelForOuter(
+       {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
+       parallelScanInner(Team, N1, INNER_LAMBDA(Int J3, Real &Accum, bool IsFinal) {
+            Accum += A(J1, J2, J3);
+            if (IsFinal) {
+              D(J1, J2, J3) = Accum;
+            }
+        });
+       });
+```
+This example computes partial sums up to and including `A(J1, J2, J3)` because the accumulator is updated
+before the if statement. That is, it performs an inclusive scan. To compute an exclusive scan
+simply move the addition after the if statement.
+```c++
+  Real FinalScanValue;
+  parallelScanInner(Team, N1, INNER_LAMBDA(Int J3, Real &Accum, bool IsFinal) {
+       if (IsFinal) {
+         D(J1, J2, J3) = Accum;
+       }
+       Accum += A(J1, J2, J3);
+  }, FinalScanValue);
+```
+Moreover, this example illustrates that the final scan value can be obtained by providing
+an additional argument `FinalScanValue`. Labels are not supported by `parallelScanInner`
+and only one-dimensional index range can be used. In contrast to `parallelReduceInner`,
+`parallelScanInner` supports only sum-based scans and only one scan variable.

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -88,6 +88,7 @@ constexpr int OMEGA_TEAMSIZE = 1;
 // Takes a functor that uses multidimensional indexing
 // and converts it into one that also accepts linear index
 template <class F, int Rank> struct LinearIdxWrapper : F {
+   static_assert(Rank >= 1 && Rank <= 5, "LinearIdxWrapper supports ranks 1-5");
    using F::operator();
 
    LinearIdxWrapper(F &&Functor, const int (&Bounds)[Rank])
@@ -156,7 +157,13 @@ template <class F, int Rank> struct LinearIdxWrapper : F {
       (*this)(I1, I2, I3, I4, I5, std::forward<Args>(OtherArgs)...);
    }
 
+// SYCL doesn't allow 0-length arrays so add one extra element even though
+// it is not needed
+#ifdef KOKKOS_ENABLE_SYCL
+   int Strides[Rank];
+#else
    int Strides[Rank - 1];
+#endif
 };
 
 template <typename V>

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "DataTypes.h"
+#include "Error.h"
 #include <functional>
 #include <type_traits>
 #include <utility>
@@ -186,6 +187,29 @@ template <typename D, typename S> void deepCopy(D &&Dst, S &&Src) {
 template <typename E, typename D, typename S>
 void deepCopy(E &Space, D &Dst, const S &Src) {
    Kokkos::deep_copy(Space, Dst, Src);
+}
+
+// Check if two arrays are identical
+template <class ArrayTypeA, class ArrayTypeB>
+bool arraysEqual(const ArrayTypeA &A, const ArrayTypeB &B) {
+   OMEGA_REQUIRE(A.span_is_contiguous() && B.span_is_contiguous(),
+                 "arraysEqual works only for contiguous arrays");
+   OMEGA_REQUIRE(A.size() == B.size(),
+                 "arrayEqual can only compare arrays of equal size");
+
+   // This is a debug utility and not performance critical
+   // so just copy to the host and compare there
+   const auto AH = createHostMirrorCopy(A);
+   const auto BH = createHostMirrorCopy(B);
+
+   bool Equal = true;
+   for (size_t I = 0; I < AH.size(); I++) {
+      if (AH.data()[I] != BH.data()[I]) {
+         Equal = false;
+         break;
+      }
+   }
+   return Equal;
 }
 
 using Bounds1D = Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<int>>;

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -75,6 +75,7 @@ using TeamPolicy      = Kokkos::TeamPolicy<ExecSpace>;
 using TeamMember      = TeamPolicy::member_type;
 using ScratchMemSpace = ExecSpace::scratch_memory_space;
 using Kokkos::MemoryUnmanaged;
+using Kokkos::PerTeam;
 using Kokkos::TeamThreadRange;
 
 /// team_size for hierarchical parallelism
@@ -91,9 +92,19 @@ template <class F, int Rank> struct LinearIdxWrapper : F {
 
    LinearIdxWrapper(F &&Functor, const int (&Bounds)[Rank])
        : F(std::move(Functor)) {
-      Strides[Rank - 2] = Bounds[Rank - 1];
-      for (int I = Rank - 3; I >= 0; --I) {
-         Strides[I] = Bounds[I + 1] * Strides[I + 1];
+      computeStrides(Bounds);
+   }
+
+   LinearIdxWrapper(const F &Functor, const int (&Bounds)[Rank]) : F(Functor) {
+      computeStrides(Bounds);
+   }
+
+   void computeStrides(const int (&Bounds)[Rank]) {
+      if constexpr (Rank > 1) {
+         Strides[Rank - 2] = Bounds[Rank - 1];
+         for (int I = Rank - 3; I >= 0; --I) {
+            Strides[I] = Bounds[I + 1] * Strides[I + 1];
+         }
       }
    }
 
@@ -195,45 +206,45 @@ using Bounds = Kokkos::MDRangePolicy<
 // parallelFor: with label
 template <int N, class F>
 inline void parallelFor(const std::string &Label, const int (&UpperBounds)[N],
-                        const F &Functor) {
+                        F &&Functor) {
    if constexpr (N == 1) {
       const auto Policy = Bounds1D(0, UpperBounds[0]);
-      Kokkos::parallel_for(Label, Policy, Functor);
+      Kokkos::parallel_for(Label, Policy, std::forward<F>(Functor));
 
    } else {
 #ifdef OMEGA_TARGET_DEVICE
       // On device convert the functor to use one dimensional indexing and use
       // 1D RangePolicy
-      const auto LinFunctor = LinearIdxWrapper{std::move(Functor), UpperBounds};
-      int LinBound          = 1;
+      auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
+      int LinBound    = 1;
       for (int Rank = 0; Rank < N; ++Rank) {
          LinBound *= UpperBounds[Rank];
       }
       const auto Policy = Bounds1D(0, LinBound);
-      Kokkos::parallel_for(Label, Policy, LinFunctor);
+      Kokkos::parallel_for(Label, Policy, std::move(LinFunctor));
 #else
       // On host use MDRangePolicy
       const int LowerBounds[N] = {0};
       const auto Policy        = Bounds<N>(LowerBounds, UpperBounds);
-      Kokkos::parallel_for(Label, Policy, Functor);
+      Kokkos::parallel_for(Label, Policy, std::forward<F>(Functor));
 #endif
    }
 }
 
 // parallelFor: without label
 template <int N, class F>
-inline void parallelFor(const int (&UpperBounds)[N], const F &Functor) {
-   parallelFor("", UpperBounds, Functor);
+inline void parallelFor(const int (&UpperBounds)[N], F &&Functor) {
+   parallelFor("", UpperBounds, std::forward<F>(Functor));
 }
 
 // parallelReduce: with label
 template <int N, class F, class... R>
 inline void parallelReduce(const std::string &Label,
-                           const int (&UpperBounds)[N], const F &Functor,
+                           const int (&UpperBounds)[N], F &&Functor,
                            R &&...Reducers) {
    if constexpr (N == 1) {
       const auto Policy = Bounds1D(0, UpperBounds[0]);
-      Kokkos::parallel_reduce(Label, Policy, Functor,
+      Kokkos::parallel_reduce(Label, Policy, std::forward<F>(Functor),
                               std::forward<R>(Reducers)...);
 
    } else {
@@ -241,19 +252,19 @@ inline void parallelReduce(const std::string &Label,
 #ifdef OMEGA_TARGET_DEVICE
       // On device convert the functor to use one dimensional indexing and use
       // 1D RangePolicy
-      const auto LinFunctor = LinearIdxWrapper{std::move(Functor), UpperBounds};
-      int LinBound          = 1;
+      auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
+      int LinBound    = 1;
       for (int Rank = 0; Rank < N; ++Rank) {
          LinBound *= UpperBounds[Rank];
       }
       const auto Policy = Bounds1D(0, LinBound);
-      Kokkos::parallel_reduce(Label, Policy, LinFunctor,
+      Kokkos::parallel_reduce(Label, Policy, std::move(LinFunctor),
                               std::forward<R>(Reducers)...);
 #else
       // On host use MDRangePolicy
       const int LowerBounds[N] = {0};
       const auto Policy        = Bounds<N>(LowerBounds, UpperBounds);
-      Kokkos::parallel_reduce(Label, Policy, Functor,
+      Kokkos::parallel_reduce(Label, Policy, std::forward<F>(Functor),
                               std::forward<R>(Reducers)...);
 #endif
    }
@@ -261,9 +272,120 @@ inline void parallelReduce(const std::string &Label,
 
 // parallelReduce: without label
 template <int N, class F, class... R>
-inline void parallelReduce(const int (&UpperBounds)[N], const F &Functor,
+inline void parallelReduce(const int (&UpperBounds)[N], F &&Functor,
                            R &&...Reducers) {
-   parallelReduce("", UpperBounds, Functor, std::forward<R>(Reducers)...);
+   parallelReduce("", UpperBounds, std::forward<F>(Functor),
+                  std::forward<R>(Reducers)...);
+}
+
+/// Hierarchical parallelism wrappers
+
+#define INNER_LAMBDA [=]
+// #define INNER_LAMBDA [&]
+
+KOKKOS_INLINE_FUNCTION void teamBarrier(const TeamMember &Team) {
+   Team.team_barrier();
+}
+
+// parallelForOuter: with label
+template <int N, class F>
+inline void parallelForOuter(const std::string &Label,
+                             const int (&UpperBounds)[N], F &&Functor) {
+
+   auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
+   int LinBound    = 1;
+   for (int Rank = 0; Rank < N; ++Rank) {
+      LinBound *= UpperBounds[Rank];
+   }
+
+   auto Policy = TeamPolicy(LinBound, OMEGA_TEAMSIZE);
+   Kokkos::parallel_for(
+       Label, Policy, KOKKOS_LAMBDA(const TeamMember &Team) {
+          const int TeamId = Team.league_rank();
+          LinFunctor(TeamId, Team);
+       });
+}
+
+// parallelForOuter: without label
+template <int N, class F>
+inline void parallelForOuter(const int (&UpperBounds)[N], F &&Functor) {
+   parallelForOuter("", UpperBounds, std::forward<F>(Functor));
+}
+
+// parallelForInner
+template <class F>
+KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int UpperBound,
+                                      F &&Functor) {
+   const auto Policy = TeamThreadRange(Team, UpperBound);
+   Kokkos::parallel_for(Policy, std::forward<F>(Functor));
+}
+
+// This struct is used to get the right accumulator type to be used in
+// the outer parallel lambda based on the final reduction variable type.
+// The final reduction variable can be either a reference to
+// an arithmetic type (int&, Real&) or a Kokkos reducer (Kokkos::Max<Real>).
+// We need to know this type because nvcc does not allow generic lambdas.
+template <class T, class Enable = void> struct AccumTypeHelper;
+
+template <class T>
+struct AccumTypeHelper<
+    T, std::enable_if_t<std::is_arithmetic_v<std::remove_reference_t<T>>>> {
+   using Type = T;
+};
+
+template <class T>
+struct AccumTypeHelper<T, std::enable_if_t<Kokkos::is_reducer_v<T>>> {
+   using Type = typename T::value_type;
+};
+
+template <class T> using AccumType = typename AccumTypeHelper<T>::Type;
+
+// parallelReduceOuter: with label
+template <int N, class F, class... R>
+inline void parallelReduceOuter(const std::string &Label,
+                                const int (&UpperBounds)[N], F &&Functor,
+                                R &&...Reducers) {
+
+   auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
+   int LinBound    = 1;
+   for (int Rank = 0; Rank < N; ++Rank) {
+      LinBound *= UpperBounds[Rank];
+   }
+
+   auto Policy = TeamPolicy(LinBound, OMEGA_TEAMSIZE);
+   Kokkos::parallel_reduce(
+       Label, Policy,
+       KOKKOS_LAMBDA(const TeamMember &Team, AccumType<R> &...Accums) {
+          const int TeamId = Team.league_rank();
+          LinFunctor(TeamId, Team, Accums...);
+       },
+       std::forward<R>(Reducers)...);
+}
+
+// parallelReduceOuter: without label
+template <int N, class F, class... R>
+inline void parallelReduceOuter(const int (&UpperBounds)[N], F &&Functor,
+                                R &&...Reducers) {
+   parallelReduceOuter("", UpperBounds, std::forward<F>(Functor),
+                       std::forward<R>(Reducers)...);
+}
+
+// parallelReduceInner
+template <class F, class... R>
+KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int UpperBound,
+                                         F &&Functor, R &&...Reducers) {
+   const auto Policy = TeamThreadRange(Team, UpperBound);
+   Kokkos::parallel_reduce(Policy, std::forward<F>(Functor),
+                           std::forward<R>(Reducers)...);
+}
+
+// parallelScanInner
+template <class F, class... R>
+KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int UpperBound,
+                                       F &&Functor, R &&...Reducers) {
+   const auto Policy = TeamThreadRange(Team, UpperBound);
+   Kokkos::parallel_scan(Policy, std::forward<F>(Functor),
+                         std::forward<R>(Reducers)...);
 }
 
 } // end namespace OMEGA

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -401,6 +401,13 @@ add_omega_test(
     "-n;1"
 )
 
+add_omega_test(
+  KOKKOS_HIPAR_TEST
+    testKokkosHiPar.exe
+    infra/OmegaKokkosHiParTest.cpp
+    "-n;1;"
+)
+
 ##################
 # Driver test
 ##################

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -390,15 +390,15 @@ add_omega_test(
     "-n;2"
 )
 
-##################
-# Kokkos test
-##################
+#######################
+# Kokkos wrappers tests
+#######################
 
 add_omega_test(
-    KOKKOS_TEST
-    testKokkos.exe
-    infra/OmegaKokkosTest.cpp
-    "-n;1"
+  KOKKOS_FLATPAR_TEST
+    testKokkosFlatPar.exe
+    infra/OmegaKokkosFlatParTest.cpp
+    "-n;1;"
 )
 
 add_omega_test(

--- a/components/omega/test/base/HaloTest.cpp
+++ b/components/omega/test/base/HaloTest.cpp
@@ -68,24 +68,9 @@ int haloExchangeTest(
       return RetErr;
    }
 
-   auto TestArrayH = createHostMirrorCopy(TestArray);
-   auto InitArrayH = createHostMirrorCopy(InitArray);
-
-   // Collapse arrays to 1D for easy iteration
-   Kokkos::View<typename T::value_type *, typename T::array_layout,
-                HostMemSpace>
-       CollapsedInit(InitArrayH.data(), InitArrayH.size());
-   Kokkos::View<typename T::value_type *, typename T::array_layout,
-                HostMemSpace>
-       CollapsedTest(TestArrayH.data(), TestArrayH.size());
-
    // Confirm all elements are identical, if not set error code
-   // and break out of loop
-   for (int N = 0; N < NTot; ++N) {
-      if (CollapsedInit(N) != CollapsedTest(N)) {
-         IErr = -1;
-         break;
-      }
+   if (!arraysEqual(TestArray, InitArray)) {
+      IErr = -1;
    }
 
    if (IErr == 0) {

--- a/components/omega/test/infra/OmegaKokkosFlatParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosFlatParTest.cpp
@@ -8,10 +8,10 @@
 //
 //===-----------------------------------------------------------------------===/
 
-#include "OmegaKokkos.h"
 #include "Error.h"
 #include "Logging.h"
 #include "MachEnv.h"
+#include "OmegaKokkos.h"
 
 #include "mpi.h"
 #include <limits>

--- a/components/omega/test/infra/OmegaKokkosFlatParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosFlatParTest.cpp
@@ -18,17 +18,6 @@
 
 using namespace OMEGA;
 
-template <class Array> bool hostArraysEqual(const Array &A, const Array &B) {
-   bool Equal = true;
-   for (size_t I = 0; I < A.span(); I++) {
-      if (A.data()[I] != B.data()[I]) {
-         Equal = false;
-         break;
-      }
-   }
-   return Equal;
-}
-
 static KOKKOS_FUNCTION int f1(int J1, int N1) { return -N1 / 4 + J1; }
 
 static KOKKOS_FUNCTION int f2(int J1, int J2, int N1, int N2) {
@@ -63,9 +52,7 @@ Error testParallelFor1D() {
    Array1DI4 A("A1", N1);
    parallelFor({N1}, KOKKOS_LAMBDA(int J1) { A(J1) = f1(J1, N1); });
 
-   auto AH = createHostMirrorCopy(A);
-
-   if (!hostArraysEqual(AH, RefAH)) {
+   if (!arraysEqual(A, RefAH)) {
       Err += Error(ErrorCode::Fail, "parallelFor 1D FAIL");
    }
 
@@ -142,9 +129,7 @@ Error testParallelFor2D() {
        {N1, N2},
        KOKKOS_LAMBDA(int J1, int J2) { A(J1, J2) = f2(J1, J2, N1, N2); });
 
-   auto AH = createHostMirrorCopy(A);
-
-   if (!hostArraysEqual(AH, RefAH)) {
+   if (!arraysEqual(A, RefAH)) {
       Err += Error(ErrorCode::Fail, "parallelFor 2D FAIL");
    }
 
@@ -232,9 +217,7 @@ Error testParallelFor3D() {
           A(J1, J2, J3) = f3(J1, J2, J3, N1, N2, N3);
        });
 
-   auto AH = createHostMirrorCopy(A);
-
-   if (!hostArraysEqual(AH, RefAH)) {
+   if (!arraysEqual(A, RefAH)) {
       Err += Error(ErrorCode::Fail, "parallelFor 3D FAIL");
    }
 
@@ -328,9 +311,7 @@ Error testParallelFor4D() {
           A(J1, J2, J3, J4) = f4(J1, J2, J3, J4, N1, N2, N3, N4);
        });
 
-   auto AH = createHostMirrorCopy(A);
-
-   if (!hostArraysEqual(AH, RefAH)) {
+   if (!arraysEqual(A, RefAH)) {
       Err += Error(ErrorCode::Fail, "parallelFor 4D FAIL");
    }
 
@@ -433,9 +414,7 @@ Error testParallelFor5D() {
           A(J1, J2, J3, J4, J5) = f5(J1, J2, J3, J4, J5, N1, N2, N3, N4, N5);
        });
 
-   auto AH = createHostMirrorCopy(A);
-
-   if (!hostArraysEqual(AH, RefAH)) {
+   if (!arraysEqual(A, RefAH)) {
       Err += Error(ErrorCode::Fail, "parallelFor 5D FAIL");
    }
 

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -1,0 +1,748 @@
+//===-- Test driver for OMEGA Kokkos -------------------------*- C++ -*-===/
+//
+/// \file
+/// \brief Test driver for OMEGA Kokkos
+///
+/// This driver tests the Omega wrappers of Kokkos capabilities.
+///
+//
+//===-----------------------------------------------------------------------===/
+
+#include "Error.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "OmegaKokkos.h"
+
+#include "mpi.h"
+#include <limits>
+#include <sstream>
+
+using namespace OMEGA;
+
+template <class Array> bool hostArraysEqual(const Array &A, const Array &B) {
+   bool Equal = true;
+   for (size_t I = 0; I < A.span(); I++) {
+      if (A.data()[I] != B.data()[I]) {
+         Equal = false;
+         break;
+      }
+   }
+   return Equal;
+}
+
+static KOKKOS_FUNCTION int f1(int J1, int N1) { return -N1 / 4 + J1; }
+
+static KOKKOS_FUNCTION int f2(int J1, int J2, int N1, int N2) {
+   return -(N1 * N2) / 4 + J1 + N1 * J2;
+}
+
+static KOKKOS_FUNCTION int f3(int J1, int J2, int J3, int N1, int N2, int N3) {
+   return -(N1 * N2 * N3) / 4 + J1 + N1 * (J2 + N2 * J3);
+}
+
+// Helpers to add test arguments to error messages
+static std::string errorMsg(const std::string &Msg, int N1) {
+   std::stringstream Stream;
+   Stream << Msg << " N1 = " << N1;
+   return Stream.str();
+}
+
+static std::string errorMsg(const std::string &Msg, int N1, int N2) {
+   std::stringstream Stream;
+   Stream << Msg << " N1 = " << N1 << " N2 = " << N2;
+   return Stream.str();
+}
+
+static std::string errorMsg(const std::string &Msg, int N1, int N2, int N3) {
+   std::stringstream Stream;
+   Stream << Msg << " N1 = " << N1 << " N2 = " << N2 << " N3 = " << N3;
+   return Stream.str();
+}
+
+Error testHiparFor1DFor1D(int N1) {
+   Error Err;
+
+   const int N2 = N1;
+
+   HostArray2DI4 RefAH("RefA2H", N1, N2);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < J1; ++J2) {
+         RefAH(J1, J2) = f2(J1, J2, N1, N2);
+      }
+   }
+
+   Array2DI4 A("A2", N1, N2);
+   parallelForOuter(
+       {N1}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+          parallelForInner(
+              Team, J1,
+              INNER_LAMBDA(int J2) { A(J1, J2) = f2(J1, J2, N1, N2); });
+       });
+
+   auto AH = createHostMirrorCopy(A);
+
+   if (!hostArraysEqual(AH, RefAH)) {
+      Err += Error(ErrorCode::Fail, errorMsg("parallelFor1DFor1D FAIL", N1));
+   }
+
+   return Err;
+}
+
+Error testHiparFor1DReduce1D(int N1) {
+   Error Err;
+
+   const int N2 = N1;
+
+   HostArray1DI4 RefSumH("RefSum1H", N1);
+   HostArray1DI4 RefMaxH("RefMax1H", N1);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      I4 Sum = 0;
+      I4 Max = std::numeric_limits<I4>::min();
+      for (int J2 = 0; J2 < J1; ++J2) {
+         Sum += f2(J1, J2, N1, N2);
+         Max = std::max(Max, f2(J1, J2, N1, N2));
+      }
+      RefSumH(J1) = Sum;
+      RefMaxH(J1) = Max;
+   }
+
+   Array1DI4 Sum1("Sum11", N1);
+   Array1DI4 Max1("Max11", N1);
+   parallelForOuter(
+       {N1}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+          I4 Sum;
+          parallelReduceInner(
+              Team, J1,
+              INNER_LAMBDA(int J2, I4 &Accum) { Accum += f2(J1, J2, N1, N2); },
+              Sum);
+          Sum1(J1) = Sum;
+
+          I4 Max;
+          parallelReduceInner(
+              Team, J1,
+              INNER_LAMBDA(int J2, I4 &Accum) {
+                 Accum = Kokkos::max(Accum, f2(J1, J2, N1, N2));
+              },
+              Kokkos::Max<I4>(Max));
+          Max1(J1) = Max;
+       });
+
+   auto Sum1H = createHostMirrorCopy(Sum1);
+   if (!hostArraysEqual(Sum1H, RefSumH)) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelFor1DReduce1D Sum FAIL", N1));
+   }
+
+   auto Max1H = createHostMirrorCopy(Max1);
+   if (!hostArraysEqual(Max1H, RefMaxH)) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelFor1DReduce1D Max FAIL", N1));
+   }
+
+   Array1DI4 Sum2("Sum21", N1);
+   Array1DI4 Max2("Max21", N1);
+   parallelForOuter(
+       {N1}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+          I4 Sum, Max;
+          parallelReduceInner(
+              Team, J1,
+              INNER_LAMBDA(int J2, I4 &AccumSum, I4 &AccumMax) {
+                 AccumSum += f2(J1, J2, N1, N2);
+                 AccumMax = Kokkos::max(AccumMax, f2(J1, J2, N1, N2));
+              },
+              Sum, Kokkos::Max<I4>(Max));
+          Sum2(J1) = Sum;
+          Max2(J1) = Max;
+       });
+
+   auto Sum2H = createHostMirrorCopy(Sum2);
+   auto Max2H = createHostMirrorCopy(Max2);
+   if (!hostArraysEqual(Sum2H, RefSumH) || !hostArraysEqual(Max2H, RefMaxH)) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelFor1DReduce1D Sum+Max FAIL", N1));
+   }
+
+   return Err;
+}
+
+Error testHiparFor1DScan1D(int N1) {
+   Error Err;
+
+   const int N2 = N1;
+
+   HostArray2DI4 RefRSumH("RefRSum2H", N1, N2);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      I4 RSum = 0;
+      for (int J2 = 0; J2 < J1; ++J2) {
+         RefRSumH(J1, J2) = RSum;
+         RSum += f2(J1, J2, N1, N2);
+      }
+   }
+
+   Array2DI4 RSum("RSum2", N1, N2);
+   parallelForOuter(
+       {N1}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+          parallelScanInner(
+              Team, J1, INNER_LAMBDA(int J2, I4 &Accum, bool IsFinal) {
+                 if (IsFinal) {
+                    RSum(J1, J2) = Accum;
+                 }
+                 Accum += f2(J1, J2, N1, N2);
+              });
+       });
+
+   auto RSumH = createHostMirrorCopy(RSum);
+   if (!hostArraysEqual(RSumH, RefRSumH)) {
+      Err +=
+          Error(ErrorCode::Fail, errorMsg("parallelFor1DScan1D Sum FAIL", N1));
+   }
+
+   return Err;
+}
+
+Error testHiparReduce1DReduce1D(int N1) {
+   Error Err;
+
+   const int N2 = N1;
+
+   I4 RefSum = 0;
+   I4 RefMax = std::numeric_limits<I4>::min();
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < J1; ++J2) {
+         RefSum += f2(J1, J2, N1, N2);
+         RefMax = std::max(RefMax, f2(J1, J2, N1, N2));
+      }
+   }
+
+   I4 Sum1;
+   parallelReduceOuter(
+       {N1},
+       KOKKOS_LAMBDA(int J1, const TeamMember &Team, I4 &AccumOuter) {
+          I4 SumInner;
+          parallelReduceInner(
+              Team, J1,
+              INNER_LAMBDA(int J2, I4 &AccumInner) {
+                 AccumInner += f2(J1, J2, N1, N2);
+              },
+              SumInner);
+
+          Kokkos::single(PerTeam(Team), [&]() { AccumOuter += SumInner; });
+       },
+       Sum1);
+
+   if (Sum1 != RefSum) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelReduce1DReduce1D Sum FAIL", N1));
+   }
+
+   I4 Max1;
+   parallelReduceOuter(
+       {N1},
+       KOKKOS_LAMBDA(int J1, const TeamMember &Team, I4 &AccumOuter) {
+          I4 MaxInner;
+          parallelReduceInner(
+              Team, J1,
+              INNER_LAMBDA(int J2, I4 &AccumInner) {
+                 AccumInner = Kokkos::max(AccumInner, f2(J1, J2, N1, N2));
+              },
+              Kokkos::Max<I4>(MaxInner));
+          AccumOuter = Kokkos::max(AccumOuter, MaxInner);
+       },
+       Kokkos::Max<I4>(Max1));
+
+   if (Max1 != RefMax) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelReduce1DReduce1D Max FAIL", N1));
+   }
+
+   I4 Sum2, Max2;
+   parallelReduceOuter(
+       {N1},
+       KOKKOS_LAMBDA(int J1, const TeamMember &Team, I4 &AccumSumOuter,
+                     I4 &AccumMaxOuter) {
+          I4 SumInner, MaxInner;
+          parallelReduceInner(
+              Team, J1,
+              INNER_LAMBDA(int J2, I4 &AccumSumInner, I4 &AccumMaxInner) {
+                 AccumSumInner += f2(J1, J2, N1, N2);
+                 AccumMaxInner = Kokkos::max(AccumMaxInner, f2(J1, J2, N1, N2));
+              },
+              SumInner, Kokkos::Max<I4>(MaxInner));
+
+          Kokkos::single(PerTeam(Team), [&]() { AccumSumOuter += SumInner; });
+          AccumMaxOuter = Kokkos::max(AccumMaxOuter, MaxInner);
+       },
+       Sum2, Kokkos::Max<I4>(Max2));
+
+   if (Sum2 != RefSum || Max2 != RefMax) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelReduce1DReduce1D Sum+Max FAIL", N1));
+   }
+
+   return Err;
+}
+
+Error testHiparFor1DMultiple1D(int N1, int N2) {
+   Error Err;
+
+   const int N2P1 = N2 + 1;
+
+   HostArray2DI4 RefAH("RefA2H", N1, N2P1);
+   HostArray2DI4 RefBH("RefB2H", N1, N2);
+   HostArray2DI4 RefCH("RefC2H", N1, N2);
+   HostArray1DI4 RefDH("RefD1H", N1);
+
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2P1; ++J2) {
+         RefAH(J1, J2) = f2(J1, J2, N1, N2P1);
+      }
+
+      for (int J2 = 0; J2 < N2; ++J2) {
+         RefBH(J1, J2) = (RefAH(J1, J2) + RefAH(J1, J2 + 1)) / 2;
+      }
+
+      Real ScanAccum = 0;
+      for (int J2 = 0; J2 < N2; ++J2) {
+         ScanAccum += RefBH(J1, J2);
+         RefCH(J1, J2) = ScanAccum;
+      }
+
+      if (J1 % 2 == 0) {
+         for (int J2 = 0; J2 < N2; ++J2) {
+            RefCH(J1, J2) += 1;
+         }
+      }
+
+      Real SumAccum = 0;
+      for (int J2 = 0; J2 < N2; ++J2) {
+         SumAccum += RefCH(J1, J2);
+      }
+      RefDH(J1) = SumAccum;
+   }
+
+   Array2DI4 A("A2", N1, N2P1);
+   Array2DI4 B("B2", N1, N2);
+   Array2DI4 C("C2", N1, N2);
+   Array1DI4 D("D1", N1);
+
+   parallelForOuter(
+       {N1}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+          parallelForInner(
+              Team, N2P1,
+              INNER_LAMBDA(int J2) { A(J1, J2) = f2(J1, J2, N1, N2P1); });
+
+          teamBarrier(Team);
+
+          parallelForInner(
+              Team, N2, INNER_LAMBDA(int J2) {
+                 B(J1, J2) = (A(J1, J2) + A(J1, J2 + 1)) / 2;
+              });
+
+          teamBarrier(Team);
+
+          parallelScanInner(
+              Team, N2, INNER_LAMBDA(int J2, I4 &Accum, bool IsFinal) {
+                 Accum += B(J1, J2);
+                 if (IsFinal) {
+                    C(J1, J2) = Accum;
+                 }
+              });
+
+          if (J1 % 2 == 0) {
+             parallelForInner(
+                 Team, N2, INNER_LAMBDA(int J2) { C(J1, J2) += 1; });
+          }
+
+          teamBarrier(Team);
+
+          parallelReduceInner(
+              Team, N2, INNER_LAMBDA(int J2, I4 &Accum) { Accum += C(J1, J2); },
+              D(J1));
+       });
+
+   auto DH = createHostMirrorCopy(D);
+
+   if (!hostArraysEqual(DH, RefDH)) {
+      Err += Error(ErrorCode::Fail, errorMsg("multiple patterns FAIL", N1, N2));
+   }
+
+   return Err;
+}
+
+Error testHiparFor2DFor1D(int N1, int N2) {
+   Error Err;
+
+   const int N3 = N1 + N2 - 1;
+
+   HostArray3DI4 RefAH("RefA3H", N1, N2, N3);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         for (int J3 = 0; J3 < J1 + J2; ++J3) {
+            RefAH(J1, J2, J3) = f3(J1, J2, J3, N1, N2, N3);
+         }
+      }
+   }
+
+   Array3DI4 A("A3", N1, N2, N3);
+   parallelForOuter(
+       {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
+          parallelForInner(
+              Team, J1 + J2, INNER_LAMBDA(int J3) {
+                 A(J1, J2, J3) = f3(J1, J2, J3, N1, N2, N3);
+              });
+       });
+
+   auto AH = createHostMirrorCopy(A);
+
+   if (!hostArraysEqual(AH, RefAH)) {
+      Err +=
+          Error(ErrorCode::Fail, errorMsg("parallelFor2DFor1D FAIL", N1, N2));
+   }
+
+   return Err;
+}
+
+Error testHiparFor2DReduce1D(int N1, int N2) {
+   Error Err;
+
+   const int N3 = N1 + N2 - 1;
+
+   HostArray2DI4 RefSumH("RefSum2H", N1, N2);
+   HostArray2DI4 RefMaxH("RefMax2H", N1, N2);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         I4 Sum = 0;
+         I4 Max = std::numeric_limits<I4>::min();
+         for (int J3 = 0; J3 < J1 + J2; ++J3) {
+            Sum += f3(J1, J2, J3, N1, N2, N3);
+            Max = std::max(Max, f3(J1, J2, J3, N1, N2, N3));
+         }
+         RefSumH(J1, J2) = Sum;
+         RefMaxH(J1, J2) = Max;
+      }
+   }
+
+   Array2DI4 Sum1("Sum12", N1, N2);
+   Array2DI4 Max1("Max12", N1, N2);
+   parallelForOuter(
+       {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
+          I4 Sum;
+          parallelReduceInner(
+              Team, J1 + J2,
+              INNER_LAMBDA(int J3, I4 &Accum) {
+                 Accum += f3(J1, J2, J3, N1, N2, N3);
+              },
+              Sum);
+          Sum1(J1, J2) = Sum;
+
+          I4 Max;
+          parallelReduceInner(
+              Team, J1 + J2,
+              INNER_LAMBDA(int J3, I4 &Accum) {
+                 Accum = Kokkos::max(Accum, f3(J1, J2, J3, N1, N2, N3));
+              },
+              Kokkos::Max<I4>(Max));
+          Max1(J1, J2) = Max;
+       });
+
+   auto Sum1H = createHostMirrorCopy(Sum1);
+   if (!hostArraysEqual(Sum1H, RefSumH)) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelFor2DReduce1D Sum FAIL", N1, N2));
+   }
+
+   auto Max1H = createHostMirrorCopy(Max1);
+   if (!hostArraysEqual(Max1H, RefMaxH)) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelFor2DReduce1D Max FAIL", N1, N2));
+   }
+
+   Array2DI4 Sum2("Sum22", N1, N2);
+   Array2DI4 Max2("Max22", N1, N2);
+   parallelForOuter(
+       {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
+          I4 Sum, Max;
+          parallelReduceInner(
+              Team, J1 + J2,
+              INNER_LAMBDA(int J3, I4 &AccumSum, I4 &AccumMax) {
+                 AccumSum += f3(J1, J2, J3, N1, N2, N3);
+                 AccumMax = Kokkos::max(AccumMax, f3(J1, J2, J3, N1, N2, N3));
+              },
+              Sum, Kokkos::Max<I4>(Max));
+          Sum2(J1, J2) = Sum;
+          Max2(J1, J2) = Max;
+       });
+
+   auto Sum2H = createHostMirrorCopy(Sum2);
+   auto Max2H = createHostMirrorCopy(Max2);
+   if (!hostArraysEqual(Sum2H, RefSumH) || !hostArraysEqual(Max2H, RefMaxH)) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelFor2DReduce1D Sum+Max FAIL", N1, N2));
+   }
+
+   return Err;
+}
+
+Error testHiparFor2DScan1D(int N1, int N2) {
+   Error Err;
+
+   const int N3 = N1 + N2 - 1;
+
+   HostArray3DI4 RefRSumH("RefRSum3H", N1, N2, N3);
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         I4 RSum = 0;
+         for (int J3 = 0; J3 < J1 + J2; ++J3) {
+            RefRSumH(J1, J2, J3) = RSum;
+            RSum += f3(J1, J2, J3, N1, N2, N3);
+         }
+      }
+   }
+
+   Array3DI4 RSum("RSum3", N1, N2, N3);
+   parallelForOuter(
+       {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
+          parallelScanInner(
+              Team, J1 + J2, INNER_LAMBDA(int J3, I4 &Accum, bool IsFinal) {
+                 if (IsFinal) {
+                    RSum(J1, J2, J3) = Accum;
+                 }
+                 Accum += f3(J1, J2, J3, N1, N2, N3);
+              });
+       });
+
+   auto RSumH = createHostMirrorCopy(RSum);
+   if (!hostArraysEqual(RSumH, RefRSumH)) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelFor2DScan1D Sum FAIL", N1, N2));
+   }
+
+   return Err;
+}
+
+Error testHiparReduce2DReduce1D(int N1, int N2) {
+   Error Err;
+
+   const int N3 = N1 + N2 - 1;
+
+   I4 RefSum = 0;
+   I4 RefMax = std::numeric_limits<I4>::min();
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         for (int J3 = 0; J3 < J1 + J2; ++J3) {
+            RefSum += f3(J1, J2, J3, N1, N2, N3);
+            RefMax = std::max(RefMax, f3(J1, J2, J3, N1, N2, N3));
+         }
+      }
+   }
+
+   I4 Sum1;
+   parallelReduceOuter(
+       {N1, N2},
+       KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team, I4 &AccumOuter) {
+          I4 SumInner;
+          parallelReduceInner(
+              Team, J1 + J2,
+              INNER_LAMBDA(int J3, I4 &AccumInner) {
+                 AccumInner += f3(J1, J2, J3, N1, N2, N3);
+              },
+              SumInner);
+
+          Kokkos::single(PerTeam(Team), [&]() { AccumOuter += SumInner; });
+       },
+       Sum1);
+
+   if (Sum1 != RefSum) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelReduce2DReduce1D Sum FAIL", N1, N2));
+   }
+
+   I4 Max1;
+   parallelReduceOuter(
+       {N1, N2},
+       KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team, I4 &AccumOuter) {
+          I4 MaxInner;
+          parallelReduceInner(
+              Team, J1 + J2,
+              INNER_LAMBDA(int J3, I4 &AccumInner) {
+                 AccumInner =
+                     Kokkos::max(AccumInner, f3(J1, J2, J3, N1, N2, N3));
+              },
+              Kokkos::Max<I4>(MaxInner));
+          AccumOuter = Kokkos::max(AccumOuter, MaxInner);
+       },
+       Kokkos::Max<I4>(Max1));
+
+   if (Max1 != RefMax) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelReduce2DReduce1D Max FAIL", N1, N2));
+   }
+
+   I4 Sum2, Max2;
+   parallelReduceOuter(
+       {N1, N2},
+       KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team, I4 &AccumSumOuter,
+                     I4 &AccumMaxOuter) {
+          I4 SumInner, MaxInner;
+          parallelReduceInner(
+              Team, J1 + J2,
+              INNER_LAMBDA(int J3, I4 &AccumSumInner, I4 &AccumMaxInner) {
+                 AccumSumInner += f3(J1, J2, J3, N1, N2, N3);
+                 AccumMaxInner =
+                     Kokkos::max(AccumMaxInner, f3(J1, J2, J3, N1, N2, N3));
+              },
+              SumInner, Kokkos::Max<I4>(MaxInner));
+
+          Kokkos::single(PerTeam(Team), [&]() { AccumSumOuter += SumInner; });
+          AccumMaxOuter = Kokkos::max(AccumMaxOuter, MaxInner);
+       },
+       Sum2, Kokkos::Max<I4>(Max2));
+
+   if (Sum2 != RefSum || Max2 != RefMax) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelReduce2DReduce1D Sum+Max FAIL", N1, N2));
+   }
+
+   return Err;
+}
+
+Error testHiparFor2DMultiple1D(int N1, int N2, int N3) {
+   Error Err;
+
+   const int N3P1 = N3 + 1;
+
+   HostArray3DI4 RefAH("RefA3H", N1, N2, N3P1);
+   HostArray3DI4 RefBH("RefB3H", N1, N2, N3);
+   HostArray3DI4 RefCH("RefC3H", N1, N2, N3);
+   HostArray2DI4 RefDH("RefD2H", N1, N2);
+
+   for (int J1 = 0; J1 < N1; ++J1) {
+      for (int J2 = 0; J2 < N2; ++J2) {
+         for (int J3 = 0; J3 < N3P1; ++J3) {
+            RefAH(J1, J2, J3) = f3(J1, J2, J3, N1, N2, N3P1);
+         }
+
+         for (int J3 = 0; J3 < N3; ++J3) {
+            RefBH(J1, J2, J3) = (RefAH(J1, J2, J3) + RefAH(J1, J2, J3 + 1)) / 2;
+         }
+
+         Real ScanAccum = 0;
+         for (int J3 = 0; J3 < N3; ++J3) {
+            ScanAccum += RefBH(J1, J2, J3);
+            RefCH(J1, J2, J3) = ScanAccum;
+         }
+
+         if (J1 % 2 == 0 && J2 % 2 == 1) {
+            for (int J3 = 0; J3 < N3; ++J3) {
+               RefCH(J1, J2, J3) += 1;
+            }
+         }
+
+         Real SumAccum = 0;
+         for (int J3 = 0; J3 < N3; ++J3) {
+            SumAccum += RefCH(J1, J2, J3);
+         }
+         RefDH(J1, J2) = SumAccum;
+      }
+   }
+
+   Array3DI4 A("A3", N1, N2, N3P1);
+   Array3DI4 B("B3", N1, N2, N3);
+   Array3DI4 C("C3", N1, N2, N3);
+   Array2DI4 D("D2", N1, N2);
+
+   parallelForOuter(
+       {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
+          parallelForInner(
+              Team, N3P1, INNER_LAMBDA(int J3) {
+                 A(J1, J2, J3) = f3(J1, J2, J3, N1, N2, N3P1);
+              });
+
+          teamBarrier(Team);
+
+          parallelForInner(
+              Team, N3, INNER_LAMBDA(int J3) {
+                 B(J1, J2, J3) = (A(J1, J2, J3) + A(J1, J2, J3 + 1)) / 2;
+              });
+
+          teamBarrier(Team);
+
+          parallelScanInner(
+              Team, N3, INNER_LAMBDA(int J3, I4 &Accum, bool IsFinal) {
+                 Accum += B(J1, J2, J3);
+                 if (IsFinal) {
+                    C(J1, J2, J3) = Accum;
+                 }
+              });
+
+          if (J1 % 2 == 0 && J2 % 2 == 1) {
+             parallelForInner(
+                 Team, N3, INNER_LAMBDA(int J3) { C(J1, J2, J3) += 1; });
+          }
+
+          teamBarrier(Team);
+
+          parallelReduceInner(
+              Team, N3,
+              INNER_LAMBDA(int J3, I4 &Accum) { Accum += C(J1, J2, J3); },
+              D(J1, J2));
+       });
+
+   auto DH = createHostMirrorCopy(D);
+
+   if (!hostArraysEqual(DH, RefDH)) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("multiple patterns FAIL", N1, N2, N3));
+   }
+
+   return Err;
+}
+
+int main(int argc, char **argv) {
+   Error Err;
+
+   MPI_Init(&argc, &argv);
+   MachEnv::init(MPI_COMM_WORLD);
+   MachEnv *DefEnv = MachEnv::getDefault();
+   initLogging(DefEnv);
+
+   try {
+      Kokkos::initialize(argc, argv);
+      {
+         for (auto N1 : {1, 4, 9, 31, 33, 63, 65}) {
+            Err += testHiparFor1DFor1D(N1);
+            Err += testHiparFor1DReduce1D(N1);
+            Err += testHiparFor1DScan1D(N1);
+            Err += testHiparReduce1DReduce1D(N1);
+
+            Err += testHiparFor1DMultiple1D(1, N1);
+            Err += testHiparFor1DMultiple1D((N1 + 1) / 2, N1);
+            Err += testHiparFor1DMultiple1D(2 * N1, N1);
+         }
+
+         for (auto N1 : {1, 5, 10}) {
+            for (auto N2 : {1, 4, 9, 31, 33, 63, 65}) {
+               Err += testHiparFor2DFor1D(N1, N2);
+               Err += testHiparFor2DReduce1D(N1, N2);
+               Err += testHiparFor2DScan1D(N1, N2);
+               Err += testHiparReduce2DReduce1D(N1, N2);
+
+               Err += testHiparFor2DMultiple1D(1, N1, N2);
+               Err += testHiparFor2DMultiple1D((N1 + 1) / 2, N1, N2);
+               Err += testHiparFor2DMultiple1D(2 * N1, N1, N2);
+            }
+         }
+      }
+      Kokkos::finalize();
+   } catch (const std::exception &Ex) {
+      Err += Error(ErrorCode::Fail, Ex.what() + std::string(": FAIL"));
+   } catch (...) {
+      Err += Error(ErrorCode::Fail, "Unknown: FAIL");
+   }
+
+   CHECK_ERROR_ABORT(Err, "Kokkos Wrappers Unit Tests FAIL");
+
+   MPI_Finalize();
+
+   return 0;
+}

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -30,8 +30,6 @@ template <class Array> bool hostArraysEqual(const Array &A, const Array &B) {
    return Equal;
 }
 
-static KOKKOS_FUNCTION int f1(int J1, int N1) { return -N1 / 4 + J1; }
-
 static KOKKOS_FUNCTION int f2(int J1, int J2, int N1, int N2) {
    return -(N1 * N2) / 4 + J1 + N1 * J2;
 }

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -713,7 +713,11 @@ int main(int argc, char **argv) {
             Err += testHiparFor1DFor1D(N1);
             Err += testHiparFor1DReduce1D(N1);
             Err += testHiparFor1DScan1D(N1);
+// outer reduce tests fail with SYCL and old Kokkos
+// remove this check once E3SM starts using Kokkos 4.7.1
+#if !defined(KOKKOS_ENABLE_SYCL) || KOKKOS_VERSION_GREATER_EQUAL(4, 7, 1)
             Err += testHiparReduce1DReduce1D(N1);
+#endif
 
             Err += testHiparFor1DMultiple1D(1, N1);
             Err += testHiparFor1DMultiple1D((N1 + 1) / 2, N1);
@@ -725,8 +729,11 @@ int main(int argc, char **argv) {
                Err += testHiparFor2DFor1D(N1, N2);
                Err += testHiparFor2DReduce1D(N1, N2);
                Err += testHiparFor2DScan1D(N1, N2);
+// outer reduce tests fail with SYCL and old Kokkos
+// remove this check once E3SM starts using Kokkos 4.7.1
+#if !defined(KOKKOS_ENABLE_SYCL) || KOKKOS_VERSION_GREATER_EQUAL(4, 7, 1)
                Err += testHiparReduce2DReduce1D(N1, N2);
-
+#endif
                Err += testHiparFor2DMultiple1D(1, N1, N2);
                Err += testHiparFor2DMultiple1D((N1 + 1) / 2, N1, N2);
                Err += testHiparFor2DMultiple1D(2 * N1, N1, N2);

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -19,17 +19,6 @@
 
 using namespace OMEGA;
 
-template <class Array> bool hostArraysEqual(const Array &A, const Array &B) {
-   bool Equal = true;
-   for (size_t I = 0; I < A.span(); I++) {
-      if (A.data()[I] != B.data()[I]) {
-         Equal = false;
-         break;
-      }
-   }
-   return Equal;
-}
-
 static KOKKOS_FUNCTION int f2(int J1, int J2, int N1, int N2) {
    return -(N1 * N2) / 4 + J1 + N1 * J2;
 }
@@ -77,9 +66,7 @@ Error testHiparFor1DFor1D(int N1) {
               INNER_LAMBDA(int J2) { A(J1, J2) = f2(J1, J2, N1, N2); });
        });
 
-   auto AH = createHostMirrorCopy(A);
-
-   if (!hostArraysEqual(AH, RefAH)) {
+   if (!arraysEqual(A, RefAH)) {
       Err += Error(ErrorCode::Fail, errorMsg("parallelFor1DFor1D FAIL", N1));
    }
 
@@ -125,14 +112,12 @@ Error testHiparFor1DReduce1D(int N1) {
           Max1(J1) = Max;
        });
 
-   auto Sum1H = createHostMirrorCopy(Sum1);
-   if (!hostArraysEqual(Sum1H, RefSumH)) {
+   if (!arraysEqual(Sum1, RefSumH)) {
       Err += Error(ErrorCode::Fail,
                    errorMsg("parallelFor1DReduce1D Sum FAIL", N1));
    }
 
-   auto Max1H = createHostMirrorCopy(Max1);
-   if (!hostArraysEqual(Max1H, RefMaxH)) {
+   if (!arraysEqual(Max1, RefMaxH)) {
       Err += Error(ErrorCode::Fail,
                    errorMsg("parallelFor1DReduce1D Max FAIL", N1));
    }
@@ -153,9 +138,7 @@ Error testHiparFor1DReduce1D(int N1) {
           Max2(J1) = Max;
        });
 
-   auto Sum2H = createHostMirrorCopy(Sum2);
-   auto Max2H = createHostMirrorCopy(Max2);
-   if (!hostArraysEqual(Sum2H, RefSumH) || !hostArraysEqual(Max2H, RefMaxH)) {
+   if (!arraysEqual(Sum2, RefSumH) || !arraysEqual(Max2, RefMaxH)) {
       Err += Error(ErrorCode::Fail,
                    errorMsg("parallelFor1DReduce1D Sum+Max FAIL", N1));
    }
@@ -189,8 +172,7 @@ Error testHiparFor1DScan1D(int N1) {
               });
        });
 
-   auto RSumH = createHostMirrorCopy(RSum);
-   if (!hostArraysEqual(RSumH, RefRSumH)) {
+   if (!arraysEqual(RSum, RefRSumH)) {
       Err +=
           Error(ErrorCode::Fail, errorMsg("parallelFor1DScan1D Sum FAIL", N1));
    }
@@ -358,9 +340,7 @@ Error testHiparFor1DMultiple1D(int N1, int N2) {
               D(J1));
        });
 
-   auto DH = createHostMirrorCopy(D);
-
-   if (!hostArraysEqual(DH, RefDH)) {
+   if (!arraysEqual(D, RefDH)) {
       Err += Error(ErrorCode::Fail, errorMsg("multiple patterns FAIL", N1, N2));
    }
 
@@ -390,9 +370,7 @@ Error testHiparFor2DFor1D(int N1, int N2) {
               });
        });
 
-   auto AH = createHostMirrorCopy(A);
-
-   if (!hostArraysEqual(AH, RefAH)) {
+   if (!arraysEqual(A, RefAH)) {
       Err +=
           Error(ErrorCode::Fail, errorMsg("parallelFor2DFor1D FAIL", N1, N2));
    }
@@ -443,14 +421,12 @@ Error testHiparFor2DReduce1D(int N1, int N2) {
           Max1(J1, J2) = Max;
        });
 
-   auto Sum1H = createHostMirrorCopy(Sum1);
-   if (!hostArraysEqual(Sum1H, RefSumH)) {
+   if (!arraysEqual(Sum1, RefSumH)) {
       Err += Error(ErrorCode::Fail,
                    errorMsg("parallelFor2DReduce1D Sum FAIL", N1, N2));
    }
 
-   auto Max1H = createHostMirrorCopy(Max1);
-   if (!hostArraysEqual(Max1H, RefMaxH)) {
+   if (!arraysEqual(Max1, RefMaxH)) {
       Err += Error(ErrorCode::Fail,
                    errorMsg("parallelFor2DReduce1D Max FAIL", N1, N2));
    }
@@ -471,9 +447,7 @@ Error testHiparFor2DReduce1D(int N1, int N2) {
           Max2(J1, J2) = Max;
        });
 
-   auto Sum2H = createHostMirrorCopy(Sum2);
-   auto Max2H = createHostMirrorCopy(Max2);
-   if (!hostArraysEqual(Sum2H, RefSumH) || !hostArraysEqual(Max2H, RefMaxH)) {
+   if (!arraysEqual(Sum2, RefSumH) || !arraysEqual(Max2, RefMaxH)) {
       Err += Error(ErrorCode::Fail,
                    errorMsg("parallelFor2DReduce1D Sum+Max FAIL", N1, N2));
    }
@@ -509,8 +483,7 @@ Error testHiparFor2DScan1D(int N1, int N2) {
               });
        });
 
-   auto RSumH = createHostMirrorCopy(RSum);
-   if (!hostArraysEqual(RSumH, RefRSumH)) {
+   if (!arraysEqual(RSum, RefRSumH)) {
       Err += Error(ErrorCode::Fail,
                    errorMsg("parallelFor2DScan1D Sum FAIL", N1, N2));
    }
@@ -686,9 +659,7 @@ Error testHiparFor2DMultiple1D(int N1, int N2, int N3) {
               D(J1, J2));
        });
 
-   auto DH = createHostMirrorCopy(D);
-
-   if (!hostArraysEqual(DH, RefDH)) {
+   if (!arraysEqual(D, RefDH)) {
       Err += Error(ErrorCode::Fail,
                    errorMsg("multiple patterns FAIL", N1, N2, N3));
    }


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
This PR adds wrappers for Kokkos hierarchical parallelism together with tests. It is based on top of #295, which should be merged first. Since hierarchical parallelism enables many combinations of For/Reduce/Scan patterns I did not attempt to enable and test every possibility, but instead focused on the patterns that we are likely to use in Omega. This PR also doesn't include any advanced optimizations that I showed before. I figured we should start with the simplest version and optimize after we start using the wrappers.

Two of the new tests that involve outer parallel reduce failed on Aurora with the SYCL backed. Updating Kokkos to 4.7.1
made them pass. I decided to disable them with `ifdef` guards and just wait for E3SM to update its Kokkos version.

The parallel loops developer docs have been expanded and can be viewed here:
https://portal.nersc.gov/project/e3sm/mwarusz/kokkos-hipar/html/devGuide/ParallelLoops.html
   
  
<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] CTest unit tests for new features have been added per the approved design.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


