### PR TITLE
Start using hierarchical parallelism to limit vertical loops extents

### DIFF
--- a/components/omega/doc/devGuide/AuxiliaryState.md
+++ b/components/omega/doc/devGuide/AuxiliaryState.md
@@ -24,10 +24,9 @@ OMEGA::AuxiliaryState* DefAuxState = OMEGA::AuxiliaryState::getDefault();
 
 ## Creation of non-default auxiliary states
 
-A non-default auxiliary state can be created from a string `Name`, horizontal mesh `Mesh`, a number of
-vertical layers `NVertLayers`, and a number of Tracers `NTracers`:
+A non-default auxiliary state can be created from a string `Name`, horizontal mesh `Mesh`, halo layer `MeshHalo`, vertical coordinate `VCoord`, and a number of Tracers `NTracers`:
 ```c++
-OMEGA::AuxiliaryState*  NewAuxState = OMEGA::AuxiliaryState::create(Name, Mesh, NVertLayers, NTracers);
+OMEGA::AuxiliaryState*  NewAuxState = OMEGA::AuxiliaryState::create(Name, Mesh, MeshHalo, VCoord, NTracers);
 ```
 For conveniece, this returns a pointer to the newly created state. Given its name, a pointer to a named auxiliary state
 can be obtained at any time by calling the static `get` method:
@@ -37,9 +36,9 @@ OMEGA::AuxiliaryState* NewAuxState = OMEGA::AuxiliaryState::get(Name);
 
 ## Computation of auxiliary variables
 To compute all auxiliary variables stored in an auxiliary state `AuxState`,
-given ocean state `State` and time level `TimeLevel` do:
+given ocean state `State`, an array of tracers `TracerArray`, and time level `TimeLevel` do:
 ```c++
-AuxState.computeAll(State, TimeLevel);
+AuxState.computeAll(State, TracerArray, TimeLevel);
 ```
 
 ## Removal of auxiliary states

--- a/components/omega/doc/devGuide/Tendencies.md
+++ b/components/omega/doc/devGuide/Tendencies.md
@@ -26,16 +26,15 @@ tendency terms, which each store constant mesh information as private member var
 ## Creation of non-default tendencies
 
 A non-default tendency group can be created with or without custom tendencies.
-Without custom tendencies, it is created from a string `Name`, horizontal mesh `Mesh`, number of
-vertical layers `NVertLayers`, number of tracers `NTracers`, and a configuration `Options`:
+Without custom tendencies, it is created from a string `Name`, horizontal mesh `Mesh`, vertical coordinate `VCoord`, number of tracers `NTracers`, and a configuration `Options`:
 ```c++
-OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, NVertLayers, NTracers, Options);
+OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, VCoord, NTracers, Options);
 ```
 For convenience, this returns a pointer to the newly created instance.
 To allow the user to provide custom tendencies, the `create` function can take two additional arguments
 `CustomThicknessTend` and `CustomVelocityTend`
 ```c++
-OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, NVertLayers, NTracers, Options, CustomThicknessTend, CustomVelocityTend);
+OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, VCoord, NTracers, Options, CustomThicknessTend, CustomVelocityTend);
 ```
 The two custom tendency arguments need to be callable objects that take a Kokkos array `Tend`, ocean state `State`,
 auxiliary state `AuxState`, two integers: `ThickTimeLevel` and `VelTimeLevel`, and time instant `Time`.
@@ -49,7 +48,7 @@ OMEGA::Tendencies* NewTendencies = OMEGA::Tendencies::get(Name);
 ## Computation of tendencies
 To compute all tendencies for layer thickness, normal velocity, and tracer equations,
 given ocean state, `State`, a group of auxiliary variables, `AuxState`, an array of tracers,
-`TracerArray`, thickness time level 'ThickTimeLevel', velocity time level `VelTimeLevel`,
+`TracerArray`, thickness time level `ThickTimeLevel`, velocity time level `VelTimeLevel`,
 and time instant `Time` do:
 ```c++
 Tendencies.computeAllTendencies(State, AuxState, TracerArray, ThickTimeLevel, VelTimeLevel, Time);

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -359,8 +359,7 @@ KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int UpperBound,
 template <class T, class Enable = void> struct AccumTypeHelper;
 
 template <class T>
-struct AccumTypeHelper<
-    T, std::enable_if_t<std::is_arithmetic_v<std::remove_reference_t<T>>>> {
+struct AccumTypeHelper<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
    using Type = T;
 };
 
@@ -386,7 +385,8 @@ inline void parallelReduceOuter(const std::string &Label,
    auto Policy = TeamPolicy(LinBound, OMEGA_TEAMSIZE);
    Kokkos::parallel_reduce(
        Label, Policy,
-       KOKKOS_LAMBDA(const TeamMember &Team, AccumType<R> &...Accums) {
+       KOKKOS_LAMBDA(const TeamMember &Team,
+                     AccumType<std::remove_reference_t<R>> &...Accums) {
           const int TeamId = Team.league_rank();
           LinFunctor(TeamId, Team, Accums...);
        },

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -74,22 +74,47 @@ void AuxiliaryState::computeMomAux(const OceanState *State, int ThickTimeLevel,
    OMEGA_SCOPE(LocVelocityDel2Aux, VelocityDel2Aux);
    OMEGA_SCOPE(LocWindForcingAux, WindForcingAux);
 
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+   OMEGA_SCOPE(MinLayerVertexBot, VCoord->MinLayerVertexBot);
+   OMEGA_SCOPE(MinLayerVertexTop, VCoord->MinLayerVertexTop);
+   OMEGA_SCOPE(MaxLayerVertexBot, VCoord->MaxLayerVertexBot);
+   OMEGA_SCOPE(MaxLayerVertexTop, VCoord->MaxLayerVertexTop);
+   OMEGA_SCOPE(MinLayerEdgeTop, VCoord->MinLayerEdgeTop);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeBot, VCoord->MaxLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
    Pacer::start("AuxState:computeMomAux", 1);
 
    Pacer::start("AuxState:vertexAuxState1", 2);
-   parallelFor(
-       "vertexAuxState1", {Mesh->NVerticesAll, NChunks},
-       KOKKOS_LAMBDA(int IVertex, int KChunk) {
-          LocVorticityAux.computeVarsOnVertex(IVertex, KChunk, LayerThickCell,
-                                              NormalVelEdge);
+   parallelForOuter(
+       "vertexAuxState1", {Mesh->NVerticesAll},
+       KOKKOS_LAMBDA(int IVertex, const TeamMember &Team) {
+          const int KMin   = MinLayerVertexTop(IVertex);
+          const int KMax   = MaxLayerVertexBot(IVertex);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocVorticityAux.computeVarsOnVertex(
+                     IVertex, KChunk, LayerThickCell, NormalVelEdge);
+              });
        });
    Pacer::stop("AuxState:vertexAuxState1", 2);
 
    Pacer::start("AuxState:cellAuxState1", 2);
-   parallelFor(
-       "cellAuxState1", {Mesh->NCellsAll, NChunks},
-       KOKKOS_LAMBDA(int ICell, int KChunk) {
-          LocKineticAux.computeVarsOnCell(ICell, KChunk, NormalVelEdge);
+   parallelForOuter(
+       "cellAuxState1", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocKineticAux.computeVarsOnCell(ICell, KChunk, NormalVelEdge);
+              });
        });
    Pacer::stop("AuxState:cellAuxState1", 2);
 
@@ -104,39 +129,79 @@ void AuxiliaryState::computeMomAux(const OceanState *State, int ThickTimeLevel,
    Pacer::stop("AuxState:edgeAuxState1", 2);
 
    Pacer::start("AuxState:edgeAuxState2", 2);
-   parallelFor(
-       "edgeAuxState2", {Mesh->NEdgesAll, NChunks},
-       KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          LocVorticityAux.computeVarsOnEdge(IEdge, KChunk);
-          LocLayerThicknessAux.computeVarsOnEdge(IEdge, KChunk, LayerThickCell,
-                                                 NormalVelEdge);
-          LocVelocityDel2Aux.computeVarsOnEdge(IEdge, KChunk, VelocityDivCell,
-                                               RelVortVertex);
+   parallelForOuter(
+       "edgeAuxState2", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocLayerThicknessAux.computeVarsOnEdge(
+                     IEdge, KChunk, LayerThickCell, NormalVelEdge);
+                 LocVelocityDel2Aux.computeVarsOnEdge(
+                     IEdge, KChunk, VelocityDivCell, RelVortVertex);
+              });
+       });
+
+   parallelForOuter(
+       "edgeAuxState2", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeTop(IEdge);
+          const int KMax   = MaxLayerEdgeBot(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocVorticityAux.computeVarsOnEdge(IEdge, KChunk);
+              });
        });
    Pacer::stop("AuxState:edgeAuxState2", 2);
 
    Pacer::start("AuxState:vertexAuxState2", 2);
-   parallelFor(
-       "vertexAuxState2", {Mesh->NVerticesAll, NChunks},
-       KOKKOS_LAMBDA(int IVertex, int KChunk) {
-          LocVelocityDel2Aux.computeVarsOnVertex(IVertex, KChunk);
+   parallelForOuter(
+       "vertexAuxState2", {Mesh->NVerticesAll},
+       KOKKOS_LAMBDA(int IVertex, const TeamMember &Team) {
+          const int KMin   = MinLayerVertexBot(IVertex);
+          const int KMax   = MaxLayerVertexTop(IVertex);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocVelocityDel2Aux.computeVarsOnVertex(IVertex, KChunk);
+              });
        });
    Pacer::stop("AuxState:vertexAuxState2", 2);
 
    Pacer::start("AuxState:cellAuxState2", 2);
-   parallelFor(
-       "cellAuxState2", {Mesh->NCellsAll, NChunks},
-       KOKKOS_LAMBDA(int ICell, int KChunk) {
-          LocVelocityDel2Aux.computeVarsOnCell(ICell, KChunk);
+   parallelForOuter(
+       "cellAuxState2", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocVelocityDel2Aux.computeVarsOnCell(ICell, KChunk);
+              });
        });
    Pacer::stop("AuxState:cellAuxState2", 2);
 
    Pacer::start("AuxState:cellAuxState3", 2);
-   parallelFor(
-       "cellAuxState3", {Mesh->NCellsAll, NChunks},
-       KOKKOS_LAMBDA(int ICell, int KChunk) {
-          LocLayerThicknessAux.computeVarsOnCells(ICell, KChunk,
-                                                  LayerThickCell);
+   parallelForOuter(
+       "cellAuxState3", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocLayerThicknessAux.computeVarsOnCells(ICell, KChunk,
+                                                         LayerThickCell);
+              });
        });
    Pacer::stop("AuxState:cellAuxState3", 2);
 
@@ -157,28 +222,46 @@ void AuxiliaryState::computeAll(const OceanState *State,
    const int NTracers    = TracerArray.extent_int(0);
 
    OMEGA_SCOPE(LocTracerAux, TracerAux);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
    Pacer::start("AuxState:computeAll", 1);
 
    computeMomAux(State, ThickTimeLevel, VelTimeLevel);
 
    Pacer::start("AuxState:edgeAuxState4", 2);
-   parallelFor(
-       "edgeAuxState4", {NTracers, Mesh->NEdgesAll, NChunks},
-       KOKKOS_LAMBDA(int LTracer, int IEdge, int KChunk) {
-          LocTracerAux.computeVarsOnEdge(LTracer, IEdge, KChunk, NormalVelEdge,
-                                         LayerThickCell, TracerArray);
+   parallelForOuter(
+       "edgeAuxState4", {NTracers, Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int LTracer, int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocTracerAux.computeVarsOnEdge(LTracer, IEdge, KChunk,
+                                                NormalVelEdge, LayerThickCell,
+                                                TracerArray);
+              });
        });
    Pacer::stop("AuxState:edgeAuxState4", 2);
 
    const auto &MeanLayerThickEdge = LayerThicknessAux.MeanLayerThickEdge;
 
    Pacer::start("AuxState:cellAuxState4", 2);
-   parallelFor(
-       "cellAuxState4", {NTracers, Mesh->NCellsAll, NChunks},
-       KOKKOS_LAMBDA(int LTracer, int ICell, int KChunk) {
-          LocTracerAux.computeVarsOnCells(LTracer, ICell, KChunk,
-                                          MeanLayerThickEdge, TracerArray);
+   parallelForOuter(
+       "cellAuxState4", {NTracers, Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int LTracer, int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocTracerAux.computeVarsOnCells(
+                     LTracer, ICell, KChunk, MeanLayerThickEdge, TracerArray);
+              });
        });
    Pacer::stop("AuxState:cellAuxState4", 2);
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -18,15 +18,15 @@ static std::string stripDefault(const std::string &Name) {
 // Constructor. Constructs the member auxiliary variables and registers their
 // fields with IOStreams
 AuxiliaryState::AuxiliaryState(const std::string &Name, const HorzMesh *Mesh,
-                               const VertCoord *VCoord, Halo *MeshHalo,
-                               int NVertLayers, int NTracers)
-    : Mesh(Mesh), VCoord(VCoord), MeshHalo(MeshHalo), Name(stripDefault(Name)),
-      KineticAux(stripDefault(Name), Mesh, NVertLayers),
-      LayerThicknessAux(stripDefault(Name), Mesh, NVertLayers),
-      VorticityAux(stripDefault(Name), Mesh, NVertLayers),
-      VelocityDel2Aux(stripDefault(Name), Mesh, VCoord, NVertLayers),
+                               Halo *MeshHalo, const VertCoord *VCoord,
+                               int NTracers)
+    : Mesh(Mesh), MeshHalo(MeshHalo), VCoord(VCoord), Name(stripDefault(Name)),
+      KineticAux(stripDefault(Name), Mesh, VCoord),
+      LayerThicknessAux(stripDefault(Name), Mesh, VCoord),
+      VorticityAux(stripDefault(Name), Mesh, VCoord),
+      VelocityDel2Aux(stripDefault(Name), Mesh, VCoord),
       WindForcingAux(stripDefault(Name), Mesh),
-      TracerAux(stripDefault(Name), Mesh, VCoord, NVertLayers, NTracers) {
+      TracerAux(stripDefault(Name), Mesh, VCoord, NTracers) {
 
    GroupName = "AuxiliaryState";
    if (Name != "Default") {
@@ -193,9 +193,9 @@ void AuxiliaryState::computeAll(const OceanState *State,
 
 // Create a non-default auxiliary state
 AuxiliaryState *AuxiliaryState::create(const std::string &Name,
-                                       const HorzMesh *Mesh,
-                                       const VertCoord *VCoord, Halo *MeshHalo,
-                                       int NVertLayers, const int NTracers) {
+                                       const HorzMesh *Mesh, Halo *MeshHalo,
+                                       const VertCoord *VCoord,
+                                       const int NTracers) {
    if (AllAuxStates.find(Name) != AllAuxStates.end()) {
       LOG_ERROR("Attempted to create a new AuxiliaryState with name {} but it "
                 "already exists",
@@ -204,7 +204,7 @@ AuxiliaryState *AuxiliaryState::create(const std::string &Name,
    }
 
    auto *NewAuxState =
-       new AuxiliaryState(Name, Mesh, VCoord, MeshHalo, NVertLayers, NTracers);
+       new AuxiliaryState(Name, Mesh, MeshHalo, VCoord, NTracers);
    AllAuxStates.emplace(Name, NewAuxState);
 
    return NewAuxState;
@@ -214,14 +214,14 @@ AuxiliaryState *AuxiliaryState::create(const std::string &Name,
 // Halo have been initialized.
 void AuxiliaryState::init() {
    const HorzMesh *DefMesh    = HorzMesh::getDefault();
-   const VertCoord *DefVCoord = VertCoord::getDefault();
    Halo *DefHalo              = Halo::getDefault();
+   const VertCoord *DefVCoord = VertCoord::getDefault();
 
    int NVertLayers = VertCoord::getDefault()->NVertLayers;
    int NTracers    = Tracers::getNumTracers();
 
-   AuxiliaryState::DefaultAuxState = AuxiliaryState::create(
-       "Default", DefMesh, DefVCoord, DefHalo, NVertLayers, NTracers);
+   AuxiliaryState::DefaultAuxState =
+       AuxiliaryState::create("Default", DefMesh, DefHalo, DefVCoord, NTracers);
 
    Config *OmegaConfig = Config::getOmegaConfig();
    DefaultAuxState->readConfigOptions(OmegaConfig);

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -65,9 +65,6 @@ void AuxiliaryState::computeMomAux(const OceanState *State, int ThickTimeLevel,
    State->getLayerThickness(LayerThickCell, ThickTimeLevel);
    State->getNormalVelocity(NormalVelEdge, VelTimeLevel);
 
-   const int NVertLayers = LayerThickCell.extent_int(1);
-   const int NChunks     = NVertLayers / VecLength;
-
    OMEGA_SCOPE(LocKineticAux, KineticAux);
    OMEGA_SCOPE(LocLayerThicknessAux, LayerThicknessAux);
    OMEGA_SCOPE(LocVorticityAux, VorticityAux);
@@ -217,9 +214,7 @@ void AuxiliaryState::computeAll(const OceanState *State,
    State->getLayerThickness(LayerThickCell, ThickTimeLevel);
    State->getNormalVelocity(NormalVelEdge, VelTimeLevel);
 
-   const int NVertLayers = LayerThickCell.extent_int(1);
-   const int NChunks     = NVertLayers / VecLength;
-   const int NTracers    = TracerArray.extent_int(0);
+   const int NTracers = TracerArray.extent_int(0);
 
    OMEGA_SCOPE(LocTracerAux, TracerAux);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
@@ -300,8 +295,7 @@ void AuxiliaryState::init() {
    Halo *DefHalo              = Halo::getDefault();
    const VertCoord *DefVCoord = VertCoord::getDefault();
 
-   int NVertLayers = VertCoord::getDefault()->NVertLayers;
-   int NTracers    = Tracers::getNumTracers();
+   int NTracers = Tracers::getNumTracers();
 
    AuxiliaryState::DefaultAuxState =
        AuxiliaryState::create("Default", DefMesh, DefHalo, DefVCoord, NTracers);

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -50,8 +50,8 @@ class AuxiliaryState {
 
    // Create a non-default auxiliary state
    static AuxiliaryState *create(const std::string &Name, const HorzMesh *Mesh,
-                                 const VertCoord *VCoord, Halo *MeshHalo,
-                                 int NVertLayers, int NTracers);
+                                 Halo *MeshHalo, const VertCoord *VCoord,
+                                 int NTracers);
 
    /// Get the default auxiliary state
    static AuxiliaryState *getDefault();
@@ -83,16 +83,15 @@ class AuxiliaryState {
                    int TimeLevel) const;
 
  private:
-   AuxiliaryState(const std::string &Name, const HorzMesh *Mesh,
-                  const VertCoord *VCoord, Halo *MeshHalo, int NVertLayers,
-                  int NTracers);
+   AuxiliaryState(const std::string &Name, const HorzMesh *Mesh, Halo *MeshHalo,
+                  const VertCoord *VCoord, int NTracers);
 
    AuxiliaryState(const AuxiliaryState &) = delete;
    AuxiliaryState(AuxiliaryState &&)      = delete;
 
    const HorzMesh *Mesh;
-   const VertCoord *VCoord;
    Halo *MeshHalo;
+   const VertCoord *VCoord;
    static AuxiliaryState *DefaultAuxState;
    static std::map<std::string, std::unique_ptr<AuxiliaryState>> AllAuxStates;
 };

--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -14,25 +14,25 @@
 namespace OMEGA {
 
 /// Constructor for Teos10Eos
-Teos10Eos::Teos10Eos(int NVertLayers) : NVertLayers(NVertLayers) {
+Teos10Eos::Teos10Eos(const VertCoord *VCoord)
+    : MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell) {
    SpecVolPCoeffs = Array2DReal("SpecVolPCoeffs", 6, VecLength);
 }
 
 /// Constructor for LinearEos
-LinearEos::LinearEos() {}
+LinearEos::LinearEos(const VertCoord *VCoord)
+    : MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell) {}
 
 /// Constructor for Eos
 Eos::Eos(const std::string &Name, ///< [in] Name for eos object
          const HorzMesh *Mesh,    ///< [in] Horizontal mesh
          const VertCoord *VCoord  ///< [in] Vertical coordinate
          )
-    : ComputeSpecVolTeos10(VCoord->NVertLayers), Name(Name), Mesh(Mesh),
-      VCoord(VCoord) {
+    : ComputeSpecVolLinear(VCoord), ComputeSpecVolTeos10(VCoord), Name(Name),
+      Mesh(Mesh), VCoord(VCoord) {
    SpecVol = Array2DReal("SpecVol", Mesh->NCellsAll, VCoord->NVertLayers);
    SpecVolDisplaced =
        Array2DReal("SpecVolDisplaced", Mesh->NCellsAll, VCoord->NVertLayers);
-   // Array dimension lengths
-   NChunks = VCoord->NVertLayers / VecLength;
 
    defineFields();
 }
@@ -117,24 +117,42 @@ void Eos::computeSpecVol(const Array2DReal &ConservTemp,
                ComputeSpecVolLinear); /// Local view for linear EOS computation
    OMEGA_SCOPE(LocComputeSpecVolTeos10,
                ComputeSpecVolTeos10); /// Local view for TEOS-10 computation
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
    deepCopy(LocSpecVol, 0); /// Initialize local specific volume to zero
 
    I4 KDisp = 0; /// No displacement in this case
 
    /// Dispatch to the correct EOS calculation
    if (EosChoice == EosType::LinearEos) {
-      parallelFor(
-          "eos-linear", {Mesh->NCellsAll, NChunks},
-          KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
-             LocComputeSpecVolLinear(LocSpecVol, ICell, KChunk, ConservTemp,
-                                     AbsSalinity);
+      parallelForOuter(
+          "eos-linear", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocComputeSpecVolLinear(LocSpecVol, ICell, KChunk,
+                                            ConservTemp, AbsSalinity);
+                 });
           });
    } else if (EosChoice == EosType::Teos10Eos) {
-      parallelFor(
-          "eos-teos10", {Mesh->NCellsAll, NChunks},
-          KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
-             LocComputeSpecVolTeos10(LocSpecVol, ICell, KChunk, ConservTemp,
-                                     AbsSalinity, Pressure, KDisp);
+      parallelForOuter(
+          "eos-teos10", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocComputeSpecVolTeos10(LocSpecVol, ICell, KChunk,
+                                            ConservTemp, AbsSalinity, Pressure,
+                                            KDisp);
+                 });
           });
    }
 }
@@ -149,6 +167,9 @@ void Eos::computeSpecVolDisp(const Array2DReal &ConservTemp,
                ComputeSpecVolLinear); /// Local view for linear EOS computation
    OMEGA_SCOPE(LocComputeSpecVolTeos10,
                ComputeSpecVolTeos10); /// Local view for TEOS-10 computation
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
    deepCopy(LocSpecVolDisplaced,
             0); /// Initialize local specific volume to zero
 
@@ -159,18 +180,31 @@ void Eos::computeSpecVolDisp(const Array2DReal &ConservTemp,
       LOG_INFO("Eos::computeSpecVolDisp called with Linear EOS. "
                "SpecVol is independent of pressure/depth, so the "
                "displaced value will be the same as SpecVol.");
-      parallelFor(
-          "eos-linear", {Mesh->NCellsAll, NChunks},
-          KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
-             LocComputeSpecVolLinear(LocSpecVolDisplaced, ICell, KChunk,
-                                     ConservTemp, AbsSalinity);
+      parallelForOuter(
+          "eos-linear", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocComputeSpecVolLinear(LocSpecVolDisplaced, ICell, KChunk,
+                                            ConservTemp, AbsSalinity);
+                 });
           });
    } else if (EosChoice == EosType::Teos10Eos) {
-      parallelFor(
-          "eos-teos10", {Mesh->NCellsAll, NChunks},
-          KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
-             LocComputeSpecVolTeos10(LocSpecVolDisplaced, ICell, KChunk,
-                                     ConservTemp, AbsSalinity, Pressure, KDisp);
+      parallelForOuter(
+          "eos-teos10", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocComputeSpecVolTeos10(LocSpecVolDisplaced, ICell, KChunk,
+                                            ConservTemp, AbsSalinity, Pressure,
+                                            KDisp);
+                 });
           });
    }
 }

--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -22,18 +22,17 @@ Teos10Eos::Teos10Eos(int NVertLayers) : NVertLayers(NVertLayers) {
 LinearEos::LinearEos() {}
 
 /// Constructor for Eos
-Eos::Eos(const std::string &Name_, ///< [in] Name for eos object
-         const HorzMesh *Mesh,     ///< [in] Horizontal mesh
-         int NVertLayers           ///< [in] Number of vertical layers
+Eos::Eos(const std::string &Name, ///< [in] Name for eos object
+         const HorzMesh *Mesh,    ///< [in] Horizontal mesh
+         const VertCoord *VCoord  ///< [in] Vertical coordinate
          )
-    : ComputeSpecVolTeos10(NVertLayers) {
-   SpecVol = Array2DReal("SpecVol", Mesh->NCellsAll, NVertLayers);
+    : ComputeSpecVolTeos10(VCoord->NVertLayers), Name(Name), Mesh(Mesh),
+      VCoord(VCoord) {
+   SpecVol = Array2DReal("SpecVol", Mesh->NCellsAll, VCoord->NVertLayers);
    SpecVolDisplaced =
-       Array2DReal("SpecVolDisplaced", Mesh->NCellsAll, NVertLayers);
+       Array2DReal("SpecVolDisplaced", Mesh->NCellsAll, VCoord->NVertLayers);
    // Array dimension lengths
-   NCellsAll = Mesh->NCellsAll;
-   NChunks   = NVertLayers / VecLength;
-   Name      = Name_;
+   NChunks = VCoord->NVertLayers / VecLength;
 
    defineFields();
 }
@@ -60,8 +59,8 @@ void Eos::destroyInstance() {
 void Eos::init() {
 
    if (!Instance) {
-      Instance = new Eos("Default", HorzMesh::getDefault(),
-                         VertCoord::getDefault()->NVertLayers);
+      Instance =
+          new Eos("Default", HorzMesh::getDefault(), VertCoord::getDefault());
    }
 
    Error Err; // error code
@@ -125,14 +124,14 @@ void Eos::computeSpecVol(const Array2DReal &ConservTemp,
    /// Dispatch to the correct EOS calculation
    if (EosChoice == EosType::LinearEos) {
       parallelFor(
-          "eos-linear", {NCellsAll, NChunks},
+          "eos-linear", {Mesh->NCellsAll, NChunks},
           KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
              LocComputeSpecVolLinear(LocSpecVol, ICell, KChunk, ConservTemp,
                                      AbsSalinity);
           });
    } else if (EosChoice == EosType::Teos10Eos) {
       parallelFor(
-          "eos-teos10", {NCellsAll, NChunks},
+          "eos-teos10", {Mesh->NCellsAll, NChunks},
           KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
              LocComputeSpecVolTeos10(LocSpecVol, ICell, KChunk, ConservTemp,
                                      AbsSalinity, Pressure, KDisp);
@@ -161,14 +160,14 @@ void Eos::computeSpecVolDisp(const Array2DReal &ConservTemp,
                "SpecVol is independent of pressure/depth, so the "
                "displaced value will be the same as SpecVol.");
       parallelFor(
-          "eos-linear", {NCellsAll, NChunks},
+          "eos-linear", {Mesh->NCellsAll, NChunks},
           KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
              LocComputeSpecVolLinear(LocSpecVolDisplaced, ICell, KChunk,
                                      ConservTemp, AbsSalinity);
           });
    } else if (EosChoice == EosType::Teos10Eos) {
       parallelFor(
-          "eos-teos10", {NCellsAll, NChunks},
+          "eos-teos10", {Mesh->NCellsAll, NChunks},
           KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
              LocComputeSpecVolTeos10(LocSpecVolDisplaced, ICell, KChunk,
                                      ConservTemp, AbsSalinity, Pressure, KDisp);

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -33,7 +33,7 @@ class Teos10Eos {
    Array2DReal SpecVolPCoeffs;
 
    /// constructor declaration
-   Teos10Eos(int NVertLayers);
+   Teos10Eos(const VertCoord *VCoord);
 
    //   The functor takes the full arrays of specific volume (inout),
    //   the indices ICell and KChunk, and the ocean tracers (conservative)
@@ -46,8 +46,9 @@ class Teos10Eos {
                                    I4 KDisp) const {
 
       OMEGA_SCOPE(LocSpecVolPCoeffs, SpecVolPCoeffs);
-      const I4 KStart = KChunk * VecLength;
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
 
          /// Calculate the local specific volume polynomial pressure
@@ -67,8 +68,8 @@ class Teos10Eos {
                 calcDelta(LocSpecVolPCoeffs, KVec, Pressure(ICell, K));
          } else {
             // Displacement, use the displaced pressure
-            I4 KTmp = Kokkos::min(K + KDisp, NVertLayers - 1);
-            KTmp    = Kokkos::max(0, KTmp);
+            I4 KTmp = Kokkos::min(K + KDisp, MaxLayerCell(ICell));
+            KTmp    = Kokkos::max(MinLayerCell(ICell), KTmp);
             SpecVol(ICell, K) =
                 calcRefProfile(Pressure(ICell, KTmp)) +
                 calcDelta(LocSpecVolPCoeffs, KVec, Pressure(ICell, KTmp));
@@ -236,7 +237,8 @@ class Teos10Eos {
    }
 
  private:
-   const int NVertLayers;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
 };
 
 /// Linear Equation of State
@@ -248,7 +250,7 @@ class LinearEos {
    Real RhoT0S0 = RhoFw; ///< Reference density (kg m^-3) at (T,S)=(0,0)
 
    /// constructor declaration
-   LinearEos();
+   LinearEos(const VertCoord *VCoord);
 
    //   The functor takes the full arrays of specific volume (inout),
    //   the indices ICell and KChunk, and the ocean tracers (conservative)
@@ -257,14 +259,21 @@ class LinearEos {
    KOKKOS_FUNCTION void operator()(Array2DReal SpecVol, I4 ICell, I4 KChunk,
                                    const Array2DReal &ConservTemp,
                                    const Array2DReal &AbsSalinity) const {
-      const I4 KStart = KChunk * VecLength;
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
          SpecVol(ICell, K) =
              1.0_Real / (RhoT0S0 + (DRhodT * ConservTemp(ICell, K) +
                                     DRhodS * AbsSalinity(ICell, K)));
       }
    }
+
+ private:
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
 };
 
 /// Class for Equation of State (EOS) calculations
@@ -317,8 +326,6 @@ class Eos {
 
    const HorzMesh *Mesh;    ///< Horizontal mesh
    const VertCoord *VCoord; ///< Vertical coordinate
-
-   I4 NChunks; ///< Number of vertical chunks (for vectorization)
 
    Teos10Eos ComputeSpecVolTeos10; ///< TEOS-10 specific volume calculator
    LinearEos ComputeSpecVolLinear; ///< Linear specific volume calculator

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -301,7 +301,7 @@ class Eos {
 
  private:
    /// Private constructor
-   Eos(const std::string &Name, const HorzMesh *Mesh, int NVertLayers);
+   Eos(const std::string &Name, const HorzMesh *Mesh, const VertCoord *VCoord);
 
    /// Private destructor
    ~Eos();
@@ -315,8 +315,10 @@ class Eos {
    Eos(Eos &&)                 = delete;
    Eos &operator=(Eos &&)      = delete;
 
-   I4 NCellsAll; ///< Number of horizontal cells
-   I4 NChunks;   ///< Number of vertical chunks (for vectorization)
+   const HorzMesh *Mesh;    ///< Horizontal mesh
+   const VertCoord *VCoord; ///< Vertical coordinate
+
+   I4 NChunks; ///< Number of vertical chunks (for vectorization)
 
    Teos10Eos ComputeSpecVolTeos10; ///< TEOS-10 specific volume calculator
    LinearEos ComputeSpecVolLinear; ///< Linear specific volume calculator

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -260,12 +260,26 @@ void Tendencies::computeThicknessTendenciesOnly(
 
    OMEGA_SCOPE(LocLayerThicknessTend, LayerThicknessTend);
    OMEGA_SCOPE(LocThicknessFluxDiv, ThicknessFluxDiv);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
    Array2DReal NormalVelEdge;
    State->getNormalVelocity(NormalVelEdge, VelTimeLevel);
 
    Pacer::start("Tend:computeThicknessTendenciesOnly", 1);
 
-   deepCopy(LocLayerThicknessTend, 0);
+   parallelForOuter(
+       {Mesh->NCellsAll}, KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K                     = KMin + KChunk;
+                 LocLayerThicknessTend(ICell, K) = 0;
+              });
+       });
 
    // Compute thickness flux divergence
    const Array2DReal &ThickFluxEdge =
@@ -273,10 +287,17 @@ void Tendencies::computeThicknessTendenciesOnly(
 
    if (LocThicknessFluxDiv.Enabled) {
       Pacer::start("Tend:thicknessFluxDiv", 2);
-      parallelFor(
-          {Mesh->NCellsAll, NChunks}, KOKKOS_LAMBDA(int ICell, int KChunk) {
-             LocThicknessFluxDiv(LocLayerThicknessTend, ICell, KChunk,
-                                 ThickFluxEdge, NormalVelEdge);
+      parallelForOuter(
+          {Mesh->NCellsAll}, KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocThicknessFluxDiv(LocLayerThicknessTend, ICell, KChunk,
+                                        ThickFluxEdge, NormalVelEdge);
+                 });
           });
       Pacer::stop("Tend:thicknessFluxDiv", 2);
    }
@@ -310,10 +331,23 @@ void Tendencies::computeVelocityTendenciesOnly(
    OMEGA_SCOPE(LocVelocityHyperDiff, VelocityHyperDiff);
    OMEGA_SCOPE(LocWindForcing, WindForcing);
    OMEGA_SCOPE(LocBottomDrag, BottomDrag);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
    Pacer::start("Tend:computeVelocityTendenciesOnly", 1);
 
-   deepCopy(LocNormalVelocityTend, 0);
+   parallelForOuter(
+       {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRange(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K                     = KMin + KChunk;
+                 LocNormalVelocityTend(IEdge, K) = 0;
+              });
+       });
 
    const Array2DReal &NormalVelEdge = State->NormalVelocity[VelTimeLevel];
 
@@ -326,11 +360,18 @@ void Tendencies::computeVelocityTendenciesOnly(
    State->getNormalVelocity(NormVelEdge, VelTimeLevel);
    if (LocPotientialVortHAdv.Enabled) {
       Pacer::start("Tend:potientialVortHAdv", 2);
-      parallelFor(
-          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-             LocPotientialVortHAdv(LocNormalVelocityTend, IEdge, KChunk,
-                                   NormRVortEdge, NormFEdge, FluxLayerThickEdge,
-                                   NormVelEdge);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocPotientialVortHAdv(LocNormalVelocityTend, IEdge, KChunk,
+                                          NormRVortEdge, NormFEdge,
+                                          FluxLayerThickEdge, NormVelEdge);
+                 });
           });
       Pacer::stop("Tend:potientialVortHAdv", 2);
    }
@@ -339,9 +380,15 @@ void Tendencies::computeVelocityTendenciesOnly(
    const Array2DReal &KECell = AuxState->KineticAux.KineticEnergyCell;
    if (LocKEGrad.Enabled) {
       Pacer::start("Tend:KEGrad", 2);
-      parallelFor(
-          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-             LocKEGrad(LocNormalVelocityTend, IEdge, KChunk, KECell);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocKEGrad(LocNormalVelocityTend, IEdge, KChunk, KECell);
+                 });
           });
       Pacer::stop("Tend:KEGrad", 2);
    }
@@ -350,9 +397,15 @@ void Tendencies::computeVelocityTendenciesOnly(
    const Array2DReal &SSHCell = AuxState->LayerThicknessAux.SshCell;
    if (LocSSHGrad.Enabled) {
       Pacer::start("Tend:SSHGrad", 2);
-      parallelFor(
-          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-             LocSSHGrad(LocNormalVelocityTend, IEdge, KChunk, SSHCell);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocSSHGrad(LocNormalVelocityTend, IEdge, KChunk, SSHCell);
+                 });
           });
       Pacer::stop("Tend:SSHGrad", 2);
    }
@@ -362,10 +415,16 @@ void Tendencies::computeVelocityTendenciesOnly(
    const Array2DReal &RVortVertex = AuxState->VorticityAux.RelVortVertex;
    if (LocVelocityDiffusion.Enabled) {
       Pacer::start("Tend:velocityDiffusion", 2);
-      parallelFor(
-          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-             LocVelocityDiffusion(LocNormalVelocityTend, IEdge, KChunk, DivCell,
-                                  RVortVertex);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocVelocityDiffusion(LocNormalVelocityTend, IEdge, KChunk,
+                                         DivCell, RVortVertex);
+                 });
           });
       Pacer::stop("Tend:velocityDiffusion", 2);
    }
@@ -376,10 +435,16 @@ void Tendencies::computeVelocityTendenciesOnly(
        AuxState->VelocityDel2Aux.Del2RelVortVertex;
    if (LocVelocityHyperDiff.Enabled) {
       Pacer::start("Tend:velocityHyperDiff", 2);
-      parallelFor(
-          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-             LocVelocityHyperDiff(LocNormalVelocityTend, IEdge, KChunk,
-                                  Del2DivCell, Del2RVortVertex);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocVelocityHyperDiff(LocNormalVelocityTend, IEdge, KChunk,
+                                         Del2DivCell, Del2RVortVertex);
+                 });
           });
       Pacer::stop("Tend:velocityHyperDiff", 2);
    }
@@ -390,10 +455,16 @@ void Tendencies::computeVelocityTendenciesOnly(
        AuxState->LayerThicknessAux.MeanLayerThickEdge;
    if (LocWindForcing.Enabled) {
       Pacer::start("Tend:windForcing", 2);
-      parallelFor(
-          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
-             LocWindForcing(LocNormalVelocityTend, IEdge, KChunk,
-                            NormalStressEdge, MeanLayerThickEdge);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocWindForcing(LocNormalVelocityTend, IEdge, KChunk,
+                                   NormalStressEdge, MeanLayerThickEdge);
+                 });
           });
       Pacer::stop("Tend:windForcing", 2);
    }
@@ -432,6 +503,8 @@ void Tendencies::computeTracerTendenciesOnly(
    OMEGA_SCOPE(LocTracerHorzAdv, TracerHorzAdv);
    OMEGA_SCOPE(LocTracerDiffusion, TracerDiffusion);
    OMEGA_SCOPE(LocTracerHyperDiff, TracerHyperDiff);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
    Pacer::start("Tend:computeTracerTendenciesOnly", 1);
 
@@ -442,11 +515,18 @@ void Tendencies::computeTracerTendenciesOnly(
    const Array3DReal &HTracersEdge  = AuxState->TracerAux.HTracersEdge;
    if (LocTracerHorzAdv.Enabled) {
       Pacer::start("Tend:tracerHorzAdv", 2);
-      parallelFor(
-          {NTracers, Mesh->NCellsAll, NChunks},
-          KOKKOS_LAMBDA(int L, int ICell, int KChunk) {
-             LocTracerHorzAdv(LocTracerTend, L, ICell, KChunk, NormalVelEdge,
-                              HTracersEdge);
+      parallelForOuter(
+          {NTracers, Mesh->NCellsAll},
+          KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocTracerHorzAdv(LocTracerTend, L, ICell, KChunk,
+                                     NormalVelEdge, HTracersEdge);
+                 });
           });
       Pacer::stop("Tend:tracerHorzAdv", 2);
    }
@@ -456,11 +536,18 @@ void Tendencies::computeTracerTendenciesOnly(
        AuxState->LayerThicknessAux.MeanLayerThickEdge;
    if (LocTracerDiffusion.Enabled) {
       Pacer::start("Tend:tracerDiffusion", 2);
-      parallelFor(
-          {NTracers, Mesh->NCellsAll, NChunks},
-          KOKKOS_LAMBDA(int L, int ICell, int KChunk) {
-             LocTracerDiffusion(LocTracerTend, L, ICell, KChunk, TracerArray,
-                                MeanLayerThickEdge);
+      parallelForOuter(
+          {NTracers, Mesh->NCellsAll},
+          KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocTracerDiffusion(LocTracerTend, L, ICell, KChunk,
+                                       TracerArray, MeanLayerThickEdge);
+                 });
           });
       Pacer::stop("Tend:tracerDiffusion", 2);
    }
@@ -469,11 +556,18 @@ void Tendencies::computeTracerTendenciesOnly(
    const Array3DReal &Del2TracersCell = AuxState->TracerAux.Del2TracersCell;
    if (LocTracerHyperDiff.Enabled) {
       Pacer::start("Tend:tracerHyperDiff", 2);
-      parallelFor(
-          {NTracers, Mesh->NCellsAll, NChunks},
-          KOKKOS_LAMBDA(int L, int ICell, int KChunk) {
-             LocTracerHyperDiff(LocTracerTend, L, ICell, KChunk,
-                                Del2TracersCell);
+      parallelForOuter(
+          {NTracers, Mesh->NCellsAll},
+          KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocTracerHyperDiff(LocTracerTend, L, ICell, KChunk,
+                                       Del2TracersCell);
+                 });
           });
       Pacer::stop("Tend:tracerHyperDiff", 2);
    }
@@ -496,15 +590,24 @@ void Tendencies::computeThicknessTendencies(
    OMEGA_SCOPE(LayerThicknessAux, AuxState->LayerThicknessAux);
    OMEGA_SCOPE(LayerThickCell, LayerThick);
    OMEGA_SCOPE(NormalVelEdge, NormVel);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
    Pacer::start("Tend:computeThicknessTendencies", 1);
 
    Pacer::start("Tend:computeLayerThickAux", 2);
-   parallelFor(
-       "computeLayerThickAux", {Mesh->NEdgesAll, NChunks},
-       KOKKOS_LAMBDA(int IEdge, int KChunk) {
-          LayerThicknessAux.computeVarsOnEdge(IEdge, KChunk, LayerThickCell,
-                                              NormalVelEdge);
+   parallelForOuter(
+       "computeLayerThickAux", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LayerThicknessAux.computeVarsOnEdge(
+                     IEdge, KChunk, LayerThickCell, NormalVelEdge);
+              });
        });
    Pacer::stop("Tend:computeLayerThickAux", 2);
 
@@ -541,26 +644,44 @@ void Tendencies::computeTracerTendencies(
    OMEGA_SCOPE(TracerAux, AuxState->TracerAux);
    OMEGA_SCOPE(LayerThickCell, State->LayerThickness[ThickTimeLevel]);
    OMEGA_SCOPE(NormalVelEdge, State->NormalVelocity[VelTimeLevel]);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
    Pacer::start("Tend:computeTracerTendencies", 1);
 
    Pacer::start("Tend:computeTracerAuxEdge", 2);
-   parallelFor(
-       "computeTracerAuxEdge", {NTracers, Mesh->NEdgesAll, NChunks},
-       KOKKOS_LAMBDA(int LTracer, int IEdge, int KChunk) {
-          TracerAux.computeVarsOnEdge(LTracer, IEdge, KChunk, NormalVelEdge,
-                                      LayerThickCell, TracerArray);
+   parallelForOuter(
+       "computeTracerAuxEdge", {NTracers, Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int LTracer, int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 TracerAux.computeVarsOnEdge(LTracer, IEdge, KChunk,
+                                             NormalVelEdge, LayerThickCell,
+                                             TracerArray);
+              });
        });
    Pacer::stop("Tend:computeTracerAuxEdge", 2);
 
    const auto &MeanLayerThickEdge =
        AuxState->LayerThicknessAux.MeanLayerThickEdge;
    Pacer::start("Tend:computeTracerAuxCell", 2);
-   parallelFor(
-       "computeTracerAuxCell", {NTracers, Mesh->NCellsAll, NChunks},
-       KOKKOS_LAMBDA(int LTracer, int ICell, int KChunk) {
-          TracerAux.computeVarsOnCells(LTracer, ICell, KChunk,
-                                       MeanLayerThickEdge, TracerArray);
+   parallelForOuter(
+       "computeTracerAuxCell", {NTracers, Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int LTracer, int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 TracerAux.computeVarsOnCells(LTracer, ICell, KChunk,
+                                              MeanLayerThickEdge, TracerArray);
+              });
        });
    Pacer::stop("Tend:computeTracerAuxCell", 2);
 

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -236,7 +236,6 @@ Tendencies::Tendencies(const std::string &Name, ///< [in] Name for tendencies
                             VCoord->NVertLayers);
 
    NTracers = NTracersIn;
-   NChunks  = VCoord->NVertLayers / VecLength;
 
 } // end constructor
 

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -218,13 +218,12 @@ Tendencies::Tendencies(const std::string &Name, ///< [in] Name for tendencies
                        Config *Options,         ///< [in] Configuration options
                        CustomTendencyType InCustomThicknessTend,
                        CustomTendencyType InCustomVelocityTend)
-    : ThicknessFluxDiv(Mesh), PotientialVortHAdv(Mesh, VCoord),
+    : Mesh(Mesh), ThicknessFluxDiv(Mesh), PotientialVortHAdv(Mesh, VCoord),
       KEGrad(Mesh, VCoord), SSHGrad(Mesh, VCoord),
       VelocityDiffusion(Mesh, VCoord), VelocityHyperDiff(Mesh, VCoord),
       WindForcing(Mesh, VCoord), BottomDrag(Mesh, VCoord),
       TracerHorzAdv(Mesh, VCoord), TracerDiffusion(Mesh, VCoord),
-      TracerHyperDiff(Mesh, VCoord), CustomThicknessTend(InCustomThicknessTend),
-      CustomVelocityTend(InCustomVelocityTend) {
+      TracerHyperDiff(Mesh, VCoord), CustomThicknessTend(InCustomThicknessTend) {
 
    // Tendency arrays
    LayerThicknessTend =
@@ -234,11 +233,8 @@ Tendencies::Tendencies(const std::string &Name, ///< [in] Name for tendencies
    TracerTend = Array3DReal("TracerTend", NTracersIn, Mesh->NCellsSize,
                             VCoord->NVertLayers);
 
-   // Array dimension lengths
-   NCellsAll = Mesh->NCellsAll;
-   NEdgesAll = Mesh->NEdgesAll;
-   NTracers  = NTracersIn;
-   NChunks   = VCoord->NVertLayers / VecLength;
+   NTracers = NTracersIn;
+   NChunks  = VCoord->NVertLayers / VecLength;
 
 } // end constructor
 
@@ -276,7 +272,7 @@ void Tendencies::computeThicknessTendenciesOnly(
    if (LocThicknessFluxDiv.Enabled) {
       Pacer::start("Tend:thicknessFluxDiv", 2);
       parallelFor(
-          {NCellsAll, NChunks}, KOKKOS_LAMBDA(int ICell, int KChunk) {
+          {Mesh->NCellsAll, NChunks}, KOKKOS_LAMBDA(int ICell, int KChunk) {
              LocThicknessFluxDiv(LocLayerThicknessTend, ICell, KChunk,
                                  ThickFluxEdge, NormalVelEdge);
           });
@@ -329,7 +325,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    if (LocPotientialVortHAdv.Enabled) {
       Pacer::start("Tend:potientialVortHAdv", 2);
       parallelFor(
-          {NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
              LocPotientialVortHAdv(LocNormalVelocityTend, IEdge, KChunk,
                                    NormRVortEdge, NormFEdge, FluxLayerThickEdge,
                                    NormVelEdge);
@@ -342,7 +338,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    if (LocKEGrad.Enabled) {
       Pacer::start("Tend:KEGrad", 2);
       parallelFor(
-          {NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
              LocKEGrad(LocNormalVelocityTend, IEdge, KChunk, KECell);
           });
       Pacer::stop("Tend:KEGrad", 2);
@@ -353,7 +349,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    if (LocSSHGrad.Enabled) {
       Pacer::start("Tend:SSHGrad", 2);
       parallelFor(
-          {NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
              LocSSHGrad(LocNormalVelocityTend, IEdge, KChunk, SSHCell);
           });
       Pacer::stop("Tend:SSHGrad", 2);
@@ -365,7 +361,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    if (LocVelocityDiffusion.Enabled) {
       Pacer::start("Tend:velocityDiffusion", 2);
       parallelFor(
-          {NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
              LocVelocityDiffusion(LocNormalVelocityTend, IEdge, KChunk, DivCell,
                                   RVortVertex);
           });
@@ -379,7 +375,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    if (LocVelocityHyperDiff.Enabled) {
       Pacer::start("Tend:velocityHyperDiff", 2);
       parallelFor(
-          {NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
              LocVelocityHyperDiff(LocNormalVelocityTend, IEdge, KChunk,
                                   Del2DivCell, Del2RVortVertex);
           });
@@ -393,7 +389,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    if (LocWindForcing.Enabled) {
       Pacer::start("Tend:windForcing", 2);
       parallelFor(
-          {NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
+          {Mesh->NEdgesAll, NChunks}, KOKKOS_LAMBDA(int IEdge, int KChunk) {
              LocWindForcing(LocNormalVelocityTend, IEdge, KChunk,
                             NormalStressEdge, MeanLayerThickEdge);
           });
@@ -404,7 +400,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    if (LocBottomDrag.Enabled) {
       Pacer::start("Tend:bottomDrag", 2);
       parallelFor(
-          {NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
              LocBottomDrag(LocNormalVelocityTend, IEdge, NormalVelEdge, KECell,
                            MeanLayerThickEdge);
           });
@@ -445,7 +441,7 @@ void Tendencies::computeTracerTendenciesOnly(
    if (LocTracerHorzAdv.Enabled) {
       Pacer::start("Tend:tracerHorzAdv", 2);
       parallelFor(
-          {NTracers, NCellsAll, NChunks},
+          {NTracers, Mesh->NCellsAll, NChunks},
           KOKKOS_LAMBDA(int L, int ICell, int KChunk) {
              LocTracerHorzAdv(LocTracerTend, L, ICell, KChunk, NormalVelEdge,
                               HTracersEdge);
@@ -459,7 +455,7 @@ void Tendencies::computeTracerTendenciesOnly(
    if (LocTracerDiffusion.Enabled) {
       Pacer::start("Tend:tracerDiffusion", 2);
       parallelFor(
-          {NTracers, NCellsAll, NChunks},
+          {NTracers, Mesh->NCellsAll, NChunks},
           KOKKOS_LAMBDA(int L, int ICell, int KChunk) {
              LocTracerDiffusion(LocTracerTend, L, ICell, KChunk, TracerArray,
                                 MeanLayerThickEdge);
@@ -472,7 +468,7 @@ void Tendencies::computeTracerTendenciesOnly(
    if (LocTracerHyperDiff.Enabled) {
       Pacer::start("Tend:tracerHyperDiff", 2);
       parallelFor(
-          {NTracers, NCellsAll, NChunks},
+          {NTracers, Mesh->NCellsAll, NChunks},
           KOKKOS_LAMBDA(int L, int ICell, int KChunk) {
              LocTracerHyperDiff(LocTracerTend, L, ICell, KChunk,
                                 Del2TracersCell);
@@ -503,7 +499,7 @@ void Tendencies::computeThicknessTendencies(
 
    Pacer::start("Tend:computeLayerThickAux", 2);
    parallelFor(
-       "computeLayerThickAux", {NEdgesAll, NChunks},
+       "computeLayerThickAux", {Mesh->NEdgesAll, NChunks},
        KOKKOS_LAMBDA(int IEdge, int KChunk) {
           LayerThicknessAux.computeVarsOnEdge(IEdge, KChunk, LayerThickCell,
                                               NormalVelEdge);
@@ -548,7 +544,7 @@ void Tendencies::computeTracerTendencies(
 
    Pacer::start("Tend:computeTracerAuxEdge", 2);
    parallelFor(
-       "computeTracerAuxEdge", {NTracers, NEdgesAll, NChunks},
+       "computeTracerAuxEdge", {NTracers, Mesh->NEdgesAll, NChunks},
        KOKKOS_LAMBDA(int LTracer, int IEdge, int KChunk) {
           TracerAux.computeVarsOnEdge(LTracer, IEdge, KChunk, NormalVelEdge,
                                       LayerThickCell, TracerArray);
@@ -559,7 +555,7 @@ void Tendencies::computeTracerTendencies(
        AuxState->LayerThicknessAux.MeanLayerThickEdge;
    Pacer::start("Tend:computeTracerAuxCell", 2);
    parallelFor(
-       "computeTracerAuxCell", {NTracers, NCellsAll, NChunks},
+       "computeTracerAuxCell", {NTracers, Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(int LTracer, int ICell, int KChunk) {
           TracerAux.computeVarsOnCells(LTracer, ICell, KChunk,
                                        MeanLayerThickEdge, TracerArray);

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -508,7 +508,18 @@ void Tendencies::computeTracerTendenciesOnly(
 
    Pacer::start("Tend:computeTracerTendenciesOnly", 1);
 
-   deepCopy(LocTracerTend, 0);
+   parallelForOuter(
+       {NTracers, Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K                = KMin + KChunk;
+                 LocTracerTend(L, ICell, K) = 0;
+              });
+       });
 
    // compute tracer horizotal advection
    const Array2DReal &NormalVelEdge = State->NormalVelocity[VelTimeLevel];

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -218,12 +218,14 @@ Tendencies::Tendencies(const std::string &Name, ///< [in] Name for tendencies
                        Config *Options,         ///< [in] Configuration options
                        CustomTendencyType InCustomThicknessTend,
                        CustomTendencyType InCustomVelocityTend)
-    : Mesh(Mesh), ThicknessFluxDiv(Mesh), PotientialVortHAdv(Mesh, VCoord),
-      KEGrad(Mesh, VCoord), SSHGrad(Mesh, VCoord),
-      VelocityDiffusion(Mesh, VCoord), VelocityHyperDiff(Mesh, VCoord),
-      WindForcing(Mesh, VCoord), BottomDrag(Mesh, VCoord),
-      TracerHorzAdv(Mesh, VCoord), TracerDiffusion(Mesh, VCoord),
-      TracerHyperDiff(Mesh, VCoord), CustomThicknessTend(InCustomThicknessTend) {
+    : Mesh(Mesh), VCoord(VCoord), ThicknessFluxDiv(Mesh, VCoord),
+      PotientialVortHAdv(Mesh, VCoord), KEGrad(Mesh, VCoord),
+      SSHGrad(Mesh, VCoord), VelocityDiffusion(Mesh, VCoord),
+      VelocityHyperDiff(Mesh, VCoord), WindForcing(Mesh, VCoord),
+      BottomDrag(Mesh, VCoord), TracerHorzAdv(Mesh, VCoord),
+      TracerDiffusion(Mesh, VCoord), TracerHyperDiff(Mesh, VCoord),
+      CustomThicknessTend(InCustomThicknessTend),
+      CustomVelocityTend(InCustomVelocityTend) {
 
    // Tendency arrays
    LayerThicknessTend =

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -167,9 +167,10 @@ class Tendencies {
    Tendencies(const Tendencies &) = delete;
    Tendencies(Tendencies &&)      = delete;
 
-   const HorzMesh *Mesh; ///< Pointer to horizontal mesh
-   I4 NTracers;          ///< Number of tracers
-   I4 NChunks;           ///< Number of vertical layer chunks
+   const HorzMesh *Mesh;    ///< Pointer to horizontal mesh
+   const VertCoord *VCoord; ///< Pointer to vertical coordinate
+   I4 NTracers;             ///< Number of tracers
+   I4 NChunks;              ///< Number of vertical layer chunks
 
    // Pointer to default tendencies
    static Tendencies *DefaultTendencies;

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -170,7 +170,6 @@ class Tendencies {
    const HorzMesh *Mesh;    ///< Pointer to horizontal mesh
    const VertCoord *VCoord; ///< Pointer to vertical coordinate
    I4 NTracers;             ///< Number of tracers
-   I4 NChunks;              ///< Number of vertical layer chunks
 
    // Pointer to default tendencies
    static Tendencies *DefaultTendencies;

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -167,11 +167,9 @@ class Tendencies {
    Tendencies(const Tendencies &) = delete;
    Tendencies(Tendencies &&)      = delete;
 
-   // Mesh sizes
-   I4 NCellsAll; ///< Number of cells including full halo
-   I4 NEdgesAll; ///< Number of edges including full halo
-   I4 NTracers;  ///< Number of tracers
-   I4 NChunks;   ///< Number of vertical layer chunks
+   const HorzMesh *Mesh; ///< Pointer to horizontal mesh
+   I4 NTracers;          ///< Number of tracers
+   I4 NChunks;           ///< Number of vertical layer chunks
 
    // Pointer to default tendencies
    static Tendencies *DefaultTendencies;

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -74,8 +74,9 @@ TracerHorzAdvOnCell::TracerHorzAdvOnCell(const HorzMesh *Mesh,
                                          const VertCoord *VCoord)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
-      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell), EdgeMask(VCoord->EdgeMask),
-      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell),
+      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
+      EdgeMask(VCoord->EdgeMask), MinLayerCell(VCoord->MinLayerCell),
+      MaxLayerCell(VCoord->MaxLayerCell),
       MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
       MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -21,62 +21,83 @@ ThicknessFluxDivOnCell::ThicknessFluxDivOnCell(const HorzMesh *Mesh,
                                                const VertCoord *VCoord)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
-      EdgeSignOnCell(Mesh->EdgeSignOnCell) {}
+      EdgeSignOnCell(Mesh->EdgeSignOnCell), MinLayerCell(VCoord->MinLayerCell),
+      MaxLayerCell(VCoord->MaxLayerCell),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 PotentialVortHAdvOnEdge::PotentialVortHAdvOnEdge(const HorzMesh *Mesh,
                                                  const VertCoord *VCoord)
     : NEdgesOnEdge(Mesh->NEdgesOnEdge), EdgesOnEdge(Mesh->EdgesOnEdge),
-      WeightsOnEdge(Mesh->WeightsOnEdge), EdgeMask(VCoord->EdgeMask) {}
+      WeightsOnEdge(Mesh->WeightsOnEdge), EdgeMask(VCoord->EdgeMask),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 KEGradOnEdge::KEGradOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord)
     : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge),
-      EdgeMask(VCoord->EdgeMask) {}
+      EdgeMask(VCoord->EdgeMask), MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 SSHGradOnEdge::SSHGradOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord)
     : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge),
-      EdgeMask(VCoord->EdgeMask) {}
+      EdgeMask(VCoord->EdgeMask), MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 VelocityDiffusionOnEdge::VelocityDiffusionOnEdge(const HorzMesh *Mesh,
                                                  const VertCoord *VCoord)
     : CellsOnEdge(Mesh->CellsOnEdge), VerticesOnEdge(Mesh->VerticesOnEdge),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge),
-      MeshScalingDel2(Mesh->MeshScalingDel2), EdgeMask(VCoord->EdgeMask) {}
+      MeshScalingDel2(Mesh->MeshScalingDel2), EdgeMask(VCoord->EdgeMask),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 VelocityHyperDiffOnEdge::VelocityHyperDiffOnEdge(const HorzMesh *Mesh,
                                                  const VertCoord *VCoord)
     : CellsOnEdge(Mesh->CellsOnEdge), VerticesOnEdge(Mesh->VerticesOnEdge),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge),
-      MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(VCoord->EdgeMask) {}
+      MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(VCoord->EdgeMask),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 WindForcingOnEdge::WindForcingOnEdge(const HorzMesh *Mesh,
                                      const VertCoord *VCoord)
-    : Enabled(false), LocRhoSw(RhoSw), EdgeMask(VCoord->EdgeMask) {}
+    : Enabled(false), LocRhoSw(RhoSw), EdgeMask(VCoord->EdgeMask),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot) {}
 
 BottomDragOnEdge::BottomDragOnEdge(const HorzMesh *Mesh,
                                    const VertCoord *VCoord)
     : Enabled(false), Coeff(0), CellsOnEdge(Mesh->CellsOnEdge),
-      NVertLayers(VCoord->NVertLayers), EdgeMask(VCoord->EdgeMask) {}
+      NVertLayers(VCoord->NVertLayers), EdgeMask(VCoord->EdgeMask),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 TracerHorzAdvOnCell::TracerHorzAdvOnCell(const HorzMesh *Mesh,
                                          const VertCoord *VCoord)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
-      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
-      EdgeMask(VCoord->EdgeMask) {}
+      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell), EdgeMask(VCoord->EdgeMask),
+      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 TracerDiffOnCell::TracerDiffOnCell(const HorzMesh *Mesh,
                                    const VertCoord *VCoord)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
       DvEdge(Mesh->DvEdge), DcEdge(Mesh->DcEdge), AreaCell(Mesh->AreaCell),
-      MeshScalingDel2(Mesh->MeshScalingDel2), EdgeMask(VCoord->EdgeMask) {}
+      MeshScalingDel2(Mesh->MeshScalingDel2), EdgeMask(VCoord->EdgeMask),
+      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 TracerHyperDiffOnCell::TracerHyperDiffOnCell(const HorzMesh *Mesh,
                                              const VertCoord *VCoord)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
       DvEdge(Mesh->DvEdge), DcEdge(Mesh->DcEdge), AreaCell(Mesh->AreaCell),
-      MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(VCoord->EdgeMask) {}
+      MeshScalingDel4(Mesh->MeshScalingDel4), EdgeMask(VCoord->EdgeMask),
+      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 } // end namespace OMEGA
 

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -14,11 +14,11 @@
 #include "HorzMesh.h"
 #include "OceanState.h"
 #include "Tracers.h"
-#include "VertCoord.h"
 
 namespace OMEGA {
 
-ThicknessFluxDivOnCell::ThicknessFluxDivOnCell(const HorzMesh *Mesh)
+ThicknessFluxDivOnCell::ThicknessFluxDivOnCell(const HorzMesh *Mesh,
+                                               const VertCoord *VCoord)
     : NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
       EdgeSignOnCell(Mesh->EdgeSignOnCell) {}

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -29,7 +29,7 @@ class ThicknessFluxDivOnCell {
    bool Enabled;
 
    /// constructor declaration
-   ThicknessFluxDivOnCell(const HorzMesh *Mesh);
+   ThicknessFluxDivOnCell(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    /// The functor takes cell index, vertical chunk index, and thickness flux
    /// array as inputs, outputs the tendency array

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -37,10 +37,9 @@ class ThicknessFluxDivOnCell {
                                    const Array2DReal &ThicknessFlux,
                                    const Array2DReal &NormalVelEdge) const {
 
-      const I4 KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
-      const I4 KLenCell =
-          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
-      const I4 KEndCell      = KStartCell + KLenCell - 1;
+      const I4 KStartCell = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLenCell = chunkLength(KChunk, KStartCell, MaxLayerCell(ICell));
+      const I4 KEndCell = KStartCell + KLenCell - 1;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real DivTmp[VecLength] = {0};
@@ -96,9 +95,8 @@ class PotentialVortHAdvOnEdge {
                                    const Array2DReal &FluxLayerThickEdge,
                                    const Array2DReal &NormVelEdge) const {
 
-      const I4 KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
-      const I4 KLen =
-          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
+      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
       Real VortTmp[VecLength] = {0};
 
       for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
@@ -143,11 +141,10 @@ class KEGradOnEdge {
    KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
                                    const Array2DReal &KECell) const {
 
-      const I4 KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
-      const I4 KLen =
-          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
-      const I4 JCell0      = CellsOnEdge(IEdge, 0);
-      const I4 JCell1      = CellsOnEdge(IEdge, 1);
+      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
+      const I4 JCell0 = CellsOnEdge(IEdge, 0);
+      const I4 JCell1 = CellsOnEdge(IEdge, 1);
       const Real InvDcEdge = 1._Real / DcEdge(IEdge);
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
@@ -179,11 +176,10 @@ class SSHGradOnEdge {
    KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
                                    const Array2DReal &SshCell) const {
 
-      const I4 KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
-      const I4 KLen =
-          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
-      const I4 ICell0      = CellsOnEdge(IEdge, 0);
-      const I4 ICell1      = CellsOnEdge(IEdge, 1);
+      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
+      const I4 ICell0 = CellsOnEdge(IEdge, 0);
+      const I4 ICell1 = CellsOnEdge(IEdge, 1);
       const Real InvDcEdge = 1._Real / DcEdge(IEdge);
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
@@ -219,9 +215,8 @@ class VelocityDiffusionOnEdge {
                                    const Array2DReal &DivCell,
                                    const Array2DReal &RVortVertex) const {
 
-      const I4 KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
-      const I4 KLen =
-          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
+      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
       const I4 ICell0 = CellsOnEdge(IEdge, 0);
       const I4 ICell1 = CellsOnEdge(IEdge, 1);
 
@@ -272,9 +267,8 @@ class VelocityHyperDiffOnEdge {
                                    const Array2DReal &Del2DivCell,
                                    const Array2DReal &Del2RVortVertex) const {
 
-      const I4 KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
-      const I4 KLen =
-          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
+      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
       const I4 ICell0 = CellsOnEdge(IEdge, 0);
       const I4 ICell1 = CellsOnEdge(IEdge, 1);
 
@@ -383,10 +377,9 @@ class TracerHorzAdvOnCell {
                                    I4 KChunk, const Array2DReal &NormVelEdge,
                                    const Array3DReal &HTracersOnEdge) const {
 
-      const I4 KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
-      const I4 KLenCell =
-          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
-      const I4 KEndCell      = KStartCell + KLenCell - 1;
+      const I4 KStartCell = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLenCell = chunkLength(KChunk, KStartCell, MaxLayerCell(ICell));
+      const I4 KEndCell = KStartCell + KLenCell - 1;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real HAdvTmp[VecLength] = {0};
@@ -438,10 +431,9 @@ class TracerDiffOnCell {
               const Array3DReal &TracerCell,
               const Array2DReal &MeanLayerThickEdge) const {
 
-      const I4 KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
-      const I4 KLenCell =
-          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
-      const I4 KEndCell      = KStartCell + KLenCell - 1;
+      const I4 KStartCell = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLenCell = chunkLength(KChunk, KStartCell, MaxLayerCell(ICell));
+      const I4 KEndCell = KStartCell + KLenCell - 1;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real DiffTmp[VecLength] = {0};
@@ -501,10 +493,9 @@ class TracerHyperDiffOnCell {
                                    I4 KChunk,
                                    const Array3DReal &TrDel2Cell) const {
 
-      const I4 KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
-      const I4 KLenCell =
-          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
-      const I4 KEndCell      = KStartCell + KLenCell - 1;
+      const I4 KStartCell = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLenCell = chunkLength(KChunk, KStartCell, MaxLayerCell(ICell));
+      const I4 KEndCell = KStartCell + KLenCell - 1;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real HypTmp[VecLength] = {0};

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -37,23 +37,30 @@ class ThicknessFluxDivOnCell {
                                    const Array2DReal &ThicknessFlux,
                                    const Array2DReal &NormalVelEdge) const {
 
-      const I4 KStart        = KChunk * VecLength;
+      const I4 KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
+      const I4 KLenCell =
+          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
+      const I4 KEndCell      = KStartCell + KLenCell - 1;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real DivTmp[VecLength] = {0};
 
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
          const I4 JEdge = EdgesOnCell(ICell, J);
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
-            const I4 K = KStart + KVec;
+
+         const I4 KStartEdge = Kokkos::max(KStartCell, MinLayerEdgeBot(JEdge));
+         const I4 KEndEdge   = Kokkos::min(KEndCell, MaxLayerEdgeTop(JEdge));
+
+         for (int K = KStartEdge; K <= KEndEdge; ++K) {
+            const I4 KVec = K - KStartCell;
             DivTmp[KVec] -= DvEdge(JEdge) * EdgeSignOnCell(ICell, J) *
                             ThicknessFlux(JEdge, K) * NormalVelEdge(JEdge, K) *
                             InvAreaCell;
          }
       }
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
-         const I4 K = KStart + KVec;
+      for (int KVec = 0; KVec < KLenCell; ++KVec) {
+         const I4 K = KStartCell + KVec;
          Tend(ICell, K) -= DivTmp[KVec];
       }
    }
@@ -64,6 +71,10 @@ class ThicknessFluxDivOnCell {
    Array1DReal DvEdge;
    Array1DReal AreaCell;
    Array2DReal EdgeSignOnCell;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
 };
 
 /// Horizontal advection of potential vorticity defined on edges, for
@@ -85,12 +96,14 @@ class PotentialVortHAdvOnEdge {
                                    const Array2DReal &FluxLayerThickEdge,
                                    const Array2DReal &NormVelEdge) const {
 
-      const I4 KStart         = KChunk * VecLength;
+      const I4 KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
+      const I4 KLen =
+          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
       Real VortTmp[VecLength] = {0};
 
       for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
          I4 JEdge = EdgesOnEdge(IEdge, J);
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
+         for (int KVec = 0; KVec < KLen; ++KVec) {
             const I4 K    = KStart + KVec;
             Real NormVort = (NormRVortEdge(IEdge, K) + NormFEdge(IEdge, K) +
                              NormRVortEdge(JEdge, K) + NormFEdge(JEdge, K)) *
@@ -102,7 +115,7 @@ class PotentialVortHAdvOnEdge {
          }
       }
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
          Tend(IEdge, K) += EdgeMask(IEdge, K) * VortTmp[KVec];
       }
@@ -113,6 +126,8 @@ class PotentialVortHAdvOnEdge {
    Array2DI4 EdgesOnEdge;
    Array2DReal WeightsOnEdge;
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
 };
 
 /// Gradient of kinetic energy defined on edges, for momentum equation
@@ -128,12 +143,14 @@ class KEGradOnEdge {
    KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
                                    const Array2DReal &KECell) const {
 
-      const I4 KStart      = KChunk * VecLength;
+      const I4 KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
+      const I4 KLen =
+          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
       const I4 JCell0      = CellsOnEdge(IEdge, 0);
       const I4 JCell1      = CellsOnEdge(IEdge, 1);
       const Real InvDcEdge = 1._Real / DcEdge(IEdge);
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
          Tend(IEdge, K) -= EdgeMask(IEdge, K) *
                            (KECell(JCell1, K) - KECell(JCell0, K)) * InvDcEdge;
@@ -144,6 +161,8 @@ class KEGradOnEdge {
    Array2DI4 CellsOnEdge;
    Array1DReal DcEdge;
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
 };
 
 /// Gradient of sea surface height defined on edges multipled by gravitational
@@ -160,12 +179,14 @@ class SSHGradOnEdge {
    KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
                                    const Array2DReal &SshCell) const {
 
-      const I4 KStart      = KChunk * VecLength;
+      const I4 KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
+      const I4 KLen =
+          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
       const I4 ICell0      = CellsOnEdge(IEdge, 0);
       const I4 ICell1      = CellsOnEdge(IEdge, 1);
       const Real InvDcEdge = 1._Real / DcEdge(IEdge);
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
          Tend(IEdge, K) -= EdgeMask(IEdge, K) * Gravity *
                            (SshCell(ICell1, K) - SshCell(ICell0, K)) *
@@ -177,6 +198,8 @@ class SSHGradOnEdge {
    Array2DI4 CellsOnEdge;
    Array1DReal DcEdge;
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
 };
 
 /// Laplacian horizontal mixing, for momentum equation
@@ -196,7 +219,9 @@ class VelocityDiffusionOnEdge {
                                    const Array2DReal &DivCell,
                                    const Array2DReal &RVortVertex) const {
 
-      const I4 KStart = KChunk * VecLength;
+      const I4 KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
+      const I4 KLen =
+          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
       const I4 ICell0 = CellsOnEdge(IEdge, 0);
       const I4 ICell1 = CellsOnEdge(IEdge, 1);
 
@@ -206,7 +231,7 @@ class VelocityDiffusionOnEdge {
       const Real DcEdgeInv = 1._Real / DcEdge(IEdge);
       const Real DvEdgeInv = 1._Real / DvEdge(IEdge);
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
          const Real Del2U =
              ((DivCell(ICell1, K) - DivCell(ICell0, K)) * DcEdgeInv -
@@ -225,6 +250,8 @@ class VelocityDiffusionOnEdge {
    Array1DReal DvEdge;
    Array1DReal MeshScalingDel2;
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
 };
 
 /// Biharmonic horizontal mixing, for momentum equation
@@ -245,7 +272,9 @@ class VelocityHyperDiffOnEdge {
                                    const Array2DReal &Del2DivCell,
                                    const Array2DReal &Del2RVortVertex) const {
 
-      const I4 KStart = KChunk * VecLength;
+      const I4 KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
+      const I4 KLen =
+          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
       const I4 ICell0 = CellsOnEdge(IEdge, 0);
       const I4 ICell1 = CellsOnEdge(IEdge, 1);
 
@@ -255,7 +284,7 @@ class VelocityHyperDiffOnEdge {
       const Real DcEdgeInv = 1._Real / DcEdge(IEdge);
       const Real DvEdgeInv = 1._Real / DvEdge(IEdge);
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
          const Real Del2U =
              (DivFactor * (Del2DivCell(ICell1, K) - Del2DivCell(ICell0, K)) *
@@ -275,6 +304,8 @@ class VelocityHyperDiffOnEdge {
    Array1DReal DvEdge;
    Array1DReal MeshScalingDel4;
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
 };
 
 /// Wind forcing
@@ -292,7 +323,7 @@ class WindForcingOnEdge {
                                    const Array1DReal &NormalStressEdge,
                                    const Array2DReal &LayerThickEdge) const {
       if (KChunk == 0) {
-         const I4 K = 0;
+         const I4 K = MinLayerEdgeBot(IEdge);
 
          const Real InvThickEdge = 1._Real / LayerThickEdge(IEdge, K);
          Tend(IEdge, K) += EdgeMask(IEdge, K) * InvThickEdge *
@@ -302,6 +333,7 @@ class WindForcingOnEdge {
 
  private:
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerEdgeBot;
 };
 
 /// Bottom drag
@@ -320,7 +352,7 @@ class BottomDragOnEdge {
                                    const Array2DReal &NormalVelEdge,
                                    const Array2DReal &KECell,
                                    const Array2DReal &LayerThickEdge) const {
-      const I4 KBot = NVertLayers - 1;
+      const I4 KBot = MaxLayerEdgeTop(IEdge);
 
       const I4 JCell0 = CellsOnEdge(IEdge, 0);
       const I4 JCell1 = CellsOnEdge(IEdge, 1);
@@ -337,6 +369,7 @@ class BottomDragOnEdge {
    I4 NVertLayers;
    Array2DI4 CellsOnEdge;
    Array2DReal EdgeMask;
+   Array1DI4 MaxLayerEdgeTop;
 };
 
 // Tracer horizontal advection term
@@ -350,24 +383,29 @@ class TracerHorzAdvOnCell {
                                    I4 KChunk, const Array2DReal &NormVelEdge,
                                    const Array3DReal &HTracersOnEdge) const {
 
-      const I4 KStart        = KChunk * VecLength;
+      const I4 KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
+      const I4 KLenCell =
+          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
+      const I4 KEndCell      = KStartCell + KLenCell - 1;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real HAdvTmp[VecLength] = {0};
 
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
-         const I4 JEdge = EdgesOnCell(ICell, J);
+         const I4 JEdge      = EdgesOnCell(ICell, J);
+         const I4 KStartEdge = Kokkos::max(KStartCell, MinLayerEdgeBot(JEdge));
+         const I4 KEndEdge   = Kokkos::min(KEndCell, MaxLayerEdgeTop(JEdge));
 
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
-            const I4 K = KStart + KVec;
+         for (int K = KStartEdge; K <= KEndEdge; ++K) {
+            const I4 KVec = K - KStartCell;
             HAdvTmp[KVec] -= EdgeMask(JEdge, K) * DvEdge(JEdge) *
                              EdgeSignOnCell(ICell, J) *
                              HTracersOnEdge(L, JEdge, K) *
                              NormVelEdge(JEdge, K) * InvAreaCell;
          }
       }
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
-         const I4 K = KStart + KVec;
+      for (int KVec = 0; KVec < KLenCell; ++KVec) {
+         const I4 K = KStartCell + KVec;
          Tend(L, ICell, K) -= HAdvTmp[KVec];
       }
    }
@@ -380,6 +418,10 @@ class TracerHorzAdvOnCell {
    Array1DReal DvEdge;
    Array1DReal AreaCell;
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
 };
 
 // Tracer horizontal diffusion term
@@ -396,13 +438,18 @@ class TracerDiffOnCell {
               const Array3DReal &TracerCell,
               const Array2DReal &MeanLayerThickEdge) const {
 
-      const I4 KStart        = KChunk * VecLength;
+      const I4 KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
+      const I4 KLenCell =
+          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
+      const I4 KEndCell      = KStartCell + KLenCell - 1;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real DiffTmp[VecLength] = {0};
 
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
-         const I4 JEdge = EdgesOnCell(ICell, J);
+         const I4 JEdge      = EdgesOnCell(ICell, J);
+         const I4 KStartEdge = Kokkos::max(KStartCell, MinLayerEdgeBot(JEdge));
+         const I4 KEndEdge   = Kokkos::min(KEndCell, MaxLayerEdgeTop(JEdge));
 
          const I4 JCell0 = CellsOnEdge(JEdge, 0);
          const I4 JCell1 = CellsOnEdge(JEdge, 1);
@@ -410,8 +457,8 @@ class TracerDiffOnCell {
          const Real RTemp =
              MeshScalingDel2(JEdge) * DvEdge(JEdge) / DcEdge(JEdge);
 
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
-            const I4 K = KStart + KVec;
+         for (int K = KStartEdge; K <= KEndEdge; ++K) {
+            const I4 KVec = K - KStartCell;
             const Real TracerGrad =
                 (TracerCell(L, JCell1, K) - TracerCell(L, JCell0, K));
 
@@ -419,8 +466,8 @@ class TracerDiffOnCell {
                              RTemp * MeanLayerThickEdge(JEdge, K) * TracerGrad;
          }
       }
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
-         const I4 K = KStart + KVec;
+      for (int KVec = 0; KVec < KLenCell; ++KVec) {
+         const I4 K = KStartCell + KVec;
          Tend(L, ICell, K) += EddyDiff2 * DiffTmp[KVec] * InvAreaCell;
       }
    }
@@ -435,6 +482,10 @@ class TracerDiffOnCell {
    Array1DReal AreaCell;
    Array1DReal MeshScalingDel2;
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
 };
 
 // Tracer biharmonic horizontal mixing term
@@ -450,13 +501,18 @@ class TracerHyperDiffOnCell {
                                    I4 KChunk,
                                    const Array3DReal &TrDel2Cell) const {
 
-      const I4 KStart        = KChunk * VecLength;
+      const I4 KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
+      const I4 KLenCell =
+          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
+      const I4 KEndCell      = KStartCell + KLenCell - 1;
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real HypTmp[VecLength] = {0};
 
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
-         const I4 JEdge = EdgesOnCell(ICell, J);
+         const I4 JEdge      = EdgesOnCell(ICell, J);
+         const I4 KStartEdge = Kokkos::max(KStartCell, MinLayerEdgeBot(JEdge));
+         const I4 KEndEdge   = Kokkos::min(KEndCell, MaxLayerEdgeTop(JEdge));
 
          const I4 JCell0 = CellsOnEdge(JEdge, 0);
          const I4 JCell1 = CellsOnEdge(JEdge, 1);
@@ -464,8 +520,8 @@ class TracerHyperDiffOnCell {
          const Real RTemp =
              MeshScalingDel4(JEdge) * DvEdge(JEdge) / DcEdge(JEdge);
 
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
-            const I4 K = KStart + KVec;
+         for (int K = KStartEdge; K <= KEndEdge; ++K) {
+            const I4 KVec = K - KStartCell;
             const Real Del2TrGrad =
                 (TrDel2Cell(L, JCell1, K) - TrDel2Cell(L, JCell0, K));
 
@@ -473,8 +529,8 @@ class TracerHyperDiffOnCell {
                             RTemp * Del2TrGrad;
          }
       }
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
-         const I4 K = KStart + KVec;
+      for (int KVec = 0; KVec < KLenCell; ++KVec) {
+         const I4 K = KStartCell + KVec;
          Tend(L, ICell, K) -= EddyDiff4 * HypTmp[KVec] * InvAreaCell;
       }
    }
@@ -489,6 +545,10 @@ class TracerHyperDiffOnCell {
    Array1DReal AreaCell;
    Array1DReal MeshScalingDel4;
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -31,6 +31,14 @@ enum class MovementWeightType {
    Uniform /// Uniform stretching
 };
 
+KOKKOS_INLINE_FUNCTION int vertRange(int KMin, int KMax) {
+   return KMax - KMin + 1;
+}
+
+KOKKOS_INLINE_FUNCTION int vertRangeChunked(int KMin, int KMax) {
+   return (vertRange(KMin, KMax) + VecLength - 1) / VecLength;
+}
+
 class VertCoord {
 
  private:

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -39,6 +39,18 @@ KOKKOS_INLINE_FUNCTION int vertRangeChunked(int KMin, int KMax) {
    return (vertRange(KMin, KMax) + VecLength - 1) / VecLength;
 }
 
+KOKKOS_INLINE_FUNCTION int chunkStart(int KChunk, int KMin) {
+   return KMin + KChunk * VecLength;
+}
+
+KOKKOS_INLINE_FUNCTION int chunkLength(int KChunk, int KStart, int KMax) {
+   if constexpr (VecLength == 1) {
+      return 1;
+   } else {
+      return (KStart + VecLength - 1) > KMax ? (KMax - KStart + 1) : VecLength;
+   }
+}
+
 class VertCoord {
 
  private:

--- a/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.cpp
@@ -14,7 +14,8 @@ KineticAuxVars::KineticAuxVars(const std::string &AuxStateSuffix,
                       VCoord->NVertLayers),
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       EdgeSignOnCell(Mesh->EdgeSignOnCell), DcEdge(Mesh->DcEdge),
-      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell) {}
+      DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
+      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell) {}
 
 void KineticAuxVars::registerFields(
     const std::string &AuxGroupName, // name of Auxiliary field group

--- a/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.cpp
@@ -7,11 +7,11 @@
 namespace OMEGA {
 
 KineticAuxVars::KineticAuxVars(const std::string &AuxStateSuffix,
-                               const HorzMesh *Mesh, int NVertLayers)
+                               const HorzMesh *Mesh, const VertCoord *VCoord)
     : KineticEnergyCell("KineticEnergyCell" + AuxStateSuffix, Mesh->NCellsSize,
-                        NVertLayers),
+                        VCoord->NVertLayers),
       VelocityDivCell("VelocityDivCell" + AuxStateSuffix, Mesh->NCellsSize,
-                      NVertLayers),
+                      VCoord->NVertLayers),
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       EdgeSignOnCell(Mesh->EdgeSignOnCell), DcEdge(Mesh->DcEdge),
       DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell) {}

--- a/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.h
@@ -21,8 +21,12 @@ class KineticAuxVars {
    KOKKOS_FUNCTION void
    computeVarsOnCell(int ICell, int KChunk,
                      const Array2DReal &NormalVelEdge) const {
+
+      const int KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
+      const int KLenCell =
+          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
+
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
-      const int KStart       = KChunk * VecLength;
 
       Real KineticEnergyCellTmp[VecLength] = {0};
       Real VelocityDivCellTmp[VecLength]   = {0};
@@ -30,8 +34,8 @@ class KineticAuxVars {
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
          const int JEdge     = EdgesOnCell(ICell, J);
          const Real AreaEdge = 0.5_Real * DvEdge(JEdge) * DcEdge(JEdge);
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
-            const int K = KStart + KVec;
+         for (int KVec = 0; KVec < KLenCell; ++KVec) {
+            const int K = KStartCell + KVec;
             KineticEnergyCellTmp[KVec] += AreaEdge * 0.5_Real * InvAreaCell *
                                           NormalVelEdge(JEdge, K) *
                                           NormalVelEdge(JEdge, K);
@@ -40,8 +44,8 @@ class KineticAuxVars {
                                         NormalVelEdge(JEdge, K);
          }
       }
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
-         const int K                 = KStart + KVec;
+      for (int KVec = 0; KVec < KLenCell; ++KVec) {
+         const int K                 = KStartCell + KVec;
          KineticEnergyCell(ICell, K) = KineticEnergyCellTmp[KVec];
          VelocityDivCell(ICell, K)   = VelocityDivCellTmp[KVec];
       }
@@ -58,6 +62,8 @@ class KineticAuxVars {
    Array1DReal DcEdge;
    Array1DReal DvEdge;
    Array1DReal AreaCell;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.h
@@ -4,6 +4,7 @@
 #include "DataTypes.h"
 #include "HorzMesh.h"
 #include "OmegaKokkos.h"
+#include "VertCoord.h"
 
 #include <string>
 
@@ -15,7 +16,7 @@ class KineticAuxVars {
    Array2DReal VelocityDivCell;
 
    KineticAuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
-                  int NVertLayers);
+                  const VertCoord *VCoord);
 
    KOKKOS_FUNCTION void
    computeVarsOnCell(int ICell, int KChunk,

--- a/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/KineticAuxVars.h
@@ -22,9 +22,8 @@ class KineticAuxVars {
    computeVarsOnCell(int ICell, int KChunk,
                      const Array2DReal &NormalVelEdge) const {
 
-      const int KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
-      const int KLenCell =
-          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
+      const int KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const int KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
 
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
@@ -34,8 +33,8 @@ class KineticAuxVars {
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
          const int JEdge     = EdgesOnCell(ICell, J);
          const Real AreaEdge = 0.5_Real * DvEdge(JEdge) * DcEdge(JEdge);
-         for (int KVec = 0; KVec < KLenCell; ++KVec) {
-            const int K = KStartCell + KVec;
+         for (int KVec = 0; KVec < KLen; ++KVec) {
+            const int K = KStart + KVec;
             KineticEnergyCellTmp[KVec] += AreaEdge * 0.5_Real * InvAreaCell *
                                           NormalVelEdge(JEdge, K) *
                                           NormalVelEdge(JEdge, K);
@@ -44,8 +43,8 @@ class KineticAuxVars {
                                         NormalVelEdge(JEdge, K);
          }
       }
-      for (int KVec = 0; KVec < KLenCell; ++KVec) {
-         const int K                 = KStartCell + KVec;
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const int K                 = KStart + KVec;
          KineticEnergyCell(ICell, K) = KineticEnergyCellTmp[KVec];
          VelocityDivCell(ICell, K)   = VelocityDivCellTmp[KVec];
       }

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
@@ -7,12 +7,13 @@ namespace OMEGA {
 
 LayerThicknessAuxVars::LayerThicknessAuxVars(const std::string &AuxStateSuffix,
                                              const HorzMesh *Mesh,
-                                             int NVertLayers)
+                                             const VertCoord *VCoord)
     : FluxLayerThickEdge("FluxLayerThickEdge" + AuxStateSuffix,
-                         Mesh->NEdgesSize, NVertLayers),
+                         Mesh->NEdgesSize, VCoord->NVertLayers),
       MeanLayerThickEdge("MeanLayerThickEdge" + AuxStateSuffix,
-                         Mesh->NEdgesSize, NVertLayers),
-      SshCell("SshCell" + AuxStateSuffix, Mesh->NCellsSize, NVertLayers),
+                         Mesh->NEdgesSize, VCoord->NVertLayers),
+      SshCell("SshCell" + AuxStateSuffix, Mesh->NCellsSize,
+              VCoord->NVertLayers),
       CellsOnEdge(Mesh->CellsOnEdge), BottomDepth(Mesh->BottomDepth) {}
 
 void LayerThicknessAuxVars::registerFields(const std::string &AuxGroupName,

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
@@ -14,7 +14,10 @@ LayerThicknessAuxVars::LayerThicknessAuxVars(const std::string &AuxStateSuffix,
                          Mesh->NEdgesSize, VCoord->NVertLayers),
       SshCell("SshCell" + AuxStateSuffix, Mesh->NCellsSize,
               VCoord->NVertLayers),
-      CellsOnEdge(Mesh->CellsOnEdge), BottomDepth(Mesh->BottomDepth) {}
+      CellsOnEdge(Mesh->CellsOnEdge), BottomDepth(Mesh->BottomDepth),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop),
+      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell) {}
 
 void LayerThicknessAuxVars::registerFields(const std::string &AuxGroupName,
                                            const std::string &MeshName) const {

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
@@ -4,6 +4,7 @@
 #include "DataTypes.h"
 #include "HorzMesh.h"
 #include "OmegaKokkos.h"
+#include "VertCoord.h"
 
 #include <string>
 
@@ -20,7 +21,7 @@ class LayerThicknessAuxVars {
    FluxThickEdgeOption FluxThickEdgeChoice;
 
    LayerThicknessAuxVars(const std::string &AuxStateSuffix,
-                         const HorzMesh *Mesh, int NVertLayers);
+                         const HorzMesh *Mesh, const VertCoord *VCoord);
 
    KOKKOS_FUNCTION void
    computeVarsOnEdge(int IEdge, int KChunk, const Array2DReal &LayerThickCell,

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
@@ -26,11 +26,14 @@ class LayerThicknessAuxVars {
    KOKKOS_FUNCTION void
    computeVarsOnEdge(int IEdge, int KChunk, const Array2DReal &LayerThickCell,
                      const Array2DReal &NormalVelEdge) const {
-      const int KStart = KChunk * VecLength;
+      const int KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
+      const int KLen =
+          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
+
       const int JCell0 = CellsOnEdge(IEdge, 0);
       const int JCell1 = CellsOnEdge(IEdge, 1);
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const int K = KStart + KVec;
          MeanLayerThickEdge(IEdge, K) =
              0.5_Real * (LayerThickCell(JCell0, K) + LayerThickCell(JCell1, K));
@@ -38,7 +41,7 @@ class LayerThicknessAuxVars {
 
       switch (FluxThickEdgeChoice) {
       case FluxThickEdgeOption::Center:
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
+         for (int KVec = 0; KVec < KLen; ++KVec) {
             const int K = KStart + KVec;
             FluxLayerThickEdge(IEdge, K) =
                 0.5_Real *
@@ -46,7 +49,7 @@ class LayerThicknessAuxVars {
          }
          break;
       case FluxThickEdgeOption::Upwind:
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
+         for (int KVec = 0; KVec < KLen; ++KVec) {
             const int K = KStart + KVec;
             if (NormalVelEdge(IEdge, K) > 0) {
                FluxLayerThickEdge(IEdge, K) = LayerThickCell(JCell0, K);
@@ -66,8 +69,10 @@ class LayerThicknessAuxVars {
                       const Array2DReal &LayerThickCell) const {
 
       // Temporary for stacked shallow water
-      const int KStart = KChunk * VecLength;
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      const int KStart = MinLayerCell(ICell) + KChunk * VecLength;
+      const int KLen = Kokkos::min(MaxLayerCell(ICell) - KStart + 1, VecLength);
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const int K       = KStart + KVec;
          SshCell(ICell, K) = LayerThickCell(ICell, K) - BottomDepth(ICell);
       }
@@ -89,6 +94,10 @@ class LayerThicknessAuxVars {
  private:
    Array2DI4 CellsOnEdge;
    Array1DReal BottomDepth;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
@@ -26,9 +26,8 @@ class LayerThicknessAuxVars {
    KOKKOS_FUNCTION void
    computeVarsOnEdge(int IEdge, int KChunk, const Array2DReal &LayerThickCell,
                      const Array2DReal &NormalVelEdge) const {
-      const int KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
-      const int KLen =
-          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
+      const int KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const int KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
 
       const int JCell0 = CellsOnEdge(IEdge, 0);
       const int JCell1 = CellsOnEdge(IEdge, 1);
@@ -69,8 +68,8 @@ class LayerThicknessAuxVars {
                       const Array2DReal &LayerThickCell) const {
 
       // Temporary for stacked shallow water
-      const int KStart = MinLayerCell(ICell) + KChunk * VecLength;
-      const int KLen = Kokkos::min(MaxLayerCell(ICell) - KStart + 1, VecLength);
+      const int KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const int KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const int K       = KStart + KVec;

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
@@ -15,7 +15,9 @@ TracerAuxVars::TracerAuxVars(const std::string &AuxStateSuffix,
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),
-      EdgeMask(VCoord->EdgeMask) {}
+      EdgeMask(VCoord->EdgeMask), MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop),
+      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell) {}
 
 void TracerAuxVars::registerFields(const std::string &AuxGroupName,
                                    const std::string &MeshName) const {

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.cpp
@@ -7,11 +7,11 @@ namespace OMEGA {
 
 TracerAuxVars::TracerAuxVars(const std::string &AuxStateSuffix,
                              const HorzMesh *Mesh, const VertCoord *VCoord,
-                             const I4 NVertLayers, const I4 NTracers)
+                             const I4 NTracers)
     : HTracersEdge("ThickTracersEdge" + AuxStateSuffix, NTracers,
-                   Mesh->NEdgesSize, NVertLayers),
+                   Mesh->NEdgesSize, VCoord->NVertLayers),
       Del2TracersCell("Del2TracerCell" + AuxStateSuffix, NTracers,
-                      Mesh->NCellsSize, NVertLayers),
+                      Mesh->NCellsSize, VCoord->NVertLayers),
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeSignOnCell(Mesh->EdgeSignOnCell),
       DcEdge(Mesh->DcEdge), DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
@@ -27,9 +27,8 @@ class TracerAuxVars {
                                           const Array2DReal &NormalVelEdge,
                                           const Array2DReal &HCell,
                                           const Array3DReal &TrCell) const {
-      const int KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
-      const int KLen =
-          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
+      const int KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const int KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
 
       const int JCell0 = CellsOnEdge(IEdge, 0);
       const int JCell1 = CellsOnEdge(IEdge, 1);
@@ -67,9 +66,8 @@ class TracerAuxVars {
                       const Array2DReal &LayerThickEdgeMean,
                       const Array3DReal &TrCell) const {
 
-      const int KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
-      const int KLenCell =
-          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
+      const int KStartCell = chunkStart(KChunk, MinLayerCell(ICell));
+      const int KLenCell = chunkLength(KChunk, KStartCell, MaxLayerCell(ICell));
       const int KEndCell = KStartCell + KLenCell - 1;
 
       const Real InvAreaCell = 1._Real / AreaCell(ICell);

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
@@ -27,13 +27,16 @@ class TracerAuxVars {
                                           const Array2DReal &NormalVelEdge,
                                           const Array2DReal &HCell,
                                           const Array3DReal &TrCell) const {
-      const int KStart = KChunk * VecLength;
+      const int KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
+      const int KLen =
+          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
+
       const int JCell0 = CellsOnEdge(IEdge, 0);
       const int JCell1 = CellsOnEdge(IEdge, 1);
 
       switch (TracersOnEdgeChoice) {
       case FluxTracerEdgeOption::Center:
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
+         for (int KVec = 0; KVec < KLen; ++KVec) {
             const int K = KStart + KVec;
             HTracersEdge(L, IEdge, K) =
                 0.5_Real * (HCell(JCell0, K) * TrCell(L, JCell0, K) +
@@ -41,7 +44,7 @@ class TracerAuxVars {
          }
          break;
       case FluxTracerEdgeOption::Upwind:
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
+         for (int KVec = 0; KVec < KLen; ++KVec) {
             const int K = KStart + KVec;
             if (NormalVelEdge(IEdge, K) > 0) {
                HTracersEdge(L, IEdge, K) =
@@ -64,7 +67,11 @@ class TracerAuxVars {
                       const Array2DReal &LayerThickEdgeMean,
                       const Array3DReal &TrCell) const {
 
-      const int KStart       = KChunk * VecLength;
+      const int KStartCell = MinLayerCell(ICell) + KChunk * VecLength;
+      const int KLenCell =
+          Kokkos::min(MaxLayerCell(ICell) - KStartCell + 1, VecLength);
+      const int KEndCell = KStartCell + KLenCell - 1;
+
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
 
       Real Del2TrCellTmp[VecLength] = {0};
@@ -77,16 +84,19 @@ class TracerAuxVars {
 
          const Real DvDcEdge = DvEdge(JEdge) / DcEdge(JEdge);
 
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
-            const int K           = KStart + KVec;
+         const int KStartEdge = Kokkos::max(KStartCell, MinLayerEdgeBot(JEdge));
+         const int KEndEdge   = Kokkos::min(KEndCell, MaxLayerEdgeTop(JEdge));
+
+         for (int K = KStartEdge; K <= KEndEdge; ++K) {
+            const int KVec        = K - KStartCell;
             const Real TracerGrad = TrCell(L, JCell1, K) - TrCell(L, JCell0, K);
             Del2TrCellTmp[KVec] -= EdgeMask(JEdge, K) *
                                    EdgeSignOnCell(ICell, J) * DvDcEdge *
                                    LayerThickEdgeMean(JEdge, K) * TracerGrad;
          }
       }
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
-         const int K                  = KStart + KVec;
+      for (int KVec = 0; KVec < KLenCell; ++KVec) {
+         const int K                  = KStartCell + KVec;
          Del2TracersCell(L, ICell, K) = Del2TrCellTmp[KVec] * InvAreaCell;
       }
    }
@@ -104,6 +114,10 @@ class TracerAuxVars {
    Array1DReal DvEdge;
    Array1DReal AreaCell;
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/TracerAuxVars.h
@@ -21,8 +21,7 @@ class TracerAuxVars {
    FluxTracerEdgeOption TracersOnEdgeChoice;
 
    TracerAuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
-                 const VertCoord *VCoord, const I4 NVertLayers,
-                 const I4 NTracers);
+                 const VertCoord *VCoord, const I4 NTracers);
 
    KOKKOS_FUNCTION void computeVarsOnEdge(int L, int IEdge, int KChunk,
                                           const Array2DReal &NormalVelEdge,

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
@@ -8,13 +8,13 @@ namespace OMEGA {
 
 VelocityDel2AuxVars::VelocityDel2AuxVars(const std::string &AuxStateSuffix,
                                          const HorzMesh *Mesh,
-                                         const VertCoord *VCoord,
-                                         int NVertLayers)
-    : Del2Edge("VelDel2Edge" + AuxStateSuffix, Mesh->NEdgesSize, NVertLayers),
+                                         const VertCoord *VCoord)
+    : Del2Edge("VelDel2Edge" + AuxStateSuffix, Mesh->NEdgesSize,
+               VCoord->NVertLayers),
       Del2DivCell("VelDel2DivCell" + AuxStateSuffix, Mesh->NCellsSize,
-                  NVertLayers),
+                  VCoord->NVertLayers),
       Del2RelVortVertex("VelDel2RelVortVertex" + AuxStateSuffix,
-                        Mesh->NVerticesSize, NVertLayers),
+                        Mesh->NVerticesSize, VCoord->NVertLayers),
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       EdgeSignOnCell(Mesh->EdgeSignOnCell), DcEdge(Mesh->DcEdge),
       DvEdge(Mesh->DvEdge), AreaCell(Mesh->AreaCell),

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
@@ -21,7 +21,14 @@ VelocityDel2AuxVars::VelocityDel2AuxVars(const std::string &AuxStateSuffix,
       EdgesOnVertex(Mesh->EdgesOnVertex), CellsOnEdge(Mesh->CellsOnEdge),
       VerticesOnEdge(Mesh->VerticesOnEdge), EdgeMask(VCoord->EdgeMask),
       EdgeSignOnVertex(Mesh->EdgeSignOnVertex),
-      AreaTriangle(Mesh->AreaTriangle), VertexDegree(Mesh->VertexDegree) {}
+      AreaTriangle(Mesh->AreaTriangle), VertexDegree(Mesh->VertexDegree),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop),
+      MinLayerVertexBot(VCoord->MinLayerVertexBot),
+      MaxLayerVertexTop(VCoord->MaxLayerVertexTop),
+      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell)
+
+{}
 
 void VelocityDel2AuxVars::registerFields(const std::string &AuxGroupName,
                                          const std::string &MeshName) const {

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
@@ -34,7 +34,7 @@ class VelocityDel2AuxVars {
       const Real InvDvEdge =
           1._Real / Kokkos::max(DvEdge(IEdge), 0.25_Real * DcEdge(IEdge));
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const int K = KStart + KVec;
          const Real GradDiv =
              (VelocityDivCell(JCell1, K) - VelocityDivCell(JCell0, K)) *

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
@@ -22,7 +22,9 @@ class VelocityDel2AuxVars {
    KOKKOS_FUNCTION void
    computeVarsOnEdge(int IEdge, int KChunk, const Array2DReal &VelocityDivCell,
                      const Array2DReal &RelVortVertex) const {
-      const int KStart = KChunk * VecLength;
+      const int KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
+      const int KLen =
+          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
 
       const int JCell0   = CellsOnEdge(IEdge, 0);
       const int JCell1   = CellsOnEdge(IEdge, 1);
@@ -47,35 +49,39 @@ class VelocityDel2AuxVars {
 
    KOKKOS_FUNCTION void computeVarsOnCell(int ICell, int KChunk) const {
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
-      const int KStart       = KChunk * VecLength;
+      const int KStart       = MinLayerCell(ICell) + KChunk * VecLength;
+      const int KLen = Kokkos::min(MaxLayerCell(ICell) - KStart + 1, VecLength);
 
       Real Del2DivCellTmp[VecLength] = {0};
 
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
          const int JEdge     = EdgesOnCell(ICell, J);
          const Real AreaEdge = 0.5_Real * DvEdge(JEdge) * DcEdge(JEdge);
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
+         for (int KVec = 0; KVec < KLen; ++KVec) {
             const int K = KStart + KVec;
             Del2DivCellTmp[KVec] -= DvEdge(JEdge) * InvAreaCell *
                                     EdgeSignOnCell(ICell, J) *
                                     Del2Edge(JEdge, K);
          }
       }
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const int K           = KStart + KVec;
          Del2DivCell(ICell, K) = Del2DivCellTmp[KVec];
       }
    }
 
    KOKKOS_FUNCTION void computeVarsOnVertex(int IVertex, int KChunk) const {
-      const int KStart           = KChunk * VecLength;
+      const int KStart = MinLayerVertexBot(IVertex) + KChunk * VecLength;
+      const int KLen =
+          Kokkos::min(MaxLayerVertexTop(IVertex) - KStart + 1, VecLength);
+
       const Real InvAreaTriangle = 1._Real / AreaTriangle(IVertex);
 
       Real Del2RelVortVertexTmp[VecLength] = {0};
 
       for (int J = 0; J < VertexDegree; ++J) {
          const int JEdge = EdgesOnVertex(IVertex, J);
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
+         for (int KVec = 0; KVec < KLen; ++KVec) {
             const int K = KStart + KVec;
             Del2RelVortVertexTmp[KVec] += InvAreaTriangle * DcEdge(JEdge) *
                                           EdgeSignOnVertex(IVertex, J) *
@@ -83,7 +89,7 @@ class VelocityDel2AuxVars {
          }
       }
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const int K                   = KStart + KVec;
          Del2RelVortVertex(IVertex, K) = Del2RelVortVertexTmp[KVec];
       }
@@ -107,6 +113,12 @@ class VelocityDel2AuxVars {
    Array1DReal AreaTriangle;
    Array2DReal EdgeMask;
    I4 VertexDegree;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
+   Array1DI4 MinLayerVertexBot;
+   Array1DI4 MaxLayerVertexTop;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
@@ -17,7 +17,7 @@ class VelocityDel2AuxVars {
    Array2DReal Del2RelVortVertex;
 
    VelocityDel2AuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
-                       const VertCoord *VCoord, int NVertLayers);
+                       const VertCoord *VCoord);
 
    KOKKOS_FUNCTION void
    computeVarsOnEdge(int IEdge, int KChunk, const Array2DReal &VelocityDivCell,

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
@@ -22,9 +22,8 @@ class VelocityDel2AuxVars {
    KOKKOS_FUNCTION void
    computeVarsOnEdge(int IEdge, int KChunk, const Array2DReal &VelocityDivCell,
                      const Array2DReal &RelVortVertex) const {
-      const int KStart = MinLayerEdgeBot(IEdge) + KChunk * VecLength;
-      const int KLen =
-          Kokkos::min(MaxLayerEdgeTop(IEdge) - KStart + 1, VecLength);
+      const int KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const int KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
 
       const int JCell0   = CellsOnEdge(IEdge, 0);
       const int JCell1   = CellsOnEdge(IEdge, 1);
@@ -49,8 +48,8 @@ class VelocityDel2AuxVars {
 
    KOKKOS_FUNCTION void computeVarsOnCell(int ICell, int KChunk) const {
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
-      const int KStart       = MinLayerCell(ICell) + KChunk * VecLength;
-      const int KLen = Kokkos::min(MaxLayerCell(ICell) - KStart + 1, VecLength);
+      const int KStart       = chunkStart(KChunk, MinLayerCell(ICell));
+      const int KLen         = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
 
       Real Del2DivCellTmp[VecLength] = {0};
 
@@ -71,9 +70,8 @@ class VelocityDel2AuxVars {
    }
 
    KOKKOS_FUNCTION void computeVarsOnVertex(int IVertex, int KChunk) const {
-      const int KStart = MinLayerVertexBot(IVertex) + KChunk * VecLength;
-      const int KLen =
-          Kokkos::min(MaxLayerVertexTop(IVertex) - KStart + 1, VecLength);
+      const int KStart = chunkStart(KChunk, MinLayerVertexBot(IVertex));
+      const int KLen = chunkLength(KChunk, KStart, MaxLayerVertexTop(IVertex));
 
       const Real InvAreaTriangle = 1._Real / AreaTriangle(IVertex);
 

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.h
@@ -48,23 +48,28 @@ class VelocityDel2AuxVars {
 
    KOKKOS_FUNCTION void computeVarsOnCell(int ICell, int KChunk) const {
       const Real InvAreaCell = 1._Real / AreaCell(ICell);
-      const int KStart       = chunkStart(KChunk, MinLayerCell(ICell));
-      const int KLen         = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
+      const int KStartCell   = chunkStart(KChunk, MinLayerCell(ICell));
+      const int KLenCell = chunkLength(KChunk, KStartCell, MaxLayerCell(ICell));
+      const int KEndCell = KStartCell + KLenCell - 1;
 
       Real Del2DivCellTmp[VecLength] = {0};
 
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
          const int JEdge     = EdgesOnCell(ICell, J);
          const Real AreaEdge = 0.5_Real * DvEdge(JEdge) * DcEdge(JEdge);
-         for (int KVec = 0; KVec < KLen; ++KVec) {
-            const int K = KStart + KVec;
+
+         const int KStartEdge = Kokkos::max(KStartCell, MinLayerEdgeBot(JEdge));
+         const int KEndEdge   = Kokkos::min(KEndCell, MaxLayerEdgeTop(JEdge));
+
+         for (int K = KStartEdge; K <= KEndEdge; ++K) {
+            const int KVec = K - KStartCell;
             Del2DivCellTmp[KVec] -= DvEdge(JEdge) * InvAreaCell *
                                     EdgeSignOnCell(ICell, J) *
                                     Del2Edge(JEdge, K);
          }
       }
-      for (int KVec = 0; KVec < KLen; ++KVec) {
-         const int K           = KStart + KVec;
+      for (int KVec = 0; KVec < KLenCell; ++KVec) {
+         const int K           = KStartCell + KVec;
          Del2DivCell(ICell, K) = Del2DivCellTmp[KVec];
       }
    }

--- a/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.cpp
@@ -24,7 +24,12 @@ VorticityAuxVars::VorticityAuxVars(const std::string &AuxStateSuffix,
       EdgeSignOnVertex(Mesh->EdgeSignOnVertex), DcEdge(Mesh->DcEdge),
       KiteAreasOnVertex(Mesh->KiteAreasOnVertex),
       AreaTriangle(Mesh->AreaTriangle), FVertex(Mesh->FVertex),
-      VerticesOnEdge(Mesh->VerticesOnEdge) {}
+      VerticesOnEdge(Mesh->VerticesOnEdge),
+      MinLayerVertexTop(VCoord->MinLayerVertexTop),
+      MaxLayerVertexBot(VCoord->MaxLayerVertexBot),
+      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell),
+      MinLayerEdgeTop(VCoord->MinLayerEdgeTop),
+      MaxLayerEdgeBot(VCoord->MaxLayerEdgeBot) {}
 
 void VorticityAuxVars::registerFields(const std::string &AuxGroupName,
                                       const std::string &MeshName) const {

--- a/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.cpp
@@ -7,17 +7,18 @@
 namespace OMEGA {
 
 VorticityAuxVars::VorticityAuxVars(const std::string &AuxStateSuffix,
-                                   const HorzMesh *Mesh, int NVertLayers)
+                                   const HorzMesh *Mesh,
+                                   const VertCoord *VCoord)
     : RelVortVertex("RelVortVertex" + AuxStateSuffix, Mesh->NVerticesSize,
-                    NVertLayers),
+                    VCoord->NVertLayers),
       NormRelVortVertex("NormRelVortVertex" + AuxStateSuffix,
-                        Mesh->NVerticesSize, NVertLayers),
+                        Mesh->NVerticesSize, VCoord->NVertLayers),
       NormPlanetVortVertex("NormPlanetVortVertex" + AuxStateSuffix,
-                           Mesh->NVerticesSize, NVertLayers),
+                           Mesh->NVerticesSize, VCoord->NVertLayers),
       NormRelVortEdge("NormRelVortEdge" + AuxStateSuffix, Mesh->NEdgesSize,
-                      NVertLayers),
+                      VCoord->NVertLayers),
       NormPlanetVortEdge("NormPlanetVortEdge" + AuxStateSuffix,
-                         Mesh->NEdgesSize, NVertLayers),
+                         Mesh->NEdgesSize, VCoord->NVertLayers),
       VertexDegree(Mesh->VertexDegree), CellsOnVertex(Mesh->CellsOnVertex),
       EdgesOnVertex(Mesh->EdgesOnVertex),
       EdgeSignOnVertex(Mesh->EdgeSignOnVertex), DcEdge(Mesh->DcEdge),

--- a/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.h
@@ -27,9 +27,9 @@ class VorticityAuxVars {
                        const Array2DReal &LayerThickCell,
                        const Array2DReal &NormalVelEdge) const {
 
-      const int KStartVertex = MinLayerVertexTop(IVertex) + KChunk * VecLength;
+      const int KStartVertex = chunkStart(KChunk, MinLayerVertexTop(IVertex));
       const int KLenVertex =
-          Kokkos::min(MaxLayerVertexBot(IVertex) - KStartVertex + 1, VecLength);
+          chunkLength(KChunk, KStartVertex, MaxLayerVertexBot(IVertex));
       const int KEndVertex = KStartVertex + KLenVertex - 1;
 
       const Real InvAreaTriangle = 1._Real / AreaTriangle(IVertex);

--- a/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.h
@@ -4,6 +4,7 @@
 #include "DataTypes.h"
 #include "HorzMesh.h"
 #include "OmegaKokkos.h"
+#include "VertCoord.h"
 
 #include <string>
 
@@ -19,7 +20,7 @@ class VorticityAuxVars {
    Array2DReal NormPlanetVortEdge;
 
    VorticityAuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
-                    int NVertLayers);
+                    const VertCoord *VCoord);
 
    KOKKOS_FUNCTION void
    computeVarsOnVertex(int IVertex, int KChunk,

--- a/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.h
@@ -76,11 +76,12 @@ class VorticityAuxVars {
    }
 
    KOKKOS_FUNCTION void computeVarsOnEdge(int IEdge, int KChunk) const {
-      const int KStart   = KChunk * VecLength;
+      const int KStart   = chunkStart(KChunk, MinLayerEdgeTop(IEdge));
+      const int KLen     = chunkLength(KChunk, KStart, MaxLayerEdgeBot(IEdge));
       const int JVertex0 = VerticesOnEdge(IEdge, 0);
       const int JVertex1 = VerticesOnEdge(IEdge, 1);
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
+      for (int KVec = 0; KVec < KLen; ++KVec) {
          const int K = KStart + KVec;
          NormRelVortEdge(IEdge, K) =
              0.5_Real *

--- a/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/VorticityAuxVars.h
@@ -26,7 +26,12 @@ class VorticityAuxVars {
    computeVarsOnVertex(int IVertex, int KChunk,
                        const Array2DReal &LayerThickCell,
                        const Array2DReal &NormalVelEdge) const {
-      const int KStart           = KChunk * VecLength;
+
+      const int KStartVertex = MinLayerVertexTop(IVertex) + KChunk * VecLength;
+      const int KLenVertex =
+          Kokkos::min(MaxLayerVertexBot(IVertex) - KStartVertex + 1, VecLength);
+      const int KEndVertex = KStartVertex + KLenVertex - 1;
+
       const Real InvAreaTriangle = 1._Real / AreaTriangle(IVertex);
 
       Real LayerThickVertex[VecLength] = {0};
@@ -34,21 +39,32 @@ class VorticityAuxVars {
 
       for (int J = 0; J < VertexDegree; ++J) {
          const int JCell = CellsOnVertex(IVertex, J);
-         const int JEdge = EdgesOnVertex(IVertex, J);
 
-         for (int KVec = 0; KVec < VecLength; ++KVec) {
-            const int K = KStart + KVec;
+         const int KStartCell = Kokkos::max(KStartVertex, MinLayerCell(JCell));
+         const int KEndCell   = Kokkos::min(KEndVertex, MaxLayerCell(JCell));
+
+         for (int K = KStartCell; K <= KEndCell; ++K) {
+            const int KVec = K - KStartVertex;
             LayerThickVertex[KVec] += InvAreaTriangle *
                                       KiteAreasOnVertex(IVertex, J) *
                                       LayerThickCell(JCell, K);
+         }
+
+         const int JEdge = EdgesOnVertex(IVertex, J);
+         const int KStartEdge =
+             Kokkos::max(KStartVertex, MinLayerEdgeTop(JEdge));
+         const int KEndEdge = Kokkos::min(KEndVertex, MaxLayerEdgeBot(JEdge));
+
+         for (int K = KStartEdge; K <= KEndEdge; ++K) {
+            const int KVec = K - KStartVertex;
             RelVortVertexTmp[KVec] += InvAreaTriangle * DcEdge(JEdge) *
                                       EdgeSignOnVertex(IVertex, J) *
                                       NormalVelEdge(JEdge, K);
          }
       }
 
-      for (int KVec = 0; KVec < VecLength; ++KVec) {
-         const int K                    = KStart + KVec;
+      for (int KVec = 0; KVec < KLenVertex; ++KVec) {
+         const int K                    = KStartVertex + KVec;
          const Real InvLayerThickVertex = 1._Real / LayerThickVertex[KVec];
 
          RelVortVertex(IVertex, K) = RelVortVertexTmp[KVec];
@@ -90,6 +106,13 @@ class VorticityAuxVars {
    Array1DReal AreaTriangle;
    Array2DI4 VerticesOnEdge;
    Array1DReal FVertex;
+
+   Array1DI4 MinLayerVertexTop;
+   Array1DI4 MaxLayerVertexBot;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
+   Array1DI4 MinLayerEdgeTop;
+   Array1DI4 MaxLayerEdgeBot;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/ocn/auxiliaryVars/WindForcingAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/WindForcingAuxVars.h
@@ -5,6 +5,7 @@
 #include "HorzMesh.h"
 #include "HorzOperators.h"
 #include "OmegaKokkos.h"
+#include "VertCoord.h"
 
 #include <string>
 

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -83,6 +83,7 @@ TimeStepper *TimeStepper::create(
     Tendencies *InTend,             ///< [in] ptr to tendencies
     AuxiliaryState *InAuxState,     ///< [in] ptr to aux state variables
     HorzMesh *InMesh,               ///< [in] ptr to mesh information
+    VertCoord *InVCoord,            ///< [in] ptr to vertical coordinate
     Halo *InMeshHalo                ///< [in] ptr to halos
 ) {
 
@@ -119,7 +120,7 @@ TimeStepper *TimeStepper::create(
    }
 
    // Attach data pointers
-   NewTimeStepper->attachData(InTend, InAuxState, InMesh, InMeshHalo);
+   NewTimeStepper->attachData(InTend, InAuxState, InMesh, InVCoord, InMeshHalo);
 
    // Store instance
    AllTimeSteppers.emplace(InName, NewTimeStepper);
@@ -182,6 +183,7 @@ void TimeStepper::attachData(
     Tendencies *InTend,         // [in] ptr to tendencies (right hand side)
     AuxiliaryState *InAuxState, // [in] ptr to needed aux state variables
     HorzMesh *InMesh,           // [in] ptr to mesh information
+    VertCoord *InVCoord,        // [in] ptr to vertical coordinate
     Halo *InMeshHalo            // [in] ptr to halos
 ) {
 
@@ -191,12 +193,15 @@ void TimeStepper::attachData(
       ABORT_ERROR("AuxState pointer not defined");
    if (!InMesh)
       ABORT_ERROR("HorzMesh pointer not defined");
+   if (!InVCoord)
+      ABORT_ERROR("VertCoord pointer not defined");
    if (!InMeshHalo)
       ABORT_ERROR("MeshHalo pointer not defined");
 
    Tend     = InTend;
    AuxState = InAuxState;
    Mesh     = InMesh;
+   VCoord   = InVCoord;
    MeshHalo = InMeshHalo;
 
    // Some time steppers have additional tasks to finalize
@@ -303,12 +308,14 @@ void TimeStepper::init2() {
 
    // Get default pointers
    HorzMesh *DefMesh        = HorzMesh::getDefault();
+   VertCoord *DefVCoord     = VertCoord::getDefault();
    Halo *DefHalo            = Halo::getDefault();
    Tendencies *DefTend      = Tendencies::getDefault();
    AuxiliaryState *AuxState = AuxiliaryState::getDefault();
 
    // Attach data pointers
-   DefaultTimeStepper->attachData(DefTend, AuxState, DefMesh, DefHalo);
+   DefaultTimeStepper->attachData(DefTend, AuxState, DefMesh, DefVCoord,
+                                  DefHalo);
 }
 
 //------------------------------------------------------------------------------
@@ -386,17 +393,28 @@ void TimeStepper::updateThicknessByTend(OceanState *State1, int TimeLevel1,
    Err = State2->getLayerThickness(LayerThick2, TimeLevel2);
    if (Err != 0)
       ABORT_ERROR("TimeStepper updateThickness: error retrieving layer thick");
-   const auto &LayerThickTend = Tend->LayerThicknessTend;
-   const int NVertLayers      = LayerThickTend.extent_int(1);
 
    R8 CoeffSeconds;
    Coeff.get(CoeffSeconds, TimeUnits::Seconds);
 
-   parallelFor(
-       "updateThickByTend", {Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(int ICell, int K) {
-          LayerThick1(ICell, K) =
-              LayerThick2(ICell, K) + CoeffSeconds * LayerThickTend(ICell, K);
+   OMEGA_SCOPE(LayerThickTend, Tend->LayerThicknessTend);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
+   parallelForOuter(
+       "updateThickByTend", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K = KMin + KChunk;
+                 LayerThick1(ICell, K) =
+                     LayerThick2(ICell, K) +
+                     CoeffSeconds * LayerThickTend(ICell, K);
+              });
        });
 }
 
@@ -415,17 +433,27 @@ void TimeStepper::updateVelocityByTend(OceanState *State1, int TimeLevel1,
    Err = State2->getNormalVelocity(NormalVel2, TimeLevel2);
    if (Err != 0)
       ABORT_ERROR("TimeStepper updateVelocity: error retrieving velocity");
-   const auto &NormalVelTend = Tend->NormalVelocityTend;
-   const int NVertLayers     = NormalVelTend.extent_int(1);
 
    R8 CoeffSeconds;
    Coeff.get(CoeffSeconds, TimeUnits::Seconds);
 
-   parallelFor(
-       "updateVelByTend", {Mesh->NEdgesAll, NVertLayers},
-       KOKKOS_LAMBDA(int IEdge, int K) {
-          NormalVel1(IEdge, K) =
-              NormalVel2(IEdge, K) + CoeffSeconds * NormalVelTend(IEdge, K);
+   OMEGA_SCOPE(NormalVelTend, Tend->NormalVelocityTend);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   parallelForOuter(
+       "updateVelByTend", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRange(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K          = KMin + KChunk;
+                 NormalVel1(IEdge, K) = NormalVel2(IEdge, K) +
+                                        CoeffSeconds * NormalVelTend(IEdge, K);
+              });
        });
 }
 
@@ -451,20 +479,29 @@ void TimeStepper::updateTracersByTend(const Array3DReal &NextTracers,
 
    const auto &LayerThick1 = State1->LayerThickness[TimeLevel1];
    const auto &LayerThick2 = State2->LayerThickness[TimeLevel2];
-   const auto &TracerTend  = Tend->TracerTend;
-   const int NTracers      = TracerTend.extent(0);
-   const int NVertLayers   = TracerTend.extent(2);
+
+   OMEGA_SCOPE(TracerTend, Tend->TracerTend);
+   const int NTracers = TracerTend.extent(0);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
    R8 CoeffSeconds;
    Coeff.get(CoeffSeconds, TimeUnits::Seconds);
 
-   parallelFor(
-       "updateTracersByTend", {NTracers, Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(int L, int ICell, int K) {
-          NextTracers(L, ICell, K) =
-              (CurTracers(L, ICell, K) * LayerThick2(ICell, K) +
-               CoeffSeconds * TracerTend(L, ICell, K)) /
-              LayerThick1(ICell, K);
+   parallelForOuter(
+       "updateTracersByTend", {NTracers, Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K = KMin + KChunk;
+                 NextTracers(L, ICell, K) =
+                     (CurTracers(L, ICell, K) * LayerThick2(ICell, K) +
+                      CoeffSeconds * TracerTend(L, ICell, K)) /
+                     LayerThick1(ICell, K);
+              });
        });
 }
 
@@ -476,13 +513,21 @@ void TimeStepper::weightTracers(const Array3DReal &NextTracers,
 
    const Array2DReal &CurThickness = CurState->LayerThickness[TimeLevel1];
    const int NTracers              = NextTracers.extent(0);
-   const int NVertLayers           = NextTracers.extent(2);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
-   parallelFor(
-       "weightTracers", {NTracers, Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(int L, int ICell, int K) {
-          NextTracers(L, ICell, K) =
-              CurTracers(L, ICell, K) * CurThickness(ICell, K);
+   parallelForOuter(
+       "weightTracers", {NTracers, Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K = KMin + KChunk;
+                 NextTracers(L, ICell, K) =
+                     CurTracers(L, ICell, K) * CurThickness(ICell, K);
+              });
        });
 }
 
@@ -494,15 +539,24 @@ void TimeStepper::accumulateTracersUpdate(const Array3DReal &AccumTracer,
 
    const auto &TracerTend = Tend->TracerTend;
    const int NTracers     = TracerTend.extent(0);
-   const int NVertLayers  = TracerTend.extent(2);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
    R8 CoeffSeconds;
    Coeff.get(CoeffSeconds, TimeUnits::Seconds);
 
-   parallelFor(
-       "accumulateTracersUpdate", {NTracers, Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(int L, int ICell, int K) {
-          AccumTracer(L, ICell, K) += CoeffSeconds * TracerTend(L, ICell, K);
+   parallelForOuter(
+       "accumulateTracersUpdate", {NTracers, Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K = KMin + KChunk;
+                 AccumTracer(L, ICell, K) +=
+                     CoeffSeconds * TracerTend(L, ICell, K);
+              });
        });
 }
 
@@ -514,12 +568,20 @@ void TimeStepper::finalizeTracersUpdate(const Array3DReal &NextTracers,
 
    const Array2DReal &NextThick = State->LayerThickness[TimeLevel];
    const int NTracers           = NextTracers.extent(0);
-   const int NVertLayers        = NextTracers.extent(2);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
-   parallelFor(
-       "finalizeTracersUpdate", {NTracers, Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(int L, int ICell, int K) {
-          NextTracers(L, ICell, K) /= NextThick(ICell, K);
+   parallelForOuter(
+       "finalizeTracersUpdate", {NTracers, Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K = KMin + KChunk;
+                 NextTracers(L, ICell, K) /= NextThick(ICell, K);
+              });
        });
 }
 

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -45,6 +45,7 @@
 #include "Tendencies.h"
 #include "TimeMgr.h"
 #include "Tracers.h"
+#include "VertCoord.h"
 
 #include <map>
 #include <memory>
@@ -99,6 +100,7 @@ class TimeStepper {
           Tendencies *InTend,             ///< [in] ptr to tendencies
           AuxiliaryState *InAuxState,     ///< [in] ptr to aux state variables
           HorzMesh *InMesh,               ///< [in] ptr to mesh information
+          VertCoord *InVCoord,            ///< [in] ptr to vertical coordinate
           Halo *InMeshHalo                ///< [in] ptr to halos
    );
 
@@ -119,6 +121,7 @@ class TimeStepper {
        Tendencies *InTend,         ///< [in] ptr to tendencies
        AuxiliaryState *InAuxState, ///< [in] ptr to needed aux state variables
        HorzMesh *InMesh,           ///< [in] ptr to mesh information
+       VertCoord *InVCoord,        ///< [in] ptr to vertical coordinate
        Halo *InMeshHalo            ///< [in] ptr to halos
    );
 
@@ -266,6 +269,7 @@ class TimeStepper {
    Tendencies *Tend;         /// Ptr to tendency terms
    AuxiliaryState *AuxState; /// Ptr to auxiliary state data
    HorzMesh *Mesh;           /// Ptr to horizontal mesh info
+   VertCoord *VCoord;        /// Ptr to vertical coordinate
    Halo *MeshHalo;           /// Ptr to defined halos
 
    /// Function for any method-specific modifications for the default stepper

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -141,10 +141,10 @@ int testAuxState() {
    }
 
    const auto *Mesh   = HorzMesh::getDefault();
-   const auto *VCoord = VertCoord::getDefault();
    auto *MeshHalo     = Halo::getDefault();
+   const auto *VCoord = VertCoord::getDefault();
    // test creation of another auxiliary state
-   AuxiliaryState::create("AnotherAuxState", Mesh, VCoord, MeshHalo, 12, 3);
+   AuxiliaryState::create("AnotherAuxState", Mesh, MeshHalo, VCoord, 3);
 
    // test retrievel of another
    if (AuxiliaryState::get("AnotherAuxState")) {

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -8,6 +8,7 @@
 #include "Halo.h"
 #include "HorzMesh.h"
 #include "IO.h"
+#include "IOStream.h"
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OceanTestCommon.h"
@@ -51,8 +52,9 @@ int initState() {
    int Err = 0;
 
    TestSetup Setup;
-   auto *Mesh  = HorzMesh::getDefault();
-   auto *State = OceanState::getDefault();
+   auto *Mesh   = HorzMesh::getDefault();
+   auto *State  = OceanState::getDefault();
+   auto *VCoord = VertCoord::getDefault();
 
    Array2DReal LayerThickCell;
    Array2DReal NormalVelEdge;
@@ -65,18 +67,21 @@ int initState() {
 
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.layerThickness(X, Y); },
-       LayerThickCell, Geom, Mesh, OnCell);
+       LayerThickCell, Geom, Mesh, OnCell, VCoord->MinLayerCell,
+       VCoord->MaxLayerCell);
 
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.tracer(X, Y); },
-       TracerArray, Geom, Mesh, OnCell);
+       TracerArray, Geom, Mesh, OnCell, VCoord->MinLayerCell,
+       VCoord->MaxLayerCell);
 
    Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real Lon, Real Lat) {
           VecField[0] = Setup.velocityX(Lon, Lat);
           VecField[1] = Setup.velocityY(Lon, Lat);
        },
-       NormalVelEdge, EdgeComponent::Normal, Geom, Mesh, ExchangeHalos::Yes,
+       NormalVelEdge, EdgeComponent::Normal, Geom, Mesh,
+       VCoord->MinLayerEdgeTop, VCoord->MaxLayerEdgeBot, ExchangeHalos::Yes,
        CartProjection::No);
 
    return Err;
@@ -102,6 +107,9 @@ int initAuxStateTest(const std::string &mesh) {
 
    IO::init(DefComm);
    Decomp::init(mesh);
+
+   // Initialize streams
+   IOStream::init();
 
    int HaloErr = Halo::init();
    if (HaloErr != 0) {
@@ -197,77 +205,88 @@ int testAuxState() {
    int NTracers       = Tracers::getNumTracers();
 
    const Real KineticEnergySum =
-       sum(DefAuxState->KineticAux.KineticEnergyCell, NCellsOwned);
+       sum(DefAuxState->KineticAux.KineticEnergyCell, NCellsOwned,
+           VCoord->MinLayerCell, VCoord->MaxLayerCell);
    if (!Kokkos::isfinite(KineticEnergySum)) {
       Err++;
       LOG_ERROR("AuxStateTest: KineticEnergy FAIL");
    }
 
    const Real VelocityDivSum =
-       sum(DefAuxState->KineticAux.VelocityDivCell, NCellsOwned);
+       sum(DefAuxState->KineticAux.VelocityDivCell, NCellsOwned,
+           VCoord->MinLayerCell, VCoord->MaxLayerCell);
    if (!Kokkos::isfinite(VelocityDivSum)) {
       Err++;
       LOG_ERROR("AuxStateTest: VelocityDivCell FAIL");
    }
 
    const Real FluxLayerThickSum =
-       sum(DefAuxState->LayerThicknessAux.FluxLayerThickEdge, NEdgesOwned);
+       sum(DefAuxState->LayerThicknessAux.FluxLayerThickEdge, NEdgesOwned,
+           VCoord->MinLayerEdgeBot, VCoord->MaxLayerEdgeTop);
    if (!Kokkos::isfinite(FluxLayerThickSum)) {
       Err++;
       LOG_ERROR("AuxStateTest: FluxLayerThickEdge FAIL");
    }
 
    const Real MeanLayerThickSum =
-       sum(DefAuxState->LayerThicknessAux.MeanLayerThickEdge, NEdgesOwned);
+       sum(DefAuxState->LayerThicknessAux.MeanLayerThickEdge, NEdgesOwned,
+           VCoord->MinLayerEdgeBot, VCoord->MaxLayerEdgeTop);
    if (!Kokkos::isfinite(MeanLayerThickSum)) {
       Err++;
       LOG_ERROR("AuxStateTest: MeanLayerThickEdge FAIL");
    }
 
    const Real RelVortVSum =
-       sum(DefAuxState->VorticityAux.RelVortVertex, NVerticesOwned);
+       sum(DefAuxState->VorticityAux.RelVortVertex, NVerticesOwned,
+           VCoord->MinLayerVertexTop, VCoord->MaxLayerVertexBot);
    if (!Kokkos::isfinite(RelVortVSum)) {
       Err++;
       LOG_ERROR("AuxStateTest: RelVortVertex FAIL");
    }
 
    const Real NormRelVortVSum =
-       sum(DefAuxState->VorticityAux.NormRelVortVertex, NVerticesOwned);
+       sum(DefAuxState->VorticityAux.NormRelVortVertex, NVerticesOwned,
+           VCoord->MinLayerVertexTop, VCoord->MaxLayerVertexBot);
    if (!Kokkos::isfinite(NormRelVortVSum)) {
       Err++;
       LOG_ERROR("AuxStateTest: NormRelVortVertex FAIL");
    }
 
    const Real NormPlanetVortVSum =
-       sum(DefAuxState->VorticityAux.NormPlanetVortVertex, NVerticesOwned);
+       sum(DefAuxState->VorticityAux.NormPlanetVortVertex, NVerticesOwned,
+           VCoord->MinLayerVertexTop, VCoord->MaxLayerVertexBot);
    if (!Kokkos::isfinite(NormPlanetVortVSum)) {
       Err++;
       LOG_ERROR("AuxStateTest: NormPlanetVortVertex FAIL");
    }
 
    const Real NormRelVortESum =
-       sum(DefAuxState->VorticityAux.NormRelVortEdge, NEdgesOwned);
+       sum(DefAuxState->VorticityAux.NormRelVortEdge, NEdgesOwned,
+           VCoord->MinLayerEdgeTop, VCoord->MaxLayerEdgeBot);
    if (!Kokkos::isfinite(NormRelVortESum)) {
       Err++;
       LOG_ERROR("AuxStateTest: NormRelVortEdge FAIL");
    }
 
    const Real NormPlanetVortESum =
-       sum(DefAuxState->VorticityAux.NormPlanetVortEdge, NEdgesOwned);
+       sum(DefAuxState->VorticityAux.NormPlanetVortEdge, NEdgesOwned,
+           VCoord->MinLayerEdgeTop, VCoord->MaxLayerEdgeBot);
    if (!Kokkos::isfinite(NormPlanetVortESum)) {
       Err++;
       LOG_ERROR("AuxStateTest: NormPlanetVortEdge FAIL");
    }
 
    const Real HTracersESum =
-       sum(DefAuxState->TracerAux.HTracersEdge, NTracers, NEdgesOwned);
+       sum(DefAuxState->TracerAux.HTracersEdge, NTracers, NEdgesOwned,
+           VCoord->MinLayerEdgeBot, VCoord->MaxLayerEdgeTop);
    if (!Kokkos::isfinite(HTracersESum)) {
       Err++;
       LOG_ERROR("AuxStateTest: HTracersOnEdge FAIL");
    }
 
    const Real Del2TracersCSum =
-       sum(DefAuxState->TracerAux.Del2TracersCell, NTracers, NCellsOwned);
+       sum(DefAuxState->TracerAux.Del2TracersCell, NTracers, NCellsOwned,
+           VCoord->MinLayerCell, VCoord->MaxLayerCell);
    if (!Kokkos::isfinite(Del2TracersCSum)) {
       Err++;
       LOG_ERROR("AuxStateTest: Del2TracersOnCell FAIL");

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -45,8 +45,7 @@ struct TestSetup {
    }
 };
 
-constexpr Geometry Geom   = Geometry::Spherical;
-constexpr int NVertLayers = 60;
+constexpr Geometry Geom = Geometry::Spherical;
 
 int initState() {
    int Err = 0;

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -276,6 +276,30 @@ int testAuxState() {
       LOG_ERROR("AuxStateTest: NormPlanetVortEdge FAIL");
    }
 
+   const Real Del2EdgeSum =
+       sum(DefAuxState->VelocityDel2Aux.Del2Edge, NEdgesOwned,
+           VCoord->MinLayerEdgeBot, VCoord->MaxLayerEdgeTop);
+   if (!Kokkos::isfinite(Del2EdgeSum)) {
+      Err++;
+      LOG_ERROR("AuxStateTest: Del2Edge FAIL");
+   }
+
+   const Real Del2DivCellSum =
+       sum(DefAuxState->VelocityDel2Aux.Del2DivCell, NCellsOwned,
+           VCoord->MinLayerCell, VCoord->MaxLayerCell);
+   if (!Kokkos::isfinite(Del2DivCellSum)) {
+      Err++;
+      LOG_ERROR("AuxStateTest: Del2DivCell FAIL");
+   }
+
+   const Real Del2RelVortVertexSum =
+       sum(DefAuxState->VelocityDel2Aux.Del2RelVortVertex, NVerticesOwned,
+           VCoord->MinLayerVertexBot, VCoord->MaxLayerVertexTop);
+   if (!Kokkos::isfinite(Del2RelVortVertexSum)) {
+      Err++;
+      LOG_ERROR("AuxStateTest: Del2RelVortVertex FAIL");
+   }
+
    const Real HTracersESum =
        sum(DefAuxState->TracerAux.HTracersEdge, NTracers, NEdgesOwned,
            VCoord->MinLayerEdgeBot, VCoord->MaxLayerEdgeTop);

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -119,7 +119,7 @@ int initAuxStateTest(const std::string &mesh) {
 
    HorzMesh::init();
 
-   VertCoord::init(false);
+   VertCoord::init();
 
    Tracers::init();
    int StateErr = OceanState::init();

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -346,7 +346,8 @@ int testKineticAuxVars(const Array2DReal &LayerThicknessCell,
    int Err = 0;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    // Compute exact result
 
@@ -364,7 +365,7 @@ int testKineticAuxVars(const Array2DReal &LayerThicknessCell,
 
    // Compute numerical result
 
-   KineticAuxVars KineticAux("", Mesh, NVertLayers);
+   KineticAuxVars KineticAux("", Mesh, VCoord);
 
    parallelFor(
        {Mesh->NCellsOwned, NVertLayers}, KOKKOS_LAMBDA(int ICell, int KLayer) {
@@ -450,7 +451,8 @@ int testLayerThicknessAuxVars(const Array2DReal &LayerThickCell,
    int Err = 0;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    // Compute exact result
 
@@ -461,7 +463,7 @@ int testLayerThicknessAuxVars(const Array2DReal &LayerThickCell,
 
    // Compute numerical result
 
-   LayerThicknessAuxVars LayerThicknessAux("", Mesh, NVertLayers);
+   LayerThicknessAuxVars LayerThicknessAux("", Mesh, VCoord);
    LayerThicknessAux.FluxThickEdgeChoice = FluxThickEdgeOption::Upwind;
    parallelFor(
        {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int KLayer) {
@@ -500,7 +502,8 @@ int testVorticityAuxVars(const Array2DReal &LayerThickCell,
 
    const auto Decomp = Decomp::getDefault();
    const auto Mesh   = HorzMesh::getDefault();
-   VorticityAuxVars VorticityAux("", Mesh, NVertLayers);
+   const auto VCoord = VertCoord::getDefault();
+   VorticityAuxVars VorticityAux("", Mesh, VCoord);
 
    // Compute exact results for vertex variables
 
@@ -617,7 +620,7 @@ int testVelocityDel2AuxVars(Real RTol) {
    const auto Decomp = Decomp::getDefault();
    const auto Mesh   = HorzMesh::getDefault();
    const auto VCoord = VertCoord::getDefault();
-   VelocityDel2AuxVars VelocityDel2Aux("", Mesh, VCoord, NVertLayers);
+   VelocityDel2AuxVars VelocityDel2Aux("", Mesh, VCoord);
 
    // Use analytical expressions to compute inputs
 
@@ -726,7 +729,7 @@ int testTracerAuxVars(const Array2DReal &LayerThickCell,
    const auto Mesh   = HorzMesh::getDefault();
    const auto VCoord = VertCoord::getDefault();
 
-   TracerAuxVars TracerAux("", Mesh, VCoord, NVertLayers, NTracers);
+   TracerAuxVars TracerAux("", Mesh, VCoord, NTracers);
    TracerAux.TracersOnEdgeChoice = FluxTracerEdgeOption::Upwind;
 
    // Set input arrays

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -101,8 +101,9 @@ I4 initEosTest(const std::string &mesh) {
 
 /// Test Linear EOS calculation for all cells/layers
 int testEosLinear() {
-   int Err          = 0;
-   const auto *Mesh = HorzMesh::getDefault();
+   int Err            = 0;
+   const auto *Mesh   = HorzMesh::getDefault();
+   const auto *VCoord = VertCoord::getDefault();
    /// Get Eos instance to test
    Eos *TestEos       = Eos::getInstance();
    TestEos->EosChoice = EosType::LinearEos;
@@ -120,24 +121,40 @@ int testEosLinear() {
    /// Compute specific volume
    TestEos->computeSpecVol(TArray, SArray, PArray);
 
+   const auto &MinLayerCell = VCoord->MinLayerCell;
+   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+
    /// Check all array values against expected value
-   int numMismatches   = 0;
+   int NumMismatches   = 0;
    Array2DReal SpecVol = TestEos->SpecVol;
-   parallelReduce(
-       "CheckSpecVolMatrix-linear", {Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(int i, int j, int &localCount) {
-          if (!isApprox(SpecVol(i, j), LinearExpValue, RTol)) {
-             localCount++;
-          }
+   parallelReduceOuter(
+       "CheckSpecVolMatrix-linear", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (!isApprox(SpecVol(ICell, K), LinearExpValue, RTol)) {
+                    InnerCount++;
+                 }
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
        },
-       numMismatches);
+       NumMismatches);
 
    auto SpecVolH = createHostMirrorCopy(SpecVol);
-   if (numMismatches != 0) {
+   if (NumMismatches != 0) {
       Err++;
       LOG_ERROR("EosTest: SpecVol Linear isApprox FAIL, "
                 "expected {}, got {} with {} mismatches",
-                LinearExpValue, SpecVolH(1, 1), numMismatches);
+                LinearExpValue, SpecVolH(1, 1), NumMismatches);
    }
    if (Err == 0) {
       LOG_INFO("EosTest SpecVolCalc Linear: PASS");
@@ -148,8 +165,9 @@ int testEosLinear() {
 
 /// Test Linear EOS calculation with vertical displacement
 int testEosLinearDisplaced() {
-   int Err          = 0;
-   const auto *Mesh = HorzMesh::getDefault();
+   int Err            = 0;
+   const auto *Mesh   = HorzMesh::getDefault();
+   const auto *VCoord = VertCoord::getDefault();
    /// Get Eos instance to test
    Eos *TestEos       = Eos::getInstance();
    TestEos->EosChoice = EosType::LinearEos;
@@ -167,24 +185,41 @@ int testEosLinearDisplaced() {
    /// Compute displaced specific volume
    TestEos->computeSpecVolDisp(TArray, SArray, PArray, KDisp);
 
+   const auto &MinLayerCell = VCoord->MinLayerCell;
+   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+
    /// Check all array values against expected value
-   int numMismatches            = 0;
+   int NumMismatches            = 0;
    Array2DReal SpecVolDisplaced = TestEos->SpecVolDisplaced;
-   parallelReduce(
-       "CheckSpecVolDispMatrix-linear", {Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(int i, int j, int &localCount) {
-          if (!isApprox(SpecVolDisplaced(i, j), LinearExpValue, RTol)) {
-             localCount++;
-          }
+   parallelReduceOuter(
+       "CheckSpecVolDispMatrix-linear", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (!isApprox(SpecVolDisplaced(ICell, K), LinearExpValue,
+                               RTol)) {
+                    InnerCount++;
+                 }
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
        },
-       numMismatches);
+       NumMismatches);
 
    auto SpecVolDisplacedH = createHostMirrorCopy(SpecVolDisplaced);
-   if (numMismatches != 0) {
+   if (NumMismatches != 0) {
       Err++;
       LOG_ERROR("EosTest: Linear SpecVolDisp isApprox FAIL, "
                 "expected {}, got {} with {} mismatches",
-                LinearExpValue, SpecVolDisplacedH(1, 1), numMismatches);
+                LinearExpValue, SpecVolDisplacedH(1, 1), NumMismatches);
    }
    if (Err == 0) {
       LOG_INFO("EosTest SpecVolCalcDisp Linear: PASS");
@@ -195,8 +230,9 @@ int testEosLinearDisplaced() {
 
 /// Test TEOS-10 EOS calculation for all cells/layers
 int testEosTeos10() {
-   int Err          = 0;
-   const auto *Mesh = HorzMesh::getDefault();
+   int Err            = 0;
+   const auto *Mesh   = HorzMesh::getDefault();
+   const auto *VCoord = VertCoord::getDefault();
    /// Get Eos instance to test
    Eos *TestEos       = Eos::getInstance();
    TestEos->EosChoice = EosType::Teos10Eos;
@@ -214,24 +250,40 @@ int testEosTeos10() {
    /// Compute specific volume
    TestEos->computeSpecVol(TArray, SArray, PArray);
 
+   const auto &MinLayerCell = VCoord->MinLayerCell;
+   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+
    /// Check all array values against expected value
-   int numMismatches   = 0;
+   int NumMismatches   = 0;
    Array2DReal SpecVol = TestEos->SpecVol;
-   parallelReduce(
-       "CheckSpecVolMatrix-Teos", {Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(int i, int j, int &localCount) {
-          if (!isApprox(SpecVol(i, j), TeosExpValue, RTol)) {
-             localCount++;
-          }
+   parallelReduceOuter(
+       "CheckSpecVolMatrix-Teos", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (!isApprox(SpecVol(ICell, K), TeosExpValue, RTol)) {
+                    InnerCount++;
+                 }
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
        },
-       numMismatches);
+       NumMismatches);
 
    auto SpecVolH = createHostMirrorCopy(SpecVol);
-   if (numMismatches != 0) {
+   if (NumMismatches != 0) {
       Err++;
       LOG_ERROR("EosTest: TEOS SpecVol isApprox FAIL, "
                 "expected {}, got {} with {} mismatches",
-                TeosExpValue, SpecVolH(1, 1), numMismatches);
+                TeosExpValue, SpecVolH(1, 1), NumMismatches);
    }
    if (Err == 0) {
       LOG_INFO("EosTest SpecVolCalc TEOS-10: PASS");
@@ -242,8 +294,9 @@ int testEosTeos10() {
 
 /// Test TEOS-10 EOS calculation with vertical displacement
 int testEosTeos10Displaced() {
-   int Err          = 0;
-   const auto *Mesh = HorzMesh::getDefault();
+   int Err            = 0;
+   const auto *Mesh   = HorzMesh::getDefault();
+   const auto *VCoord = VertCoord::getDefault();
    /// Get Eos instance to test
    Eos *TestEos       = Eos::getInstance();
    TestEos->EosChoice = EosType::Teos10Eos;
@@ -261,24 +314,41 @@ int testEosTeos10Displaced() {
    /// Compute displaced specific volume
    TestEos->computeSpecVolDisp(TArray, SArray, PArray, KDisp);
 
+   const auto &MinLayerCell = VCoord->MinLayerCell;
+   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+
    /// Check all array values against expected value
-   int numMismatches            = 0;
+   int NumMismatches            = 0;
    Array2DReal SpecVolDisplaced = TestEos->SpecVolDisplaced;
-   parallelReduce(
-       "CheckSpecVolDispMatrix-Teos", {Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(int i, int j, int &localCount) {
-          if (!isApprox(SpecVolDisplaced(i, j), TeosExpValue, RTol)) {
-             localCount++;
-          }
+   parallelReduceOuter(
+       "CheckSpecVolDispMatrix-Teos", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (!isApprox(SpecVolDisplaced(ICell, K), TeosExpValue,
+                               RTol)) {
+                    InnerCount++;
+                 }
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
        },
-       numMismatches);
+       NumMismatches);
 
    auto SpecVolDisplacedH = createHostMirrorCopy(SpecVolDisplaced);
-   if (numMismatches != 0) {
+   if (NumMismatches != 0) {
       Err++;
       LOG_ERROR("EosTest: TEOS SpecVolDisp isApprox FAIL, "
                 "expected {}, got {} with {} mismatches",
-                TeosExpValue, SpecVolDisplacedH(1, 1), numMismatches);
+                TeosExpValue, SpecVolDisplacedH(1, 1), NumMismatches);
    }
    if (Err == 0) {
       LOG_INFO("EosTest SpecVolCalcDisp TEOS-10: PASS");

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -70,7 +70,7 @@ enum class SetBoundary { Yes = 1, No = 0 };
 
 // helper to get vertical iteration bounds that can be provided
 // either as an integer or an array
-template <class T> int getVertBound(const T &VertBound, int I) {
+template <class T> KOKKOS_FUNCTION int getVertBound(const T &VertBound, int I) {
    if constexpr (std::is_integral_v<T>) {
       return VertBound;
    } else {

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -66,6 +66,7 @@ KOKKOS_INLINE_FUNCTION void tangentVector(Real (&TanVec)[3],
 enum class EdgeComponent { Normal, Tangential };
 enum class Geometry { Planar, Spherical };
 enum class ExchangeHalos { Yes, No };
+enum class SetBoundary { Yes = 1, No = 0 };
 
 // helper to get vertical iteration bounds that can be provided
 // either as an integer or an array
@@ -84,17 +85,20 @@ template <class Functor, class Array, class VertMin, class VertMax>
 int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
               const HorzMesh *Mesh, MeshElement Element, const VertMin &VMin,
               const VertMax &VMax,
-              ExchangeHalos ExchangeHalosOpt = ExchangeHalos::Yes) {
+              ExchangeHalos ExchangeHalosOpt = ExchangeHalos::Yes,
+              SetBoundary SetBndOpt          = SetBoundary::No) {
 
    int Err = 0;
 
    int NElementsOwned;
+   int NElementsSize;
    Array1DReal XElement, YElement;
    Array1DReal LonElement, LatElement;
 
    switch (Element) {
    case OnCell:
       NElementsOwned = Mesh->NCellsOwned;
+      NElementsSize  = Mesh->NCellsSize;
       XElement       = createDeviceMirrorCopy(Mesh->XCellH);
       YElement       = createDeviceMirrorCopy(Mesh->YCellH);
       LonElement     = createDeviceMirrorCopy(Mesh->LonCellH);
@@ -102,6 +106,7 @@ int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
       break;
    case OnVertex:
       NElementsOwned = Mesh->NVerticesOwned;
+      NElementsSize  = Mesh->NVerticesSize;
       XElement       = createDeviceMirrorCopy(Mesh->XVertexH);
       YElement       = createDeviceMirrorCopy(Mesh->YVertexH);
       LonElement     = createDeviceMirrorCopy(Mesh->LonVertexH);
@@ -109,6 +114,7 @@ int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
       break;
    case OnEdge:
       NElementsOwned = Mesh->NEdgesOwned;
+      NElementsSize  = Mesh->NEdgesSize;
       XElement       = createDeviceMirrorCopy(Mesh->XEdgeH);
       YElement       = createDeviceMirrorCopy(Mesh->YEdgeH);
       LonElement     = createDeviceMirrorCopy(Mesh->LonEdgeH);
@@ -120,9 +126,14 @@ int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
       return 1;
    }
 
+   const int NElementsSet = NElementsOwned + static_cast<int>(SetBndOpt);
+
    if constexpr (Array::rank == 1) {
       parallelFor(
-          {NElementsOwned}, KOKKOS_LAMBDA(int IElement) {
+          {NElementsSet}, KOKKOS_LAMBDA(int IElement) {
+             if (SetBndOpt == SetBoundary::Yes) {
+                IElement = IElement == 0 ? (NElementsSize - 1) : (IElement - 1);
+             }
              if (Geom == Geometry::Planar) {
                 const Real X            = XElement(IElement);
                 const Real Y            = YElement(IElement);
@@ -139,8 +150,10 @@ int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
       const int NVertLayers = ScalarElement.extent_int(1);
 
       parallelForOuter(
-          {NElementsOwned},
-          KOKKOS_LAMBDA(int IElement, const TeamMember &Team) {
+          {NElementsSet}, KOKKOS_LAMBDA(int IElement, const TeamMember &Team) {
+             if (SetBndOpt == SetBoundary::Yes) {
+                IElement = IElement == 0 ? (NElementsSize - 1) : (IElement - 1);
+             }
              const int KMin   = getVertBound(VMin, IElement);
              const int KMax   = getVertBound(VMax, IElement);
              const int KRange = KMax - KMin + 1;
@@ -163,8 +176,11 @@ int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
    if constexpr (Array::rank == 3) {
       const int NTracers = ScalarElement.extent_int(0);
       parallelForOuter(
-          {NTracers, NElementsOwned},
+          {NTracers, NElementsSet},
           KOKKOS_LAMBDA(int L, int IElement, const TeamMember &Team) {
+             if (SetBndOpt == SetBoundary::Yes) {
+                IElement = IElement == 0 ? (NElementsSize - 1) : (IElement - 1);
+             }
              const int KMin   = getVertBound(VMin, IElement);
              const int KMax   = getVertBound(VMax, IElement);
              const int KRange = KMax - KMin + 1;
@@ -213,7 +229,8 @@ int setVectorEdge(const Functor &Fun, const Array &VectorFieldEdge,
                   EdgeComponent EdgeComp, Geometry Geom, const HorzMesh *Mesh,
                   const VertMin &VMin, const VertMax &VMax,
                   ExchangeHalos ExchangeHalosOpt   = ExchangeHalos::Yes,
-                  CartProjection CartProjectionOpt = CartProjection::Yes) {
+                  CartProjection CartProjectionOpt = CartProjection::Yes,
+                  SetBoundary SetBndOpt            = SetBoundary::No) {
 
    int Err = 0;
 
@@ -235,6 +252,8 @@ int setVectorEdge(const Functor &Fun, const Array &VectorFieldEdge,
    auto &AngleEdge      = Mesh->AngleEdge;
    auto &CellsOnEdge    = Mesh->CellsOnEdge;
    auto &VerticesOnEdge = Mesh->VerticesOnEdge;
+   const int NEdgesSize = Mesh->NEdgesSize;
+   const int NEdgesSet  = Mesh->NEdgesOwned + static_cast<int>(SetBndOpt);
 
    auto ProjectVector = KOKKOS_LAMBDA(int IEdge) {
       Real VecFieldEdge;
@@ -316,15 +335,20 @@ int setVectorEdge(const Functor &Fun, const Array &VectorFieldEdge,
 
    if constexpr (Array::rank == 1) {
       parallelFor(
-          {Mesh->NEdgesOwned}, KOKKOS_LAMBDA(int IEdge) {
+          {NEdgesSet}, KOKKOS_LAMBDA(int IEdge) {
+             if (SetBndOpt == SetBoundary::Yes) {
+                IEdge = IEdge == 0 ? (NEdgesSize - 1) : (IEdge - 1);
+             }
              VectorFieldEdge(IEdge) = ProjectVector(IEdge);
           });
    }
 
    if constexpr (Array::rank == 2) {
       parallelForOuter(
-          {Mesh->NEdgesOwned},
-          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          {NEdgesSet}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             if (SetBndOpt == SetBoundary::Yes) {
+                IEdge = IEdge == 0 ? (NEdgesSize - 1) : (IEdge - 1);
+             }
              const int KMin   = getVertBound(VMin, IEdge);
              const int KMax   = getVertBound(VMax, IEdge);
              const int KRange = KMax - KMin + 1;

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -359,97 +359,114 @@ int setVectorEdge(const Functor &Fun, const Array &VectorFieldEdge,
                         ExchangeHalosOpt, CartProjectionOpt);
 }
 
-inline Real maxVal(const Array1DReal &Arr) {
-   Real MaxVal;
-
+template <class Reducer> Real reduceArray(const Array1DReal &Arr, int Extent0) {
+   Real Res;
+   Reducer R(Res);
    parallelReduce(
-       {Arr.extent_int(0)},
-       KOKKOS_LAMBDA(int I, Real &Accum) {
-          Accum = Kokkos::max(Arr(I), Accum);
+       {Extent0}, KOKKOS_LAMBDA(int I, Real &Accum) { R.join(Accum, Arr(I)); },
+       R);
+
+   return Res;
+}
+
+template <class Reducer> Real reduceArray(const Array1DReal &Arr) {
+   return reduceArray<Reducer>(Arr, Arr.extent_int(0));
+}
+
+template <class Reducer, class VertMin, class VertMax>
+Real reduceArray(const Array2DReal &Arr, int Extent0, const VertMin &VMin,
+                 const VertMax &VMax) {
+   Real Res;
+   Reducer ROuter(Res);
+
+   parallelReduceOuter(
+       {Extent0},
+       KOKKOS_LAMBDA(int I, const TeamMember &Team, Real &AccumOuter) {
+          Real ResInner;
+          Reducer RInner(ResInner);
+
+          const int KMin   = getVertBound(VMin, I);
+          const int KMax   = getVertBound(VMax, I);
+          const int KRange = KMax - KMin + 1;
+
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, Real &AccumInner) {
+                 const int K = KMin + KOff;
+                 RInner.join(AccumInner, Arr(I, K));
+              },
+              RInner);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { ROuter.join(AccumOuter, ResInner); });
        },
-       Kokkos::Max<Real>(MaxVal));
+       ROuter);
 
-   return MaxVal;
+   return Res;
 }
 
-inline Real maxVal(const Array2DReal &Arr) {
-   Real MaxVal;
-
-   parallelReduce(
-       {Arr.extent_int(0), Arr.extent_int(1)},
-       KOKKOS_LAMBDA(int I, int J, Real &Accum) {
-          Accum = Kokkos::max(Arr(I, J), Accum);
-       },
-       Kokkos::Max<Real>(MaxVal));
-
-   return MaxVal;
+template <class Reducer> Real reduceArray(const Array2DReal &Arr, int Extent0) {
+   return reduceArray<Reducer>(Arr, Extent0, 0, Arr.extent_int(1) - 1);
 }
 
-inline Real maxVal(const Array3DReal &Arr) {
-   Real MaxVal;
-
-   parallelReduce(
-       {Arr.extent_int(0), Arr.extent_int(1), Arr.extent_int(2)},
-       KOKKOS_LAMBDA(int I, int J, int K, Real &Accum) {
-          Accum = Kokkos::max(Arr(I, J, K), Accum);
-       },
-       Kokkos::Max<Real>(MaxVal));
-
-   return MaxVal;
+template <class Reducer> Real reduceArray(const Array2DReal &Arr) {
+   return reduceArray<Reducer>(Arr, Arr.extent_int(0), 0,
+                               Arr.extent_int(1) - 1);
 }
 
-inline Real sum(const Array1DReal &Arr, int Extent0) {
-   Real Sum;
+template <class Reducer, class VertMin, class VertMax>
+Real reduceArray(const Array3DReal &Arr, int Extent0, int Extent1,
+                 const VertMin &VMin, const VertMax &VMax) {
+   Real Res;
+   Reducer ROuter(Res);
 
-   parallelReduce(
-       {Extent0}, KOKKOS_LAMBDA(int I, Real &Accum) { Accum += Arr(I); }, Sum);
-
-   return Sum;
-}
-
-inline Real sum(const Array1DReal &Arr) { return sum(Arr, Arr.extent_int(0)); }
-
-inline Real sum(const Array2DReal &Arr, int Extent0, int Extent1) {
-   Real Sum;
-
-   parallelReduce(
+   parallelReduceOuter(
        {Extent0, Extent1},
-       KOKKOS_LAMBDA(int I, int J, Real &Accum) { Accum += Arr(I, J); }, Sum);
+       KOKKOS_LAMBDA(int L, int I, const TeamMember &Team, Real &AccumOuter) {
+          Real ResInner;
+          Reducer RInner(ResInner);
 
-   return Sum;
-}
+          const int KMin   = getVertBound(VMin, I);
+          const int KMax   = getVertBound(VMax, I);
+          const int KRange = KMax - KMin + 1;
 
-inline Real sum(const Array2DReal &Arr) {
-   return sum(Arr, Arr.extent_int(0), Arr.extent_int(1));
-}
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, Real &AccumInner) {
+                 const int K = KMin + KOff;
+                 RInner.join(AccumInner, Arr(L, I, K));
+              },
+              RInner);
 
-inline Real sum(const Array2DReal &Arr, int Extent0) {
-   return sum(Arr, Extent0, Arr.extent_int(1));
-}
-
-inline Real sum(const Array3DReal &Arr, int Extent0, int Extent1, int Extent2) {
-   Real Sum;
-
-   parallelReduce(
-       {Extent0, Extent1, Extent2},
-       KOKKOS_LAMBDA(int I, int J, int K, Real &Accum) {
-          Accum += Arr(I, J, K);
+          Kokkos::single(PerTeam(Team),
+                         [&]() { ROuter.join(AccumOuter, ResInner); });
        },
-       Sum);
+       ROuter);
 
-   return Sum;
+   return Res;
 }
 
-inline Real sum(const Array3DReal &Arr) {
-   return sum(Arr, Arr.extent_int(0), Arr.extent_int(1), Arr.extent_int(2));
+template <class Reducer>
+Real reduceArray(const Array3DReal &Arr, int Extent0, int Extent1) {
+   return reduceArray<Reducer>(Arr, Extent0, Extent1, 0, Arr.extent_int(2) - 1);
 }
 
-inline Real sum(const Array3DReal &Arr, int Extent0) {
-   return sum(Arr, Extent0, Arr.extent_int(1), Arr.extent_int(2));
+template <class Reducer> Real reduceArray(const Array3DReal &Arr, int Extent0) {
+   return reduceArray<Reducer>(Arr, Extent0, Arr.extent_int(1), 0,
+                               Arr.extent_int(2) - 1);
 }
 
-inline Real sum(const Array3DReal &Arr, int Extent0, int Extent1) {
-   return sum(Arr, Extent0, Extent1, Arr.extent_int(2));
+template <class Reducer> Real reduceArray(const Array3DReal &Arr) {
+   return reduceArray<Reducer>(Arr, Arr.extent_int(0), Arr.extent_int(1), 0,
+                               Arr.extent_int(2) - 1);
+}
+
+template <class... ArgTypes> Real maxVal(ArgTypes &&...Args) {
+   return reduceArray<Kokkos::Max<Real>>(std::forward<ArgTypes>(Args)...);
+}
+
+template <class... ArgTypes> Real sum(ArgTypes &&...Args) {
+   return reduceArray<Kokkos::Sum<Real>>(std::forward<ArgTypes>(Args)...);
 }
 
 struct ErrorMeasures {

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -67,11 +67,23 @@ enum class EdgeComponent { Normal, Tangential };
 enum class Geometry { Planar, Spherical };
 enum class ExchangeHalos { Yes, No };
 
+// helper to get vertical iteration bounds that can be provided
+// either as an integer or an array
+template <class T> int getVertBound(const T &VertBound, int I) {
+   if constexpr (std::is_integral_v<T>) {
+      return VertBound;
+   } else {
+      static_assert(Kokkos::is_view_v<T>);
+      return VertBound(I);
+   }
+}
+
 // set scalar field on chosen elements (cells/vertices/edges) based on
 // analytical formula and optionally exchange halos
-template <class Functor, class Array>
+template <class Functor, class Array, class VertMin, class VertMax>
 int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
-              const HorzMesh *Mesh, MeshElement Element,
+              const HorzMesh *Mesh, MeshElement Element, const VertMin &VMin,
+              const VertMax &VMax,
               ExchangeHalos ExchangeHalosOpt = ExchangeHalos::Yes) {
 
    int Err = 0;
@@ -126,35 +138,49 @@ int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
    if constexpr (Array::rank == 2) {
       const int NVertLayers = ScalarElement.extent_int(1);
 
-      parallelFor(
-          {NElementsOwned, NVertLayers}, KOKKOS_LAMBDA(int IElement, int K) {
-             if (Geom == Geometry::Planar) {
-                const Real X               = XElement(IElement);
-                const Real Y               = YElement(IElement);
-                ScalarElement(IElement, K) = Fun(X, Y);
-             } else {
-                const Real Lon             = LonElement(IElement);
-                const Real Lat             = LatElement(IElement);
-                ScalarElement(IElement, K) = Fun(Lon, Lat);
-             }
+      parallelForOuter(
+          {NElementsOwned},
+          KOKKOS_LAMBDA(int IElement, const TeamMember &Team) {
+             const int KMin   = getVertBound(VMin, IElement);
+             const int KMax   = getVertBound(VMax, IElement);
+             const int KRange = KMax - KMin + 1;
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KOff) {
+                    const int K = KMin + KOff;
+                    if (Geom == Geometry::Planar) {
+                       const Real X               = XElement(IElement);
+                       const Real Y               = YElement(IElement);
+                       ScalarElement(IElement, K) = Fun(X, Y);
+                    } else {
+                       const Real Lon             = LonElement(IElement);
+                       const Real Lat             = LatElement(IElement);
+                       ScalarElement(IElement, K) = Fun(Lon, Lat);
+                    }
+                 });
           });
    }
 
    if constexpr (Array::rank == 3) {
-      const int NTracers    = ScalarElement.extent_int(0);
-      const int NVertLayers = ScalarElement.extent_int(2);
-      parallelFor(
-          {NTracers, NElementsOwned, NVertLayers},
-          KOKKOS_LAMBDA(int L, int IElement, int K) {
-             if (Geom == Geometry::Planar) {
-                const Real X                  = XElement(IElement);
-                const Real Y                  = YElement(IElement);
-                ScalarElement(L, IElement, K) = Fun(X, Y);
-             } else {
-                const Real Lon                = LonElement(IElement);
-                const Real Lat                = LatElement(IElement);
-                ScalarElement(L, IElement, K) = Fun(Lon, Lat);
-             }
+      const int NTracers = ScalarElement.extent_int(0);
+      parallelForOuter(
+          {NTracers, NElementsOwned},
+          KOKKOS_LAMBDA(int L, int IElement, const TeamMember &Team) {
+             const int KMin   = getVertBound(VMin, IElement);
+             const int KMax   = getVertBound(VMax, IElement);
+             const int KRange = KMax - KMin + 1;
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KOff) {
+                    const int K = KMin + KOff;
+                    if (Geom == Geometry::Planar) {
+                       const Real X                  = XElement(IElement);
+                       const Real Y                  = YElement(IElement);
+                       ScalarElement(L, IElement, K) = Fun(X, Y);
+                    } else {
+                       const Real Lon                = LonElement(IElement);
+                       const Real Lat                = LatElement(IElement);
+                       ScalarElement(L, IElement, K) = Fun(Lon, Lat);
+                    }
+                 });
           });
    }
 
@@ -167,13 +193,25 @@ int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
    return Err;
 }
 
+// This overload calls setScalar with vertical bounds based on the array size
+template <class Functor, class Array>
+int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
+              const HorzMesh *Mesh, MeshElement Element,
+              ExchangeHalos ExchangeHalosOpt = ExchangeHalos::Yes) {
+   const int VMin = 0;
+   const int VMax = ScalarElement.extent_int(Array::rank - 1) - 1;
+   return setScalar(Fun, ScalarElement, Geom, Mesh, Element, VMin, VMax,
+                    ExchangeHalosOpt);
+}
+
 enum class CartProjection { Yes, No };
 
 // set vector field on edges based on analytical formula and optionally
 // exchange halos
-template <class Functor, class Array>
+template <class Functor, class Array, class VertMin, class VertMax>
 int setVectorEdge(const Functor &Fun, const Array &VectorFieldEdge,
                   EdgeComponent EdgeComp, Geometry Geom, const HorzMesh *Mesh,
+                  const VertMin &VMin, const VertMax &VMax,
                   ExchangeHalos ExchangeHalosOpt   = ExchangeHalos::Yes,
                   CartProjection CartProjectionOpt = CartProjection::Yes) {
 
@@ -284,10 +322,17 @@ int setVectorEdge(const Functor &Fun, const Array &VectorFieldEdge,
    }
 
    if constexpr (Array::rank == 2) {
-      const int NVertLayers = VectorFieldEdge.extent_int(1);
-      parallelFor(
-          {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int K) {
-             VectorFieldEdge(IEdge, K) = ProjectVector(IEdge);
+      parallelForOuter(
+          {Mesh->NEdgesOwned},
+          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = getVertBound(VMin, IEdge);
+             const int KMax   = getVertBound(VMax, IEdge);
+             const int KRange = KMax - KMin + 1;
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KOff) {
+                    const int K               = KMin + KOff;
+                    VectorFieldEdge(IEdge, K) = ProjectVector(IEdge);
+                 });
           });
    }
 
@@ -298,6 +343,20 @@ int setVectorEdge(const Functor &Fun, const Array &VectorFieldEdge,
          LOG_ERROR("setVectorEdge: error in halo exchange");
    }
    return Err;
+}
+
+// This overload calls setVectorEdge with vertical bounds based on the array
+// size
+template <class Functor, class Array>
+int setVectorEdge(const Functor &Fun, const Array &VectorFieldEdge,
+                  EdgeComponent EdgeComp, Geometry Geom, const HorzMesh *Mesh,
+                  ExchangeHalos ExchangeHalosOpt   = ExchangeHalos::Yes,
+                  CartProjection CartProjectionOpt = CartProjection::Yes) {
+
+   const int VMin = 0;
+   const int VMax = VectorFieldEdge.extent_int(Array::rank - 1) - 1;
+   return setVectorEdge(Fun, VectorFieldEdge, EdgeComp, Geom, Mesh, VMin, VMax,
+                        ExchangeHalosOpt, CartProjectionOpt);
 }
 
 inline Real maxVal(const Array1DReal &Arr) {

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -124,7 +124,7 @@ int initTendenciesTest(const std::string &mesh) {
    }
 
    HorzMesh::init();
-   VertCoord::init(false);
+   VertCoord::init();
    Tracers::init();
 
    // VertCoord::init2();

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -10,6 +10,7 @@
 #include "Halo.h"
 #include "HorzMesh.h"
 #include "IO.h"
+#include "IOStream.h"
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OceanTestCommon.h"
@@ -52,8 +53,9 @@ int initState() {
    int Err = 0;
 
    TestSetup Setup;
-   auto *Mesh  = HorzMesh::getDefault();
-   auto *State = OceanState::getDefault();
+   auto *Mesh   = HorzMesh::getDefault();
+   auto *VCoord = VertCoord::getDefault();
+   auto *State  = OceanState::getDefault();
 
    Array2DReal LayerThickCell;
    Array2DReal NormalVelEdge;
@@ -66,21 +68,28 @@ int initState() {
 
    int NTracers = Tracers::getNumTracers();
 
+   deepCopy(LayerThickCell, NAN);
+   deepCopy(NormalVelEdge, NAN);
+   deepCopy(TracersCell, NAN);
+
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.layerThickness(X, Y); },
-       LayerThickCell, Geom, Mesh, OnCell);
+       LayerThickCell, Geom, Mesh, OnCell, VCoord->MinLayerCell,
+       VCoord->MaxLayerCell, ExchangeHalos::Yes, SetBoundary::Yes);
 
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.tracer(X, Y); },
-       TracersCell, Geom, Mesh, OnCell);
+       TracersCell, Geom, Mesh, OnCell, VCoord->MinLayerCell,
+       VCoord->MaxLayerCell, ExchangeHalos::Yes, SetBoundary::Yes);
 
    Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real Lon, Real Lat) {
           VecField[0] = Setup.velocityX(Lon, Lat);
           VecField[1] = Setup.velocityY(Lon, Lat);
        },
-       NormalVelEdge, EdgeComponent::Normal, Geom, Mesh, ExchangeHalos::Yes,
-       CartProjection::No);
+       NormalVelEdge, EdgeComponent::Normal, Geom, Mesh,
+       VCoord->MinLayerEdgeTop, VCoord->MaxLayerEdgeBot, ExchangeHalos::Yes,
+       CartProjection::No, SetBoundary::Yes);
 
    return Err;
 }
@@ -105,6 +114,9 @@ int initTendenciesTest(const std::string &mesh) {
    IO::init(DefComm);
    Decomp::init(mesh);
 
+   // Initialize streams
+   IOStream::init();
+
    int HaloErr = Halo::init();
    if (HaloErr != 0) {
       Err++;
@@ -114,6 +126,8 @@ int initTendenciesTest(const std::string &mesh) {
    HorzMesh::init();
    VertCoord::init(false);
    Tracers::init();
+
+   // VertCoord::init2();
 
    int StateErr = OceanState::init();
    if (StateErr != 0) {
@@ -192,21 +206,24 @@ int testTendencies() {
    int NTracers    = Tracers::getNumTracers();
 
    const Real LayerThickTendSum =
-       sum(DefTendencies->LayerThicknessTend, NCellsOwned);
+       sum(DefTendencies->LayerThicknessTend, NCellsOwned, VCoord->MinLayerCell,
+           VCoord->MaxLayerCell);
    if (!Kokkos::isfinite(LayerThickTendSum) || LayerThickTendSum == 0) {
       Err++;
       LOG_ERROR("TendenciesTest: LayerThickTend FAIL");
    }
 
    const Real NormVelTendSum =
-       sum(DefTendencies->NormalVelocityTend, NEdgesOwned);
+       sum(DefTendencies->NormalVelocityTend, NEdgesOwned,
+           VCoord->MinLayerEdgeBot, VCoord->MaxLayerEdgeTop);
    if (!Kokkos::isfinite(NormVelTendSum) || NormVelTendSum == 0) {
       Err++;
       LOG_ERROR("TendenciesTest: NormVelTendSum FAIL");
    }
 
    const Real TraceTendSum =
-       sum(DefTendencies->TracerTend, NTracers, NCellsOwned);
+       sum(DefTendencies->TracerTend, NTracers, NCellsOwned,
+           VCoord->MinLayerCell, VCoord->MaxLayerCell);
    if (!Kokkos::isfinite(TraceTendSum) || TraceTendSum == 0) {
       Err++;
       LOG_ERROR("TendenciesTest: TraceTendSum FAIL");

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -334,7 +334,8 @@ int testThickFluxDiv(int NVertLayers, Real RTol) {
    int Err = 0;
    TestSetup Setup;
 
-   const auto Mesh = HorzMesh::getDefault();
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
 
    // Compute exact result
    Array2DReal ExactThickFluxDiv("ExactThickFluxDiv", Mesh->NCellsOwned,
@@ -361,7 +362,7 @@ int testThickFluxDiv(int NVertLayers, Real RTol) {
    // Compute numerical result
    Array2DReal NumThickFluxDiv("NumThickFluxDiv", Mesh->NCellsOwned,
                                NVertLayers);
-   ThicknessFluxDivOnCell ThickFluxDivOnC(Mesh);
+   ThicknessFluxDivOnCell ThickFluxDivOnC(Mesh, VCoord);
    parallelFor(
        {Mesh->NCellsOwned, NVertLayers}, KOKKOS_LAMBDA(int ICell, int KLayer) {
           ThickFluxDivOnC(NumThickFluxDiv, ICell, KLayer, OnesEdge,
@@ -1048,8 +1049,7 @@ int tendencyTermsTest(const std::string &MeshFile = DefaultMeshFile) {
 
    initTendTest(MeshFile, NVertLayers);
 
-   const auto &Mesh = HorzMesh::getDefault();
-   int NTracers     = 3;
+   int NTracers = 3;
 
    const Real RTol = sizeof(Real) == 4 ? 2e-2 : 1e-5;
 

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -204,8 +204,8 @@ int initTimeStepperTest(const std::string &mesh) {
       LOG_ERROR("TimeStepperTest: error creating test state");
    }
 
-   auto *TestAuxState = AuxiliaryState::create(
-       "TestAuxState", DefMesh, DefVertCoord, DefHalo, NVertLayers, NTracers);
+   auto *TestAuxState = AuxiliaryState::create("TestAuxState", DefMesh, DefHalo,
+                                               DefVertCoord, NTracers);
 
    Config *OmegaConfig = Config::getOmegaConfig();
    TestAuxState->readConfigOptions(OmegaConfig);

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -404,7 +404,7 @@ int main(int argc, char *argv[]) {
 
    LOG_INFO("----- Time Stepper Unit Test -----");
 
-   RetVal += timeStepperTest();
+   RetVal += timeStepperTest("OmegaSphereMesh.nc");
 
    Pacer::finalize();
    Kokkos::finalize();

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -293,6 +293,7 @@ int testTimeStepper(const std::string &Name, TimeStepperType Type,
 
    // Set pointers to data
    auto *DefMesh        = HorzMesh::getDefault();
+   auto *DefVCoord      = VertCoord::getDefault();
    auto *DefHalo        = Halo::getDefault();
    auto *TestAuxState   = AuxiliaryState::get("TestAuxState");
    auto *TestTendencies = Tendencies::get("TestTendencies");
@@ -308,7 +309,7 @@ int testTimeStepper(const std::string &Name, TimeStepperType Type,
 
    auto *TestTimeStepper = TimeStepper::create(
        "TestTimeStepper", Type, TimeStart, TimeEndTI, TimeStepTI,
-       TestTendencies, TestAuxState, DefMesh, DefHalo);
+       TestTendencies, TestAuxState, DefMesh, DefVCoord, DefHalo);
 
    if (!TestTimeStepper) {
       Err++;


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
This PR converts the following Omega modules to use hierarchical parallelism for limiting vertical loops extents:
- Auxiliary state
- Tendencies
- EOS

It includes some minor changes to the vertical coordinate module, but #309 has more substantial updates and needs to be merged first.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [ ] User's Guide has been updated
  * [x] Developer's Guide has been updated
  * [x] Documentation has been [built locally](https://e3sm-project.github.io/Omega/omega/develop/devGuide/BuildDocs.html) and changes look as expected
* [ ] Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [x] CTest unit tests for new features have been added per the approved design.
  * [x] Unit tests have passed. Please provide a relevant CDash build entry for verification.
  * [ ] Polaris test suite has passed

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


