### PR TITLE
Fix out-of-bounds access to FieldDims array in IOStream.cpp

### DIFF
--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -2528,6 +2528,7 @@ void IOStream::writeStream(
       if (ThisField->isTimeDependent()) {
          ++NDims;
          DimNames.insert(DimNames.begin(), "time");
+         FieldDims.resize(NDims);
       }
       // Get the dim IDs
       for (int IDim = 0; IDim < NDims; ++IDim) {

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1593,7 +1593,7 @@ Error IOStream::readFieldData(
    // get the relevant size information
    int DecompID;
    int LocSize;
-   int NDimsTmp = std::min(NDims, 1);
+   int NDimsTmp = std::max(NDims, 1);
    std::vector<int> DimLengths(NDimsTmp);
    if (IsDistributed) {
       computeDecomp(FieldPtr, DecompID, LocSize, DimLengths);


### PR DESCRIPTION
When building with GCC 15, which introduced assertion errors for out-of-bounds accesses to `std::vector`, I see these errors in several of the tests:
```
/usr/include/c++/15/bits/stl_vector.h:1263: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = int; _Alloc = std::allocator<int>; reference = int&
; size_type = long unsigned int]: Assertion '__n < this->size()' failed.   
```
They originate in two different parts of `IOStream.cpp`, where the `FieldDims` array was too small. This PR fixes that by changing the size accordingly.

As this is my first PR to Omega, I'd appreciate some comments because I don't know the details of the I/O framework.