### PR TITLE
Fixes CUDA sanitizer issues

### DIFF
--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -804,8 +804,9 @@ void Decomp::erase(std::string InName // [in] name of decomp to remove
 
 void Decomp::clear() {
 
-   AllDecomps.clear(); // removes all decomps from the list (map) and in
-                       // the process, calls the destructors for each
+   AllDecomps.clear();      // removes all decomps from the list (map) and in
+                            // the process, calls the destructors for each
+   DefaultDecomp = nullptr; // prevent dangling pointer
 
 } // end decomp clear
 

--- a/components/omega/src/base/Halo.cpp
+++ b/components/omega/src/base/Halo.cpp
@@ -247,8 +247,9 @@ void Halo::erase(std::string InName // name of Halo to remove
 
 void Halo::clear() {
 
-   AllHalos.clear(); // removes all Halos from the map and in the
-                     // process, calls the destructor for each
+   AllHalos.clear();      // removes all Halos from the map and in the
+                          // process, calls the destructor for each
+   DefaultHalo = nullptr; // prevent dangling pointer
 
 } // end Halo clear
 

--- a/components/omega/src/base/MachEnv.cpp
+++ b/components/omega/src/base/MachEnv.cpp
@@ -135,6 +135,10 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
       MasterTaskFlag = false;
    }
 
+   // Free the MPI_Group objects to prevent memory leaks
+   MPI_Group_free(&InGroup);
+   MPI_Group_free(&NewGroup);
+
 #ifdef OMEGA_THREADED
    // total number of OpenMP threads
    NumThreads = omp_get_num_threads();
@@ -217,6 +221,10 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
       MasterTaskFlag = false;
    }
 
+   // Free the MPI_Group objects to prevent memory leaks
+   MPI_Group_free(&InGroup);
+   MPI_Group_free(&NewGroup);
+
 #ifdef OMEGA_THREADED
    // total number of OpenMP threads
    NumThreads = omp_get_num_threads();
@@ -238,7 +246,6 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
                  const int Tasks[],      // [in] vector of parent tasks to incl
                  const int InMasterTask  // [in] optionally set Master Task
 ) {
-
    // Check for valid master task input
    OMEGA_REQUIRE(
        (InMasterTask >= 0 || InMasterTask < NewSize),
@@ -298,6 +305,10 @@ MachEnv::MachEnv(const std::string Name, // [in] name of environment
       MasterTaskFlag = false;
    }
 
+   // Free the MPI_Group objects to prevent memory leaks
+   MPI_Group_free(&InGroup);
+   MPI_Group_free(&NewGroup);
+
 #ifdef OMEGA_THREADED
    // total number of OpenMP threads
    NumThreads = omp_get_num_threads();
@@ -334,7 +345,8 @@ void MachEnv::removeEnv(const std::string Name // [in] name of env to remove
 
 void MachEnv::removeAll() {
 
-   AllEnvs.clear(); // removes all environments by removing them from map
+   AllEnvs.clear();      // removes all environments by removing them from map
+   DefaultEnv = nullptr; // prevent dangling pointer
 
 } // end removeAll
 

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -73,8 +73,9 @@ void IOStream::init(Clock *&ModelClock //< [inout] Omega model clock
 /// Initialize with no clock. Convenience overload for testing.
 void IOStream::init(void) {
 
-   // Create an empty dummy clock
-   Clock *ModelClock = new Clock;
+   // Create an empty dummy clock on the stack (no heap alloc)
+   Clock ModelClockObj;
+   Clock *ModelClock = &ModelClockObj;
    init(ModelClock);
 
 } // End initialize(void)
@@ -112,8 +113,9 @@ void IOStream::finalize(
 // Finalize with no clock. Convenience overload for testing.
 void IOStream::finalize(void) {
 
-   // Create an empty dummy clock
-   Clock *ModelClock = new Clock;
+   // Create an empty dummy clock on the stack (no heap alloc)
+   Clock ModelClockObj;
+   Clock *ModelClock = &ModelClockObj;
    finalize(ModelClock);
 
 } // End finalize(void)
@@ -268,8 +270,9 @@ Error IOStream::read(const std::string &StreamName // [in] Name of stream
 
    Error Err; // returned error code
 
-   // create empty Clock and Metadata
-   Clock *ModelClock = new Clock;
+   // create empty Clock and Metadata (stack-allocated to avoid leak)
+   Clock ModelClockObj;
+   Clock *ModelClock = &ModelClockObj;
    Metadata ReqMetaData;
    bool ForceRead = true;
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -333,7 +333,10 @@ void AuxiliaryState::erase(const std::string &Name) {
 }
 
 // Remove all auxiliary states
-void AuxiliaryState::clear() { AllAuxStates.clear(); }
+void AuxiliaryState::clear() {
+   AllAuxStates.clear();
+   DefaultAuxState = nullptr; // prevent dangling pointer
+}
 
 // Read and set config options
 void AuxiliaryState::readConfigOptions(Config *OmegaConfig) {

--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -186,6 +186,7 @@ void HorzMesh::clear() {
    AllHorzMeshes.clear(); // removes all meshes from the list and in
                           // the porcess, calls the destructors for each
 
+   DefaultHorzMesh = nullptr; // prevent dangling pointer
 } // end clear
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/ocn/OceanFinal.cpp
+++ b/components/omega/src/ocn/OceanFinal.cpp
@@ -7,10 +7,12 @@
 
 #include "AuxiliaryState.h"
 #include "Decomp.h"
+#include "Eos.h"
 #include "Field.h"
 #include "Halo.h"
 #include "HorzMesh.h"
 #include "IO.h"
+#include "IOStream.h"
 #include "MachEnv.h"
 #include "OceanDriver.h"
 #include "OceanState.h"
@@ -19,6 +21,7 @@
 #include "TimeStepper.h"
 #include "Tracers.h"
 #include "VertCoord.h"
+#include "VertMix.h"
 
 namespace OMEGA {
 
@@ -31,6 +34,10 @@ int ocnFinalize(const TimeInstant &CurrTime ///< [in] current sim time
    // Write restart file if necessary
 
    // clean up all objects
+   // finalize IO streams (perform on-shutdown writes)
+   if (TimeStepper::getDefault())
+      IOStream::finalize(TimeStepper::getDefault()->getClock());
+
    Tracers::clear();
    TimeStepper::clear();
    Tendencies::clear();
@@ -44,6 +51,10 @@ int ocnFinalize(const TimeInstant &CurrTime ///< [in] current sim time
    Halo::clear();
    Decomp::clear();
    MachEnv::removeAll();
+
+   // destroy singletons that use raw new/delete
+   Eos::destroyInstance();
+   VertMix::destroyInstance();
 
    return RetVal;
 } // end ocnFinalize

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -170,8 +170,8 @@ void OceanState::erase(std::string InName // [in] name of state to remove
 // Removes all states to clean up before exit
 void OceanState::clear() {
 
-   AllOceanStates.clear(); // removes all states from the list and in
-                           // the process, calls the destructors for each
+   AllOceanStates.clear();      // removes all states from the list and in
+                                // the process, calls the destructors for each
    DefaultOceanState = nullptr; // prevent dangling pointer
 } // end clear
 

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -172,7 +172,7 @@ void OceanState::clear() {
 
    AllOceanStates.clear(); // removes all states from the list and in
                            // the process, calls the destructors for each
-
+   DefaultOceanState = nullptr; // prevent dangling pointer
 } // end clear
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -83,8 +83,8 @@ Tendencies::~Tendencies() {
 //------------------------------------------------------------------------------
 // Removes all tendencies instances before exit
 void Tendencies::clear() {
-    AllTendencies.clear();
-    DefaultTendencies = nullptr; // prevent dangling pointer
+   AllTendencies.clear();
+   DefaultTendencies = nullptr; // prevent dangling pointer
 } // end clear
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -82,7 +82,10 @@ Tendencies::~Tendencies() {
 
 //------------------------------------------------------------------------------
 // Removes all tendencies instances before exit
-void Tendencies::clear() { AllTendencies.clear(); } // end clear
+void Tendencies::clear() {
+    AllTendencies.clear();
+    DefaultTendencies = nullptr; // prevent dangling pointer
+} // end clear
 
 //------------------------------------------------------------------------------
 // Removes tendencies from list by name

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -450,6 +450,7 @@ void VertCoord::clear() {
    AllVertCoords.clear(); // removes all VertCoords from the list and in the
                           // process, calls the destructors for each
 
+   DefaultVertCoord = nullptr; // prevent dangling pointer
 } // end clear
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/VelocityDel2AuxVars.cpp
@@ -26,9 +26,7 @@ VelocityDel2AuxVars::VelocityDel2AuxVars(const std::string &AuxStateSuffix,
       MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop),
       MinLayerVertexBot(VCoord->MinLayerVertexBot),
       MaxLayerVertexTop(VCoord->MaxLayerVertexTop),
-      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell)
-
-{}
+      MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell) {}
 
 void VelocityDel2AuxVars::registerFields(const std::string &AuxGroupName,
                                          const std::string &MeshName) const {

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -217,7 +217,10 @@ void TimeStepper::erase(const std::string &Name) {
 }
 
 // Remove all time steppers
-void TimeStepper::clear() { AllTimeSteppers.clear(); }
+void TimeStepper::clear() {
+   AllTimeSteppers.clear();
+   DefaultTimeStepper = nullptr; // prevent dangling pointer
+}
 
 //------------------------------------------------------------------------------
 // Initialize the default time stepper in two phases


### PR DESCRIPTION
Add more initialization, finalization and Kokkos fences to eliminate CUDA meminit and memleak check issues.

* Tests passed on Perlmutter-GPU and Perlmutter-CPU.
* Initialized default static Omega objects, such as `DefaultDecomp = nullptr;`.
* Added `MPI_Group_Free` to prevent memory leaks.
* Created `Clock ModelClockObj;` on the stack instead of the heap.
* Added destroy functions, such as `Eos::destroyInstance();`, in the Omega finalize routine.



