### PR TITLE
Fixes Omega ssh calculation

### DIFF
--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -244,7 +244,8 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
    Pacer::start("AuxState:computeVerticalVelocity", 2);
 
    const auto &FluxLayerThickEdge = LayerThicknessAux.FluxLayerThickEdge;
-   VAdv->computeVerticalVelocity(NormalVelEdge, FluxLayerThickEdge);
+   VAdv->computeVerticalVelocity(NormalVelEdge, FluxLayerThickEdge,
+                                 LayerThickCell, ProjDtSeconds); 
 
    Pacer::stop("AuxState:computeVerticalVelocity", 2);
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -245,7 +245,7 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
 
    const auto &FluxLayerThickEdge = LayerThicknessAux.FluxLayerThickEdge;
    VAdv->computeVerticalVelocity(NormalVelEdge, FluxLayerThickEdge,
-                                 LayerThickCell, ProjDtSeconds); 
+                                 LayerThickCell, ProjDtSeconds);
 
    Pacer::stop("AuxState:computeVerticalVelocity", 2);
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -241,31 +241,6 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
        });
    Pacer::stop("AuxState:cellAuxState2", 2);
 
-   Pacer::start("AuxState:cellAuxState3", 2);
-   parallelForOuter(
-       "cellAuxState3", {Mesh->NCellsAll},
-       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRangeChunked(KMin, KMax);
-
-          parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 LocLayerThicknessAux.computeVarsOnCells(
-                     ICell, KChunk, LayerThickCell, NormalVelEdge,
-                     TimeStepSeconds);
-              });
-       });
-   Pacer::stop("AuxState:cellAuxState3", 2);
-
-   Pacer::start("AuxState:computeVerticalVelocity", 2);
-
-   const auto &FluxLayerThickEdge = LayerThicknessAux.FluxLayerThickEdge;
-   VAdv->computeVerticalVelocity(NormalVelEdge, FluxLayerThickEdge,
-                                 LayerThickCell, ProjDtSeconds);
-
-   Pacer::stop("AuxState:computeVerticalVelocity", 2);
-
    Pacer::stop("AuxState:computeMomAux", 1);
 }
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -241,6 +241,13 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
        });
    Pacer::stop("AuxState:cellAuxState2", 2);
 
+   Pacer::start("AuxState:computeVerticalVelocity", 2);
+
+   const auto &FluxLayerThickEdge = LayerThicknessAux.FluxLayerThickEdge;
+   VAdv->computeVerticalVelocity(NormalVelEdge, FluxLayerThickEdge);
+
+   Pacer::stop("AuxState:computeVerticalVelocity", 2);
+
    Pacer::stop("AuxState:computeMomAux", 1);
 }
 

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -563,7 +563,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    }
 
    // Compute sea surface height gradient
-   const Array1DReal &SSHCell = LocSshCell; 
+   const Array1DReal &SSHCell = LocSshCell;
    if (LocSSHGrad.Enabled) {
       Pacer::start("Tend:SSHGrad", 2);
       parallelForOuter(

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -504,6 +504,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    OMEGA_SCOPE(LocBottomDrag, BottomDrag);
    OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
    OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+   OMEGA_SCOPE(LocSshCell, VCoord->SshCell);
 
    Pacer::start("Tend:computeVelocityTendenciesOnly", 1);
 
@@ -562,7 +563,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    }
 
    // Compute sea surface height gradient
-   const Array2DReal &SSHCell = AuxState->LayerThicknessAux.SshCell;
+   const Array1DReal &SSHCell = LocSshCell; 
    if (LocSSHGrad.Enabled) {
       Pacer::start("Tend:SSHGrad", 2);
       parallelForOuter(

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -184,8 +184,7 @@ class SSHGradOnEdge {
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
          Tend(IEdge, K) -= EdgeMask(IEdge, K) * Gravity *
-                           (SshCell(ICell1) - SshCell(ICell0)) *
-                           InvDcEdge;
+                           (SshCell(ICell1) - SshCell(ICell0)) * InvDcEdge;
       }
    }
 

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -173,7 +173,7 @@ class SSHGradOnEdge {
    /// The functor takes edge index, vertical chunk index, and array of
    /// layer thickness/SSH, outputs tendency array
    KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
-                                   const Array2DReal &SshCell) const {
+                                   const Array1DReal &SshCell) const {
 
       const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
@@ -184,7 +184,7 @@ class SSHGradOnEdge {
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
          Tend(IEdge, K) -= EdgeMask(IEdge, K) * Gravity *
-                           (SshCell(ICell1, K) - SshCell(ICell0, K)) *
+                           (SshCell(ICell1) - SshCell(ICell0)) *
                            InvDcEdge;
       }
    }

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -144,10 +144,10 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    BottomDepth  = Array1DReal("BottomDepth", NCellsSize);
    PressureInterface =
        Array2DReal("PressureInterface", NCellsSize, NVertLayersP1);
-   PressureMid     = Array2DReal("PressureMid", NCellsSize, NVertLayers);
-   ZInterface      = Array2DReal("ZInterface", NCellsSize, NVertLayersP1);
-   ZMid            = Array2DReal("ZMid", NCellsSize, NVertLayers);
-   SshCell         = Array1DReal("SshCell", NCellsSize);
+   PressureMid = Array2DReal("PressureMid", NCellsSize, NVertLayers);
+   ZInterface  = Array2DReal("ZInterface", NCellsSize, NVertLayersP1);
+   ZMid        = Array2DReal("ZMid", NCellsSize, NVertLayers);
+   SshCell     = Array1DReal("SshCell", NCellsSize);
 
    GeopotentialMid = Array2DReal("GeopotentialMid", NCellsSize, NVertLayers);
    LayerThicknessTarget =
@@ -162,11 +162,11 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    deepCopy(SurfacePressure, 0);
 
    // Make host copies for device arrays not being read from file
-   PressureInterfaceH    = createHostMirrorCopy(PressureInterface);
-   PressureMidH          = createHostMirrorCopy(PressureMid);
-   ZInterfaceH           = createHostMirrorCopy(ZInterface);
-   ZMidH                 = createHostMirrorCopy(ZMid);
-   SshCellH              = createHostMirrorCopy(SshCellH);
+   PressureInterfaceH = createHostMirrorCopy(PressureInterface);
+   PressureMidH       = createHostMirrorCopy(PressureMid);
+   ZInterfaceH        = createHostMirrorCopy(ZInterface);
+   ZMidH              = createHostMirrorCopy(ZMid);
+   SshCellH           = createHostMirrorCopy(SshCellH);
 
    GeopotentialMidH      = createHostMirrorCopy(GeopotentialMid);
    LayerThicknessTargetH = createHostMirrorCopy(LayerThicknessTarget);
@@ -293,17 +293,16 @@ void VertCoord::defineFields() {
    );
 
    auto SshField = Field::create(
-       SshFldName,                     // field name
+       SshFldName,                          // field name
        "sea surface height at cell center", // long Name or description
        "m",                                 // units
        "sea_surface_height",                // CF standard Name
        std::numeric_limits<Real>::min(),    // min valid value
        std::numeric_limits<Real>::max(),    // max valid value
-       FillValueReal,                           // scalar for undefined entries
+       FillValueReal,                       // scalar for undefined entries
        NDims,                               // number of dimensions
-       DimNames                          // dimension names
+       DimNames                             // dimension names
    );
-
 
    NDims = 2;
    DimNames.resize(NDims);
@@ -1001,8 +1000,8 @@ void VertCoord::computeZHeight(
                     LocZInterf(ICell, KLyr) = -LocBotDepth(ICell) + Accum;
                     LocZMid(ICell, KLyr) =
                         -LocBotDepth(ICell) + Accum - 0.5 * DZ;
-                    if (KLyr == 0) {
-                       LocSshCell(ICell) = LocZInterf(ICell,KLyr);
+                    if (KLyr == KMin) {
+                       LocSshCell(ICell) = LocZInterf(ICell, KLyr);
                     }
                  }
               });

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -147,6 +147,8 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    PressureMid     = Array2DReal("PressureMid", NCellsSize, NVertLayers);
    ZInterface      = Array2DReal("ZInterface", NCellsSize, NVertLayersP1);
    ZMid            = Array2DReal("ZMid", NCellsSize, NVertLayers);
+   SshCell         = Array1DReal("SshCell", NCellsSize);
+
    GeopotentialMid = Array2DReal("GeopotentialMid", NCellsSize, NVertLayers);
    LayerThicknessTarget =
        Array2DReal("LayerThicknessTarget", NCellsSize, NVertLayers);
@@ -164,6 +166,8 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    PressureMidH          = createHostMirrorCopy(PressureMid);
    ZInterfaceH           = createHostMirrorCopy(ZInterface);
    ZMidH                 = createHostMirrorCopy(ZMid);
+   SshCellH              = createHostMirrorCopy(SshCellH);
+
    GeopotentialMidH      = createHostMirrorCopy(GeopotentialMid);
    LayerThicknessTargetH = createHostMirrorCopy(LayerThicknessTarget);
 
@@ -224,6 +228,8 @@ void VertCoord::defineFields() {
    PressMidFldName       = "PressureMid";
    ZInterfFldName        = "ZInterface";
    ZMidFldName           = "ZMid";
+   SshFldName            = "SshCell";
+
    GeopotFldName         = "GeopotentialMid";
    LyrThickTargetFldName = "LayerThicknessTarget";
 
@@ -239,6 +245,7 @@ void VertCoord::defineFields() {
       ZMidFldName.append(Name);
       GeopotFldName.append(Name);
       LyrThickTargetFldName.append(Name);
+      SshFldName.append(Name);
    }
 
    // Create fields for VertCoord variables
@@ -284,6 +291,19 @@ void VertCoord::defineFields() {
        NDims,                            // number of dimensions
        DimNames                          // dimension names
    );
+
+   auto SshField = Field::create(
+       SshFldName,                     // field name
+       "sea surface height at cell center", // long Name or description
+       "m",                                 // units
+       "sea_surface_height",                // CF standard Name
+       std::numeric_limits<Real>::min(),    // min valid value
+       std::numeric_limits<Real>::max(),    // max valid value
+       FillValueReal,                           // scalar for undefined entries
+       NDims,                               // number of dimensions
+       DimNames                          // dimension names
+   );
+
 
    NDims = 2;
    DimNames.resize(NDims);
@@ -431,6 +451,7 @@ void VertCoord::defineFields() {
    VCoordGroup->addField(ZMidFldName);
    VCoordGroup->addField(GeopotFldName);
    VCoordGroup->addField(LyrThickTargetFldName);
+   VCoordGroup->addField(SshFldName);
 
    // Associate Field with data
    PressureInterfaceField->attachData<Array2DReal>(PressureInterface);
@@ -439,6 +460,7 @@ void VertCoord::defineFields() {
    ZMidField->attachData<Array2DReal>(ZMid);
    GeopotentialMidField->attachData<Array2DReal>(GeopotentialMid);
    LayerThicknessTargetField->attachData<Array2DReal>(LayerThicknessTarget);
+   SshField->attachData<Array1DReal>(SshCell);
 
 } // end defineFields
 
@@ -462,6 +484,7 @@ VertCoord::~VertCoord() {
       Field::destroy(ZMidFldName);
       Field::destroy(GeopotFldName);
       Field::destroy(LyrThickTargetFldName);
+      Field::destroy(SshFldName);
       FieldGroup::destroy(GroupName);
    }
 
@@ -958,6 +981,7 @@ void VertCoord::computeZHeight(
    OMEGA_SCOPE(LocZInterf, ZInterface);
    OMEGA_SCOPE(LocZMid, ZMid);
    OMEGA_SCOPE(LocBotDepth, BottomDepth);
+   OMEGA_SCOPE(LocSshCell, SshCell);
 
    parallelForOuter(
        "computeZHeight", {NCellsAll},
@@ -977,6 +1001,9 @@ void VertCoord::computeZHeight(
                     LocZInterf(ICell, KLyr) = -LocBotDepth(ICell) + Accum;
                     LocZMid(ICell, KLyr) =
                         -LocBotDepth(ICell) + Accum - 0.5 * DZ;
+                    if (KLyr == 0) {
+                       LocSshCell(ICell) = LocZInterf(ICell,KLyr);
+                    }
                  }
               });
        });
@@ -1080,6 +1107,8 @@ void VertCoord::copyToHost() {
    deepCopy(PressureMidH, PressureMid);
    deepCopy(ZInterfaceH, ZInterface);
    deepCopy(ZMidH, ZMid);
+   deepCopy(SshCellH, SshCell);
+
    deepCopy(GeopotentialMidH, GeopotentialMid);
    deepCopy(LayerThicknessTargetH, LayerThicknessTarget);
    deepCopy(RefPseudoThicknessH, RefPseudoThickness);
@@ -1093,6 +1122,8 @@ void VertCoord::copyToDevice() {
    deepCopy(PressureMid, PressureMidH);
    deepCopy(ZInterface, ZInterfaceH);
    deepCopy(ZMid, ZMidH);
+   deepCopy(SshCell, SshCellH);
+
    deepCopy(GeopotentialMid, GeopotentialMidH);
    deepCopy(LayerThicknessTarget, LayerThicknessTargetH);
    deepCopy(RefPseudoThickness, RefPseudoThicknessH);

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -98,6 +98,7 @@ class VertCoord {
    Array2DReal ZMid;
    Array2DReal GeopotentialMid;
    Array2DReal LayerThicknessTarget;
+   Array1DReal SshCell;
 
    HostArray2DReal PressureInterfaceH;
    HostArray2DReal PressureMidH;
@@ -105,6 +106,7 @@ class VertCoord {
    HostArray2DReal ZMidH;
    HostArray2DReal GeopotentialMidH;
    HostArray2DReal LayerThicknessTargetH;
+   HostArray1DReal SshCellH;
 
    // Vertical loop bounds
    Array1DI4 MinLayerCell;
@@ -178,6 +180,7 @@ class VertCoord {
    std::string ZMidFldName;        ///< Field name for midpoint Z height
    std::string GeopotFldName;      ///< Field name for geopotential
    std::string LyrThickTargetFldName; ///< Field name for target thickness
+   std::string SshFldName;        ///< Field name for sea surface height
 
    // methods
 

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -180,7 +180,7 @@ class VertCoord {
    std::string ZMidFldName;        ///< Field name for midpoint Z height
    std::string GeopotFldName;      ///< Field name for geopotential
    std::string LyrThickTargetFldName; ///< Field name for target thickness
-   std::string SshFldName;        ///< Field name for sea surface height
+   std::string SshFldName;            ///< Field name for sea surface height
 
    // methods
 

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.cpp
@@ -12,14 +12,11 @@ LayerThicknessAuxVars::LayerThicknessAuxVars(const std::string &AuxStateSuffix,
                          Mesh->NEdgesSize, VCoord->NVertLayers),
       MeanLayerThickEdge("MeanLayerThickEdge" + AuxStateSuffix,
                          Mesh->NEdgesSize, VCoord->NVertLayers),
-      SshCell("SshCell" + AuxStateSuffix, Mesh->NCellsSize,
-              VCoord->NVertLayers),
       ProvThickness("ProvThickness" + AuxStateSuffix, Mesh->NCellsSize,
                     VCoord->NVertLayers),
       AreaCell(Mesh->AreaCell), DvEdge(Mesh->DvEdge),
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       EdgeSignOnCell(Mesh->EdgeSignOnCell), CellsOnEdge(Mesh->CellsOnEdge),
-      BottomDepth(VCoord->BottomDepth),
       MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
       MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop),
       MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell) {}
@@ -69,20 +66,6 @@ void LayerThicknessAuxVars::registerFields(const std::string &AuxGroupName,
        DimNames   // dimension names
    );
 
-   // Sea surface height
-   DimNames[0]       = "NCells" + DimSuffix;
-   auto SshCellField = Field::create(
-       SshCell.label(),                     // field name
-       "sea surface height at cell center", // long Name or description
-       "m",                                 // units
-       "sea_surface_height",                // CF standard Name
-       0,                                   // min valid value
-       std::numeric_limits<Real>::max(),    // max valid value
-       FillValue,                           // scalar for undefined entries
-       NDims,                               // number of dimensions
-       DimNames                             // dimension names
-   );
-
    // Provisional Thickness
    auto ProvThicknessField = Field::create(
        ProvThickness.label(),                   // field name
@@ -99,20 +82,17 @@ void LayerThicknessAuxVars::registerFields(const std::string &AuxGroupName,
    // Add fields to Aux field group
    FieldGroup::addFieldToGroup(FluxLayerThickEdge.label(), AuxGroupName);
    FieldGroup::addFieldToGroup(MeanLayerThickEdge.label(), AuxGroupName);
-   FieldGroup::addFieldToGroup(SshCell.label(), AuxGroupName);
    FieldGroup::addFieldToGroup(ProvThickness.label(), AuxGroupName);
 
    // Attach field data
    FluxLayerThickEdgeField->attachData<Array2DReal>(FluxLayerThickEdge);
    MeanLayerThickEdgeField->attachData<Array2DReal>(MeanLayerThickEdge);
-   SshCellField->attachData<Array2DReal>(SshCell);
    ProvThicknessField->attachData<Array2DReal>(ProvThickness);
 }
 
 void LayerThicknessAuxVars::unregisterFields() const {
    Field::destroy(FluxLayerThickEdge.label());
    Field::destroy(MeanLayerThickEdge.label());
-   Field::destroy(SshCell.label());
    Field::destroy(ProvThickness.label());
 }
 

--- a/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/LayerThicknessAuxVars.h
@@ -16,7 +16,6 @@ class LayerThicknessAuxVars {
  public:
    Array2DReal FluxLayerThickEdge;
    Array2DReal MeanLayerThickEdge;
-   Array2DReal SshCell;
    Array2DReal ProvThickness;
 
    FluxThickEdgeOption FluxThickEdgeChoice;
@@ -73,11 +72,6 @@ class LayerThicknessAuxVars {
       const int KStart = chunkStart(KChunk, MinLayerCell(ICell));
       const int KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
 
-      for (int KVec = 0; KVec < KLen; ++KVec) {
-         const int K       = KStart + KVec;
-         SshCell(ICell, K) = LayerThickCell(ICell, K) - BottomDepth(ICell);
-      }
-
       Real TmpProv[VecLength] = {0.};
 
       Real DtInvAreaCell = Dt / AreaCell(ICell);
@@ -109,7 +103,6 @@ class LayerThicknessAuxVars {
    Array2DI4 EdgesOnCell;
    Array2DReal EdgeSignOnCell;
    Array2DI4 CellsOnEdge;
-   Array1DReal BottomDepth;
    Array1DI4 MinLayerEdgeBot;
    Array1DI4 MaxLayerEdgeTop;
    Array1DI4 MinLayerCell;

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -532,8 +532,7 @@ int testSSHGrad(int NVertLayers, Real RTol) {
        },
        ExactSSHGrad, EdgeComponent::Normal, Geom, Mesh, ExchangeHalos::No);
 
-   // Set input array
-   Array2DReal SSHCell("SSHCell", Mesh->NCellsSize, NVertLayers);
+   Array1DReal SSHCell("SSHCell", Mesh->NCellsSize);
 
    Err += setScalar(
        KOKKOS_LAMBDA(Real X, Real Y) { return Setup.scalar(X, Y); }, SSHCell,


### PR DESCRIPTION
The current SSH calculation is designed for stacked shallow water only and was causing issues (such as NaNs in the barotropic channel case) in current tests.  The SSH calculation is moved to the VertCoord class and computed alongside ZMid and ZInterface

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [ ] Indicate "All tests passed" or document failing tests
    * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.

resolves #321 
resolves #332 


