### PR TITLE
Better document testing requirements for Omega PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,19 +8,27 @@ Below are a few things we ask you or your reviewers to kindly check.
 -->
 Checklist
 * [ ] Documentation:
-  * [ ] Design document has been generated and added to the docs
-  * [ ] User's Guide has been updated
-  * [ ] Developer's Guide has been updated
-  * [ ] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
+  * [ ] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
+  * [ ] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
+  * [ ] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
+  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
+* [ ] Linting
+  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/omega/develop/devGuide/Linting.html) run locally
 * [ ] Building
   * [ ] CMake build does not produce any new warnings from changes in this PR
 * [ ] Testing
-  * [ ] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
-  * [ ] CTest unit tests for new features have been added per the approved design.
-  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
-  * [ ] Unit tests have passed. Please provide a relevant CDash build entry for verification.
-  * [ ] Polaris test suite has passed
-  * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
+  * [ ] Add a comment to the PR titled `Testing` with the following:
+    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/omega/develop/devGuide/QuickStart.html#running-ctests)
+          have been run on and indicate that are all passing.
+    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/omega/develop/devGuide/Testing.html)
+          has passed, using `develop` as a baseline
+    * [ ] Document machine(s), compiler(s) and test path(s) (`-p` in `polaris suite`) used
+    * [ ] Indicate "All tests passed" or document failing tests
+    * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.
+    * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
+  * [ ] New tests:
+    * [ ] CTest unit tests for new features have been added per the approved design.
+    * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
 * [ ] Stealth Features
   * [ ] If any stealth features are included in the PR, please confirm that they have been documented.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,16 +11,16 @@ Checklist
   * [ ] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
   * [ ] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
   * [ ] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
-  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
+  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
 * [ ] Linting
-  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/omega/develop/devGuide/Linting.html) run locally
+  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
 * [ ] Building
   * [ ] CMake build does not produce any new warnings from changes in this PR
 * [ ] Testing
   * [ ] Add a comment to the PR titled `Testing` with the following:
-    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/omega/develop/devGuide/QuickStart.html#running-ctests)
+    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
           have been run on and indicate that are all passing.
-    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/omega/develop/devGuide/Testing.html)
+    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
           has passed, using `develop` as a baseline
     * [ ] Document machine(s), compiler(s) and test path(s) (`-p` in `polaris suite`) used
     * [ ] Indicate "All tests passed" or document failing tests

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,8 +21,8 @@ Checklist
     * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
           have been run on and indicate that are all passing.
     * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
-          has passed, using `develop` as a baseline
-    * [ ] Document machine(s), compiler(s) and test path(s) (`-p` in `polaris suite`) used
+       has passed, using the Polaris `e3sm_submodules/Omega` baseline
+    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
     * [ ] Indicate "All tests passed" or document failing tests
     * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.
     * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.

--- a/components/omega/doc/devGuide/QuickStart.md
+++ b/components/omega/doc/devGuide/QuickStart.md
@@ -12,10 +12,10 @@ branches.  To do this, go to the page for the
 click on the `fork` button near the upper right corner.  Set "owner" to your
 GitHub username (this should be the default) and click "Create fork".
 
-There is no need to have a separate for for Omega, since the Omega repository
-is also a fork of E3SM.  Your E3SM fork will server for both E3SM and Omega
+There is no need to have a separate fork for Omega, since the Omega repository
+is also a fork of E3SM.  Your E3SM fork will serve for both E3SM and Omega
 development.  In fact, GitHub will not let you make an Omega fork if you
-already have an E3SM fork (or visa versa).
+already have an E3SM fork (or vice versa).
 
 ### Check out the code
 
@@ -52,7 +52,7 @@ If you do not have conda set up in your own space yet, follow
 
 
 Activate the `base` conda environment.  Go to the base of the Omega branch you
-plan to develop and create conda environment for
+plan to develop and create a conda environment for
 linting your code and building the documentation:
 ```sh
 cd components/omega/
@@ -74,13 +74,19 @@ that `pre-commit` and the associated linting utilities are available and that
 they check your code as it is committed (rather than requiring fix-up commits
 later on).
 
+(omega-dev-quick-start-build-test)=
+
 ## Building and testing Omega
+
+(omega-dev-quick-start-ctest-util)=
 
 ### Polaris CTest Utility
 
 If you are using Polaris, you may wish to use its
 [Omega CTest utility](https://github.com/E3SM-Project/polaris/tree/main/utils/omega/ctest)
-to buid and test Omega. The utility automates many of the steps below.
+to build and test Omega. The utility automates many of the steps below.
+
+(omega-dev-quick-start-build)=
 
 ### Building Omega
 
@@ -96,7 +102,7 @@ git submodule update --init --recursive \
     cime
 ```
 
-Since some systems require tests to be run on in a scratch space, it is a good
+Since some systems require tests to be run in a scratch space, it is a good
 idea to build the code somewhere in your scratch space.  We will simply refer
 to the build directory as `$BUILD_DIR` and leave it up to you to decide where
 it is best to put it.  If you have previously built in `$BUILD_DIR`, you
@@ -109,8 +115,8 @@ cd $BUILD_DIR
 
 Set `$PARMETIS_ROOT` to the appropriate location for Metis and Parmetis
 libraries built for your machine and compiler (see
-{ref}`omega-dev-parmetis-libs` below for some shared locations on some
-supported machines):
+{ref}`omega-dev-parmetis-libs` below for shared locations on supported
+machines):
 ```sh
 export PARMETIS_ROOT=<parmetis_root>
 ```
@@ -204,8 +210,8 @@ Total Test time (real) =   8.91 sec
 
 If Omega CTests are failing or simulations are crashing, setting
 `OMEGA_BUILD_TYPE` to `Debug` can be helpful for debugging purposes. If you
-need to identify which test has failed, it may be useful to examine the CMake
-ctest log file located at `$BUILD_DIR/Testing/Temporary/LastTest.log`.
+need to identify which test has failed, it may be useful to examine the CTest
+log file located at `$BUILD_DIR/Testing/Temporary/LastTest.log`.
 
 (omega-dev-parmetis-libs)=
 
@@ -264,16 +270,16 @@ used to but the hope is that it leads to a coherent code style in Omega.
 You may wish to consider using an integrated development environment (IDE) to
 develop your code.  A convenient option for developing on HPC is
 [Visual Studio Code (VS Code)](https://code.visualstudio.com/).  It has plugins
-for [c++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools),
+for [C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools),
 [CMake](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools),
 [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python),
 and so on.  If configured correctly, it should help to enforce the
 [code formatting style](https://code.visualstudio.com/docs/cpp/cpp-ide#_code-formatting)
 by recognizing Omega's `.clang-format` file.
 
-A convenient feature is the ability to connect to edit code directly on HPC
+A convenient feature is the ability to connect and edit code directly on HPC
 systems from your laptop or desktop
-[using a n SSH connection](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh).
+[using an SSH connection](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh).
 
 VS Code also provides a convenient way to preview the Markdown files used in
 the Omega documentation as you are writing them.

--- a/components/omega/doc/devGuide/Testing.md
+++ b/components/omega/doc/devGuide/Testing.md
@@ -23,6 +23,19 @@ and once on your development branch.  This means you will need to
 the suite.  You may wish to use the {ref}`omega-dev-quick-start-ctest-util` to
 automate the build and run the CTests for each branch.
 
+### Prerequisites: build Omega on both branches
+
+Before setting up and running the `omega_pr` suite, you must build Omega twice:
+
+- Build from the `develop` branch. Record the CMake build directory path as
+  `DEVELOP_BUILD` (used below with `polaris suite -p`).
+- Build from your development (test) branch. Record the CMake build directory
+  path as `TEST_BRANCH_BUILD` (also used with `-p`).
+
+The `-p` option passed to `polaris suite` should point to the CMake build
+directory for the corresponding branch (the directory where you ran CMake and
+invoked `./omega_build.sh`).
+
 ```{note}
 Run both baseline and PR suite on the same machine, CPU/GPU partition,
 compiler, and Omega build type (Debug/Release) to avoid false positive/negative

--- a/components/omega/doc/devGuide/Testing.md
+++ b/components/omega/doc/devGuide/Testing.md
@@ -183,10 +183,14 @@ Copy-paste template you can use in your PR comment:
 ## Testing
 
 CTest unit tests
-- Machine(s): <machine>[, <partition>]
-- Compiler(s): <compiler>[, ...]
-- Build type(s): <Debug|Release>[, ...]
-- Result: All tests passed | Failures: <name> (<one-line note>), ...
+- Machine: <machine>[, <partition>]
+- Compiler: <compiler>
+- Build type: <Debug|Release>
+- Result: All tests passed | Failures (X of Y): <name> (<one-line note>), ...
+
+- Machine: <machine>[, <partition>]
+- Compiler: <compiler>
+- ...
 
 Polaris omega_pr regression suite
 - Baseline build (-p): <path/to/develop/build>
@@ -208,6 +212,11 @@ Performance (if applicable)
 - After: <metric(s)>
 - Delta: <summary>
 ```
+
+The [Omega CTest Utility](https://github.com/E3SM-Project/polaris/blob/main/utils/omega/ctest/README.md)
+will also produce output in a format you can copy/paste into the PR description.
+In the future, we hope to make this easier to do from the output of the `omega_pr`
+suite as well.
 
 (omega-dev-testing-update-polaris)=
 

--- a/components/omega/doc/devGuide/Testing.md
+++ b/components/omega/doc/devGuide/Testing.md
@@ -16,21 +16,28 @@ test suite from Polaris.  The tests in the suite are defined in
 [omega_pr.txt](https://github.com/E3SM-Project/polaris/blob/main/polaris/suites/ocean/omega_pr.txt)
 in the Polaris repository.
 
-You will need to run `omega_pr` once on the Omega
-[develop branch](https://github.com/E3SM-Project/Omega)
-and once on your development branch.  This means you will need to
-{ref}`build Omega <omega-dev-quick-start-build>` for each branch before running
-the suite.  You may wish to use the {ref}`omega-dev-quick-start-ctest-util` to
-automate the build and run the CTests for each branch.
+You will run the suite twice: once using the Omega version vendored in Polaris
+under `e3sm_submodules/Omega` (the official baseline) and once using your
+development branch. This means you will need to
+{ref}`build Omega <omega-dev-quick-start-build>` from both sources before
+running the suite. You may wish to use the {ref}`omega-dev-quick-start-ctest-util`
+to automate the build and run the CTests for each.
 
-### Prerequisites: build Omega on both branches
+```{note}
+While the Omega `develop` branch often matches the Polaris submodule
+bit-for-bit (b4b), the submodule at `e3sm_submodules/Omega` is the
+authoritative baseline for regression comparison.
+```
+
+### Prerequisites: build Omega for baseline and PR
 
 Before setting up and running the `omega_pr` suite, you must build Omega twice:
 
-- Build from the `develop` branch. Record the CMake build directory path as
-  `DEVELOP_BUILD` (used below with `polaris suite -p`).
-- Build from your development (test) branch. Record the CMake build directory
-  path as `TEST_BRANCH_BUILD` (also used with `-p`).
+- Build the baseline from the Omega sources vendored by Polaris at
+  `<path-to-polaris-repo>/e3sm_submodules/Omega`. Record the CMake build
+  directory path as `BASELINE_BUILD` (used below with `polaris suite -p`).
+- Build from your development (PR) branch. Record the CMake build directory
+  path as `PR_BUILD` (also used with `-p`).
 
 The `-p` option passed to `polaris suite` should point to the CMake build
 directory for the corresponding branch (the directory where you ran CMake and
@@ -53,31 +60,31 @@ and [activating the environment](https://docs.e3sm.org/polaris/main/developers_g
 Then, with the Polaris environment active, you can set up the baseline
 `omega_pr` suite as follows:
 ``` bash
-DEVELOP_BUILD=/path/to/omega/develop/build
+BASELINE_BUILD=/path/to/build/from/polaris/e3sm_submodules/Omega
 POLARIS_SCRATCH=/path/to/scratch/polaris_testing/
 polaris suite -c ocean -t omega_pr --model omega \
-    -w $POLARIS_SCRATCH/baseline_omega_pr \
-    -p $DEVELOP_BUILD
+  -w $POLARIS_SCRATCH/baseline_omega_pr \
+  -p $BASELINE_BUILD
 ```
 where `$POLARIS_SCRATCH` is a directory within your scratch space that is
 useful for setting up and running the Polaris test suites and
-`$DEVELOP_BUILD` is the directory where you built Omega from the `develop`
-branch, or where the Polaris CTest utility built if for you (e.g.
-`build_omega/build_chrysalis_intel`).
+`$BASELINE_BUILD` is the directory where you built Omega from the Omega
+sources located at `<polaris-repo>/e3sm_submodules/Omega`, or where the
+Polaris CTest utility built it for you (e.g. `build_omega/build_chrysalis_intel`).
 
 Next, you can set up the `omega_pr` for your development branch, using the
-baseline from the `develop` branch:
+baseline set up above:
 
 ``` bash
-TEST_BRANCH_BUILD=/path/to/omega/test/branch/build
+PR_BUILD=/path/to/omega/pr/branch/build
 POLARIS_SCRATCH=/path/to/scratch/polaris_testing/
 polaris suite -c ocean -t omega_pr --model omega \
     -b $POLARIS_SCRATCH/baseline_omega_pr \
     -w $POLARIS_SCRATCH/my_branch_omega_pr \
-    -p $TEST_BRANCH_BUILD
+  -p $PR_BUILD
 ```
 Here, `$POLARIS_SCRATCH` is the same scratch directory as above,
-`$TEST_BRANCH_BUILD` is the directory where you build Omega from your
+`$PR_BUILD` is the directory where you build Omega from your
 development branch (or where the CTest utility built for you), and
 `my_branch_omega_pr` can be any name that helps you keep track of what you
 were testing.
@@ -111,9 +118,10 @@ documentation for equivalent commands.
 
 What should you do if you see test failures?
 
-#### Test execution errors for `develop` baseline
+#### Test execution errors for baseline (Polaris `e3sm_submodules/Omega`)
 
-If you see test execution failures in the baseline run from `develop`,
+If you see test execution failures in the baseline run from Polaris
+`e3sm_submodules/Omega`,
 these need to be reported as [issues](https://github.com/E3SM-Project/Omega/issues)
 on the Omega repo, preferably mentioning a relevant Omega developer who may
 be able to investigate the cause of the failure.  Please provide the contents
@@ -151,7 +159,7 @@ We do not update `e3sm_submodules/Omega` after every branch is merged into
 ```
 
 If you see unexpected differences between the results for your development
-branch and those from `develop`, you should attempt to debug the cause yourself
+branch and those from the baseline, you should attempt to debug the cause yourself
 and then reach out to the Omega team if you need help.
 
 
@@ -173,8 +181,8 @@ machine and compiler.
       a one-line note each
 
 - Polaris `omega_pr` regression suite
-    - Baseline run (develop)
-        - Build directory used for -p
+  - Baseline run (Polaris `e3sm_submodules/Omega`)
+    - Build path used for -p (from Polaris `e3sm_submodules/Omega`)
         - Work directory used for -w
     - PR branch run
         - Build directory used for -p
@@ -201,12 +209,8 @@ CTest unit tests
 - Build type: <Debug|Release>
 - Result: All tests passed | Failures (X of Y): <name> (<one-line note>), ...
 
-- Machine: <machine>[, <partition>]
-- Compiler: <compiler>
-- ...
-
 Polaris omega_pr regression suite
-- Baseline build (-p): <path/to/develop/build>
+- Baseline build (-p): <path/to/build of Polaris e3sm_submodules/Omega>
 - Baseline workdir (-w): <path/to/baseline_omega_pr>
 - PR build (-p): <path/to/pr/build>
 - PR workdir (-w): <path/to/my_branch_omega_pr>

--- a/components/omega/doc/devGuide/Testing.md
+++ b/components/omega/doc/devGuide/Testing.md
@@ -98,23 +98,38 @@ documentation for equivalent commands.
 
 What should you do if you see test failures?
 
-First, if you see test execution failures in the baseline run from `develop`,
+#### Test execution errors for `develop` baseline
+
+If you see test execution failures in the baseline run from `develop`,
 these need to be reported as [issues](https://github.com/E3SM-Project/Omega/issues)
 on the Omega repo, preferably mentioning a relevant Omega developer who may
 be able to investigate the cause of the failure.  Please provide the contents
 of the relevant log file for the failing test(s) and optionally the location of
 the tests (and log files) if other Omega developers will have access.
 
+#### Test execution errors for your branch
+
 If you see execution failures on the tests for your development branch, please
 take a look at the log files and attempt to debug the issues yourself first,
-then reach out to the Omega team if you need help.
+then reach out to the Omega team if you need help.  In many cases, the test
+failures may related to changes that are required in Polaris, see
+{ref}`omega-dev-testing-update-polaris` below.
+
+#### Diffs between your branch and baseline
+
+If diffs are expected:
+- Document the diffs (PR comment)
+- Update `e3sm_submodules/Omega` in Polaris (after merge)
+
+If *not* expected:
+- Debug and eliminate
 
 If you see errors related to comparisons with the baseline, you will need to
 determine if these are expected based on the code changes or not.  If they
-are expected, you will need to document how large the differences are in the
-tests that show differences.  In addition, you will need to make a pull
-request to the Polaris repository to update the Omega submodule in
-`e3sm_submodules/Omega` once your branch has been merged so that the changes
+are expected, you will need to document (in a PR comment) how large the
+differences are in the tests that show differences.  In addition, you will need
+to make a pull request to the Polaris repository to update the Omega submodule
+in `e3sm_submodules/Omega` once your branch has been merged so that the changes
 become the new baseline in Polaris.
 
 ```{note}
@@ -133,6 +148,11 @@ Please add a PR comment titled "Testing" that summarizes what you ran and the
 outcomes. Include the following so reviewers can validate apples-to-apples
 runs.
 
+```{note}
+At a minimum, you need to run both CTests and the `omega_pr` suite on one
+machine and compiler.
+```
+
 - CTest unit tests
     - Machine(s) and partition/queue (if applicable)
     - Compiler(s), and build type(s) (Debug/Release)
@@ -148,7 +168,8 @@ runs.
         - Work directory used for -w
     - Machine/partition, compiler, and build type (should match between baseline and PR)
     - Result: "All tests passed" or a concise list of diffs/failures with a brief note
-    - If there are issues, add the path to the relevant log(s) (e.g., polaris_omega_pr.o$JOBID) and a short excerpt if helpful
+    - If there are issues, add the path to the relevant log(s) (e.g.,
+      polaris_omega_pr.o$JOBID) and a short excerpt if helpful
 
 - Tests added/modified/impacted
     - Briefly list any new or updated CTest or Polaris tests and what they cover
@@ -187,3 +208,106 @@ Performance (if applicable)
 - After: <metric(s)>
 - Delta: <summary>
 ```
+
+(omega-dev-testing-update-polaris)=
+
+### Updating Polaris
+
+Many Omega changes are likely to also require Polaris changes.  In such cases,
+it makes sense to co-develop your Omega branch and a Polaris branch.  The
+Omega branch will need to be merged first, then the `e3sm_submodules/Omega`
+submodule will need to be updated to include the Omega changes as part of
+the Polaris pull request.
+
+Here are some examples of Omega changes that will require corresponding
+Polaris changes.
+
+#### Adding new Omega dimensions or variables
+
+If you add new Omega variables that have a corresponding MPAS-Ocean name,
+you need to add the mapping between the names to
+[mpaso_to_omega.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/mpaso_to_omega.yaml).
+For more details, see the Polaris
+[Ocean Framework documentation](https://docs.e3sm.org/polaris/main/developers_guide/ocean/framework.html).
+
+For example:
+```yaml
+dimensions:
+  Time: time
+  nVertLevels: NVertLayers
+
+variables:
+  temperature: Temperature
+  salinity: Salinity
+  ssh: SshCell
+```
+In each case, the keys are the MPAS-Ocean names and the values are the
+corresponding Omega names.
+
+#### Updates to Default.yml
+
+If you add or remove sections, config options, streams, etc. in
+[Default.yml](https://github.com/E3SM-Project/Omega/blob/develop/components/omega/configs/Default.yml),
+you may need to make corresponding changes to the YAML files for Polaris
+test cases for them to continue to work as expected.
+
+Whenever possible, we try to use a mapping between MPAS-Ocean namelist options
+and Omega config options within
+[mpaso_to_omega.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/mpaso_to_omega.yaml).
+For example:
+```yaml
+config:
+- section:
+    time_management: TimeIntegration
+  options:
+    config_start_time: StartTime
+    config_stop_time: StopTime
+    config_run_duration: RunDuration
+    config_calendar_type: CalendarType
+```
+
+If you have added new Omega config sections or options that have corresponding
+MPAS-Ocean namelist sections or options, please add them to the map. In each
+case, the keys are the MPAS-Ocean names and the values are the corresponding
+Omega names.
+
+Frequently, there is no MPAS-Ocean equivalent to an Omega config option, and
+we currently do not try to map streams from MPAS-Ocean to Omega (their
+syntax is too different).  In such cases, we have do define Omega YAML config
+options and streams in each test case, and you may need to update each one
+with your changes.  Here is an example exerpt from the
+[manufactured_solution](https://github.com/E3SM-Project/polaris/blob/main/polaris/tasks/ocean/manufactured_solution/forward.yaml)
+test:
+```yaml
+Omega:
+  Tendencies:
+    VelDiffTendencyEnable: false
+    VelHyperDiffTendencyEnable: false
+    UseCustomTendency: true
+    ManufacturedSolutionTendency: true
+  IOStreams:
+    InitialVertCoord:
+      Filename: init.nc
+    InitialState:
+      UsePointerFile: false
+      Filename: init.nc
+      Contents:
+      - NormalVelocity
+      - LayerThickness
+    RestartRead: {}
+    History:
+      Filename: output.nc
+      Freq: {{ output_freq }}
+      FreqUnits: Seconds
+      IfExists: append
+      # effectively never
+      FileFreq: 9999
+      FileFreqUnits: years
+      Contents:
+      - NormalVelocity
+      - LayerThickness
+      - SshCell
+```
+For more details on updating either the map or the YAML files for individual
+tests, see the Polaris
+[Ocean Framework documentation](https://docs.e3sm.org/polaris/main/developers_guide/ocean/framework.html).

--- a/components/omega/doc/devGuide/Testing.md
+++ b/components/omega/doc/devGuide/Testing.md
@@ -1,0 +1,189 @@
+(omega-dev-testing)=
+
+# Testing Code
+
+For instructions on how to build Omega and run CTest unit tests, see
+{ref}`omega-dev-quick-start-build-test`.
+
+
+## Running the Polaris `omega_pr` Test Suite
+
+The CTest unit tests on their own are not sufficient to ensure that changes
+to Omega behave as expected.  Developers also need to run the regression tests
+in the form of the
+[omega_pr](https://docs.e3sm.org/polaris/main/users_guide/ocean/suites.html#omega-pr-suite)
+test suite from Polaris.  The tests in the suite are defined in
+[omega_pr.txt](https://github.com/E3SM-Project/polaris/blob/main/polaris/suites/ocean/omega_pr.txt)
+in the Polaris repository.
+
+You will need to run `omega_pr` once on the Omega
+[develop branch](https://github.com/E3SM-Project/Omega)
+and once on your development branch.  This means you will need to
+{ref}`build Omega <omega-dev-quick-start-build>` for each branch before running
+the suite.  You may wish to use the {ref}`omega-dev-quick-start-ctest-util` to
+automate the build and run the CTests for each branch.
+
+```{note}
+Run both baseline and PR suite on the same machine, CPU/GPU partition,
+compiler, and Omega build type (Debug/Release) to avoid false positive/negative
+diffs.
+```
+
+### Setting up the suite
+
+If you have not yet set up Polaris, you will need to follow its
+[quick start](https://docs.e3sm.org/polaris/main/developers_guide/quick_start.html)
+including [cloning the repo](https://docs.e3sm.org/polaris/main/developers_guide/quick_start.html#set-up-a-polaris-repository-for-beginners),
+[configuring the software environment](https://docs.e3sm.org/polaris/main/developers_guide/quick_start.html#supported-machines),
+and [activating the environment](https://docs.e3sm.org/polaris/main/developers_guide/quick_start.html#activating-the-environment).
+
+Then, with the Polaris environment active, you can set up the baseline
+`omega_pr` suite as follows:
+``` bash
+DEVELOP_BUILD=/path/to/omega/develop/build
+POLARIS_SCRATCH=/path/to/scratch/polaris_testing/
+polaris suite -c ocean -t omega_pr --model omega \
+    -w $POLARIS_SCRATCH/baseline_omega_pr \
+    -p $DEVELOP_BUILD
+```
+where `$POLARIS_SCRATCH` is a directory within your scratch space that is
+useful for setting up and running the Polaris test suites and
+`$DEVELOP_BUILD` is the directory where you built Omega from the `develop`
+branch, or where the Polaris CTest utility built if for you (e.g.
+`build_omega/build_chrysalis_intel`).
+
+Next, you can set up the `omega_pr` for your development branch, using the
+baseline from the `develop` branch:
+
+``` bash
+TEST_BRANCH_BUILD=/path/to/omega/test/branch/build
+POLARIS_SCRATCH=/path/to/scratch/polaris_testing/
+polaris suite -c ocean -t omega_pr --model omega \
+    -b $POLARIS_SCRATCH/baseline_omega_pr \
+    -w $POLARIS_SCRATCH/my_branch_omega_pr \
+    -p $TEST_BRANCH_BUILD
+```
+Here, `$POLARIS_SCRATCH` is the same scratch directory as above,
+`$TEST_BRANCH_BUILD` is the directory where you build Omega from your
+development branch (or where the CTest utility built for you), and
+`my_branch_omega_pr` can be any name that helps you keep track of what you
+were testing.
+
+### Running the suite
+
+First, run the baseline, e.g. for Slurm systems:
+``` bash
+cd $POLARIS_SCRATCH/baseline_omega_pr
+sbatch job_script.omega_pr.sh
+```
+Note the job ID for the next step.  Next, run the suite for the test branch,
+waiting until the baseline is done:
+``` bash
+cd $POLARIS_SCRATCH/my_branch_omega_pr
+sbatch --kill-on-invalid-dep=yes --dependency=afterok:$JOBID job_script.omega_pr.sh
+```
+where `$JOBID` is the JOB ID of the baseline slurm job.
+
+Monitor the jobs (e.g. `squeue -j $JOBID`) and take a look at combined
+stdout/stderr log in `polaris_omega_pr.o$JOBID` in each work directory to see
+whether the tests passed.  Report the results as part of any (non-trivial)
+Omega PR.
+
+```{note}
+For other schedulers (e.g. PBS on Aurora), take a look at the machine's
+documentation for equivalent commands.
+```
+
+### Handling test failures
+
+What should you do if you see test failures?
+
+First, if you see test execution failures in the baseline run from `develop`,
+these need to be reported as [issues](https://github.com/E3SM-Project/Omega/issues)
+on the Omega repo, preferably mentioning a relevant Omega developer who may
+be able to investigate the cause of the failure.  Please provide the contents
+of the relevant log file for the failing test(s) and optionally the location of
+the tests (and log files) if other Omega developers will have access.
+
+If you see execution failures on the tests for your development branch, please
+take a look at the log files and attempt to debug the issues yourself first,
+then reach out to the Omega team if you need help.
+
+If you see errors related to comparisons with the baseline, you will need to
+determine if these are expected based on the code changes or not.  If they
+are expected, you will need to document how large the differences are in the
+tests that show differences.  In addition, you will need to make a pull
+request to the Polaris repository to update the Omega submodule in
+`e3sm_submodules/Omega` once your branch has been merged so that the changes
+become the new baseline in Polaris.
+
+```{note}
+We do not update `e3sm_submodules/Omega` after every branch is merged into
+`develop` on Omega to reduce maintenance burden.
+```
+
+If you see unexpected differences between the results for your development
+branch and those from `develop`, you should attempt to debug the cause yourself
+and then reach out to the Omega team if you need help.
+
+
+### What to include in your PR Testing comment
+
+Please add a PR comment titled "Testing" that summarizes what you ran and the
+outcomes. Include the following so reviewers can validate apples-to-apples
+runs.
+
+- CTest unit tests
+    - Machine(s) and partition/queue (if applicable)
+    - Compiler(s), and build type(s) (Debug/Release)
+    - Result: either "All tests passed" or a short list of failing tests with
+      a one-line note each
+
+- Polaris `omega_pr` regression suite
+    - Baseline run (develop)
+        - Build directory used for -p
+        - Work directory used for -w
+    - PR branch run
+        - Build directory used for -p
+        - Work directory used for -w
+    - Machine/partition, compiler, and build type (should match between baseline and PR)
+    - Result: "All tests passed" or a concise list of diffs/failures with a brief note
+    - If there are issues, add the path to the relevant log(s) (e.g., polaris_omega_pr.o$JOBID) and a short excerpt if helpful
+
+- Tests added/modified/impacted
+    - Briefly list any new or updated CTest or Polaris tests and what they cover
+
+- Performance PRs
+    - Link to the relevant PACE experiment and summarize before/after metrics
+
+Copy-paste template you can use in your PR comment:
+
+```text
+## Testing
+
+CTest unit tests
+- Machine(s): <machine>[, <partition>]
+- Compiler(s): <compiler>[, ...]
+- Build type(s): <Debug|Release>[, ...]
+- Result: All tests passed | Failures: <name> (<one-line note>), ...
+
+Polaris omega_pr regression suite
+- Baseline build (-p): <path/to/develop/build>
+- Baseline workdir (-w): <path/to/baseline_omega_pr>
+- PR build (-p): <path/to/pr/build>
+- PR workdir (-w): <path/to/my_branch_omega_pr>
+- Machine/partition: <machine>[, <partition>]
+- Compiler/build type: <compiler>, <Debug|Release>
+- Result: All tests passed | Diffs/Failures: <brief summary>
+- Logs (if applicable): <path/to/polaris_omega_pr.o$JOBID>
+
+Tests added/modified/impacted
+- CTest: <name> — <one-line purpose>
+- Polaris: <path or name> — <one-line purpose>
+
+Performance (if applicable)
+- PACE: <link>
+- Before: <metric(s)>
+- After: <metric(s)>
+- Delta: <summary>
+```

--- a/components/omega/doc/devGuide/Testing.md
+++ b/components/omega/doc/devGuide/Testing.md
@@ -139,8 +139,8 @@ failures may related to changes that are required in Polaris, see
 #### Diffs between your branch and baseline
 
 If diffs are expected:
-- Document the diffs (PR comment)
-- Update `e3sm_submodules/Omega` in Polaris (after merge)
+- Document the diffs (in Omega PR comment)
+- Update `e3sm_submodules/Omega` in Polaris (after merge of Omega PR)
 
 If *not* expected:
 - Debug and eliminate
@@ -161,6 +161,10 @@ We do not update `e3sm_submodules/Omega` after every branch is merged into
 If you see unexpected differences between the results for your development
 branch and those from the baseline, you should attempt to debug the cause yourself
 and then reach out to the Omega team if you need help.
+
+You may want to look at Polaris'
+[bisect](https://github.com/E3SM-Project/polaris/blob/main/utils/bisect/README.md)
+utility to help debug which commit introduced the unexpected differences.
 
 
 ### What to include in your PR Testing comment
@@ -198,7 +202,10 @@ machine and compiler.
 - Performance PRs
     - Link to the relevant PACE experiment and summarize before/after metrics
 
-Copy-paste template you can use in your PR comment:
+The [Omega CTest Utility](https://github.com/E3SM-Project/polaris/blob/main/utils/omega/ctest/README.md)
+and the `omega_pr` suite will produce output in a format you can copy/paste into the PR
+description. These outputs follow roughly the template below.  If you want to add the
+information manually, you can copy-paste template you can use in your PR comment:
 
 ```text
 ## Testing
@@ -229,11 +236,6 @@ Performance (if applicable)
 - After: <metric(s)>
 - Delta: <summary>
 ```
-
-The [Omega CTest Utility](https://github.com/E3SM-Project/polaris/blob/main/utils/omega/ctest/README.md)
-will also produce output in a format you can copy/paste into the PR description.
-In the future, we hope to make this easier to do from the output of the `omega_pr`
-suite as well.
 
 (omega-dev-testing-update-polaris)=
 

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -61,6 +61,7 @@ devGuide/CondaEnv
 devGuide/Linting
 devGuide/Docs
 devGuide/BuildDocs
+devGuide/Testing
 devGuide/DataTypes
 devGuide/MachEnv
 devGuide/Config


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

This merge adds a "Code Testing" page to the documentation that describes running the `omega_pr` test suite for
each Omega PR.

It also updates the PR checklist to better describe testing.  The updated version provides better links to the documentation
and a more thorough list of testing requirements.

It includes many fixes to typos in the Quick Start.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


