### PR TITLE
Vertical coordinate updates and fixes

### DIFF
--- a/components/omega/doc/devGuide/VertCoord.md
+++ b/components/omega/doc/devGuide/VertCoord.md
@@ -4,11 +4,23 @@
 
 ### Initialization
 
-The default `VertCoord` instance is  created by the `init` method, which assumes that `Decomp` has already been initialized.
+The default `VertCoord` instance is created by the `init` method, which assumes that `Decomp` has already been initialized.
 ```
 Decomp::init();
 VertCoord::init();
 ```
+The `init` method accepts two optional arguments with default values:
+```
+VertCoord::init(const bool ReadStream = true, const int NVertLayers = 0)
+```
+These arguments provide flexibility, particularly for unit testing. When `init(false)` is used, the method skips reading
+the `InitialVertCoord` stream. This is useful for unit tests that rely on meshes lacking the fields required by that stream.
+In this case, the min/max layer arrays are initialized with default values based on the number of vertical layers, and
+`bottomDepth` remains uninitialized. Some tests may utilize a specific number of vertical layers that differs from what is
+defined in the mesh file. To handle this, the `VertCoord` can be initialized with `init(false, LocNVertLayers)` to explicitly
+set the number of vertical layers. An argument for `ReadStream` must be provided in order to explicitly set `NVertLayers`.
+For example, `init(42)` is invalid, `init(false, 42)` must be called instead.
+
 The default instance can be retrieved by:
 ```
 auto *DefVertCoord = VertCoord::getDefault();
@@ -16,9 +28,12 @@ auto *DefVertCoord = VertCoord::getDefault();
 
 Additional instances can be created by calling the `create` method.
 ```
-VertCoord *VertCoord::create(const std::string &Name,  ///< [in] Name for vertical coordinate
-                             const Decomp *MeshDecomp, ///< [in] Decomp for mesh
-                             Config *Options)          ///< [in] Confiuration options
+VertCoord *VertCoord::create(const std::string &Name,      ///< [in] Name for vertical coordinate
+                             const Decomp *MeshDecomp,     ///< [in] Decomp for mesh
+                             Config *Options,              ///< [in] Confiuration options
+                             const bool ReadStream = true, ///< [in] optional logical to read stream
+                             const int NVertLayers = 0     ///< [in] optional int to set vertical dim
+)
 ```
 This calls the constructor and places the instance in a map that can be used to retrieve the instance by name:
 ```

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1579,11 +1579,19 @@ Error IOStream::readFieldData(
    // lower case
    std::string OldFieldName = FieldName;
    OldFieldName[0]          = std::tolower(OldFieldName[0]);
-   bool OnHost              = FieldPtr->isOnHost();
-   bool IsDistributed       = FieldPtr->isDistributed();
-   bool IsTimeDependent     = FieldPtr->isTimeDependent();
-   ArrayDataType MyType     = FieldPtr->getType();
-   int NDims                = FieldPtr->getNumDims();
+   // Check for "Layer" in field name, backwards compatibility requires
+   // replacing "Layer" with "Level"
+   std::string OmegaSubStr = "Layer";
+   std::string MPASSubStr  = "Level";
+   size_t pos              = OldFieldName.find(OmegaSubStr);
+   if (pos != std::string::npos) {
+      OldFieldName.replace(pos, OmegaSubStr.length(), MPASSubStr);
+   }
+   bool OnHost          = FieldPtr->isOnHost();
+   bool IsDistributed   = FieldPtr->isDistributed();
+   bool IsTimeDependent = FieldPtr->isTimeDependent();
+   ArrayDataType MyType = FieldPtr->getType();
+   int NDims            = FieldPtr->getNumDims();
    if (NDims < 0)
       ABORT_ERROR("IOStream readFieldData: "
                   "Invalid number of dimensions for Field {}",

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -18,14 +18,15 @@ static std::string stripDefault(const std::string &Name) {
 // Constructor. Constructs the member auxiliary variables and registers their
 // fields with IOStreams
 AuxiliaryState::AuxiliaryState(const std::string &Name, const HorzMesh *Mesh,
-                               Halo *MeshHalo, int NVertLayers, int NTracers)
-    : Mesh(Mesh), MeshHalo(MeshHalo), Name(stripDefault(Name)),
+                               const VertCoord *VCoord, Halo *MeshHalo,
+                               int NVertLayers, int NTracers)
+    : Mesh(Mesh), VCoord(VCoord), MeshHalo(MeshHalo), Name(stripDefault(Name)),
       KineticAux(stripDefault(Name), Mesh, NVertLayers),
       LayerThicknessAux(stripDefault(Name), Mesh, NVertLayers),
       VorticityAux(stripDefault(Name), Mesh, NVertLayers),
-      VelocityDel2Aux(stripDefault(Name), Mesh, NVertLayers),
+      VelocityDel2Aux(stripDefault(Name), Mesh, VCoord, NVertLayers),
       WindForcingAux(stripDefault(Name), Mesh),
-      TracerAux(stripDefault(Name), Mesh, NVertLayers, NTracers) {
+      TracerAux(stripDefault(Name), Mesh, VCoord, NVertLayers, NTracers) {
 
    GroupName = "AuxiliaryState";
    if (Name != "Default") {
@@ -192,7 +193,8 @@ void AuxiliaryState::computeAll(const OceanState *State,
 
 // Create a non-default auxiliary state
 AuxiliaryState *AuxiliaryState::create(const std::string &Name,
-                                       const HorzMesh *Mesh, Halo *MeshHalo,
+                                       const HorzMesh *Mesh,
+                                       const VertCoord *VCoord, Halo *MeshHalo,
                                        int NVertLayers, const int NTracers) {
    if (AllAuxStates.find(Name) != AllAuxStates.end()) {
       LOG_ERROR("Attempted to create a new AuxiliaryState with name {} but it "
@@ -202,7 +204,7 @@ AuxiliaryState *AuxiliaryState::create(const std::string &Name,
    }
 
    auto *NewAuxState =
-       new AuxiliaryState(Name, Mesh, MeshHalo, NVertLayers, NTracers);
+       new AuxiliaryState(Name, Mesh, VCoord, MeshHalo, NVertLayers, NTracers);
    AllAuxStates.emplace(Name, NewAuxState);
 
    return NewAuxState;
@@ -211,14 +213,15 @@ AuxiliaryState *AuxiliaryState::create(const std::string &Name,
 // Create the default auxiliary state. Assumes that HorzMesh, VertCoord and
 // Halo have been initialized.
 void AuxiliaryState::init() {
-   const HorzMesh *DefMesh = HorzMesh::getDefault();
-   Halo *DefHalo           = Halo::getDefault();
+   const HorzMesh *DefMesh    = HorzMesh::getDefault();
+   const VertCoord *DefVCoord = VertCoord::getDefault();
+   Halo *DefHalo              = Halo::getDefault();
 
    int NVertLayers = VertCoord::getDefault()->NVertLayers;
    int NTracers    = Tracers::getNumTracers();
 
    AuxiliaryState::DefaultAuxState = AuxiliaryState::create(
-       "Default", DefMesh, DefHalo, NVertLayers, NTracers);
+       "Default", DefMesh, DefVCoord, DefHalo, NVertLayers, NTracers);
 
    Config *OmegaConfig = Config::getOmegaConfig();
    DefaultAuxState->readConfigOptions(OmegaConfig);

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -50,7 +50,8 @@ class AuxiliaryState {
 
    // Create a non-default auxiliary state
    static AuxiliaryState *create(const std::string &Name, const HorzMesh *Mesh,
-                                 Halo *MeshHalo, int NVertLayers, int NTracers);
+                                 const VertCoord *VCoord, Halo *MeshHalo,
+                                 int NVertLayers, int NTracers);
 
    /// Get the default auxiliary state
    static AuxiliaryState *getDefault();
@@ -82,13 +83,15 @@ class AuxiliaryState {
                    int TimeLevel) const;
 
  private:
-   AuxiliaryState(const std::string &Name, const HorzMesh *Mesh, Halo *MeshHalo,
-                  int NVertLayers, int NTracers);
+   AuxiliaryState(const std::string &Name, const HorzMesh *Mesh,
+                  const VertCoord *VCoord, Halo *MeshHalo, int NVertLayers,
+                  int NTracers);
 
    AuxiliaryState(const AuxiliaryState &) = delete;
    AuxiliaryState(AuxiliaryState &&)      = delete;
 
    const HorzMesh *Mesh;
+   const VertCoord *VCoord;
    Halo *MeshHalo;
    static AuxiliaryState *DefaultAuxState;
    static std::map<std::string, std::unique_ptr<AuxiliaryState>> AllAuxStates;

--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -37,27 +37,21 @@ void HorzMesh::init() {
    // Retrieve the default decomposition
    Decomp *DefDecomp = Decomp::getDefault();
 
-   I4 NVertLayers = VertCoord::getDefault()->NVertLayers;
-
    // Create the default mesh and set pointer to it
-   HorzMesh::DefaultHorzMesh = create("Default", DefDecomp, NVertLayers);
+   HorzMesh::DefaultHorzMesh = create("Default", DefDecomp);
 }
 
 //------------------------------------------------------------------------------
 // Construct a new local mesh given a decomposition
 
 HorzMesh::HorzMesh(const std::string &Name, //< [in] Name for new mesh
-                   Decomp *MeshDecomp,      //< [in] Decomp for the new mesh
-                   I4 InNVertLayers         //< [in} num vertical layers
+                   Decomp *MeshDecomp       //< [in] Decomp for the new mesh
 ) {
 
    MeshName = Name;
 
    // Retrieve mesh files name from Decomp
    MeshFileName = MeshDecomp->MeshFileName;
-
-   // Set NVertLayers
-   NVertLayers = InNVertLayers;
 
    // Retrieve mesh cell/edge/vertex totals from Decomp
    NCellsHalo  = MeshDecomp->NCellsHalo;
@@ -141,9 +135,6 @@ HorzMesh::HorzMesh(const std::string &Name, //< [in] Name for new mesh
    // Compute EdgeSignOnCells and EdgeSignOnVertex
    computeEdgeSign();
 
-   // TODO: implement setMasks during Mesh constructor
-   setMasks(NVertLayers);
-
    // set mesh scaling coefficients
    setMeshScaling();
 
@@ -152,8 +143,7 @@ HorzMesh::HorzMesh(const std::string &Name, //< [in] Name for new mesh
 /// Creates a new mesh by calling the constructor and puts it in the
 /// AllHorzMeshes map
 HorzMesh *HorzMesh::create(const std::string &Name, //< [in] Name for new mesh
-                           Decomp *MeshDecomp, //< [in] Decomp for the new mesh
-                           I4 InNVertLayers    //< [in] num vertical layers
+                           Decomp *MeshDecomp //< [in] Decomp for the new mesh
 ) {
    // Check to see if a mesh of the same name already exists and
    // if so, exit with an error
@@ -166,7 +156,7 @@ HorzMesh *HorzMesh::create(const std::string &Name, //< [in] Name for new mesh
 
    // create a new mesh on the heap and put it in a map of
    // unique_ptrs, which will manage its lifetime
-   auto *NewHorzMesh = new HorzMesh(Name, MeshDecomp, InNVertLayers);
+   auto *NewHorzMesh = new HorzMesh(Name, MeshDecomp);
    AllHorzMeshes.emplace(Name, NewHorzMesh);
 
    return NewHorzMesh;
@@ -573,33 +563,6 @@ void HorzMesh::computeEdgeSign() {
 
    EdgeSignOnVertexH = createHostMirrorCopy(EdgeSignOnVertex);
 } // end computeEdgeSign
-
-//------------------------------------------------------------------------------
-// set computational masks for mesh elements
-// TODO: this is just a placeholder, implement actual masks for edges, cells,
-// and vertices
-void HorzMesh::setMasks(int NVertLayers) {
-
-   EdgeMask = Array2DReal("EdgeMask", NEdgesSize, NVertLayers);
-
-   OMEGA_SCOPE(LocEdgeMask, EdgeMask);
-   OMEGA_SCOPE(LocCellsOnEdge, CellsOnEdge);
-   OMEGA_SCOPE(LocNCellsAll, NCellsAll);
-
-   deepCopy(EdgeMask, 1.0);
-   parallelFor(
-       {NEdgesAll, NVertLayers}, KOKKOS_LAMBDA(int Edge, int K) {
-          const I4 Cell1 = LocCellsOnEdge(Edge, 0);
-          const I4 Cell2 = LocCellsOnEdge(Edge, 1);
-          if (!(Cell1 >= 0 and Cell1 < LocNCellsAll) or
-              !(Cell2 >= 0 and Cell2 < LocNCellsAll)) {
-             LocEdgeMask(Edge, K) = 0.0;
-          }
-       });
-
-   EdgeMaskH = createHostMirrorCopy(EdgeMask);
-
-} // end setMasks
 
 //------------------------------------------------------------------------------
 // Set mesh scaling coefficients for mixing terms in momentum and tracer

--- a/components/omega/src/ocn/HorzMesh.h
+++ b/components/omega/src/ocn/HorzMesh.h
@@ -14,7 +14,6 @@
 #include "Decomp.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
-#include "VertCoord.h"
 
 #include <memory>
 #include <string>
@@ -68,8 +67,7 @@ class HorzMesh {
 
    /// Construct a new local mesh for a given decomposition
    HorzMesh(const std::string &Name, ///< [in] Name for mesh
-            Decomp *Decomp,          ///< [in] Decomposition for mesh
-            I4 InNVertLayers         ///< [in] num vertical layers
+            Decomp *Decomp           ///< [in] Decomposition for mesh
    );
 
    // Forbid copy and move construction
@@ -80,8 +78,6 @@ class HorzMesh {
    // KOKKOS_LAMBDA does not allow to have parallel_* functions inside of a
    // private function.
    void computeEdgeSign();
-
-   void setMasks(int NVertLayers);
 
    void setMeshScaling();
 
@@ -96,8 +92,6 @@ class HorzMesh {
    // Sizes and global IDs
    // Note that all sizes are actual counts (1-based) so that loop extents
    // should always use the 0:NCellsXX-1 form.
-
-   I4 NVertLayers; ///< number of vertical layers
 
    Array1DI4 NCellsHalo;      ///< num cells owned+halo for halo layer
    HostArray1DI4 NCellsHaloH; ///< num cells owned+halo for halo layer
@@ -251,12 +245,6 @@ class HorzMesh {
    Array2DReal EdgeSignOnVertex;      ///< Sign of vector connecting vertices
    HostArray2DReal EdgeSignOnVertexH; ///< Sign of vector connecting vertices
 
-   // Masks
-   Array2DReal EdgeMask;      ///< Mask to determine if computations should be
-                              ///  done on edge
-   HostArray2DReal EdgeMaskH; ///< Mask to determine if computations should be
-                              ///  done on edge
-
    // Mesh scaling
    Array1DReal MeshScalingDel2;      /// Coef to Laplacian mixing terms
    HostArray1DReal MeshScalingDel2H; /// Coef to Laplacian mixing terms
@@ -272,8 +260,7 @@ class HorzMesh {
    /// Creates a new mesh by calling the constructor and puts it in the
    /// AllHorzMeshes map
    static HorzMesh *create(const std::string &Name, ///< [in] Name for mesh
-                           Decomp *Decomp,  ///< [in] Decomposition for mesh
-                           I4 InNVertLayers ///< [in] num vertival layers
+                           Decomp *Decomp ///< [in] Decomposition for mesh
    );
 
    /// Destructor - deallocates all memory and deletes a HorzMesh

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -128,9 +128,8 @@ int initOmegaModules(MPI_Comm Comm) {
       ABORT_ERROR("ocnInit: Error initializing default halo");
    }
 
-   VertCoord::init1();
    HorzMesh::init();
-   VertCoord::init2();
+   VertCoord::init();
    Tracers::init();
    AuxiliaryState::init();
    Tendencies::init();

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -218,11 +218,12 @@ Tendencies::Tendencies(const std::string &Name, ///< [in] Name for tendencies
                        Config *Options,         ///< [in] Configuration options
                        CustomTendencyType InCustomThicknessTend,
                        CustomTendencyType InCustomVelocityTend)
-    : ThicknessFluxDiv(Mesh), PotientialVortHAdv(Mesh), KEGrad(Mesh),
-      SSHGrad(Mesh), VelocityDiffusion(Mesh), VelocityHyperDiff(Mesh),
-      WindForcing(Mesh), BottomDrag(Mesh, VCoord), TracerHorzAdv(Mesh),
-      TracerDiffusion(Mesh), TracerHyperDiff(Mesh),
-      CustomThicknessTend(InCustomThicknessTend),
+    : ThicknessFluxDiv(Mesh), PotientialVortHAdv(Mesh, VCoord),
+      KEGrad(Mesh, VCoord), SSHGrad(Mesh, VCoord),
+      VelocityDiffusion(Mesh, VCoord), VelocityHyperDiff(Mesh, VCoord),
+      WindForcing(Mesh, VCoord), BottomDrag(Mesh, VCoord),
+      TracerHorzAdv(Mesh, VCoord), TracerDiffusion(Mesh, VCoord),
+      TracerHyperDiff(Mesh, VCoord), CustomThicknessTend(InCustomThicknessTend),
       CustomVelocityTend(InCustomVelocityTend) {
 
    // Tendency arrays

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -23,53 +23,60 @@ ThicknessFluxDivOnCell::ThicknessFluxDivOnCell(const HorzMesh *Mesh)
       DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
       EdgeSignOnCell(Mesh->EdgeSignOnCell) {}
 
-PotentialVortHAdvOnEdge::PotentialVortHAdvOnEdge(const HorzMesh *Mesh)
+PotentialVortHAdvOnEdge::PotentialVortHAdvOnEdge(const HorzMesh *Mesh,
+                                                 const VertCoord *VCoord)
     : NEdgesOnEdge(Mesh->NEdgesOnEdge), EdgesOnEdge(Mesh->EdgesOnEdge),
-      WeightsOnEdge(Mesh->WeightsOnEdge), EdgeMask(Mesh->EdgeMask) {}
+      WeightsOnEdge(Mesh->WeightsOnEdge), EdgeMask(VCoord->EdgeMask) {}
 
-KEGradOnEdge::KEGradOnEdge(const HorzMesh *Mesh)
+KEGradOnEdge::KEGradOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord)
     : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge),
-      EdgeMask(Mesh->EdgeMask) {}
+      EdgeMask(VCoord->EdgeMask) {}
 
-SSHGradOnEdge::SSHGradOnEdge(const HorzMesh *Mesh)
+SSHGradOnEdge::SSHGradOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord)
     : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge),
-      EdgeMask(Mesh->EdgeMask) {}
+      EdgeMask(VCoord->EdgeMask) {}
 
-VelocityDiffusionOnEdge::VelocityDiffusionOnEdge(const HorzMesh *Mesh)
+VelocityDiffusionOnEdge::VelocityDiffusionOnEdge(const HorzMesh *Mesh,
+                                                 const VertCoord *VCoord)
     : CellsOnEdge(Mesh->CellsOnEdge), VerticesOnEdge(Mesh->VerticesOnEdge),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge),
-      MeshScalingDel2(Mesh->MeshScalingDel2), EdgeMask(Mesh->EdgeMask) {}
+      MeshScalingDel2(Mesh->MeshScalingDel2), EdgeMask(VCoord->EdgeMask) {}
 
-VelocityHyperDiffOnEdge::VelocityHyperDiffOnEdge(const HorzMesh *Mesh)
+VelocityHyperDiffOnEdge::VelocityHyperDiffOnEdge(const HorzMesh *Mesh,
+                                                 const VertCoord *VCoord)
     : CellsOnEdge(Mesh->CellsOnEdge), VerticesOnEdge(Mesh->VerticesOnEdge),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge),
-      MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(Mesh->EdgeMask) {}
+      MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(VCoord->EdgeMask) {}
 
-WindForcingOnEdge::WindForcingOnEdge(const HorzMesh *Mesh)
-    : Enabled(false), LocRhoSw(RhoSw), EdgeMask(Mesh->EdgeMask) {}
+WindForcingOnEdge::WindForcingOnEdge(const HorzMesh *Mesh,
+                                     const VertCoord *VCoord)
+    : Enabled(false), LocRhoSw(RhoSw), EdgeMask(VCoord->EdgeMask) {}
 
 BottomDragOnEdge::BottomDragOnEdge(const HorzMesh *Mesh,
                                    const VertCoord *VCoord)
     : Enabled(false), Coeff(0), CellsOnEdge(Mesh->CellsOnEdge),
-      NVertLayers(VCoord->NVertLayers), EdgeMask(Mesh->EdgeMask) {}
+      NVertLayers(VCoord->NVertLayers), EdgeMask(VCoord->EdgeMask) {}
 
-TracerHorzAdvOnCell::TracerHorzAdvOnCell(const HorzMesh *Mesh)
+TracerHorzAdvOnCell::TracerHorzAdvOnCell(const HorzMesh *Mesh,
+                                         const VertCoord *VCoord)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
-      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell), EdgeMask(Mesh->EdgeMask) {
-}
+      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
+      EdgeMask(VCoord->EdgeMask) {}
 
-TracerDiffOnCell::TracerDiffOnCell(const HorzMesh *Mesh)
-    : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
-      CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
-      DvEdge(Mesh->DvEdge), DcEdge(Mesh->DcEdge), AreaCell(Mesh->AreaCell),
-      MeshScalingDel2(Mesh->MeshScalingDel2), EdgeMask(Mesh->EdgeMask) {}
-
-TracerHyperDiffOnCell::TracerHyperDiffOnCell(const HorzMesh *Mesh)
+TracerDiffOnCell::TracerDiffOnCell(const HorzMesh *Mesh,
+                                   const VertCoord *VCoord)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
       DvEdge(Mesh->DvEdge), DcEdge(Mesh->DcEdge), AreaCell(Mesh->AreaCell),
-      MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(Mesh->EdgeMask) {}
+      MeshScalingDel2(Mesh->MeshScalingDel2), EdgeMask(VCoord->EdgeMask) {}
+
+TracerHyperDiffOnCell::TracerHyperDiffOnCell(const HorzMesh *Mesh,
+                                             const VertCoord *VCoord)
+    : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
+      CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
+      DvEdge(Mesh->DvEdge), DcEdge(Mesh->DcEdge), AreaCell(Mesh->AreaCell),
+      MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(VCoord->EdgeMask) {}
 
 } // end namespace OMEGA
 

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -73,7 +73,7 @@ class PotentialVortHAdvOnEdge {
    bool Enabled;
 
    /// constructor declaration
-   PotentialVortHAdvOnEdge(const HorzMesh *Mesh);
+   PotentialVortHAdvOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    /// The functor takes edge index, vertical chunk index, and arrays for
    /// normalized relative vorticity, normalized planetary vorticity, layer
@@ -121,7 +121,7 @@ class KEGradOnEdge {
    bool Enabled;
 
    /// constructor declaration
-   KEGradOnEdge(const HorzMesh *Mesh);
+   KEGradOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    /// The functor takes edge index, vertical chunk index, and kinetic energy
    /// array as inputs, outputs the tendency array
@@ -153,7 +153,7 @@ class SSHGradOnEdge {
    bool Enabled;
 
    /// constructor declaration
-   SSHGradOnEdge(const HorzMesh *Mesh);
+   SSHGradOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    /// The functor takes edge index, vertical chunk index, and array of
    /// layer thickness/SSH, outputs tendency array
@@ -187,7 +187,7 @@ class VelocityDiffusionOnEdge {
    Real ViscDel2;
 
    /// constructor declaration
-   VelocityDiffusionOnEdge(const HorzMesh *Mesh);
+   VelocityDiffusionOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    /// The functor takes edge index, vertical chunk index, and arrays for
    /// divergence of horizontal velocity (defined at cell centers) and relative
@@ -236,7 +236,7 @@ class VelocityHyperDiffOnEdge {
    Real DivFactor;
 
    /// Constructor declaration
-   VelocityHyperDiffOnEdge(const HorzMesh *Mesh);
+   VelocityHyperDiffOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    /// The functor takes the edge index, vertical chunk index, and arrays for
    /// the laplacian of divergence of horizontal velocity and the laplacian of
@@ -284,7 +284,7 @@ class WindForcingOnEdge {
    Real LocRhoSw;
 
    /// constructor declaration
-   WindForcingOnEdge(const HorzMesh *Mesh);
+   WindForcingOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    /// The functor takes the edge index, vertical chunk index, and arrays for
    /// normal wind stress and edge layer thickness, outputs tendency array
@@ -344,7 +344,7 @@ class TracerHorzAdvOnCell {
  public:
    bool Enabled;
 
-   TracerHorzAdvOnCell(const HorzMesh *Mesh);
+   TracerHorzAdvOnCell(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    KOKKOS_FUNCTION void operator()(const Array3DReal &Tend, I4 L, I4 ICell,
                                    I4 KChunk, const Array2DReal &NormVelEdge,
@@ -389,7 +389,7 @@ class TracerDiffOnCell {
 
    Real EddyDiff2;
 
-   TracerDiffOnCell(const HorzMesh *Mesh);
+   TracerDiffOnCell(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    KOKKOS_FUNCTION void
    operator()(const Array3DReal &Tend, I4 L, I4 ICell, I4 KChunk,
@@ -444,7 +444,7 @@ class TracerHyperDiffOnCell {
 
    Real EddyDiff4;
 
-   TracerHyperDiffOnCell(const HorzMesh *Mesh);
+   TracerHyperDiffOnCell(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    KOKKOS_FUNCTION void operator()(const Array3DReal &Tend, I4 L, I4 ICell,
                                    I4 KChunk,

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -24,33 +24,69 @@ VertCoord *VertCoord::DefaultVertCoord = nullptr;
 std::map<std::string, std::unique_ptr<VertCoord>> VertCoord::AllVertCoords;
 
 //------------------------------------------------------------------------------
-// Begin initialization of default vertical coordinate, requires prior
-// initialization of Decomp.
-void VertCoord::init1() {
+// Initialize the default vertical coordinate, requires prior initialization
+// of Decomp and Halo. The optional arguments simplify the use of the VertCoord
+// in some unit tests. If ReadStream is false, the InitialVertCoord stream will
+// not be read during construction. If a value for NVertLayers is passed as
+// argument, the dimension will not be read from the mesh file.
+void VertCoord::init(
+    const bool
+        ReadStream, //< [in] optional argument to read stream, true by default
+    const int
+        InNVertLayers //< [in] optional argument to set NVertLayers explicitly
+                      //< instead of reading dimension from mesh file
+) {
 
    Decomp *DefDecomp = Decomp::getDefault();
 
-   VertCoord::DefaultVertCoord = create("Default", DefDecomp);
-
-} // end init1
-
-//------------------------------------------------------------------------------
-// Complete initialization of default vertical coordinate, requires prior
-// initialization of HorzMesh.
-void VertCoord::init2() {
+   Halo *DefHalo = Halo::getDefault();
 
    Config *OmegaConfig = Config::getOmegaConfig();
 
-   DefaultVertCoord->completeSetup(OmegaConfig);
+   VertCoord::DefaultVertCoord = create("Default", DefDecomp, DefHalo,
+                                        OmegaConfig, ReadStream, InNVertLayers);
 
-} // end init2
+} // end init
 
 //------------------------------------------------------------------------------
-// Construct a new VertCoord instance given a Decomp. New object is incomplete
-// and completeSetup must be called afterwards
+// Construct a new VertCoord instance given a Decomp.
 VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
-                     const Decomp *Decomp      //< [in] associated Decomp
+                     const Decomp *Decomp,     //< [in] associated Decomp
+                     Halo *MeshHalo,           //< [in] mesh halo exchanger
+                     Config *Options,          //< [in] configuration options
+                     const bool ReadStream,    //< [in] logical to read stream
+                     const int InNVertLayers   //< [in] int to set vertical dim
 ) {
+   Error Err; // Error code
+
+   // If ReadStream is true, a prescribed value for NVertLayers is not valid
+   if (ReadStream == true and InNVertLayers != 0) {
+      ABORT_ERROR("VertCoord: ReadStream is true but a value for NVertLayers "
+                  "is explicitly provided, which is not a valid combination");
+   }
+
+   // Read Config for movement weight type, store in enum
+   Config VCoordConfig("VertCoord");
+   Err += Options->get(VCoordConfig);
+   CHECK_ERROR_ABORT(Err, "VertCoord: VertCoord group not found in Config");
+
+   std::string MovementWeightStr;
+   Err += VCoordConfig.get("MovementWeightType", MovementWeightStr);
+   CHECK_ERROR_ABORT(Err,
+                     "VertCoord: MovementWeightType not found in VertCoord");
+
+   if (MovementWeightStr == "Fixed") {
+      MvmtWgtChoice = MovementWeightType::Fixed;
+   } else if (MovementWeightStr == "Uniform") {
+      MvmtWgtChoice = MovementWeightType::Uniform;
+   } else {
+      ABORT_ERROR("VertCoord: Unknown MovementWeightType requested");
+   }
+
+   // Fetch reference density from Config
+   Err.reset();
+   Err += VCoordConfig.get("Density0", Rho0);
+   CHECK_ERROR_ABORT(Err, "VertCoord: Density0 not found in VertCoord");
 
    // Store name suffix
    Name = Name_;
@@ -58,19 +94,36 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    // Retrieve mesh filename from Decomp
    MeshFileName = Decomp->MeshFileName;
 
-   // Open the mesh file for reading (assume IO has already been initialized)
-   IO::openFile(MeshFileID, MeshFileName, IO::ModeRead);
+   // If InNVertlayers is 0 (default), attempt to read the dimension from the
+   // mesh file. If the mesh file does not define a vertical dimension, use
+   // NVertLayers = 1. If a value for InNVertLayers is explicitly provided,
+   // use that value is instead.
+   if (InNVertLayers == 0) {
 
-   // Set NVertLayers and NVertLayersP1 and create the vertical dimensions
-   Error Err; // Error code
-   I4 NVertLayersID;
-   Err = IO::getDimFromFile(MeshFileID, "nVertLevels", NVertLayersID,
-                            NVertLayers);
-   if (!Err.isSuccess()) {
-      LOG_WARN("VertCoord: error reading nVertLevels from mesh file, "
-               "using NVertLayers = 1");
-      NVertLayers = 1;
+      std::string OmegaDimName = "NVertLayers";
+      std::string MPASDimName  = "nVertLevels";
+
+      // Open the mesh file for reading (assume IO has already been initialized)
+      IO::openFile(MeshFileID, MeshFileName, IO::ModeRead);
+
+      // Set NVertLayers
+      I4 NVertLayersID;
+      Err = IO::getDimFromFile(MeshFileID, OmegaDimName, NVertLayersID,
+                               NVertLayers);
+      if (Err.isFail()) { // dim not found, try again with older MPAS name
+         Err = IO::getDimFromFile(MeshFileID, MPASDimName, NVertLayersID,
+                                  NVertLayers);
+         if (Err.isFail()) {
+            LOG_INFO("VertCoord: vertical dimension not found in mesh file, "
+                     "using NVertLayers = 1");
+            NVertLayers = 1;
+         }
+      }
+   } else {
+      NVertLayers = InNVertLayers;
    }
+
+   // Create the dimensions
    NVertLayersP1 = NVertLayers + 1;
 
    std::string DimName   = "NVertLayers";
@@ -97,7 +150,7 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    NVerticesSize  = Decomp->NVerticesSize;
    VertexDegree   = Decomp->VertexDegree;
 
-   // Retrieve connectivity arrays from HorzMesh
+   // Retrieve connectivity arrays from Decomp
    CellsOnEdge   = Decomp->CellsOnEdge;
    CellsOnVertex = Decomp->CellsOnVertex;
 
@@ -125,114 +178,33 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    LayerThicknessTargetH = createHostMirrorCopy(LayerThicknessTarget);
    RefLayerThicknessH    = createHostMirrorCopy(RefLayerThickness);
 
-} // end constructor
-
-//------------------------------------------------------------------------------
-// Complete construction of new VertCoord instance
-void VertCoord::completeSetup(Config *Options //< [in] configuration options
-) {
-
    // Define field metadata
    defineFields();
 
-   I4 FillValueI4     = -1;
-   Real FillValueReal = -999._Real;
-
-   deepCopy(MinLayerCell, FillValueI4);
-   deepCopy(MaxLayerCell, FillValueI4);
-   deepCopy(BottomDepth, FillValueReal);
-
-   OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
-   OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
-   OMEGA_SCOPE(LocBottomDepth, BottomDepth);
-
-   // Fetch input stream and validate
-   std::string StreamName = "InitialVertCoord";
-   if (Name != "Default") {
-      StreamName.append(Name);
-   }
-
-   auto VCoordStream = IOStream::get(StreamName);
-
-   bool IsValidated = VCoordStream->validate();
-
-   // Read InitialVertCoord stream
-   Error Err; // Error code
-   if (IsValidated) {
-      Err = IOStream::read(StreamName);
-      if (!Err.isSuccess()) {
-         LOG_WARN("VertCoord: Error reading {} stream", StreamName);
-         I4 Sum1 = 0;
-         parallelReduce(
-             {MinLayerCell.extent_int(0)},
-             KOKKOS_LAMBDA(int I, int &Accum) { Accum += LocMinLayerCell(I); },
-             Sum1);
-         if (Sum1 < 0) {
-            LOG_WARN("VertCoord: Error reading minLevelCell from {}, "
-                     "using MinLayerCell = 0",
-                     StreamName);
-            deepCopy(MinLayerCell, 1);
-         }
-         I4 Sum2 = 0;
-         parallelReduce(
-             {MaxLayerCell.extent_int(0)},
-             KOKKOS_LAMBDA(int I, int &Accum) { Accum += LocMaxLayerCell(I); },
-             Sum2);
-         if (Sum2 < 0) {
-            LOG_WARN("VertCoord: Error reading maxLevelCell from {}, "
-                     "using MaxLayerCell = NVertLayers - 1",
-                     StreamName);
-            deepCopy(MaxLayerCell, NVertLayers);
-         }
-         Real Sum3 = 0.;
-         parallelReduce(
-             {BottomDepth.extent_int(0)},
-             KOKKOS_LAMBDA(int I, Real &Accum) { Accum += LocBottomDepth(I); },
-             Sum3);
-         if (Sum3 < 0.) {
-            ABORT_ERROR("VertCoord: Error reading bottomDepth from {}",
-                        StreamName);
-         }
-      }
-   } else {
-      ABORT_ERROR("Error validating IO stream {}", StreamName);
-   }
-
-   // Subtract 1 to convert to zero-based indexing
-   parallelFor(
-       {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
-          LocMinLayerCell(ICell) -= 1;
-          LocMaxLayerCell(ICell) -= 1;
-       });
+   // Set MinLayerCell, MaxLayerCell, and BottomDepth arrays
+   setStreamArrays(ReadStream, MeshHalo);
 
    // Compute Edge and Vertex vertical ranges
-   minMaxLayerEdge();
-   minMaxLayerVertex();
+   minMaxLayerEdge(MeshHalo);
+   minMaxLayerVertex(MeshHalo);
+
+   // Set computational masks
+   setMasks();
 
    // Initialize movement weights
-   initMovementWeights(Options);
+   initMovementWeights();
 
-   // Make host copies for device arrays read from mesh file
-   MaxLayerCellH = createHostMirrorCopy(MaxLayerCell);
-   MinLayerCellH = createHostMirrorCopy(MinLayerCell);
-   BottomDepthH  = createHostMirrorCopy(BottomDepth);
-
-   // Fetch reference density from Config
-   Config VCoordConfig("VertCoord");
-   Err.reset();
-   Err += Options->get(VCoordConfig);
-   CHECK_ERROR_ABORT(Err, "VertCoord: VertCoord group not found in Config");
-
-   Err += VCoordConfig.get("Density0", Rho0);
-   CHECK_ERROR_ABORT(Err, "VertCoord: Density0 not found in VertCoord");
-
-} // end completeSetup
+} // end constructor
 
 //------------------------------------------------------------------------------
 // Calls the VertCoord constructor and places it in the AllVertCoords map
-VertCoord *
-VertCoord::create(const std::string &Name, // [in] name for new VertCoord
-                  const Decomp *Decomp     // [in] associated Decomp
+VertCoord *VertCoord::create(
+    const std::string &Name, // [in] name for new VertCoord
+    const Decomp *Decomp,    // [in] associated Decomp
+    Halo *MeshHalo,          // [in] mesh halo exchanger
+    Config *Options,         // [in] configuration options
+    const bool ReadStream,   // [in] optional logical to read stream
+    const int InNVertLayers  // [in] optional int to set vertical dim
 ) {
    // Check to see if a VertCoord of the same name already exists and, if so,
    // exit with an error
@@ -245,7 +217,8 @@ VertCoord::create(const std::string &Name, // [in] name for new VertCoord
 
    // create a new VertCoord on the heap and put it in a map of unique_ptrs,
    // which will manage its lifetime
-   auto *NewVertCoord = new VertCoord(Name, Decomp);
+   auto *NewVertCoord = new VertCoord(Name, Decomp, MeshHalo, Options,
+                                      ReadStream, InNVertLayers);
    AllVertCoords.emplace(Name, NewVertCoord);
 
    return NewVertCoord;
@@ -256,8 +229,8 @@ VertCoord::create(const std::string &Name, // [in] name for new VertCoord
 void VertCoord::defineFields() {
 
    // Set field names (append Name if not default)
-   MinLayerCellFldName   = "MinLevelCell";
-   MaxLayerCellFldName   = "MaxLevelCell";
+   MinLayerCellFldName   = "MinLayerCell";
+   MaxLayerCellFldName   = "MaxLayerCell";
    BottomDepthFldName    = "BottomDepth";
    PressInterfFldName    = "PressureInterface";
    PressMidFldName       = "PressureMid";
@@ -480,9 +453,126 @@ void VertCoord::clear() {
 } // end clear
 
 //------------------------------------------------------------------------------
+// If ReadStream = true, read MinLayerCell, MaxLayerCell, and BottomDepth from
+// the initial stream. If ReadStream = false, default values are used.
+void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
+
+   Error Err; // Error code
+
+   OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
+   OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
+   OMEGA_SCOPE(LocBottomDepth, BottomDepth);
+
+   // If ReadStream is true (default) attempt to read values for MinLayerCell,
+   // MaxLayerCell, and BottomDepth from the InitialVertCoord stream. Otherwise,
+   // MinLayerCell and MaxLayerCell will be set to the first and last indices of
+   // the vertical range, BottomDepth will remain uninitialized and will need
+   // to be initialized explicitly if needed.
+   if (ReadStream) {
+
+      I4 FillValueI4     = -1;
+      Real FillValueReal = -999._Real;
+
+      deepCopy(MinLayerCell, FillValueI4);
+      deepCopy(MaxLayerCell, FillValueI4);
+      deepCopy(BottomDepth, FillValueReal);
+
+      // Fetch input stream and validate
+      std::string StreamName = "InitialVertCoord";
+      if (Name != "Default") {
+         StreamName.append(Name);
+      }
+
+      // Validate InitalVertCoord stream
+      auto VCoordStream = IOStream::get(StreamName);
+      bool IsValidated  = VCoordStream->validate();
+
+      // Read InitialVertCoord stream
+      if (IsValidated) {
+         // Attempt to read stream, an error will be raised if any field fails
+         // to be read. Determine which fields may not have been read properly.
+         // If MinLayerCell or MaxLayerCell were not read properly default
+         // values will be used. If BottomDepth was not read properly, abort
+         // with error.
+         Err = IOStream::read(StreamName);
+         if (Err.isFail()) {
+            LOG_INFO("VertCoord: Error while reading {} stream", StreamName);
+            I4 Sum1 = 0;
+            parallelReduce(
+                {MinLayerCell.extent_int(0)},
+                KOKKOS_LAMBDA(int I, int &Accum) {
+                   Accum += LocMinLayerCell(I);
+                },
+                Sum1);
+            if (Sum1 < 0) {
+               LOG_INFO("VertCoord: Error reading MinLayerCell from {}, "
+                        "using MinLayerCell = 0",
+                        StreamName);
+               deepCopy(MinLayerCell, 1);
+            }
+            I4 Sum2 = 0;
+            parallelReduce(
+                {MaxLayerCell.extent_int(0)},
+                KOKKOS_LAMBDA(int I, int &Accum) {
+                   Accum += LocMaxLayerCell(I);
+                },
+                Sum2);
+            if (Sum2 < 0) {
+               LOG_INFO("VertCoord: Error reading MaxLayerCell from {}, "
+                        "using MaxLayerCell = NVertLayers - 1",
+                        StreamName);
+               deepCopy(MaxLayerCell, NVertLayers);
+            }
+            Real Sum3 = 0.;
+            parallelReduce(
+                {BottomDepth.extent_int(0)},
+                KOKKOS_LAMBDA(int I, Real &Accum) {
+                   Accum += LocBottomDepth(I);
+                },
+                Sum3);
+            if (Sum3 < 0.) {
+               ABORT_ERROR("VertCoord: Error reading bottomDepth from {}",
+                           StreamName);
+            }
+         }
+      } else {
+         ABORT_ERROR("Error validating IO stream {}", StreamName);
+      }
+   } else {
+      deepCopy(MinLayerCell, 1);
+      deepCopy(MaxLayerCell, NVertLayers);
+   }
+
+   // Subtract 1 to convert to zero-based indexing
+   parallelFor(
+       {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+          LocMinLayerCell(ICell) -= 1;
+          LocMaxLayerCell(ICell) -= 1;
+       });
+
+   // Exchange halos since stream only reads owned cells
+   MeshHalo->exchangeFullArrayHalo(MinLayerCell, OnCell);
+   MeshHalo->exchangeFullArrayHalo(MaxLayerCell, OnCell);
+
+   // The index ICell = NCellsAll represents an inactive cell
+   OMEGA_SCOPE(LocNCellsAll, NCellsAll);
+   OMEGA_SCOPE(LocNVertLayersP1, NVertLayersP1);
+   parallelFor(
+       {1}, KOKKOS_LAMBDA(const int &) {
+          LocMinLayerCell(LocNCellsAll) = LocNVertLayersP1;
+          LocMaxLayerCell(LocNCellsAll) = -1;
+       });
+
+   // Make host copies for device arrays read from mesh file
+   MaxLayerCellH = createHostMirrorCopy(MaxLayerCell);
+   MinLayerCellH = createHostMirrorCopy(MinLayerCell);
+   BottomDepthH  = createHostMirrorCopy(BottomDepth);
+}
+
+//------------------------------------------------------------------------------
 // Compute min and max layer indices for edges based on MinLayerCell and
 // MaxLayerCell
-void VertCoord::minMaxLayerEdge() {
+void VertCoord::minMaxLayerEdge(Halo *MeshHalo) {
 
    MinLayerEdgeTop = Array1DI4("MinLayerEdgeTop", NEdgesSize);
    MinLayerEdgeBot = Array1DI4("MinLayerEdgeBot", NEdgesSize);
@@ -498,15 +588,16 @@ void VertCoord::minMaxLayerEdge() {
    OMEGA_SCOPE(LocMaxLayerEdgeTop, MaxLayerEdgeTop);
    OMEGA_SCOPE(LocMaxLayerEdgeBot, MaxLayerEdgeBot);
    parallelFor(
-       {NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
+       {NEdgesOwned}, KOKKOS_LAMBDA(int IEdge) {
           I4 Lyr1;
           I4 Lyr2;
           const I4 ICell1 = LocCellsOnEdge(IEdge, 0);
           const I4 ICell2 = LocCellsOnEdge(IEdge, 1);
-          Lyr1            = LocMaxLayerCell(ICell1) == -1 ? LocNVertLayersP1
-                                                          : LocMinLayerCell(ICell1);
-          Lyr2            = LocMaxLayerCell(ICell2) == -1 ? LocNVertLayersP1
-                                                          : LocMinLayerCell(ICell2);
+
+          Lyr1 = LocMaxLayerCell(ICell1) == -1 ? LocNVertLayersP1
+                                               : LocMinLayerCell(ICell1);
+          Lyr2 = LocMaxLayerCell(ICell2) == -1 ? LocNVertLayersP1
+                                               : LocMinLayerCell(ICell2);
           LocMinLayerEdgeTop(IEdge) = Kokkos::min(Lyr1, Lyr2);
 
           Lyr1 = LocMaxLayerCell(ICell1) == -1 ? 0 : LocMinLayerCell(ICell1);
@@ -518,6 +609,11 @@ void VertCoord::minMaxLayerEdge() {
           LocMaxLayerEdgeBot(IEdge) =
               Kokkos::max(LocMaxLayerCell(ICell1), LocMaxLayerCell(ICell2));
        });
+
+   MeshHalo->exchangeFullArrayHalo(MinLayerEdgeTop, OnEdge);
+   MeshHalo->exchangeFullArrayHalo(MinLayerEdgeBot, OnEdge);
+   MeshHalo->exchangeFullArrayHalo(MaxLayerEdgeTop, OnEdge);
+   MeshHalo->exchangeFullArrayHalo(MaxLayerEdgeBot, OnEdge);
 
    OMEGA_SCOPE(LocNEdgesAll, NEdgesAll);
    parallelFor(
@@ -537,7 +633,7 @@ void VertCoord::minMaxLayerEdge() {
 //------------------------------------------------------------------------------
 // Compute min and max layer indices for vertices based on MinLayerCell and
 // MaxLayerCell
-void VertCoord::minMaxLayerVertex() {
+void VertCoord::minMaxLayerVertex(Halo *MeshHalo) {
 
    MinLayerVertexTop = Array1DI4("MinLayerVertexTop", NVerticesSize);
    MinLayerVertexBot = Array1DI4("MinLayerVertexBot", NVerticesSize);
@@ -555,7 +651,7 @@ void VertCoord::minMaxLayerVertex() {
    OMEGA_SCOPE(LocMaxLayerVertexBot, MaxLayerVertexBot);
 
    parallelFor(
-       {NVerticesAll}, KOKKOS_LAMBDA(int IVertex) {
+       {NVerticesOwned}, KOKKOS_LAMBDA(int IVertex) {
           I4 Lyr;
           I4 ICell = LocCellsOnVertex(IVertex, 0);
           Lyr      = LocMaxLayerCell(ICell) == -1 ? 0 : LocMinLayerCell(ICell);
@@ -595,6 +691,12 @@ void VertCoord::minMaxLayerVertex() {
                  LocMaxLayerVertexTop(IVertex), LocMaxLayerCell(ICell));
           }
        });
+
+   MeshHalo->exchangeFullArrayHalo(MinLayerVertexTop, OnVertex);
+   MeshHalo->exchangeFullArrayHalo(MinLayerVertexBot, OnVertex);
+   MeshHalo->exchangeFullArrayHalo(MaxLayerVertexTop, OnVertex);
+   MeshHalo->exchangeFullArrayHalo(MaxLayerVertexBot, OnVertex);
+
    OMEGA_SCOPE(LocNVerticesAll, NVerticesAll);
    parallelFor(
        {1}, KOKKOS_LAMBDA(const int &) {
@@ -611,36 +713,99 @@ void VertCoord::minMaxLayerVertex() {
 } // end MinMaxLayerVertex
 
 //------------------------------------------------------------------------------
+// set computational masks for mesh elements
+void VertCoord::setMasks() {
+
+   EdgeMask = Array2DReal("EdgeMask", NEdgesSize, NVertLayers);
+
+   OMEGA_SCOPE(LocEdgeMask, EdgeMask);
+   OMEGA_SCOPE(LocMinLyrEdgeBot, MinLayerEdgeBot);
+   OMEGA_SCOPE(LocMaxLyrEdgeTop, MaxLayerEdgeTop);
+
+   // EdgeMask = 1 if active layers on both sides, 0 otherwise.
+   deepCopy(EdgeMask, 0.);
+   parallelForOuter(
+       {NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const I4 KMin = LocMinLyrEdgeBot(IEdge);
+          const I4 KMax = LocMaxLyrEdgeTop(IEdge);
+
+          parallelForInner(
+              Team, KMax - KMin + 1, INNER_LAMBDA(int K) {
+                 I4 KLyr = KMin + K;
+
+                 LocEdgeMask(IEdge, KLyr) = 1._Real;
+              });
+       });
+
+   EdgeMaskH = createHostMirrorCopy(EdgeMask);
+
+   CellMask = Array2DReal("CellMask", NCellsSize, NVertLayers);
+
+   OMEGA_SCOPE(LocCellMask, CellMask);
+   OMEGA_SCOPE(LocMinLyrCell, MinLayerCell);
+   OMEGA_SCOPE(LocMaxLyrCell, MaxLayerCell);
+
+   // CellMask = 1 in active layers, 0 otherwise.
+   deepCopy(CellMask, 0.);
+   parallelForOuter(
+       {NCellsAll}, KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          const I4 KMin = LocMinLyrCell(ICell);
+          const I4 KMax = LocMaxLyrCell(ICell);
+
+          parallelForInner(
+              Team, KMax - KMin + 1, INNER_LAMBDA(int K) {
+                 I4 KLyr = KMin + K;
+
+                 LocCellMask(ICell, KLyr) = 1._Real;
+              });
+       });
+
+   CellMaskH = createHostMirrorCopy(CellMask);
+
+   VertexMask = Array2DReal("VertexMask", NVerticesSize, NVertLayers);
+
+   OMEGA_SCOPE(LocVrtxMask, VertexMask);
+   OMEGA_SCOPE(LocMinLyrVrtxTop, MinLayerVertexTop);
+   OMEGA_SCOPE(LocMaxLyrVrtxBot, MaxLayerVertexBot);
+
+   // VertexMask = 1 if at least 1 surrounding cell layer is active,
+   // 0 otherwise.
+   deepCopy(VertexMask, 0.);
+   parallelForOuter(
+       {NVerticesAll}, KOKKOS_LAMBDA(int IVertex, const TeamMember &Team) {
+          const I4 KMin = LocMinLyrVrtxTop(IVertex);
+          const I4 KMax = LocMaxLyrVrtxBot(IVertex);
+
+          parallelForInner(
+              Team, KMax - KMin + 1, INNER_LAMBDA(int K) {
+                 I4 KLyr = KMin + K;
+
+                 LocVrtxMask(IVertex, KLyr) = 1._Real;
+              });
+       });
+
+   VertexMaskH = createHostMirrorCopy(VertexMask);
+
+} // end setMasks()
+
+//------------------------------------------------------------------------------
 // Store VertCoordMovementWeights based on config choice
-void VertCoord::initMovementWeights(
-    Config *Options // [in] configuration options
-) {
+void VertCoord::initMovementWeights() {
 
    Error Err; // default successful error code
-
-   Config VCoordConfig("VertCoord");
-   Err += Options->get(VCoordConfig);
-   CHECK_ERROR_ABORT(Err, "VertCoord: VertCoord group not found in Config");
-
-   std::string MovementWeightType;
-   Err += VCoordConfig.get("MovementWeightType", MovementWeightType);
-   CHECK_ERROR_ABORT(Err,
-                     "VertCoord: MovementWeightType not found in VertCoord");
 
    VertCoordMovementWeights =
        Array1DReal("VertCoordMovementWeights", NVertLayers);
 
    OMEGA_SCOPE(LocVertCoordMovementWeights, VertCoordMovementWeights);
-   if (MovementWeightType == "Fixed") {
+   if (MvmtWgtChoice == MovementWeightType::Fixed) {
       deepCopy(VertCoordMovementWeights, 0._Real);
       parallelFor(
           {1}, KOKKOS_LAMBDA(const int &) {
              LocVertCoordMovementWeights(0) = 1._Real;
           });
-   } else if (MovementWeightType == "Uniform") {
+   } else if (MvmtWgtChoice == MovementWeightType::Uniform) {
       deepCopy(VertCoordMovementWeights, 1._Real);
-   } else {
-      ABORT_ERROR("VertCoord: Unknown MovementWeightType requested");
    }
 
    VertCoordMovementWeightsH = createHostMirrorCopy(VertCoordMovementWeights);

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -15,6 +15,7 @@
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "Error.h"
+#include "Halo.h"
 #include "HorzMesh.h"
 #include "Logging.h"
 #include "MachEnv.h"
@@ -24,6 +25,11 @@
 #include <string>
 
 namespace OMEGA {
+
+enum class MovementWeightType {
+   Fixed,  /// Distribute perturbations in top level
+   Uniform /// Uniform stretching
+};
 
 class VertCoord {
 
@@ -42,6 +48,9 @@ class VertCoord {
    Array2DI4 CellsOnEdge;
    Array2DI4 CellsOnVertex;
 
+   // Choice of VertCoorMovementWeight type
+   MovementWeightType MvmtWgtChoice;
+
    std::string MeshFileName;
    int MeshFileID;
 
@@ -51,8 +60,12 @@ class VertCoord {
    // methods
 
    /// construct a new vertical coordinate object
-   VertCoord(const std::string &Name, ///< [in] Name for new VertCoord
-             const Decomp *MeshDecomp ///< [in] associated Decomp
+   VertCoord(const std::string &Name,  ///< [in] Name for new VertCoord
+             const Decomp *MeshDecomp, ///< [in] associated Decomp
+             Halo *MeshHalo,           ///< [in] mesh halo exchanger
+             Config *Options,          ///< [in] configuration options
+             const bool ReadStream,    ///< [in] logical to read stream
+             const int NVertLayers     ///< [in] int to set vertical dim
    );
 
    /// define field metadata
@@ -112,6 +125,20 @@ class VertCoord {
    HostArray1DReal VertCoordMovementWeightsH;
    HostArray2DReal RefLayerThicknessH;
 
+   // Masks
+   Array2DReal EdgeMask;        ///< Mask to determine if computations should be
+                                ///  done on edge
+   HostArray2DReal EdgeMaskH;   ///< Mask to determine if computations should be
+                                ///  done on edge
+   Array2DReal CellMask;        ///< Mask to determine if computations should be
+                                ///  done on cell
+   HostArray2DReal CellMaskH;   ///< Mask to determine if computations should be
+                                ///  done on cell
+   Array2DReal VertexMask;      ///< Mask to determine if computations should be
+                                ///  done on vertex
+   HostArray2DReal VertexMaskH; ///< Mask to determine if computations should be
+                                ///  done on vertex
+
    // BottomDepth read from mesh file
    Array1DReal BottomDepth;
 
@@ -137,22 +164,18 @@ class VertCoord {
 
    // methods
 
-   /// 1st phase of initialization for default vertical coordinate
-   static void init1();
-
-   /// 2nd phase of initialization for default vertical coordinate
-   static void init2();
+   /// Initialization of default vertical coordinate
+   static void init(const bool ReadStream = true, const int NVertLayers = 0);
 
    /// Creates a new vertical coordinate object by calling the constructor and
-   /// puts it in the AllVertCoords map. This object is mostly empty and must
-   /// completed by completeSetup.
+   /// puts it in the AllVertCoords map.
    static VertCoord *
-   create(const std::string &Name, /// [in] name for new VertCoord
-          const Decomp *MeshDecomp /// [in] associated Decomp
-   );
-
-   /// Read InitialVertCoord stream and complete initialization
-   void completeSetup(Config *Options /// [in] configuration options
+   create(const std::string &Name,      /// [in] name for new VertCoord
+          const Decomp *MeshDecomp,     /// [in] associated Decomp
+          Halo *MeshHalo,               /// [in] mesh halo exchanger
+          Config *Options,              /// [in] configuration options
+          const bool ReadStream = true, /// [in] optional logical to read stream
+          const int NVertLayers = 0 /// [in] optional int to set vertical dim
    );
 
    /// Copy member arrays from device to host
@@ -176,11 +199,14 @@ class VertCoord {
    /// Retreive a VertCoord by name
    static VertCoord *get(std::string name);
 
-   // Variable initialization methods
-   void minMaxLayerEdge();
-   void minMaxLayerVertex();
-   void initMovementWeights(Config *Options ///< [in] configuration options
-   );
+   // Array initialization methods
+   void setStreamArrays(const bool ReadStream, Halo *MeshHalo);
+   void minMaxLayerEdge(Halo *MeshHalo);
+   void minMaxLayerVertex(Halo *MeshHalo);
+   void initMovementWeights();
+
+   /// Initialize computational masks
+   void setMasks();
 
    /// Sums the mass thickness times g from the top layer down, starting with
    /// the surface pressure

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
@@ -6,8 +6,8 @@
 namespace OMEGA {
 
 TracerAuxVars::TracerAuxVars(const std::string &AuxStateSuffix,
-                             const HorzMesh *Mesh, const I4 NVertLayers,
-                             const I4 NTracers)
+                             const HorzMesh *Mesh, const VertCoord *VCoord,
+                             const I4 NVertLayers, const I4 NTracers)
     : HTracersEdge("ThickTracersEdge" + AuxStateSuffix, NTracers,
                    Mesh->NEdgesSize, NVertLayers),
       Del2TracersCell("Del2TracerCell" + AuxStateSuffix, NTracers,
@@ -15,7 +15,7 @@ TracerAuxVars::TracerAuxVars(const std::string &AuxStateSuffix,
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
-      EdgeMask(Mesh->EdgeMask) {}
+      EdgeMask(VCoord->EdgeMask) {}
 
 void TracerAuxVars::registerFields(const std::string &AuxGroupName,
                                    const std::string &MeshName) const {

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
@@ -5,6 +5,7 @@
 #include "Field.h"
 #include "HorzMesh.h"
 #include "OmegaKokkos.h"
+#include "VertCoord.h"
 
 #include <string>
 
@@ -20,7 +21,8 @@ class TracerAuxVars {
    FluxTracerEdgeOption TracersOnEdgeChoice;
 
    TracerAuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
-                 const I4 NVertLayers, const I4 NTracers);
+                 const VertCoord *VCoord, const I4 NVertLayers,
+                 const I4 NTracers);
 
    KOKKOS_FUNCTION void computeVarsOnEdge(int L, int IEdge, int KChunk,
                                           const Array2DReal &NormalVelEdge,

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
@@ -7,7 +7,9 @@
 namespace OMEGA {
 
 VelocityDel2AuxVars::VelocityDel2AuxVars(const std::string &AuxStateSuffix,
-                                         const HorzMesh *Mesh, int NVertLayers)
+                                         const HorzMesh *Mesh,
+                                         const VertCoord *VCoord,
+                                         int NVertLayers)
     : Del2Edge("VelDel2Edge" + AuxStateSuffix, Mesh->NEdgesSize, NVertLayers),
       Del2DivCell("VelDel2DivCell" + AuxStateSuffix, Mesh->NCellsSize,
                   NVertLayers),
@@ -17,7 +19,7 @@ VelocityDel2AuxVars::VelocityDel2AuxVars(const std::string &AuxStateSuffix,
       EdgeSignOnCell(Mesh->EdgeSignOnCell), DcEdge(Mesh->DcEdge),
       DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
       EdgesOnVertex(Mesh->EdgesOnVertex), CellsOnEdge(Mesh->CellsOnEdge),
-      VerticesOnEdge(Mesh->VerticesOnEdge), EdgeMask(Mesh->EdgeMask),
+      VerticesOnEdge(Mesh->VerticesOnEdge), EdgeMask(VCoord->EdgeMask),
       EdgeSignOnVertex(Mesh->EdgeSignOnVertex),
       AreaTriangle(Mesh->AreaTriangle), VertexDegree(Mesh->VertexDegree) {}
 

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
@@ -4,6 +4,7 @@
 #include "DataTypes.h"
 #include "HorzMesh.h"
 #include "OmegaKokkos.h"
+#include "VertCoord.h"
 
 #include <string>
 
@@ -16,7 +17,7 @@ class VelocityDel2AuxVars {
    Array2DReal Del2RelVortVertex;
 
    VelocityDel2AuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
-                       int NVertLayers);
+                       const VertCoord *VCoord, int NVertLayers);
 
    KOKKOS_FUNCTION void
    computeVarsOnEdge(int IEdge, int KChunk, const Array2DReal &VelocityDivCell,

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -91,21 +91,12 @@ void initIOStreamTest(Clock *&ModelClock // Model clock
    // Initialize IOStreams
    IOStream::init(ModelClock);
 
-   // Initialize the vertical coordinate (phase 1)
-   VertCoord::init1();
-
-   // Reset vertical layers dimension
-   Dimension::destroy("NVertLayers");
-   I4 NVertLayers = 60;
-   std::shared_ptr<Dimension> VertDim =
-       Dimension::create("NVertLayers", NVertLayers);
-
    // Initialize HorzMesh - this should read Mesh stream
    HorzMesh::init();
    HorzMesh *DefMesh = HorzMesh::getDefault();
 
-   // Initialize the vertical coordinate (phase 2)
-   VertCoord::init2();
+   // Initialize the vertical coordinate
+   VertCoord::init();
 
    // Initialize State
    TmpErr = OceanState::init();

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -109,8 +109,9 @@ int initAuxStateTest(const std::string &mesh) {
       LOG_ERROR("AuxStateTest: error initializing default halo");
    }
 
-   VertCoord::init1();
    HorzMesh::init();
+
+   VertCoord::init(false);
 
    Tracers::init();
    int StateErr = OceanState::init();
@@ -139,10 +140,11 @@ int testAuxState() {
       return -1;
    }
 
-   const auto *Mesh = HorzMesh::getDefault();
-   auto *MeshHalo   = Halo::getDefault();
+   const auto *Mesh   = HorzMesh::getDefault();
+   const auto *VCoord = VertCoord::getDefault();
+   auto *MeshHalo     = Halo::getDefault();
    // test creation of another auxiliary state
-   AuxiliaryState::create("AnotherAuxState", Mesh, MeshHalo, 12, 3);
+   AuxiliaryState::create("AnotherAuxState", Mesh, VCoord, MeshHalo, 12, 3);
 
    // test retrievel of another
    if (AuxiliaryState::get("AnotherAuxState")) {
@@ -280,11 +282,10 @@ void finalizeAuxStateTest() {
    Tracers::clear();
    OceanState::clear();
    VertCoord::clear();
+   HorzMesh::clear();
    Field::clear();
    Dimension::clear();
    TimeStepper::clear();
-   HorzMesh::clear();
-   VertCoord::clear();
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -616,7 +616,8 @@ int testVelocityDel2AuxVars(Real RTol) {
 
    const auto Decomp = Decomp::getDefault();
    const auto Mesh   = HorzMesh::getDefault();
-   VelocityDel2AuxVars VelocityDel2Aux("", Mesh, NVertLayers);
+   const auto VCoord = VertCoord::getDefault();
+   VelocityDel2AuxVars VelocityDel2Aux("", Mesh, VCoord, NVertLayers);
 
    // Use analytical expressions to compute inputs
 
@@ -722,9 +723,10 @@ int testTracerAuxVars(const Array2DReal &LayerThickCell,
    TestSetup Setup;
    int Err = 0;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
-   TracerAuxVars TracerAux("", Mesh, NVertLayers, NTracers);
+   TracerAuxVars TracerAux("", Mesh, VCoord, NVertLayers, NTracers);
    TracerAux.TracersOnEdgeChoice = FluxTracerEdgeOption::Upwind;
 
    // Set input arrays
@@ -824,25 +826,20 @@ int initAuxVarsTest(const std::string &mesh) {
       LOG_ERROR("AuxVarsTest: error initializing default halo");
    }
 
-   VertCoord::init1();
-   // Reset NVertLayers to the test value
-   auto *DefVertCoord        = VertCoord::getDefault();
-   DefVertCoord->NVertLayers = NVertLayers;
-   Dimension::destroy("NVertLayers");
-   std::shared_ptr<Dimension> VertDim =
-       Dimension::create("NVertLayers", NVertLayers);
-
    HorzMesh::init();
+
+   // initialize vertical coordinate, do not read stream and use local
+   // NVertLayers value
+   VertCoord::init(false, NVertLayers);
 
    return Err;
 }
 
 void finalizeAuxVarsTest() {
    VertCoord::clear();
+   HorzMesh::clear();
    Field::clear();
    Dimension::clear();
-   HorzMesh::clear();
-   VertCoord::clear();
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -74,11 +74,14 @@ I4 initEosTest(const std::string &mesh) {
    /// Initialize decomposition
    Decomp::init(mesh);
 
-   /// Initialize vertical coordinate (phase 1)
-   VertCoord::init1();
+   /// Initialize Halo
+   Halo::init();
 
    /// Initialize mesh
    HorzMesh::init();
+
+   /// Initialize vertical coordinate
+   VertCoord::init(false);
 
    /// Initialize Eos
    Eos::init();
@@ -286,8 +289,9 @@ int testEosTeos10Displaced() {
 
 /// Finalize and clean up all test infrastructure
 void finalizeEosTest() {
-   HorzMesh::clear();
    VertCoord::clear();
+   HorzMesh::clear();
+   Halo::clear();
    Decomp::clear();
    Field::clear();
    Dimension::clear();

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -20,7 +20,6 @@
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
-#include "VertCoord.h"
 #include "mpi.h"
 
 #include <iostream>
@@ -59,9 +58,6 @@ int initHorzMeshTest() {
    Err = Halo::init();
    if (Err != 0)
       LOG_ERROR("HorzMeshTest: error initializing default halo");
-
-   // Initialize the vertical coordinate (phase 1)
-   VertCoord::init1();
 
    // Initialize the default mesh
    HorzMesh::init();
@@ -773,7 +769,6 @@ int main(int argc, char *argv[]) {
       }
       // Finalize Omega objects
       HorzMesh::clear();
-      VertCoord::clear();
       Dimension::clear();
       Halo::clear();
       Decomp::clear();

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -12,7 +12,6 @@
 #include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
-#include "VertCoord.h"
 #include "mpi.h"
 
 #include <cmath>
@@ -448,8 +447,6 @@ int initOperatorsTest(const std::string &MeshFile) {
       LOG_ERROR("OperatorsTest: error initializing default halo");
    }
 
-   VertCoord::init1();
-
    HorzMesh::init();
 
    return Err;
@@ -457,7 +454,6 @@ int initOperatorsTest(const std::string &MeshFile) {
 
 void finalizeOperatorsTest() {
    HorzMesh::clear();
-   VertCoord::clear();
    Dimension::clear();
    Halo::clear();
    Decomp::clear();

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -78,14 +78,11 @@ void initStateTest() {
    if (Err != 0)
       ABORT_ERROR("State: error initializing default halo");
 
-   // Initialize the vertical coordinate (phase 1)
-   VertCoord::init1();
-
    // Initialize the default mesh
    HorzMesh::init();
 
-   // Initialize the vertical coordinate (phase 2)
-   VertCoord::init2();
+   // Initialize the vertical coordinate
+   VertCoord::init();
 
    // Initialize tracers
    Tracers::init();

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -111,8 +111,8 @@ int initTendenciesTest(const std::string &mesh) {
       LOG_ERROR("TendenciesTest: error initializing default halo");
    }
 
-   VertCoord::init1();
    HorzMesh::init();
+   VertCoord::init(false);
    Tracers::init();
 
    int StateErr = OceanState::init();
@@ -222,11 +222,10 @@ void finalizeTendenciesTest() {
    AuxiliaryState::clear();
    OceanState::clear();
    VertCoord::clear();
+   HorzMesh::clear();
    Field::clear();
    Dimension::clear();
    TimeStepper::clear();
-   HorzMesh::clear();
-   VertCoord::clear();
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -389,7 +389,8 @@ int testPotVortHAdv(int NVertLayers, Real RTol) {
    int Err = 0;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    // Compute exact result
    Array2DReal ExactPotVortHAdv("ExactPotVortHAdv", Mesh->NEdgesOwned,
@@ -437,7 +438,7 @@ int testPotVortHAdv(int NVertLayers, Real RTol) {
    // Compute numerical result
    Array2DReal NumPotVortHAdv("NumPotVortHAdv", Mesh->NEdgesOwned, NVertLayers);
 
-   PotentialVortHAdvOnEdge PotVortHAdvOnE(Mesh);
+   PotentialVortHAdvOnEdge PotVortHAdvOnE(Mesh, VCoord);
    parallelFor(
        {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int KLayer) {
           PotVortHAdvOnE(NumPotVortHAdv, IEdge, KLayer, NormRelVortEdge,
@@ -465,7 +466,8 @@ int testKEGrad(int NVertLayers, Real RTol) {
    int Err = 0;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    // Compute exact result
    Array2DReal ExactKEGrad("ExactKEGrad", Mesh->NEdgesOwned, NVertLayers);
@@ -487,7 +489,7 @@ int testKEGrad(int NVertLayers, Real RTol) {
    // Compute numerical result
    Array2DReal NumKEGrad("NumKEGrad", Mesh->NEdgesOwned, NVertLayers);
 
-   KEGradOnEdge KEGradOnE(Mesh);
+   KEGradOnEdge KEGradOnE(Mesh, VCoord);
    parallelFor(
        {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int KLayer) {
           KEGradOnE(NumKEGrad, IEdge, KLayer, KECell);
@@ -513,7 +515,8 @@ int testSSHGrad(int NVertLayers, Real RTol) {
    int Err = 0;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    // Compute exact result
    Array2DReal ExactSSHGrad("ExactSSHGrad", Mesh->NEdgesOwned, NVertLayers);
@@ -535,7 +538,7 @@ int testSSHGrad(int NVertLayers, Real RTol) {
    // Compute numerical result
    Array2DReal NumSSHGrad("NumSSHGrad", Mesh->NEdgesOwned, NVertLayers);
 
-   SSHGradOnEdge SSHGradOnE(Mesh);
+   SSHGradOnEdge SSHGradOnE(Mesh, VCoord);
    parallelFor(
        {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int KLayer) {
           SSHGradOnE(NumSSHGrad, IEdge, KLayer, SSHCell);
@@ -558,14 +561,15 @@ int testVelDiff(int NVertLayers, Real RTol) {
    Error Err1;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    Config *OmegaConfig = Config::getOmegaConfig();
    Config TendConfig("Tendencies");
    Err1 += OmegaConfig->get(TendConfig);
    CHECK_ERROR_ABORT(Err1, "Tendencies: Tendencies group not found in Config");
 
-   VelocityDiffusionOnEdge VelDiffOnE(Mesh);
+   VelocityDiffusionOnEdge VelDiffOnE(Mesh, VCoord);
    Err1 += TendConfig.get("ViscDel2", VelDiffOnE.ViscDel2);
    CHECK_ERROR_ABORT(Err1, "Tendencies: ViscDel2 not found in TendConfig");
 
@@ -623,14 +627,15 @@ int testVelHyperDiff(int NVertLayers, Real RTol) {
    Error Err1;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    Config *OmegaConfig = Config::getOmegaConfig();
    Config TendConfig("Tendencies");
    Err1 += OmegaConfig->get(TendConfig);
    CHECK_ERROR_ABORT(Err1, "Tendencies: Tendencies group not found in Config");
 
-   VelocityHyperDiffOnEdge VelHyperDiffOnE(Mesh);
+   VelocityHyperDiffOnEdge VelHyperDiffOnE(Mesh, VCoord);
    Err1 += TendConfig.get("ViscDel4", VelHyperDiffOnE.ViscDel4);
    CHECK_ERROR_ABORT(Err1, "Tendencies: ViscDel4 not found in TendConfig");
 
@@ -693,7 +698,8 @@ int testWindForcing(int NVertLayers) {
    int Err = 0;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    const Real SaltWaterDensity = 0.987654321;
 
@@ -733,7 +739,7 @@ int testWindForcing(int NVertLayers) {
    // Compute numerical result
    Array2DReal NumWindForcing("NumWindForcing", Mesh->NEdgesOwned, NVertLayers);
 
-   WindForcingOnEdge WindForcingOnE(Mesh);
+   WindForcingOnEdge WindForcingOnE(Mesh, VCoord);
    WindForcingOnE.LocRhoSw = SaltWaterDensity;
 
    parallelFor(
@@ -836,7 +842,8 @@ int testTracerHorzAdvOnCell(int NVertLayers, int NTracers, Real RTol) {
    I4 Err = 0;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    // Compute exact result
    Array3DReal ExactTrFluxDiv("ExactTrFluxDiv", NTracers, Mesh->NCellsOwned,
@@ -865,7 +872,7 @@ int testTracerHorzAdvOnCell(int NVertLayers, int NTracers, Real RTol) {
    // Compute numerical result
    Array3DReal NumTrFluxDiv("NumTrFluxDiv", NTracers, Mesh->NCellsOwned,
                             NVertLayers);
-   TracerHorzAdvOnCell TrHorzAdvOnC(Mesh);
+   TracerHorzAdvOnCell TrHorzAdvOnC(Mesh, VCoord);
    parallelFor(
        {NTracers, Mesh->NCellsOwned, NVertLayers},
        KOKKOS_LAMBDA(int L, int ICell, int KLayer) {
@@ -892,7 +899,8 @@ int testTracerDiffOnCell(int NVertLayers, int NTracers, Real RTol) {
    I4 Err = 0;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    // Compute exact result
    Array3DReal ExactTracerDiff("ExactTracerDiff", NTracers, Mesh->NCellsOwned,
@@ -919,7 +927,7 @@ int testTracerDiffOnCell(int NVertLayers, int NTracers, Real RTol) {
    // Compute numerical result
    Array3DReal NumTracerDiff("NumTracerDiff", NTracers, Mesh->NCellsOwned,
                              NVertLayers);
-   TracerDiffOnCell TrDiffOnC(Mesh);
+   TracerDiffOnCell TrDiffOnC(Mesh, VCoord);
    TrDiffOnC.EddyDiff2 = 1._Real;
 
    parallelFor(
@@ -948,7 +956,8 @@ int testTracerHyperDiffOnCell(int NVertLayers, int NTracers, Real RTol) {
    I4 Err = 0;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    // Compute exact result
    Array3DReal ExactTracerHyperDiff("ExactTracerHyperDiff", NTracers,
@@ -969,7 +978,7 @@ int testTracerHyperDiffOnCell(int NVertLayers, int NTracers, Real RTol) {
    // Compute numerical result
    Array3DReal NumTracerHyperDiff("NumTracerHyperDiff", NTracers,
                                   Mesh->NCellsOwned, NVertLayers);
-   TracerHyperDiffOnCell TrHypDiffOnC(Mesh);
+   TracerHyperDiffOnCell TrHypDiffOnC(Mesh, VCoord);
    TrHypDiffOnC.EddyDiff4 = 1._Real;
    parallelFor(
        {NTracers, Mesh->NCellsOwned, NVertLayers},
@@ -1015,16 +1024,11 @@ void initTendTest(const std::string &MeshFile, int NVertLayers) {
       ABORT_ERROR("TendencyTermsTest: error initializing default halo");
    }
 
-   VertCoord::init1();
-
-   // Reset NVertLayers to the test value
-   auto *DefVertCoord        = VertCoord::getDefault();
-   DefVertCoord->NVertLayers = NVertLayers;
-   Dimension::destroy("NVertLayers");
-   std::shared_ptr<Dimension> VertDim =
-       Dimension::create("NVertLayers", NVertLayers);
-
    HorzMesh::init();
+
+   // initialize vertical coordinate, do not read stream and use local
+   // NVertLayers value
+   VertCoord::init(false, NVertLayers);
 
 } // end initTendTest
 

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -69,11 +69,11 @@ I4 initTracersTest() {
       return Err;
    }
 
-   // Initialize the vertical coordinate (phase 1)
-   VertCoord::init1();
-
    // Initialize the default mesh
    HorzMesh::init();
+
+   // Initialize the vertical coordinate
+   VertCoord::init(false);
 
    return 0;
 }

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -26,6 +26,7 @@
 #include "mpi.h"
 
 #include <algorithm>
+#include <random>
 
 using namespace OMEGA;
 
@@ -61,14 +62,11 @@ int initVertCoordTest() {
    if (Err != 0)
       LOG_ERROR("VertCoordTest: error initializing default halo");
 
-   // Begin initialization of the default vertical coordinate
-   VertCoord::init1();
-
    // Initialize the default mesh
    HorzMesh::init();
 
-   // Complete initialization of the default vertical coordinate
-   VertCoord::init2();
+   // Initialize the default vertical coordinate
+   VertCoord::init();
 
    return Err;
 } // end initVertCoordTest
@@ -93,13 +91,18 @@ int main(int argc, char *argv[]) {
 
       auto *DefVertCoord = VertCoord::getDefault();
       auto *DefMesh      = HorzMesh::getDefault();
+      auto *DefHalo      = Halo::getDefault();
+      auto *DefDecomp    = Decomp::getDefault();
 
-      I4 NCellsSize   = DefMesh->NCellsSize;
-      I4 NCellsAll    = DefMesh->NCellsAll;
-      I4 NEdgesAll    = DefMesh->NEdgesAll;
-      I4 NVerticesAll = DefMesh->NVerticesAll;
-      I4 VertexDegree = DefMesh->VertexDegree;
-      I4 NVertLayers  = DefVertCoord->NVertLayers;
+      I4 NCellsSize     = DefMesh->NCellsSize;
+      I4 NCellsOwned    = DefMesh->NCellsOwned;
+      I4 NCellsAll      = DefMesh->NCellsAll;
+      I4 NEdgesOwned    = DefMesh->NEdgesOwned;
+      I4 NEdgesAll      = DefMesh->NEdgesAll;
+      I4 NVerticesOwned = DefMesh->NVerticesOwned;
+      I4 NVerticesAll   = DefMesh->NVerticesAll;
+      I4 VertexDegree   = DefMesh->VertexDegree;
+      I4 NVertLayers    = DefVertCoord->NVertLayers;
 
       // Tests for computePressure
 
@@ -449,15 +452,16 @@ int main(int argc, char *argv[]) {
       /// edge
       const auto &LocMinLayerCell = DefVertCoord->MinLayerCell;
       const auto &LocMaxLayerCell = DefVertCoord->MaxLayerCell;
+      const auto &LocCellID       = DefDecomp->CellID;
       parallelFor(
           {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
-             LocMinLayerCell(ICell) = -2 * ICell;
-             LocMaxLayerCell(ICell) = 2 * ICell;
+             LocMinLayerCell(ICell) = -2 * LocCellID(ICell);
+             LocMaxLayerCell(ICell) = 2 * LocCellID(ICell);
           });
       Kokkos::fence();
 
       /// Call function, outputs are member variables of class
-      DefVertCoord->minMaxLayerEdge();
+      DefVertCoord->minMaxLayerEdge(DefHalo);
 
       /// Check results
       Err = 0;
@@ -470,30 +474,28 @@ int main(int argc, char *argv[]) {
             continue;
          }
 
+         I4 CellID1 = DefDecomp->CellIDH(DefMesh->CellsOnEdgeH(IEdge, 0));
+         I4 CellID2 = DefDecomp->CellIDH(DefMesh->CellsOnEdgeH(IEdge, 1));
          /// MinLayerEdgeTop is the min of the min cell values on edge
-         Expected  = std::min(-2 * DefMesh->CellsOnEdgeH(IEdge, 0),
-                              -2 * DefMesh->CellsOnEdgeH(IEdge, 1));
+         Expected  = std::min(-2 * CellID1, -2 * CellID2);
          Real Diff = std::abs(DefVertCoord->MinLayerEdgeTopH(IEdge) - Expected);
          if (Diff > 1e-10) {
             Err += 1;
          }
          /// MinLayerEdgeBot is the max of the min cell values on edge
-         Expected = std::max(-2 * DefMesh->CellsOnEdgeH(IEdge, 0),
-                             -2 * DefMesh->CellsOnEdgeH(IEdge, 1));
+         Expected = std::max(-2 * CellID1, -2 * CellID2);
          Diff     = std::abs(DefVertCoord->MinLayerEdgeBotH(IEdge) - Expected);
          if (Diff > 1e-10) {
             Err += 1;
          }
          /// MaxLayerEdgeTop is the min of the max cell values on edge
-         Expected = std::min(2 * DefMesh->CellsOnEdgeH(IEdge, 0),
-                             2 * DefMesh->CellsOnEdgeH(IEdge, 1));
+         Expected = std::min(2 * CellID1, 2 * CellID2);
          Diff     = std::abs(DefVertCoord->MaxLayerEdgeTopH(IEdge) - Expected);
          if (Diff > 1e-10) {
             Err += 1;
          }
          /// MaxLayerEdgeBot is the max of the max cell values on edge
-         Expected = std::max(2 * DefMesh->CellsOnEdgeH(IEdge, 0),
-                             2 * DefMesh->CellsOnEdgeH(IEdge, 1));
+         Expected = std::max(2 * CellID1, 2 * CellID2);
          Diff     = std::abs(DefVertCoord->MaxLayerEdgeBotH(IEdge) - Expected);
          if (Diff > 1e-10) {
             Err += 1;
@@ -515,7 +517,7 @@ int main(int argc, char *argv[]) {
       /// vertex
 
       /// Call function, outputs are member variables of class
-      DefVertCoord->minMaxLayerVertex();
+      DefVertCoord->minMaxLayerVertex(DefHalo);
 
       /// Check results
       Err = 0;
@@ -532,11 +534,14 @@ int main(int argc, char *argv[]) {
             continue;
          }
 
+         std::vector<I4> CellIDs = {
+             DefDecomp->CellIDH(DefMesh->CellsOnVertexH(IVertex, 0)),
+             DefDecomp->CellIDH(DefMesh->CellsOnVertexH(IVertex, 1)),
+             DefDecomp->CellIDH(DefMesh->CellsOnVertexH(IVertex, 2))};
          /// MinLayerVertexTop is the min of the min cell values on vertex
          I4 Expected = 1e7;
          for (int I = 0; I < VertexDegree; I++) {
-            Expected =
-                std::min(Expected, -2 * DefMesh->CellsOnVertexH(IVertex, I));
+            Expected = std::min(Expected, -2 * CellIDs[I]);
          }
          Real Diff =
              std::abs(DefVertCoord->MinLayerVertexTopH(IVertex) - Expected);
@@ -547,8 +552,7 @@ int main(int argc, char *argv[]) {
          /// MinLayerVertexBot is the max of the min cell values on vertex
          Expected = -1e7;
          for (int I = 0; I < VertexDegree; I++) {
-            Expected =
-                std::max(Expected, -2 * DefMesh->CellsOnVertexH(IVertex, I));
+            Expected = std::max(Expected, -2 * CellIDs[I]);
          }
          Diff = std::abs(DefVertCoord->MinLayerVertexBotH(IVertex) - Expected);
          if (Diff > 1e-10) {
@@ -558,8 +562,7 @@ int main(int argc, char *argv[]) {
          /// MaxLayerVertexTop is the min of the max cell values on vertex
          Expected = 1e7;
          for (int I = 0; I < VertexDegree; I++) {
-            Expected =
-                std::min(Expected, 2 * DefMesh->CellsOnVertexH(IVertex, I));
+            Expected = std::min(Expected, 2 * CellIDs[I]);
          }
          Diff = std::abs(DefVertCoord->MaxLayerVertexTopH(IVertex) - Expected);
          if (Diff > 1e-10) {
@@ -569,8 +572,7 @@ int main(int argc, char *argv[]) {
          /// MaxLayerVertexBot is the max of the max cell values on vertex
          Expected = -1e7;
          for (int I = 0; I < VertexDegree; I++) {
-            Expected =
-                std::max(Expected, 2 * DefMesh->CellsOnVertexH(IVertex, I));
+            Expected = std::max(Expected, 2 * CellIDs[I]);
          }
          Diff = std::abs(DefVertCoord->MaxLayerVertexBotH(IVertex) - Expected);
          if (Diff > 1e-10) {
@@ -584,6 +586,95 @@ int main(int argc, char *argv[]) {
       } else {
          ErrAll +=
              Error(ErrorCode::Fail, "VertCoordTest: minMaxLayerVertex FAIL");
+      }
+
+      // Tests for Masks
+
+      /// Setup random values for MinLayerCell and MaxLayerCell near the top
+      /// and bottom of each column
+      I4 Seed = 12345;
+      std::mt19937 Generator(Seed);
+
+      I4 MinMin = 0;
+      I4 MaxMin = 10;
+      I4 MinMax = NVertLayers - 11;
+      I4 MaxMax = NVertLayers - 1;
+
+      std::uniform_int_distribution<int> MinDist(MinMin, MaxMin);
+      std::uniform_int_distribution<int> MaxDist(MinMax, MaxMax);
+
+      for (int ICell = 0; ICell < NCellsAll; ICell++) {
+         DefVertCoord->MinLayerCellH(ICell) = MinDist(Generator);
+         DefVertCoord->MaxLayerCellH(ICell) = MaxDist(Generator);
+      }
+
+      deepCopy(DefVertCoord->MinLayerCell, DefVertCoord->MinLayerCellH);
+      deepCopy(DefVertCoord->MaxLayerCell, DefVertCoord->MaxLayerCellH);
+      Kokkos::fence();
+
+      /// Reset min/max layer arrays and set masks
+      DefVertCoord->minMaxLayerEdge(DefHalo);
+      DefVertCoord->minMaxLayerVertex(DefHalo);
+      DefVertCoord->setMasks();
+
+      Err = 0;
+      for (int ICell = 0; ICell < NCellsOwned; ++ICell) {
+         /// The sum of the masks in a column is the number of active
+         /// layers in that column
+         Real Expected = DefVertCoord->MaxLayerCellH(ICell) -
+                         DefVertCoord->MinLayerCellH(ICell) + 1._Real;
+         Real Sum = 0.;
+         for (int K = 0; K < NVertLayers; ++K) {
+            Sum += DefVertCoord->CellMaskH(ICell, K);
+         }
+
+         Real Diff = std::abs(Sum - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+      }
+
+      for (int IEdge = 0; IEdge < NEdgesOwned; ++IEdge) {
+         Real Expected;
+
+         /// The sum of the masks along an edge is the number of layers with
+         /// active cells on both sides.
+         if ((DefMesh->CellsOnEdgeH(IEdge, 1) == NCellsAll) ||
+             (DefMesh->CellsOnEdgeH(IEdge, 0) == NCellsAll)) {
+            Expected = 0.;
+         } else {
+            Expected = DefVertCoord->MaxLayerEdgeTopH(IEdge) -
+                       DefVertCoord->MinLayerEdgeBotH(IEdge) + 1._Real;
+         }
+         Real Sum = 0.;
+         for (int K = 0; K < NVertLayers; ++K) {
+            Sum += DefVertCoord->EdgeMaskH(IEdge, K);
+         }
+         Real Diff = std::abs(Sum - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+      }
+
+      for (int IVertex = 0; IVertex < NVerticesOwned; ++IVertex) {
+         Real Expected = DefVertCoord->MaxLayerVertexBotH(IVertex) -
+                         DefVertCoord->MinLayerVertexTopH(IVertex) + 1._Real;
+
+         Real Sum = 0.;
+         for (int K = 0; K < NVertLayers; ++K) {
+            Sum += DefVertCoord->VertexMaskH(IVertex, K);
+         }
+         Real Diff = std::abs(Sum - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
+         }
+      }
+
+      /// Determine test pass/fail
+      if (Err == 0) {
+         LOG_INFO("VertCoordTest: setMasks PASS");
+      } else {
+         ErrAll += Error(ErrorCode::Fail, "VertCoordTest: setMasks FAIL");
       }
 
       // Finalize Omega objects

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -37,7 +37,6 @@
 
 #include <cmath>
 #include <iomanip>
-#include <iostream>
 
 using namespace OMEGA;
 
@@ -170,15 +169,13 @@ int initTimeStepperTest(const std::string &mesh) {
       LOG_ERROR("TimeStepperTest: error initializing default halo");
    }
 
-   // Initialize the vertical coordinate and reset NVertLayers to 1
-   VertCoord::init1();
-   auto *DefVertCoord        = VertCoord::getDefault();
-   DefVertCoord->NVertLayers = 1;
-   Dimension::destroy("NVertLayers");
-   std::shared_ptr<Dimension> VertDim =
-       Dimension::create("NVertLayers", NVertLayers);
-
    HorzMesh::init();
+
+   // initialize vertical coordinate, do not read stream and use local
+   // NVertLayers value
+   VertCoord::init(false, NVertLayers);
+   auto *DefVertCoord = VertCoord::getDefault();
+
    Tracers::init();
    AuxiliaryState::init();
    Tendencies::init();
@@ -207,8 +204,8 @@ int initTimeStepperTest(const std::string &mesh) {
       LOG_ERROR("TimeStepperTest: error creating test state");
    }
 
-   auto *TestAuxState = AuxiliaryState::create("TestAuxState", DefMesh, DefHalo,
-                                               NVertLayers, NTracers);
+   auto *TestAuxState = AuxiliaryState::create(
+       "TestAuxState", DefMesh, DefVertCoord, DefHalo, NVertLayers, NTracers);
 
    Config *OmegaConfig = Config::getOmegaConfig();
    TestAuxState->readConfigOptions(OmegaConfig);
@@ -282,10 +279,9 @@ void finalizeTimeStepperTest() {
    AuxiliaryState::clear();
    OceanState::clear();
    VertCoord::clear();
+   HorzMesh::clear();
    Dimension::clear();
    Field::clear();
-   HorzMesh::clear();
-   VertCoord::clear();
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

This PR implements fixes, additions, and refactoring for the vertical coordinate module, including:
- Moving `EdgeMask` from `HorzMesh` to `VertCoord`, and fixing initialization so `EdgeMask` properly accounts for bathymetry
- This change removes the need for bootstrapping the `VertCoord`, initialization is consolidated into a single `VertCoord::init()` method
- Replacing `LOG_WARN` messages with `LOG_INFO` during construction
- Adding support for both new Omega names and old MPAS names when reading `NVertLayers`, `MaxLayerCell`, and `MinLayerCell` from mesh file
- Adding optional arguments to `VertCoord::init()` to enhance flexibility in unit tests
- Adding `CellMask` and `VertexMask` arrays for potential future use
- Introducing new mask tests to the `VertCoord` unit test

Ctests were run successfully on Frontier CPU & GPU, pm-cpu, pm-gpu, and Chrysalis

Fixes #290 

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] A comment in the PR documents testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] CTest unit tests for new features have been added per the approved design.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


