### PR TITLE
fixes stream read failure when freq is never

### DIFF
--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -250,7 +250,8 @@ Error IOStream::read(
    // Retrieve stream by name and make sure it exists
    auto StreamItr = AllStreams.find(StreamName);
    if (StreamItr == AllStreams.end())
-      ABORT_ERROR("IOStream::Read: Stream {} not found", StreamName);
+      RETURN_ERROR(Err, ErrorCode::Fail,
+                   "IOStream::Read: Stream {} not found", StreamName);
 
    // Stream found, call the read function
    std::shared_ptr<IOStream> ThisStream = StreamItr->second;

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -250,8 +250,8 @@ Error IOStream::read(
    // Retrieve stream by name and make sure it exists
    auto StreamItr = AllStreams.find(StreamName);
    if (StreamItr == AllStreams.end())
-      RETURN_ERROR(Err, ErrorCode::Fail,
-                   "IOStream::Read: Stream {} not found", StreamName);
+      RETURN_ERROR(Err, ErrorCode::Fail, "IOStream::Read: Stream {} not found",
+                   StreamName);
 
    // Stream found, call the read function
    std::shared_ptr<IOStream> ThisStream = StreamItr->second;

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -167,6 +167,8 @@ int initOmegaModules(MPI_Comm Comm) {
    // One of the above two streams must be successful to initialize the
    // state and other fields used in the model
    if (Err1.isFail() and Err2.isFail()) {
+      CHECK_ERROR(Err1, "Errors encountered reading InitialState");
+      CHECK_ERROR(Err2, "Errors encountered reading RestartRead");
       ABORT_ERROR("Error initializing ocean variables from input streams");
    }
 


### PR DESCRIPTION
When the frequency of a stream is never, the read routine should return an error, but during the recent propagation of error codes, the read routine was aborting instead. This fixes that and also adds some error checking to diagnose problems if both InitialState and RestartRead fail

I have tested this with the standalone driver unit test with the InitialState as never in the config, but was unable to test with the polaris restart tests due to problems getting a working updated polaris.

Fixes #306  

Checklist
* [x] Testing
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
  * [x] Polaris test suite has passed


