### PR TITLE
fix ctest MPI mpirun arguments

### DIFF
--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -302,7 +302,7 @@ add_omega_test(
     TEND_PLANE_TEST
     testTendencyTermsPlane.exe
     ocn/TendencyTermsTest.cpp
-    "-n 8;"
+    "-n;8"
 )
 target_compile_definitions(
   testTendencyTermsPlane.exe
@@ -314,7 +314,7 @@ add_omega_test(
     TEND_PLANE_SINGLE_PRECISION_TEST
     testTendencyTermsPlaneSinglePrecision.exe
     ocn/TendencyTermsTest.cpp
-    "-n 8;"
+    "-n;8"
     single_precision
 )
 target_compile_definitions(
@@ -327,7 +327,7 @@ add_omega_test(
   TEND_SPHERE_TEST
     testTendencyTermsSphere.exe
     ocn/TendencyTermsTest.cpp
-    "-n 8;"
+    "-n;8"
 )
 target_compile_definitions(
   testTendencyTermsSphere.exe
@@ -416,7 +416,7 @@ add_omega_test(
   KOKKOS_FLATPAR_TEST
     testKokkosFlatPar.exe
     infra/OmegaKokkosFlatParTest.cpp
-    "-n;1;"
+    "-n;1"
 )
 
 add_omega_test(


### PR DESCRIPTION
Some MPI implementations do not like `-n 8` as a single argument to mpirun. Splitting it into two is more portable.

The CTest tests pass locally on my laptop but I haven't run any part of the test suite on a different machine.

Fixes #339.


Checklist

* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [ ] Indicate "All tests passed" or document failing tests
    * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.
    * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.


