### PR TITLE
Fix MPI race in IO

### DIFF
--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -8,10 +8,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "IO.h"
+#include "Broadcast.h"
 #include "Config.h"
 #include "DataTypes.h"
 #include "Error.h"
 #include "Logging.h"
+#include "MachEnv.h"
 #include "mpi.h"
 #include "pio.h"
 
@@ -289,8 +291,17 @@ void openFile(
       // If the write should append or add to an existing file
       // we open the file for reading and writing, but also must create
       // the file if it doesn't already exist
-      case IfExists::Append:
-         if (std::filesystem::exists(Filename)) {
+      case IfExists::Append: {
+         // Check for existence with one task and then broadcast to avoid
+         // the case where some tasks create and some open
+         bool FileExists;
+         MachEnv *DefEnv = MachEnv::getDefault();
+         if (DefEnv->isMasterTask()) {
+            FileExists = std::filesystem::exists(Filename);
+         }
+         Broadcast(FileExists);
+
+         if (FileExists) {
             PIOErr = PIOc_openfile(SysID, &FileID, &Format, Filename.c_str(),
                                    IsCDF5 | InMode);
          } else {
@@ -301,7 +312,7 @@ void openFile(
          if (PIOErr != PIO_NOERR)
             ABORT_ERROR("IO::openFile: PIO error opening file {} for writing",
                         Filename);
-         break;
+      } break;
 
       default:
          ABORT_ERROR("IO::openFile: unknown IfExists option for writing");


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
Fixes an issue in IO where it is possible that some tasks are attempting to create a file and some are trying to open it at the same time leading to hangs. I need to test this change more thoroughly, but initial testing on Perlmutter indicates that it fixes at least some of the problems reported in https://github.com/E3SM-Project/polaris/issues/396 @xylar 

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [ ] Indicate "All tests passed" or document failing tests
    * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.
    * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


