### PR TITLE
fix a bug in reading IODefaultFormat from omega.yml

### DIFF
--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -193,7 +193,7 @@ void init(const MPI_Comm &InComm // [in] MPI communicator to use
    Err                   = IOConfig.get("IODefaultFormat", InFileFmt);
    CHECK_ERROR_WARN(Err, "IO: DefaultFileFmt not found in Config - using {}",
                     InFileFmt);
-   FileFmt DefaultFileFmt = FileFmtFromString(InFileFmt);
+   DefaultFileFmt = FileFmtFromString(InFileFmt);
 
    // Read parallel IO settings - default to single-task if config
    // values do not exist

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -2285,7 +2285,7 @@ Error IOStream::readStream(
 
    // Open input file
    int InFileID;
-   IO::openFile(InFileID, InFileName, Mode, IO::FmtDefault, ExistAction);
+   IO::openFile(InFileID, InFileName, Mode, IO::DefaultFileFmt, ExistAction);
 
    // Read any requested global metadata
    for (auto Iter = ReqMetadata.begin(); Iter != ReqMetadata.end(); ++Iter) {
@@ -2438,7 +2438,7 @@ void IOStream::writeStream(
 
    // Open output file
    int OutFileID;
-   IO::openFile(OutFileID, OutFileName, Mode, IO::FmtDefault, ExistAction);
+   IO::openFile(OutFileID, OutFileName, Mode, IO::DefaultFileFmt, ExistAction);
 
    // For files with multiple frames or time slices, we need to determine the
    // default Frame number for time-dependent fields. If the frame/time already


### PR DESCRIPTION
This PR fixes a bug in reading `IODefaultFormat` from `omega.yml`.

The tests passed on Perlmutter GPU for `netcdf4c` format only.

As of this commit, the only supported format for the `IODefaultFormat` parameter in `omega.yml` is `netcdf4c`. Other formats produce various errors due to possibly remaining bugs in IO and IOStream modules.

This PR is intended to expedite debugging of those issues.