### PR TITLE
Fix order of `MaxCellsOnEdge`/`TWO` dimension read

### DIFF
--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -195,10 +195,10 @@ void readMesh(const int MeshFileID, // file ID for open mesh file
    DimName    = "MaxCellsOnEdge";
    DimNameOld = "TWO";
    I4 MaxCellsOnEdgeID;
-   Err = IO::getDimFromFile(MeshFileID, DimNameOld, MaxCellsOnEdgeID,
+   Err = IO::getDimFromFile(MeshFileID, DimName, MaxCellsOnEdgeID,
                             MaxCellsOnEdge);
    if (Err.isFail()) { // dim not found, try again with older MPAS name
-      Err = IO::getDimFromFile(MeshFileID, DimName, MaxCellsOnEdgeID,
+      Err = IO::getDimFromFile(MeshFileID, DimNameOld, MaxCellsOnEdgeID,
                                MaxCellsOnEdge);
       CHECK_ERROR_ABORT(Err, "Decomp: error reading MaxCellsOnEdge");
       if (MaxCellsOnEdge <= 0)


### PR DESCRIPTION
We want to try the new name first, then the old one.  As it stands, we get an error message like:
```
[error] [IO.cpp:343] PIO error while reading dimension TWO
```
even if `MaxCellsOnEdge` is then successfully read.  It isn't great that we're getting an error message at all but at least with this fix the error will only be logged if the old dimension name is being used.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
  * [ ] ~~Polaris test suite has passed~~ The `omega_pr` suite is failing for reasons being addressed in https://github.com/E3SM-Project/polaris/pull/384 and https://github.com/E3SM-Project/Omega/issues/306

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


