### PR TITLE
Change default IO type from NETCDF4C to PNETCDF

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -129,7 +129,7 @@ Omega:
       UsePointerFile: false
       Filename: ocn.hifreq.$Y-$M
       Mode: write
-      IfExists: append
+      IfExists: replace
       Precision: single
       Freq: 10
       FreqUnits: days

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -114,7 +114,7 @@ Omega:
         - Restart
     History:
       UsePointerFile: false
-      Filename: ocn.hist.$SimTime
+      Filename: ocn.hist.$Y-$M-$D_$h.$m.$s
       Mode: write
       IfExists: replace
       Precision: double
@@ -129,7 +129,7 @@ Omega:
       UsePointerFile: false
       Filename: ocn.hifreq.$Y-$M
       Mode: write
-      IfExists: replace
+      IfExists: append
       Precision: single
       Freq: 10
       FreqUnits: days

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -19,7 +19,7 @@ Omega:
     IOStride: 1
     IOBaseTask: 0
     IORearranger: box
-    IODefaultFormat: NetCDF4
+    IODefaultFormat: pnetcdf
   State:
     NTimeLevels: 2
   Advection:

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -193,7 +193,7 @@ void init(const MPI_Comm &InComm // [in] MPI communicator to use
    Err                   = IOConfig.get("IODefaultFormat", InFileFmt);
    CHECK_ERROR_WARN(Err, "IO: DefaultFileFmt not found in Config - using {}",
                     InFileFmt);
-   FileFmt DefaultFileFmt = FileFmtFromString(InFileFmt);
+   DefaultFileFmt = FileFmtFromString(InFileFmt);
 
    // Read parallel IO settings - default to single-task if config
    // values do not exist

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -249,6 +249,7 @@ void openFile(
 
    int PIOErr = 0;        // internal SCORPIO/PIO return call
    int Format = InFormat; // coerce to integer for PIO calls
+   int IsCDF5 = (InFormat == PIO_IOTYPE_PNETCDF) ? PIO_64BIT_DATA : 0;
 
    switch (InMode) {
 
@@ -269,7 +270,7 @@ void openFile(
       // file exists, we use create and fail with an error
       case IfExists::Fail:
          PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
-                                  NC_NOCLOBBER | PIO_64BIT_DATA | InMode);
+                                  NC_NOCLOBBER | IsCDF5 | InMode);
          if (PIOErr != PIO_NOERR)
             ABORT_ERROR("IO::openFile: PIO error opening file {} for writing",
                         Filename);
@@ -279,7 +280,7 @@ void openFile(
       // we use create with the CLOBBER option
       case IfExists::Replace:
          PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
-                                  NC_CLOBBER | PIO_64BIT_DATA | InMode);
+                                  NC_CLOBBER | IsCDF5 | InMode);
          if (PIOErr != PIO_NOERR)
             ABORT_ERROR("IO::openFile: PIO error opening file {} for writing",
                         Filename);
@@ -291,10 +292,10 @@ void openFile(
       case IfExists::Append:
          if (std::filesystem::exists(Filename)) {
             PIOErr = PIOc_openfile(SysID, &FileID, &Format, Filename.c_str(),
-                                   NC_CLOBBER | PIO_64BIT_DATA | InMode);
+                                   IsCDF5 | InMode);
          } else {
             PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
-                                     PIO_64BIT_DATA | InMode);
+                                     IsCDF5 | InMode);
          }
 
          if (PIOErr != PIO_NOERR)

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -291,7 +291,7 @@ void openFile(
       case IfExists::Append:
          if (std::filesystem::exists(Filename)) {
             PIOErr = PIOc_openfile(SysID, &FileID, &Format, Filename.c_str(),
-                                   InMode);
+                                   NC_CLOBBER | PIO_64BIT_DATA | InMode);
          } else {
             PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
                                      PIO_64BIT_DATA | InMode);

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -189,7 +189,7 @@ void init(const MPI_Comm &InComm // [in] MPI communicator to use
    CHECK_ERROR_ABORT(Err, "IO: IO group not found in input Config");
 
    // Read default file format
-   std::string InFileFmt = "netcdf4c"; // set default value
+   std::string InFileFmt = "pnetcdf"; // set default value
    Err                   = IOConfig.get("IODefaultFormat", InFileFmt);
    CHECK_ERROR_WARN(Err, "IO: DefaultFileFmt not found in Config - using {}",
                     InFileFmt);

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -269,7 +269,7 @@ void openFile(
       // file exists, we use create and fail with an error
       case IfExists::Fail:
          PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
-                                  NC_NOCLOBBER | InMode);
+                                  NC_NOCLOBBER | PIO_64BIT_DATA | InMode);
          if (PIOErr != PIO_NOERR)
             ABORT_ERROR("IO::openFile: PIO error opening file {} for writing",
                         Filename);
@@ -279,7 +279,7 @@ void openFile(
       // we use create with the CLOBBER option
       case IfExists::Replace:
          PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
-                                  NC_CLOBBER | InMode);
+                                  NC_CLOBBER | PIO_64BIT_DATA | InMode);
          if (PIOErr != PIO_NOERR)
             ABORT_ERROR("IO::openFile: PIO error opening file {} for writing",
                         Filename);
@@ -294,7 +294,7 @@ void openFile(
                                    InMode);
          } else {
             PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
-                                     InMode);
+                                     PIO_64BIT_DATA | InMode);
          }
 
          if (PIOErr != PIO_NOERR)

--- a/components/omega/src/base/IO.h
+++ b/components/omega/src/base/IO.h
@@ -74,7 +74,7 @@ enum FileFmt {
    FmtHDF5     = PIO_IOTYPE_HDF5,     ///< native HDF5 format
    FmtADIOS    = PIO_IOTYPE_ADIOS,    ///< ADIOS format
    FmtUnknown  = -1,                  ///< Unknown or undefined
-   FmtDefault  = PIO_IOTYPE_NETCDF4C, ///< NetCDF4 is default
+   FmtDefault  = PIO_IOTYPE_PNETCDF,  ///< PNETCDF is default
 };
 
 /// File operations

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -2439,6 +2439,7 @@ void IOStream::writeStream(
    // Open output file
    int OutFileID;
    IO::openFile(OutFileID, OutFileName, Mode, IO::FmtDefault, ExistAction);
+   bool NeedEndDef = false; // check if we need to call end-define-mode
 
    // For files with multiple frames or time slices, we need to determine the
    // default Frame number for time-dependent fields. If the frame/time already
@@ -2491,6 +2492,7 @@ void IOStream::writeStream(
    if (Frame < 1) {
       writeFieldMeta(CodeMeta, OutFileID, IO::GlobalID);
       writeFieldMeta(SimMeta, OutFileID, IO::GlobalID);
+      NeedEndDef = true;
    }
 
    // Create and write a field for any global data that is file or time
@@ -2506,6 +2508,10 @@ void IOStream::writeStream(
       FileField->addMetadata(SimTimeName, SimTimeStr);
    }
    // Write and then destroy temporary field
+   if (!NeedEndDef) { // in data-mode, need to redef
+      PIOc_redef(OutFileID);
+      NeedEndDef = true;
+   }
    writeFieldMeta("FileField", OutFileID, IO::GlobalID);
    Field::destroy("FileField");
 
@@ -2557,7 +2563,11 @@ void IOStream::writeStream(
       // Now we can write the field metadata
       if (Frame < 1) { // only write if it's the first time
          writeFieldMeta(FieldName, OutFileID, FieldID);
+         NeedEndDef = true;
       }
+   }
+   if (NeedEndDef) {
+      IO::endDefinePhase(OutFileID);
    }
 
    // Now write data arrays for all fields in contents

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -2285,7 +2285,7 @@ Error IOStream::readStream(
 
    // Open input file
    int InFileID;
-   IO::openFile(InFileID, InFileName, Mode, IO::FmtDefault, ExistAction);
+   IO::openFile(InFileID, InFileName, Mode, IO::DefaultFileFmt, ExistAction);
 
    // Read any requested global metadata
    for (auto Iter = ReqMetadata.begin(); Iter != ReqMetadata.end(); ++Iter) {
@@ -2438,7 +2438,7 @@ void IOStream::writeStream(
 
    // Open output file
    int OutFileID;
-   IO::openFile(OutFileID, OutFileName, Mode, IO::FmtDefault, ExistAction);
+   IO::openFile(OutFileID, OutFileName, Mode, IO::DefaultFileFmt, ExistAction);
    bool NeedEndDef = false; // check if we need to call end-define-mode
 
    // For files with multiple frames or time slices, we need to determine the


### PR DESCRIPTION
Change default IO type from NETCDF4C to PNETCDF

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests
    * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.
    * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

Fixes #333 
Closes #334 
