### PR TITLE
Change shear mixing to LMD94 formulation and add ri smoothing

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -89,7 +89,7 @@ Omega:
       BaseShearValue: 0.005
       RiCrit: 0.7
       Exponent: 3.0
-      RiSmoothLoops: 3
+      RiSmoothLoops: 2
   IOStreams:
     HorzMeshIn:
       UsePointerFile: false

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -86,9 +86,10 @@ Omega:
       TriggerBVF: 0.0
     Shear:
       Enable: true
-      NuZero: 0.005
-      Alpha: 5.0
-      Exponent: 2.0
+      BaseShearValue: 0.005
+      RiCrit: 0.7
+      Exponent: 3.0
+      RiSmoothLoops: 3
   IOStreams:
     HorzMeshIn:
       UsePointerFile: false

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -81,9 +81,10 @@ Omega:
       TriggerBVF: 0.0
     Shear:
       Enable: true
-      NuZero: 0.005
-      Alpha: 5.0
-      Exponent: 2.0
+      BaseShearValue: 0.005
+      RiCrit: 0.7
+      Exponent: 3.0
+      RiSmoothLoops: 3
   IOStreams:
     InitialVertCoord:
       UsePointerFile: false

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -84,7 +84,7 @@ Omega:
       BaseShearValue: 0.005
       RiCrit: 0.7
       Exponent: 3.0
-      RiSmoothLoops: 3
+      RiSmoothLoops: 2
   IOStreams:
     InitialVertCoord:
       UsePointerFile: false

--- a/components/omega/doc/devGuide/VerticalMixingCoeff.md
+++ b/components/omega/doc/devGuide/VerticalMixingCoeff.md
@@ -7,7 +7,7 @@ vertical diffusivity and viscosity, the gradient Richardson number, a smoothed g
 Currently the values of `VertDiff` and `VertVisc` are calculated using the linear combination of three options: (1) a
 constant background mixing value, (2) a convective instability mixing value, and (3) a Richardson
 number dependent shear instability driven mixing value from the [Large et al (1994)](https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/94RG01872) or LMD94 interior shear instability driven mixing parameterization. These options are linearly additive. In the future, additional additive options will be implemented, such as the K Profile Parameterization [(KPP; Large et al., 1994)](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872). For both the convective and shear instability driven mixing values `BruntVaisalaFreqSq` is needed, which
-is calculated by the `EOS` class. `GradRichNum` is smoothed using a 1-2-1 filter to produce `GradRichNumSmoothed` which is used by the LMD94 shear instability driven mixing formulation.
+is calculated by the `EOS` class. `GradRichNum` is smoothed using a 1-2-1 (vertical) filter to produce `GradRichNumSmoothed` which is used by the LMD94 shear instability driven mixing formulation.
 
 ## Initialization and Usage
 

--- a/components/omega/doc/devGuide/VerticalMixingCoeff.md
+++ b/components/omega/doc/devGuide/VerticalMixingCoeff.md
@@ -6,8 +6,8 @@ Omega includes a `VertMix` class that provides functions that compute `VertDiff`
 vertical diffusivity and viscosity, the gradient Richardson number, a smoothed gradient Richardson number, where all are defined at the center of the cell and top of the layer.
 Currently the values of `VertDiff` and `VertVisc` are calculated using the linear combination of three options: (1) a
 constant background mixing value, (2) a convective instability mixing value, and (3) a Richardson
-number dependent shear mixing value from the [Large et al (1994)](https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/94RG01872) or LMD94 interior shear parameterization. These options are linearly additive. In the future, additional additive options will be implemented, such as the K Profile Parameterization [(KPP; Large et al., 1994)](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872). For both the convective and shear mixing values `BruntVaisalaFreq` is needed, which
-is calculated by the `EOS` class. `GradRichNum` is smoothed using a 1-2-1 filter to produce `GradRichNumSmoothed` which is used by the LMD94 shear mixing formulation.
+number dependent shear instability driven mixing value from the [Large et al (1994)](https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/94RG01872) or LMD94 interior shear instability driven mixing parameterization. These options are linearly additive. In the future, additional additive options will be implemented, such as the K Profile Parameterization [(KPP; Large et al., 1994)](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872). For both the convective and shear instability driven mixing values `BruntVaisalaFreqSq` is needed, which
+is calculated by the `EOS` class. `GradRichNum` is smoothed using a 1-2-1 filter to produce `GradRichNumSmoothed` which is used by the LMD94 shear instability driven mixing formulation.
 
 ## Initialization and Usage
 
@@ -40,7 +40,7 @@ VertMix:
     BaseShearValue: 0.005
     RiCrit: 0.7
     Exponent: 3.0
-    RiSmoothLoops: 3
+    RiSmoothLoops: 2
 ```
 
 ## Class Structure
@@ -63,12 +63,12 @@ VertMix:
    - `ConvDiff`: Convective mixing coefficient (m²/s; Default: 1.0)
    - `ConvTriggerBVF`: Trigger threshold for convective mixing (Default: 0.0)
 
-3. Shear Mixing:
-   - `EnableShearMix`: Flag to enable/disable shear mixing (Default: True)
-   - `BaseShearValue`: Base values of shear for the LMD94 interior shear mixing formulation (Default: 0.005)
-   - `RiCrit`: Critical Richerson number for the LMB94 formulation (Default: 0.7)
-   - `ShearExponent`: Exponent parameter number for the LMB94 formulation (Default: 3.0)
-   - `RiSmoothLoops`: Number of 1-2-1 filter passes to apply to the gradient Richardson number smoothing (Default: 3)
+3. Shear Instability Driven Mixing:
+   - `EnableShearMix`: Flag to enable/disable shear instability driven mixing (Default: True)
+   - `BaseShearValue`: Base values of maximum viscosity and diffusivity for the LMD94 interior shear instability driven mixing formulation (Default: 0.005)
+   - `RiCrit`: Critical Richardson number for the LMD94 formulation (Default: 0.7)
+   - `ShearExponent`: Exponent parameter number for the LMD94 formulation (Default: 3.0)
+   - `RiSmoothLoops`: Number of 1-2-1 filter passes to apply to the gradient Richardson number smoothing (Default: 2)
 
 ## Core Functionality (Vertical Mixing Coefficient Calculation)
 

--- a/components/omega/doc/devGuide/VerticalMixingCoeff.md
+++ b/components/omega/doc/devGuide/VerticalMixingCoeff.md
@@ -2,12 +2,12 @@
 
 # Vertical Mixing Coefficients
 
-Omega includes a `VertMix` class that provides functions that compute `VertDiff` and `VertVisc`, the
-vertical diffusivity and viscosity, where both are defined at the center of the cell and top of the layer.
+Omega includes a `VertMix` class that provides functions that compute `VertDiff`, `VertVisc`, `GradRichNum`, and `GradRichNumSmoothed`, the
+vertical diffusivity and viscosity, the gradient Richardson number, a smoothed gradient Richardson number, where all are defined at the center of the cell and top of the layer.
 Currently the values of `VertDiff` and `VertVisc` are calculated using the linear combination of three options: (1) a
 constant background mixing value, (2) a convective instability mixing value, and (3) a Richardson
-number dependent shear mixing value from the [Pacanowski and Philander (1981)](https://journals.ametsoc.org/view/journals/phoc/11/11/1520-0485_1981_011_1443_povmin_2_0_co_2.xml) parameterization. These options are linearly additive. In the future, additional additive options will be implemented, such as the K Profile Parameterization [(KPP; Large et al., 1994)](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872). For both the convective and shear mixing values `BruntVaisalaFreqSq` is needed, which
-is calculated by the `EOS` class.
+number dependent shear mixing value from the [Large et al (1994)](https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/94RG01872) or LMD94 interior shear parameterization. These options are linearly additive. In the future, additional additive options will be implemented, such as the K Profile Parameterization [(KPP; Large et al., 1994)](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872). For both the convective and shear mixing values `BruntVaisalaFreq` is needed, which
+is calculated by the `EOS` class. `GradRichNum` is smoothed using a 1-2-1 filter to produce `GradRichNumSmoothed` which is used by the LMD94 shear mixing formulation.
 
 ## Initialization and Usage
 
@@ -37,9 +37,10 @@ VertMix:
     TriggerBVF: 0.0
   Shear:
     Enable: true
-    NuZero: 0.005
-    Alpha: 5.0
-    Exponent: 2.0
+    BaseShearValue: 0.005
+    RiCrit: 0.7
+    Exponent: 3.0
+    RiSmoothLoops: 3
 ```
 
 ## Class Structure
@@ -48,6 +49,8 @@ VertMix:
 
 - `VertDiff`: 2D array storing vertical diffusivity coefficients (m²/s)
 - `VertVisc`: 2D array storing vertical viscosity coefficients (m²/s)
+- `GradRichNum`: 2D array storing the gradient Richardson number
+- `GradRichNumSmoothed`: 2D array storing the smoothed gradient Richardson number
 
 ### Mixing Parameters
 
@@ -62,9 +65,10 @@ VertMix:
 
 3. Shear Mixing:
    - `EnableShearMix`: Flag to enable/disable shear mixing (Default: True)
-   - `ShearNuZero`: Base coefficient for Pacanowski-Philander scheme (Default: 0.005)
-   - `ShearAlpha`: Alpha parameter for P-P scheme (Default: 5.0)
-   - `ShearExponent`: Exponent parameter for P-P scheme (Default: 2.0)
+   - `BaseShearValue`: Base values of shear for the LMD94 interior shear mixing formulation (Default: 0.005)
+   - `RiCrit`: Critical Richerson number for the LMB94 formulation (Default: 0.7)
+   - `ShearExponent`: Exponent parameter number for the LMB94 formulation (Default: 3.0)
+   - `RiSmoothLoops`: Number of 1-2-1 filter passes to apply to the gradient Richardson number smoothing (Default: 3)
 
 ## Core Functionality (Vertical Mixing Coefficient Calculation)
 
@@ -75,8 +79,3 @@ void computeVertMix(const Array2DReal &NormalVelocity,
                    const Array2DReal &TangentialVelocity,
                    const Array2DReal &BruntVaisalaFreqSq);
 ```
-
-This method combines the effects of:
-- Background mixing (constant coefficients)
-- Convective mixing (triggered by static instability)
-- Shear instability driven mixing (Pacanowski-Philander scheme; to be changed to [Large et al., 1994](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872) shear mixing scheme in a later development)

--- a/components/omega/doc/userGuide/VerticalMixingCoeff.md
+++ b/components/omega/doc/userGuide/VerticalMixingCoeff.md
@@ -6,9 +6,8 @@ The vertical mixing module in Omega handles the parameterization of unresolved v
 processes in the ocean. It calculates vertical diffusivity and viscosity coefficients that
 determine how properties (like momentum, heat, salt, and biogeochemical tracers) mix vertically
 in the ocean model. Currently, Omega offers three different mixing processes within the water column: (1) a constant
-background mixing value, (2) a convective instability mixing value, and (3) a Richardson number
-dependent shear instability driven mixing value from the [Large et al (1994)](https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/94RG01872) or LMD94 interior shear parameterization. These are linearly additive and are describe a bit
-more in detail below. Other mixing processes and parameterizations, such as the the K Profile Parameterization [(KPP; Large et al., 1994)](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872) will be added in the future. In addition to diffusivity and viscosity coefficients, the vertical mixing module calculates the gradient Richardson number and smooths that gradient Richardson number using a 1-2-1 filter before using it in the shear mixing calculation.
+background mixing value, (2) a convective instability mixing value, and (3) a Richardson number-dependent shear-instability-driven mixing value from the [Large et al (1994)](https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/94RG01872) or LMD94 shear instability driven mixing parameterization. These are linearly additive and are describe a bit
+more in detail below. Other mixing processes and parameterizations, such as the the K Profile Parameterization [(KPP; Large et al., 1994)](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872) will be added in the future. In addition to diffusivity and viscosity coefficients, the vertical mixing module calculates the gradient Richardson number and smooths that gradient Richardson number using a 1-2-1 filter before using it in the shear instability driven mixing calculation.
 
 The user-configurable options are the following parameters in the yaml configuration file:
 
@@ -26,14 +25,14 @@ VertMix:
     BaseShearValue: 0.005 # Base viscosity/diffusivity value
     RiCrit: 0.7          # Critical Richardson number
     Exponent: 3.0        # Richardson number exponent
-    RiSmoothLoops: 3     # Number of Richardson number smoothing loops
+    RiSmoothLoops: 2     # Number of Richardson number smoothing loops
 ```
 
 ## Vertical Mixing Processes/Types
 
 ### 1. Background Mixing
 
-A constant background mixing value that represents small-scale mixing processes not explicitly resolved or modeled. Typically, this is chosen to represent low values of vertical mixing happening in the ocean's stratified interior.
+A constant background mixing value that represents small-scale mixing processes not explicitly resolved or modeled. Typically, this is chosen to represent low values of vertical mixing happening in the ocean's stratified interior and is assumed roughly equivalent to the globally averaged interior mixing from all sources (e.g., from internal wave breaking).
 
 ### 2. Convective Mixing
 
@@ -49,16 +48,16 @@ $$
 
 This is different than some current implementations (i.e. in MPAS-Ocean and the CVMix package), where convective adjustment occurs both with unstable and neutral conditions ($N^2 \leq N^2_{crit}$). $\kappa_{conv}$ and $N^2_{crit}$ are constant parameters set in the `VertMix` section of the yaml file (`Diffusivity` and `TriggerBVF` under the `Convective` header).
 
-### 3. Shear Mixing
+### 3. Shear-Instability-Driven Mixing
 
 Mixing induced by vertical velocity shear, implemented using the LMD94 scheme, through the gradient Richardson number (ratio of buoyancy to shear).
 
 $$
-\nu_{shear}\,, \kappa_{shear} = =
+\nu_{shear} = = \kappa_{shear} = =
 \begin{cases}
 \nu_o \quad \text{ if } Ri_g < 0\\
-\nu_o \left[1 - \left( \frac{Ri_g}{Ri_{crit}} \right)^2 \right]^p \text{ if } 0 < Ri_g < Ri_{crit}\\
-0.0 \quad \text{ if } Ri_{crit} < Ri_g
+\nu_o \left[1 - \left( \frac{Ri_g}{Ri_{crit}} \right)^2 \right]^p \text{ if } 0 \leq Ri_g < Ri_{crit}\\
+0.0 \quad \text{ if } Ri_{crit} \leq Ri_g
 \end{cases}
 $$
 
@@ -68,4 +67,4 @@ $$
 Ri = \frac{N^2}{\left|\frac{\partial \mathbf{U}}{\partial z}\right|^2}\,,
 $$
 
-where $N^2$ is calculated by the EOS based on the ocean state and $\mathbf{U}$ is the magnitude of the horizontal velocity. $Ri$ is calculated by the vertical mixing module and then smoothed with a 1-2-1 filter before being used to calculate the shear. $N^2$, $\partial \mathbf{U}}{\partial z}\right|^2$ and $Ri$ of `K` are all defined at the cell center, top interface of layer `K`. $N^2$, $\nu_{shear}$ and $\kappa_{shear}$ are set to zero for the surface layer.
+where $N^2$ is calculated by the EOS based on the ocean state and $\mathbf{U}$ is the magnitude of the horizontal velocity. $Ri$ is calculated by the vertical mixing module and then smoothed with a 1-2-1 (vertical) filter before being used to calculate the shear-instability-driven mixing. $N^2$, $\partial \mathbf{U}}{\partial z}\right|^2$ and $Ri$ of `K` are all defined at the cell center, top interface of layer `K`. $N^2$, $\nu_{shear}$ and $\kappa_{shear}$ are set to zero at the surface.

--- a/components/omega/doc/userGuide/VerticalMixingCoeff.md
+++ b/components/omega/doc/userGuide/VerticalMixingCoeff.md
@@ -36,13 +36,13 @@ A constant background mixing value that represents small-scale mixing processes 
 
 ### 2. Convective Mixing
 
-Enhanced convective adjustment mixing that occurs in statically unstable regions of the water column to parameterize convection and homogenize properties. In Omega this is mixing is defaulted to occur when the squared Brunt Vaisala Frequency is less than 0.0 (unstable), and is off when equal to (neutral) or greater than (stable) 0.0.
+Enhanced convective adjustment mixing that occurs in statically unstable regions of the water column to parameterize convection and homogenize properties. In Omega this mixing is defaulted to occur when the squared Brunt Vaisala Frequency is less than 0.0 (unstable), and is off when equal to (neutral) or greater than (stable) 0.0. The convective diffusivity is thus added to the background diffusivity ($\kappa_b$) to form the total diffusivity coefficient $\kappa$.
 
 $$
 \kappa =
 \begin{cases}
-+\kappa_b + \kappa_{conv} \quad \text{ if } N^2 < N^2_{crit}\\
-+\kappa_b \quad \text{ if } N^2 \geq N^2_{crit}
+\kappa_b + \kappa_{conv} \quad \text{ if } N^2 < N^2_{crit}\\
+\kappa_b \quad \text{ if } N^2 \geq N^2_{crit}
 \end{cases}
 $$
 
@@ -53,7 +53,7 @@ This is different than some current implementations (i.e. in MPAS-Ocean and the 
 Mixing induced by vertical pseudo-velocity shear, implemented using the LMD94 scheme, through the gradient Richardson number (ratio of buoyancy to shear).
 
 $$
-\nu_{shear} = = \kappa_{shear} = =
+\nu_{shear} = \kappa_{shear} =
 \begin{cases}
 \nu_o \quad \text{ if } Ri_g < 0\\
 \nu_o \left[1 - \left( \frac{Ri_g}{Ri_{crit}} \right)^2 \right]^p \text{ if } 0 \leq Ri_g < Ri_{crit}\\
@@ -61,10 +61,10 @@ $$
 \end{cases}
 $$
 
-where $\nu_o$, $Ri_{crit}$, and $p$ are constant parameters set in the `VertMix` section of the yaml file (`BaseShearValue`, `RiCrit`, and `Exponent` under the `Shear` header). $Ri$ is defined as:
+where $\nu_o$, $Ri_{crit}$, and $p$ are constant parameters set in the `VertMix` section of the yaml file (`BaseShearValue`, `RiCrit`, and `Exponent` under the `Shear` header). $Ri_g$ is defined as:
 
 $$
-Ri = \frac{N^2}{\left|\frac{\partial \mathbf{U}}{\partial z}\right|^2}\,,
+Ri_g = \frac{N^2}{\left|\frac{\partial \mathbf{U}}{\partial z}\right|^2}\,,
 $$
 
-where $N^2$ is calculated by the EOS based on the ocean state and $\mathbf{U}$ is the magnitude of the horizontal velocity. $Ri$ is calculated by the vertical mixing module and then smoothed with a 1-2-1 (vertical) filter before being used to calculate the shear-instability-driven mixing. $N^2$, $\partial \mathbf{U}}{\partial z}\right|^2$ and $Ri$ of `K` are all defined at the cell center, top interface of layer `K`. $N^2$, $\nu_{shear}$ and $\kappa_{shear}$ are set to zero at the surface.
+where $N^2$ is calculated by the EOS based on the ocean state and $\mathbf{U}$ is the magnitude of the horizontal velocity. $Ri_g$ is calculated by the vertical mixing module and then smoothed with a 1-2-1 (vertical) filter before being used to calculate the shear-instability-driven mixing. $N^2$, $\left| \frac{\partial \mathbf{U}}{\partial z}\right|^2$ and $Ri_g$ of `k` are all defined at the cell center, top interface of layer `k`. $N^2$, $\nu$ and $\kappa$ are set to zero at the surface.

--- a/components/omega/doc/userGuide/VerticalMixingCoeff.md
+++ b/components/omega/doc/userGuide/VerticalMixingCoeff.md
@@ -50,7 +50,7 @@ This is different than some current implementations (i.e. in MPAS-Ocean and the 
 
 ### 3. Shear-Instability-Driven Mixing
 
-Mixing induced by vertical velocity shear, implemented using the LMD94 scheme, through the gradient Richardson number (ratio of buoyancy to shear).
+Mixing induced by vertical pseudo-velocity shear, implemented using the LMD94 scheme, through the gradient Richardson number (ratio of buoyancy to shear).
 
 $$
 \nu_{shear} = = \kappa_{shear} = =

--- a/components/omega/doc/userGuide/VerticalMixingCoeff.md
+++ b/components/omega/doc/userGuide/VerticalMixingCoeff.md
@@ -7,8 +7,8 @@ processes in the ocean. It calculates vertical diffusivity and viscosity coeffic
 determine how properties (like momentum, heat, salt, and biogeochemical tracers) mix vertically
 in the ocean model. Currently, Omega offers three different mixing processes within the water column: (1) a constant
 background mixing value, (2) a convective instability mixing value, and (3) a Richardson number
-dependent shear instability driven mixing value from the [Pacanowski and Philander (1981)](https://journals.ametsoc.org/view/journals/phoc/11/11/1520-0485_1981_011_1443_povmin_2_0_co_2.xml) parameterization. These are linearly additive and are describe a bit
-more in detail below. Other mixing processes and parameterizations, such as the the K Profile Parameterization [(KPP; Large et al., 1994)](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872) will be added in the future.
+dependent shear instability driven mixing value from the [Large et al (1994)](https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/94RG01872) or LMD94 interior shear parameterization. These are linearly additive and are describe a bit
+more in detail below. Other mixing processes and parameterizations, such as the the K Profile Parameterization [(KPP; Large et al., 1994)](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872) will be added in the future. In addition to diffusivity and viscosity coefficients, the vertical mixing module calculates the gradient Richardson number and smooths that gradient Richardson number using a 1-2-1 filter before using it in the shear mixing calculation.
 
 The user-configurable options are the following parameters in the yaml configuration file:
 
@@ -23,17 +23,17 @@ VertMix:
     TriggerBVF: 0.0      # Squared Brunt-Vaisala frequency threshold
   Shear:
     Enable: true         # Enables the shear-instability driven mixing option
-    NuZero: 1.0e-2       # Base viscosity coefficient
-    Alpha: 5.0           # Stability parameter
-    Exponent: 2          # Richardson number exponent
+    BaseShearValue: 0.005 # Base viscosity/diffusivity value
+    RiCrit: 0.7          # Critical Richardson number
+    Exponent: 3.0        # Richardson number exponent
+    RiSmoothLoops: 3     # Number of Richardson number smoothing loops
 ```
 
 ## Vertical Mixing Processes/Types
 
 ### 1. Background Mixing
 
-A constant background mixing value that represents small-scale mixing processes not explicitly resolved by the model. Typically, this is chosen to represent low values of vertical mixing
-happening in the ocean's stratified interior.
+A constant background mixing value that represents small-scale mixing processes not explicitly resolved or modeled. Typically, this is chosen to represent low values of vertical mixing happening in the ocean's stratified interior.
 
 ### 2. Convective Mixing
 
@@ -51,20 +51,21 @@ This is different than some current implementations (i.e. in MPAS-Ocean and the 
 
 ### 3. Shear Mixing
 
-Mixing induced by vertical pseudo-velocity shear, implemented using the Pacanowski-Philander scheme, through the gradient Richardson number (ratio of buoyancy to shear).
+Mixing induced by vertical velocity shear, implemented using the LMD94 scheme, through the gradient Richardson number (ratio of buoyancy to shear).
 
 $$
-\nu = \frac{\nu_o}{(1+\alpha Ri)^n} + \nu_b\,,
+\nu_{shear}\,, \kappa_{shear} = =
+\begin{cases}
+\nu_o \quad \text{ if } Ri_g < 0\\
+\nu_o \left[1 - \left( \frac{Ri_g}{Ri_{crit}} \right)^2 \right]^p \text{ if } 0 < Ri_g < Ri_{crit}\\
+0.0 \quad \text{ if } Ri_{crit} < Ri_g
+\end{cases}
 $$
 
-$$
-\kappa = \frac{\nu}{(1+\alpha Ri)} + \kappa_b\,.
-$$
-
-where $Ri$ is defined as:
+where $\nu_o$, $Ri_{crit}$, and $p$ are constant parameters set in the `VertMix` section of the yaml file (`BaseShearValue`, `RiCrit`, and `Exponent` under the `Shear` header). $Ri$ is defined as:
 
 $$
 Ri = \frac{N^2}{\left|\frac{\partial \mathbf{U}}{\partial z}\right|^2}\,,
 $$
 
-where $\nu_o$, $\alpha$, $n$, $\nu_b$, $\kappa_b$ are constant parameters set in the `VertMix` section of the yaml file (`NuZero`, `Alpha`, `Exponent` under the `Shear` header and `Viscosity`, `Diffusivity` under the `Background` header). $N^2$ is calculated by the EOS based on the ocean state and $\mathbf{U}$ is the magnitude of the horizontal velocity. $N^2$, $\partial \mathbf{U}}{\partial z}\right|^2$ and $Ri$ of `K` are all defined at the cell center, top interface of layer `K`.  $N^2$, $\nu_{shear}$ and $\kappa_{shear}$ are set to zero for the surface layer. In a later development, the shear mixing option will be changed to the interior shear mixing formulation in [Large et al., 1994](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/94rg01872).
+where $N^2$ is calculated by the EOS based on the ocean state and $\mathbf{U}$ is the magnitude of the horizontal velocity. $Ri$ is calculated by the vertical mixing module and then smoothed with a 1-2-1 filter before being used to calculate the shear. $N^2$, $\partial \mathbf{U}}{\partial z}\right|^2$ and $Ri$ of `K` are all defined at the cell center, top interface of layer `K`. $N^2$, $\nu_{shear}$ and $\kappa_{shear}$ are set to zero for the surface layer.

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -680,9 +680,6 @@ class Teos10BruntVaisalaFreqSq {
 /// Linear squared Brunt-Vaisala frequency calculator
 class LinearBruntVaisalaFreqSq {
  public:
-   /// Coefficients from LinearEos (overwritten by config file if set there)
-   Real RhoT0S0 = 1000.0; ///< Reference density (kg m^-3) at (T,S)=(0,0)
-
    /// constructor declaration
    LinearBruntVaisalaFreqSq(const VertCoord *VCoord);
 
@@ -702,7 +699,7 @@ class LinearBruntVaisalaFreqSq {
          /// K-1 and K Do not need to use displaced specific volume here
          /// since only the linear EOS is used with this BVF formulation.
          BruntVaisalaFreqSq(ICell, K) =
-             -(Gravity / RhoT0S0) *
+             -(Gravity / RhoSw) *
              ((1.0_Real / SpecVol(ICell, K - 1)) -
               (1.0_Real / SpecVol(ICell, K))) /
              (GeomZMid(ICell, K - 1) - GeomZMid(ICell, K));

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -520,9 +520,6 @@ class Teos10BruntVaisalaFreqSq {
 /// Linear squared Brunt-Vaisala frequency calculator
 class LinearBruntVaisalaFreqSq {
  public:
-   /// Coefficients from LinearEos (overwritten by config file if set there)
-   Real RhoT0S0 = 1000.0; ///< Reference density (kg m^-3) at (T,S)=(0,0)
-
    /// constructor declaration
    LinearBruntVaisalaFreqSq(const VertCoord *VCoord);
 
@@ -546,7 +543,7 @@ class LinearBruntVaisalaFreqSq {
             /// K-1 and K Do not need to use displaced specific volume here
             /// since only the linear EOS is used with this BVF formulation.
             BruntVaisalaFreqSq(ICell, K) =
-                -(Gravity / RhoT0S0) *
+                -(Gravity / RhoSw) *
                 ((1.0_Real / SpecVol(ICell, K - 1)) -
                  (1.0_Real / SpecVol(ICell, K))) /
                 (GeomZMid(ICell, K - 1) - GeomZMid(ICell, K));

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -200,14 +200,32 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
-   /// Initialize VertDiff and VertVisc to background values
-   deepCopy(LocVertDiff, BackDiff);
-   deepCopy(LocVertVisc, BackVisc);
-   deepCopy(LocGradRichNum, 100.0_Real);
-   deepCopy(LocGradRichNumSmoothed, 100.0_Real);
+   /// First, initialize VertDiff and VertVisc to background values
+   parallelForOuter(
+       "VertMix-BackAndRich", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
+          const int KRange = vertRangeChunked(KMin, KMax);
 
-   /// Dispatch to the correct VertMix calculation
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int KStart = chunkStart(KChunk, KMin);
+                 const int KLen   = chunkLength(KChunk, KStart, KMax);
+                 for (int KVec = 0; KVec < KLen; ++KVec) {
+                    const int K           = KStart + KVec;
+                    LocVertDiff(ICell, K) = BackDiff;
+                    LocVertVisc(ICell, K) = BackVisc;
+                    LocGradRichNum(ICell, K) =
+                        LocComputeGradRichardsonNum.RiInitValue;
+                    LocGradRichNumSmoothed(ICell, K) =
+                        LocComputeGradRichardsonNum.RiInitValue;
+                 }
+              });
+       });
+   /// Second, compute shear mixing if enabled
    if (LocComputeVertMixShear.Enabled) {
+      /// Compute Richardson number
       parallelForOuter(
           "VertMix-ComputeRi", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
@@ -235,6 +253,8 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                         LocGradRichNum(ICell, KMax);
                  });
           });
+      /// Smooth Richardson number with 1-2-1 filter the number of times
+      /// specified by RiSmoothLoops
       deepCopy(LocGradRichNumSmoothed, LocGradRichNum);
       for (int SmoothLoop = 0;
            SmoothLoop < LocComputeVertMixShear.RiSmoothLoops; ++SmoothLoop) {
@@ -246,15 +266,12 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                 const int KRange = vertRangeChunked(KMin, KMax);
                 parallelForInner(
                     Team, KRange, INNER_LAMBDA(int KChunk) {
-                       if (SmoothLoop == 0)
-                          LocOneTwoOneFilter(LocGradRichNumSmoothed, ICell,
-                                             KChunk, LocGradRichNum);
-                       else
-                          LocOneTwoOneFilter(LocGradRichNumSmoothed, ICell,
-                                             KChunk, LocGradRichNumSmoothed);
+                       LocOneTwoOneFilter(LocGradRichNumSmoothed, ICell, KChunk,
+                                          LocGradRichNumSmoothed);
                     });
              });
       }
+      /// Compute shear mixing using smoothed Richardson number
       parallelForOuter(
           "VertMix-Shear", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
@@ -267,23 +284,9 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                     LocComputeVertMixShear(LocVertDiff, LocVertVisc, ICell,
                                            KChunk, LocGradRichNumSmoothed);
                  });
-
-             teamBarrier(Team);
-
-             // Fill vertical diffusivity and viscosity at vertical
-             // boundaries using the closest valid value. This is equivalent
-             // to doing one-sided differencing at the boundary.
-             Kokkos::single(
-                 PerTeam(Team), INNER_LAMBDA() {
-                    LocVertDiff(ICell, MinLayerCell(ICell)) = 0.0_Real;
-                    LocVertVisc(ICell, MinLayerCell(ICell)) = 0.0_Real;
-                    LocVertDiff(ICell, MaxLayerCell(ICell) + 1) =
-                        LocVertDiff(ICell, KMax);
-                    LocVertVisc(ICell, MaxLayerCell(ICell) + 1) =
-                        LocVertVisc(ICell, KMax);
-                 });
           });
    }
+   /// Third, compute convective mixing if enabled
    if (LocComputeVertMixConv.Enabled) {
       parallelForOuter(
           "VertMix-Conv", {Mesh->NCellsAll},
@@ -297,27 +300,17 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                     LocComputeVertMixConv(LocVertDiff, LocVertVisc, ICell,
                                           KChunk, BruntVaisalaFreqSq);
                  });
-
-             teamBarrier(Team);
-
-             // Fill vertical diffusivity and viscosity at vertical
-             // boundaries using the closest valid value. This is equivalent
-             // to doing one-sided differencing at the boundary.
-             Kokkos::single(
-                 PerTeam(Team), INNER_LAMBDA() {
-                    LocVertDiff(ICell, MinLayerCell(ICell)) = 0.0_Real;
-                    LocVertVisc(ICell, MinLayerCell(ICell)) = 0.0_Real;
-                    LocVertDiff(ICell, MaxLayerCell(ICell) + 1) =
-                        LocVertDiff(ICell, KMax);
-                    LocVertVisc(ICell, MaxLayerCell(ICell) + 1) =
-                        LocVertVisc(ICell, KMax);
-                 });
           });
    }
+   /// Finally, zero viscosity/diffusivity at surface and bottom boundaries
    parallelFor(
-       "VertMix-Surface", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
-          LocVertDiff(ICell, 0) = 0.0_Real;
-          LocVertVisc(ICell, 0) = 0.0_Real;
+       "VertMix-Boundaries", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          const int KMin           = MinLayerCell(ICell);
+          const int KMax           = MaxLayerCell(ICell) + 1;
+          LocVertDiff(ICell, KMin) = 0.0_Real;
+          LocVertVisc(ICell, KMin) = 0.0_Real;
+          LocVertDiff(ICell, KMax) = 0.0_Real;
+          LocVertVisc(ICell, KMax) = 0.0_Real;
        });
 }
 

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -197,6 +197,8 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
        ComputeGradRichardsonNum); /// Local view for GradRichNum computation
    OMEGA_SCOPE(LocOneTwoOneFilter,
                ComputeOneTwoOneFilter); /// Local view for 1-2-1 filter
+   OMEGA_SCOPE(LocBackDiff, BackDiff);
+   OMEGA_SCOPE(LocBackVisc, BackVisc);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
@@ -214,8 +216,8 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                  const int KLen   = chunkLength(KChunk, KStart, KMax);
                  for (int KVec = 0; KVec < KLen; ++KVec) {
                     const int K           = KStart + KVec;
-                    LocVertDiff(ICell, K) = BackDiff;
-                    LocVertVisc(ICell, K) = BackVisc;
+                    LocVertDiff(ICell, K) = LocBackDiff;
+                    LocVertVisc(ICell, K) = LocBackVisc;
                     LocGradRichNum(ICell, K) =
                         LocComputeGradRichardsonNum.RiInitValue;
                     LocGradRichNumSmoothed(ICell, K) =

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -16,13 +16,23 @@
 
 namespace OMEGA {
 
-ShearMix::ShearMix(const HorzMesh *Mesh, const VertCoord *VCoord)
-    : MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell),
-      GeomZMid(VCoord->GeomZMid), NEdgesOnCell(Mesh->NEdgesOnCell),
-      AreaCell(Mesh->AreaCell), EdgesOnCell(Mesh->EdgesOnCell),
-      DvEdge(Mesh->DvEdge), DcEdge(Mesh->DcEdge) {}
+ShearMix::ShearMix(const VertCoord *VCoord)
+    : MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell) {}
 
 ConvectiveMix::ConvectiveMix(const VertCoord *VCoord)
+    : MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell) {}
+
+GradRichardsonNum::GradRichardsonNum(const HorzMesh *Mesh,
+                                     const VertCoord *VCoord)
+    : NVertLayers(VCoord->NVertLayers), ZMid(VCoord->ZMid),
+      NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
+      CellsOnCell(Mesh->CellsOnCell), MinLayerCell(VCoord->MinLayerCell),
+      MaxLayerCell(VCoord->MaxLayerCell),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop), DcEdge(Mesh->DcEdge),
+      DvEdge(Mesh->DvEdge) {}
+
+OneTwoOneFilter::OneTwoOneFilter(const VertCoord *VCoord)
     : MinLayerCell(VCoord->MinLayerCell), MaxLayerCell(VCoord->MaxLayerCell) {}
 
 /// Constructor for VertMix
@@ -30,10 +40,15 @@ VertMix::VertMix(const std::string &Name, ///< [in] Name for VertMix object
                  const HorzMesh *Mesh,    ///< [in] Horizontal mesh
                  const VertCoord *VCoord  ///< [in] Vertical coordinate
                  )
-    : ComputeVertMixConv(VCoord), ComputeVertMixShear(Mesh, VCoord), Name(Name),
-      Mesh(Mesh), VCoord(VCoord) {
-   VertDiff = Array2DReal("VertDiff", Mesh->NCellsSize, VCoord->NVertLayers);
-   VertVisc = Array2DReal("VertVisc", Mesh->NCellsSize, VCoord->NVertLayers);
+    : ComputeVertMixConv(VCoord), ComputeVertMixShear(VCoord),
+      ComputeGradRichardsonNum(Mesh, VCoord), ComputeOneTwoOneFilter(VCoord),
+      Name(Name), Mesh(Mesh), VCoord(VCoord) {
+   VertDiff = Array2DReal("VertDiff", Mesh->NCellsAll, VCoord->NVertLayers);
+   VertVisc = Array2DReal("VertVisc", Mesh->NCellsAll, VCoord->NVertLayers);
+   GradRichNum =
+       Array2DReal("GradRichNum", Mesh->NCellsAll, VCoord->NVertLayers);
+   GradRichNumSmoothed =
+       Array2DReal("GradRichNumSmoothed", Mesh->NCellsAll, VCoord->NVertLayers);
 
    defineFields();
 }
@@ -54,7 +69,7 @@ void VertMix::destroyInstance() {
 }
 
 /// Initializes the VertMix (Vertical Mixing Coefficients) class and its
-/// options. it ASSUMES that HorzMesh was initialized and initializes the
+/// options. It ASSUMES that HorzMesh was initialized and initializes the
 /// VertMix class by using the default mesh, reading the config file, and
 /// setting parameters for the background, convective, and/or shear mixing
 /// routines. Returns 0 on success, or an error code if any required option is
@@ -136,22 +151,27 @@ void VertMix::init() {
       LOG_INFO("VertMix::init: Shear mixing is disabled.");
    } else {
       LOG_INFO("VertMix::init: Shear mixing is enabled.");
-      Err += ShearConfig.get("NuZero",
-                             DefVertMix->ComputeVertMixShear.ShearNuZero);
+      Err += ShearConfig.get("BaseShearValue",
+                             DefVertMix->ComputeVertMixShear.BaseShearValue);
+      CHECK_ERROR_ABORT(Err, "VertMix::init: Parameter Shear:BaseShearValue "
+                             "not found in ShearConfig");
+
+      Err += ShearConfig.get("RiCrit",
+                             DefVertMix->ComputeVertMixShear.ShearRiCrit);
       CHECK_ERROR_ABORT(
           Err,
-          "VertMix::init: Parameter Shear:NuZero not found in ShearConfig");
-
-      Err +=
-          ShearConfig.get("Alpha", DefVertMix->ComputeVertMixShear.ShearAlpha);
-      CHECK_ERROR_ABORT(
-          Err, "VertMix::init: Parameter Shear:Alpha not found in ShearConfig");
+          "VertMix::init: Parameter Shear:RiCrit not found in ShearConfig");
 
       Err += ShearConfig.get("Exponent",
                              DefVertMix->ComputeVertMixShear.ShearExponent);
       CHECK_ERROR_ABORT(
           Err,
           "VertMix::init: Parameter Shear:Exponent not found in ShearConfig");
+
+      Err += ShearConfig.get("RiSmoothLoops",
+                             DefVertMix->ComputeVertMixShear.RiSmoothLoops);
+      CHECK_ERROR_ABORT(Err, "VertMix::init: Parameter Shear:RiSmoothLoops not "
+                             "found in ShearConfig");
    }
 } // end init
 
@@ -161,18 +181,28 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                              const Array2DReal &BruntVaisalaFreqSq) {
    OMEGA_SCOPE(LocVertDiff, VertDiff); /// Create a local view for computation
    OMEGA_SCOPE(LocVertVisc, VertVisc); /// Create a local view for computation
+   OMEGA_SCOPE(LocGradRichNum,
+               GradRichNum); /// Local view for computation
    OMEGA_SCOPE(
        LocComputeVertMixConv,
        ComputeVertMixConv); /// Local view for Convective VertMix computation
    OMEGA_SCOPE(
        LocComputeVertMixShear,
        ComputeVertMixShear); /// Local view for Shear VertMix computation
+   OMEGA_SCOPE(
+       LocComputeGradRichardsonNum,
+       ComputeGradRichardsonNum); /// Local view for GradRichNum computation
+   OMEGA_SCOPE(LocOneTwoOneFilter,
+               ComputeOneTwoOneFilter); /// Local view for 1-2-1 filter
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+   OMEGA_SCOPE(NVertLayers, VCoord->NVertLayers);
 
    /// Initialize VertDiff and VertVisc to background values
    deepCopy(LocVertDiff, BackDiff);
    deepCopy(LocVertVisc, BackVisc);
+   deepCopy(LocGradRichNum, 100.0_Real);
+   deepCopy(GradRichNumSmoothed, 100.0_Real);
 
    /// Dispatch to the correct VertMix calculation
    if (LocComputeVertMixShear.Enabled && LocComputeVertMixConv.Enabled) {
@@ -185,16 +215,38 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocComputeVertMixShear(
-                        LocVertDiff, LocVertVisc, ICell, KChunk, NormalVelocity,
-                        TangentialVelocity, BruntVaisalaFreqSq);
                     LocComputeVertMixConv(LocVertDiff, LocVertVisc, ICell,
                                           KChunk, BruntVaisalaFreqSq);
+                    LocComputeGradRichardsonNum(
+                        LocGradRichNum, ICell, KChunk, NormalVelocity,
+                        TangentialVelocity, BruntVaisalaFreqSq);
                  });
+             LocGradRichNum(ICell, 0) = LocGradRichNum(ICell, 1);
+             LocGradRichNum(ICell, NVertLayers) =
+                 LocGradRichNum(ICell, NVertLayers - 1);
           });
-   } else if (LocComputeVertMixShear.Enabled) {
+      deepCopy(GradRichNumSmoothed, LocGradRichNum);
+      for (int SmoothLoop = 0;
+           SmoothLoop < LocComputeVertMixShear.RiSmoothLoops; ++SmoothLoop) {
+         parallelForOuter(
+             "VertMix-ConvPlusShear", {Mesh->NCellsAll},
+             KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+                const int KMin   = MinLayerCell(ICell);
+                const int KMax   = MaxLayerCell(ICell);
+                const int KRange = vertRangeChunked(KMin, KMax);
+                parallelForInner(
+                    Team, KRange, INNER_LAMBDA(int KChunk) {
+                       if (SmoothLoop == 0)
+                          LocOneTwoOneFilter(GradRichNumSmoothed, ICell, KChunk,
+                                             LocGradRichNum);
+                       else
+                          LocOneTwoOneFilter(GradRichNumSmoothed, ICell, KChunk,
+                                             GradRichNumSmoothed);
+                    });
+             });
+      }
       parallelForOuter(
-          "VertMix-ShearOnly", {Mesh->NCellsAll},
+          "VertMix-ConvPlusShear", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
              const int KMin   = MinLayerCell(ICell);
              const int KMax   = MaxLayerCell(ICell);
@@ -202,9 +254,58 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocComputeVertMixShear(
-                        LocVertDiff, LocVertVisc, ICell, KChunk, NormalVelocity,
+                    LocComputeVertMixShear(LocVertDiff, LocVertVisc, ICell,
+                                           KChunk, GradRichNumSmoothed);
+                 });
+          });
+   } else if (LocComputeVertMixShear.Enabled) {
+      parallelForOuter(
+          "VertMix-ConvPlusShear", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocComputeGradRichardsonNum(
+                        LocGradRichNum, ICell, KChunk, NormalVelocity,
                         TangentialVelocity, BruntVaisalaFreqSq);
+                 });
+             LocGradRichNum(ICell, 0) = LocGradRichNum(ICell, 1);
+             LocGradRichNum(ICell, NVertLayers) =
+                 LocGradRichNum(ICell, NVertLayers - 1);
+          });
+      deepCopy(GradRichNumSmoothed, LocGradRichNum);
+      for (int SmoothLoop = 0;
+           SmoothLoop < LocComputeVertMixShear.RiSmoothLoops; ++SmoothLoop) {
+         parallelForOuter(
+             "VertMix-ConvPlusShear", {Mesh->NCellsAll},
+             KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+                const int KMin   = MinLayerCell(ICell);
+                const int KMax   = MaxLayerCell(ICell);
+                const int KRange = vertRangeChunked(KMin, KMax);
+                parallelForInner(
+                    Team, KRange, INNER_LAMBDA(int KChunk) {
+                       if (SmoothLoop == 0)
+                          LocOneTwoOneFilter(GradRichNumSmoothed, ICell, KChunk,
+                                             LocGradRichNum);
+                       else
+                          LocOneTwoOneFilter(GradRichNumSmoothed, ICell, KChunk,
+                                             GradRichNumSmoothed);
+                    });
+             });
+      }
+      parallelForOuter(
+          "VertMix-ConvPlusShear", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocComputeVertMixShear(LocVertDiff, LocVertVisc, ICell,
+                                           KChunk, GradRichNumSmoothed);
                  });
           });
    } else if (LocComputeVertMixConv.Enabled) {
@@ -221,24 +322,27 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                                           KChunk, BruntVaisalaFreqSq);
                  });
           });
-   } else {
-      parallelFor(
-          "VertMix-Background", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
-             LocVertDiff(ICell, 0) = 0.0_Real;
-             LocVertVisc(ICell, 0) = 0.0_Real;
-          });
    }
+   parallelFor(
+       "VertMix-Surface", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          LocVertDiff(ICell, 0) = 0.0_Real;
+          LocVertVisc(ICell, 0) = 0.0_Real;
+       });
 }
 
 /// Define IO fields and metadata for output
 void VertMix::defineFields() {
 
    /// Set field names (append Name if not default)
-   VertDiffFldName = "VertDiff";
-   VertViscFldName = "VertVisc";
+   VertDiffFldName            = "VertDiff";
+   VertViscFldName            = "VertVisc";
+   GradRichNumFldName         = "GradRichNum";
+   GradRichNumSmoothedFldName = "GradRichNumSmoothed";
    if (Name != "Default") {
       VertDiffFldName.append(Name);
       VertViscFldName.append(Name);
+      GradRichNumFldName.append(Name);
+      GradRichNumSmoothedFldName.append(Name);
    }
 
    /// Create fields for state variables
@@ -274,6 +378,30 @@ void VertMix::defineFields() {
                      NDims,     // Number of dimensions
                      DimNames   // Dimension names
        );
+   /// Create and register the GradRichNum field
+   auto GradRichNumField =
+       Field::create(GradRichNumFldName,                     // Field name
+                     "Gradient Richardson number",           // Long Name
+                     "dimensionless",                        // Units
+                     "sea_water_gradient_richardson_number", // CF-ish Name
+                     std::numeric_limits<Real>::min(),       // Min valid value
+                     std::numeric_limits<Real>::max(),       // Max valid value
+                     FillValue, // Scalar used for undefined entries
+                     NDims,     // Number of dimensions
+                     DimNames   // Dimension names
+       );
+   /// Create and register the GradRichNumSmoothed field
+   auto GradRichNumSmoothedField = Field::create(
+       GradRichNumSmoothedFldName,                      // Field name
+       "Smoothed Gradient Richardson number",           // Long Name
+       "dimensionless",                                 // Units
+       "sea_water_gradient_richardson_number_smoothed", // CF-ish Name
+       std::numeric_limits<Real>::min(),                // Min valid value
+       std::numeric_limits<Real>::max(),                // Max valid value
+       FillValue, // Scalar used for undefined entries
+       NDims,     // Number of dimensions
+       DimNames   // Dimension names
+   );
 
    // Create a field group for the vertmix-specific state fields
    VertMixGroupName = "VertMix";
@@ -285,10 +413,14 @@ void VertMix::defineFields() {
    // Add fields to the VertMix group
    VertMixGroup->addField(VertDiffFldName);
    VertMixGroup->addField(VertViscFldName);
+   VertMixGroup->addField(GradRichNumFldName);
+   VertMixGroup->addField(GradRichNumSmoothedFldName);
 
    // Attach Kokkos views to the fields
    VertDiffField->attachData<Array2DReal>(VertDiff);
    VertViscField->attachData<Array2DReal>(VertVisc);
+   GradRichNumField->attachData<Array2DReal>(GradRichNum);
+   GradRichNumSmoothedField->attachData<Array2DReal>(GradRichNumSmoothed);
 
 } // end defineIOFields
 

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -29,7 +29,8 @@ GradRichardsonNum::GradRichardsonNum(const HorzMesh *Mesh,
       CellsOnCell(Mesh->CellsOnCell), MinLayerCell(VCoord->MinLayerCell),
       MaxLayerCell(VCoord->MaxLayerCell),
       MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
-      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop), DcEdge(Mesh->DcEdge),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop),
+      MaxLayerEdgeBot(VCoord->MaxLayerEdgeBot), DcEdge(Mesh->DcEdge),
       DvEdge(Mesh->DvEdge) {}
 
 OneTwoOneFilter::OneTwoOneFilter(const VertCoord *VCoord)

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -183,6 +183,8 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
    OMEGA_SCOPE(LocVertVisc, VertVisc); /// Create a local view for computation
    OMEGA_SCOPE(LocGradRichNum,
                GradRichNum); /// Local view for computation
+   OMEGA_SCOPE(LocGradRichNumSmoothed,
+               GradRichNumSmoothed); /// Local view for computation
    OMEGA_SCOPE(
        LocComputeVertMixConv,
        ComputeVertMixConv); /// Local view for Convective VertMix computation
@@ -202,65 +204,12 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
    deepCopy(LocVertDiff, BackDiff);
    deepCopy(LocVertVisc, BackVisc);
    deepCopy(LocGradRichNum, 100.0_Real);
-   deepCopy(GradRichNumSmoothed, 100.0_Real);
+   deepCopy(LocGradRichNumSmoothed, 100.0_Real);
 
    /// Dispatch to the correct VertMix calculation
-   if (LocComputeVertMixShear.Enabled && LocComputeVertMixConv.Enabled) {
+   if (LocComputeVertMixShear.Enabled) {
       parallelForOuter(
-          "VertMix-ConvPlusShear", {Mesh->NCellsAll},
-          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
-             const int KMin   = MinLayerCell(ICell);
-             const int KMax   = MaxLayerCell(ICell);
-             const int KRange = vertRangeChunked(KMin, KMax);
-
-             parallelForInner(
-                 Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocComputeVertMixConv(LocVertDiff, LocVertVisc, ICell,
-                                          KChunk, BruntVaisalaFreqSq);
-                    LocComputeGradRichardsonNum(
-                        LocGradRichNum, ICell, KChunk, NormalVelocity,
-                        TangentialVelocity, BruntVaisalaFreqSq);
-                 });
-             LocGradRichNum(ICell, 0) = LocGradRichNum(ICell, 1);
-             LocGradRichNum(ICell, NVertLayers) =
-                 LocGradRichNum(ICell, NVertLayers - 1);
-          });
-      deepCopy(GradRichNumSmoothed, LocGradRichNum);
-      for (int SmoothLoop = 0;
-           SmoothLoop < LocComputeVertMixShear.RiSmoothLoops; ++SmoothLoop) {
-         parallelForOuter(
-             "VertMix-ConvPlusShear", {Mesh->NCellsAll},
-             KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
-                const int KMin   = MinLayerCell(ICell);
-                const int KMax   = MaxLayerCell(ICell);
-                const int KRange = vertRangeChunked(KMin, KMax);
-                parallelForInner(
-                    Team, KRange, INNER_LAMBDA(int KChunk) {
-                       if (SmoothLoop == 0)
-                          LocOneTwoOneFilter(GradRichNumSmoothed, ICell, KChunk,
-                                             LocGradRichNum);
-                       else
-                          LocOneTwoOneFilter(GradRichNumSmoothed, ICell, KChunk,
-                                             GradRichNumSmoothed);
-                    });
-             });
-      }
-      parallelForOuter(
-          "VertMix-ConvPlusShear", {Mesh->NCellsAll},
-          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
-             const int KMin   = MinLayerCell(ICell);
-             const int KMax   = MaxLayerCell(ICell);
-             const int KRange = vertRangeChunked(KMin, KMax);
-
-             parallelForInner(
-                 Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocComputeVertMixShear(LocVertDiff, LocVertVisc, ICell,
-                                           KChunk, GradRichNumSmoothed);
-                 });
-          });
-   } else if (LocComputeVertMixShear.Enabled) {
-      parallelForOuter(
-          "VertMix-ConvPlusShear", {Mesh->NCellsAll},
+          "VertMix-ComputeRi", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
              const int KMin   = MinLayerCell(ICell);
              const int KMax   = MaxLayerCell(ICell);
@@ -272,15 +221,12 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                         LocGradRichNum, ICell, KChunk, NormalVelocity,
                         TangentialVelocity, BruntVaisalaFreqSq);
                  });
-             LocGradRichNum(ICell, 0) = LocGradRichNum(ICell, 1);
-             LocGradRichNum(ICell, NVertLayers) =
-                 LocGradRichNum(ICell, NVertLayers - 1);
           });
-      deepCopy(GradRichNumSmoothed, LocGradRichNum);
+      deepCopy(LocGradRichNumSmoothed, LocGradRichNum);
       for (int SmoothLoop = 0;
            SmoothLoop < LocComputeVertMixShear.RiSmoothLoops; ++SmoothLoop) {
          parallelForOuter(
-             "VertMix-ConvPlusShear", {Mesh->NCellsAll},
+             "VertMix-RiSmooth", {Mesh->NCellsAll},
              KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
                 const int KMin   = MinLayerCell(ICell);
                 const int KMax   = MaxLayerCell(ICell);
@@ -288,29 +234,31 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                 parallelForInner(
                     Team, KRange, INNER_LAMBDA(int KChunk) {
                        if (SmoothLoop == 0)
-                          LocOneTwoOneFilter(GradRichNumSmoothed, ICell, KChunk,
-                                             LocGradRichNum);
+                          LocOneTwoOneFilter(LocGradRichNumSmoothed, ICell,
+                                             KChunk, LocGradRichNum);
                        else
-                          LocOneTwoOneFilter(GradRichNumSmoothed, ICell, KChunk,
-                                             GradRichNumSmoothed);
+                          LocOneTwoOneFilter(LocGradRichNumSmoothed, ICell,
+                                             KChunk, LocGradRichNumSmoothed);
                     });
              });
       }
       parallelForOuter(
-          "VertMix-ConvPlusShear", {Mesh->NCellsAll},
+          "VertMix-Shear", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
              const int KMin   = MinLayerCell(ICell);
              const int KMax   = MaxLayerCell(ICell);
              const int KRange = vertRangeChunked(KMin, KMax);
+
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
                     LocComputeVertMixShear(LocVertDiff, LocVertVisc, ICell,
-                                           KChunk, GradRichNumSmoothed);
+                                           KChunk, LocGradRichNumSmoothed);
                  });
           });
-   } else if (LocComputeVertMixConv.Enabled) {
+   }
+   if (LocComputeVertMixConv.Enabled) {
       parallelForOuter(
-          "VertMix-ConvOnly", {Mesh->NCellsAll},
+          "VertMix-Conv", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
              const int KMin   = MinLayerCell(ICell);
              const int KMax   = MaxLayerCell(ICell);

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -199,7 +199,6 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                ComputeOneTwoOneFilter); /// Local view for 1-2-1 filter
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
-   // OMEGA_SCOPE(NVertLayers, VCoord->NVertLayers);
 
    /// Initialize VertDiff and VertVisc to background values
    deepCopy(LocVertDiff, BackDiff);
@@ -278,7 +277,6 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                  PerTeam(Team), INNER_LAMBDA() {
                     LocVertDiff(ICell, MinLayerCell(ICell)) = 0.0_Real;
                     LocVertVisc(ICell, MinLayerCell(ICell)) = 0.0_Real;
-                    // LocGradRichNum(ICell, KMin);
                     LocVertDiff(ICell, MaxLayerCell(ICell) + 1) =
                         LocVertDiff(ICell, KMax);
                     LocVertVisc(ICell, MaxLayerCell(ICell) + 1) =
@@ -309,7 +307,6 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                  PerTeam(Team), INNER_LAMBDA() {
                     LocVertDiff(ICell, MinLayerCell(ICell)) = 0.0_Real;
                     LocVertVisc(ICell, MinLayerCell(ICell)) = 0.0_Real;
-                    // LocGradRichNum(ICell, KMin);
                     LocVertDiff(ICell, MaxLayerCell(ICell) + 1) =
                         LocVertDiff(ICell, KMax);
                     LocVertVisc(ICell, MaxLayerCell(ICell) + 1) =

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -44,12 +44,12 @@ VertMix::VertMix(const std::string &Name, ///< [in] Name for VertMix object
     : ComputeVertMixConv(VCoord), ComputeVertMixShear(VCoord),
       ComputeGradRichardsonNum(Mesh, VCoord), ComputeOneTwoOneFilter(VCoord),
       Name(Name), Mesh(Mesh), VCoord(VCoord) {
-   VertDiff = Array2DReal("VertDiff", Mesh->NCellsSize, VCoord->NVertLayers);
-   VertVisc = Array2DReal("VertVisc", Mesh->NCellsSize, VCoord->NVertLayers);
+   VertDiff = Array2DReal("VertDiff", Mesh->NCellsSize, VCoord->NVertLayersP1);
+   VertVisc = Array2DReal("VertVisc", Mesh->NCellsSize, VCoord->NVertLayersP1);
    GradRichNum =
-       Array2DReal("GradRichNum", Mesh->NCellsSize, VCoord->NVertLayers);
+       Array2DReal("GradRichNum", Mesh->NCellsSize, VCoord->NVertLayersP1);
    GradRichNumSmoothed = Array2DReal("GradRichNumSmoothed", Mesh->NCellsSize,
-                                     VCoord->NVertLayers);
+                                     VCoord->NVertLayersP1);
 
    defineFields();
 }
@@ -212,7 +212,7 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
       parallelForOuter(
           "VertMix-ComputeRi", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
-             const int KMin   = MinLayerCell(ICell);
+             const int KMin   = MinLayerCell(ICell) + 1;
              const int KMax   = MaxLayerCell(ICell);
              const int KRange = vertRangeChunked(KMin, KMax);
 
@@ -221,6 +221,19 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                     LocComputeGradRichardsonNum(
                         LocGradRichNum, ICell, KChunk, NormalVelocity,
                         TangentialVelocity, BruntVaisalaFreqSq);
+                 });
+
+             teamBarrier(Team);
+
+             // Fill Richardson number at vertical boundaries using the
+             // closest valid value. This is equivalent to doing one-sided
+             // differencing at the boundary.
+             Kokkos::single(
+                 PerTeam(Team), INNER_LAMBDA() {
+                    LocGradRichNum(ICell, MinLayerCell(ICell)) =
+                        LocGradRichNum(ICell, KMin);
+                    LocGradRichNum(ICell, MaxLayerCell(ICell) + 1) =
+                        LocGradRichNum(ICell, KMax);
                  });
           });
       deepCopy(LocGradRichNumSmoothed, LocGradRichNum);
@@ -246,7 +259,7 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
       parallelForOuter(
           "VertMix-Shear", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
-             const int KMin   = MinLayerCell(ICell);
+             const int KMin   = MinLayerCell(ICell) + 1;
              const int KMax   = MaxLayerCell(ICell);
              const int KRange = vertRangeChunked(KMin, KMax);
 
@@ -255,13 +268,29 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                     LocComputeVertMixShear(LocVertDiff, LocVertVisc, ICell,
                                            KChunk, LocGradRichNumSmoothed);
                  });
+
+             teamBarrier(Team);
+
+             // Fill vertical diffusivity and viscosity at vertical
+             // boundaries using the closest valid value. This is equivalent
+             // to doing one-sided differencing at the boundary.
+             Kokkos::single(
+                 PerTeam(Team), INNER_LAMBDA() {
+                    LocVertDiff(ICell, MinLayerCell(ICell)) = 0.0_Real;
+                    LocVertVisc(ICell, MinLayerCell(ICell)) = 0.0_Real;
+                    // LocGradRichNum(ICell, KMin);
+                    LocVertDiff(ICell, MaxLayerCell(ICell) + 1) =
+                        LocVertDiff(ICell, KMax);
+                    LocVertVisc(ICell, MaxLayerCell(ICell) + 1) =
+                        LocVertVisc(ICell, KMax);
+                 });
           });
    }
    if (LocComputeVertMixConv.Enabled) {
       parallelForOuter(
           "VertMix-Conv", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
-             const int KMin   = MinLayerCell(ICell);
+             const int KMin   = MinLayerCell(ICell) + 1;
              const int KMax   = MaxLayerCell(ICell);
              const int KRange = vertRangeChunked(KMin, KMax);
 
@@ -269,6 +298,22 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                  Team, KRange, INNER_LAMBDA(int KChunk) {
                     LocComputeVertMixConv(LocVertDiff, LocVertVisc, ICell,
                                           KChunk, BruntVaisalaFreqSq);
+                 });
+
+             teamBarrier(Team);
+
+             // Fill vertical diffusivity and viscosity at vertical
+             // boundaries using the closest valid value. This is equivalent
+             // to doing one-sided differencing at the boundary.
+             Kokkos::single(
+                 PerTeam(Team), INNER_LAMBDA() {
+                    LocVertDiff(ICell, MinLayerCell(ICell)) = 0.0_Real;
+                    LocVertVisc(ICell, MinLayerCell(ICell)) = 0.0_Real;
+                    // LocGradRichNum(ICell, KMin);
+                    LocVertDiff(ICell, MaxLayerCell(ICell) + 1) =
+                        LocVertDiff(ICell, KMax);
+                    LocVertVisc(ICell, MaxLayerCell(ICell) + 1) =
+                        LocVertVisc(ICell, KMax);
                  });
           });
    }
@@ -299,7 +344,7 @@ void VertMix::defineFields() {
    int NDims            = 2;
    std::vector<std::string> DimNames(NDims);
    DimNames[0] = "NCells";
-   DimNames[1] = "NVertLayers";
+   DimNames[1] = "NVertLayersP1";
 
    /// Create and register the Diffusivity field
    auto VertDiffField =

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -24,7 +24,7 @@ ConvectiveMix::ConvectiveMix(const VertCoord *VCoord)
 
 GradRichardsonNum::GradRichardsonNum(const HorzMesh *Mesh,
                                      const VertCoord *VCoord)
-    : NVertLayers(VCoord->NVertLayers), ZMid(VCoord->ZMid),
+    : NVertLayers(VCoord->NVertLayers), GeomZMid(VCoord->GeomZMid),
       NEdgesOnCell(Mesh->NEdgesOnCell), EdgesOnCell(Mesh->EdgesOnCell),
       CellsOnCell(Mesh->CellsOnCell), MinLayerCell(VCoord->MinLayerCell),
       MaxLayerCell(VCoord->MaxLayerCell),
@@ -199,7 +199,7 @@ void VertMix::computeVertMix(const Array2DReal &NormalVelocity,
                ComputeOneTwoOneFilter); /// Local view for 1-2-1 filter
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
-   OMEGA_SCOPE(NVertLayers, VCoord->NVertLayers);
+   // OMEGA_SCOPE(NVertLayers, VCoord->NVertLayers);
 
    /// Initialize VertDiff and VertVisc to background values
    deepCopy(LocVertDiff, BackDiff);

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -43,12 +43,12 @@ VertMix::VertMix(const std::string &Name, ///< [in] Name for VertMix object
     : ComputeVertMixConv(VCoord), ComputeVertMixShear(VCoord),
       ComputeGradRichardsonNum(Mesh, VCoord), ComputeOneTwoOneFilter(VCoord),
       Name(Name), Mesh(Mesh), VCoord(VCoord) {
-   VertDiff = Array2DReal("VertDiff", Mesh->NCellsAll, VCoord->NVertLayers);
-   VertVisc = Array2DReal("VertVisc", Mesh->NCellsAll, VCoord->NVertLayers);
+   VertDiff = Array2DReal("VertDiff", Mesh->NCellsSize, VCoord->NVertLayers);
+   VertVisc = Array2DReal("VertVisc", Mesh->NCellsSize, VCoord->NVertLayers);
    GradRichNum =
-       Array2DReal("GradRichNum", Mesh->NCellsAll, VCoord->NVertLayers);
-   GradRichNumSmoothed =
-       Array2DReal("GradRichNumSmoothed", Mesh->NCellsAll, VCoord->NVertLayers);
+       Array2DReal("GradRichNum", Mesh->NCellsSize, VCoord->NVertLayers);
+   GradRichNumSmoothed = Array2DReal("GradRichNumSmoothed", Mesh->NCellsSize,
+                                     VCoord->NVertLayers);
 
    defineFields();
 }

--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -104,9 +104,6 @@ class ShearMix {
                             (GradRichNumSmoothed(ICell, K) / ShearRiCrit),
                     ShearExponent) *
                 BaseShearValue;
-         } else {
-            VertDiff(ICell, K) += 0.0_Real;
-            VertVisc(ICell, K) += 0.0_Real;
          }
       }
    }

--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -62,10 +62,10 @@ class ShearMix {
 
    // Shear mixing parameters
    Real BaseShearValue = 0.005; ///< Base shear vertical viscosity and
-                                ///< diffusivity (m^2 s^-1) of LMG94
-   Real ShearRiCrit = 0.7;      ///< Critical Richardson number of LMG94
+                                ///< diffusivity (m^2 s^-1) of LMD94
+   Real ShearRiCrit = 0.7;      ///< Critical Richardson number of LMD94
    Real ShearExponent =
-       3.0; /// Exponent value used interior shear mixing calculation of LMG94
+       3.0; /// Exponent value used interior shear mixing calculation of LMD94
    I4 RiSmoothLoops = 2; ///< Number of smoothing loops for Richardson number
 
    /// Constructor for ShearMix
@@ -112,6 +112,8 @@ class ShearMix {
 /// Class for Gradient Richardson Number calculation
 class GradRichardsonNum {
  public:
+   Real RiInitValue = 100.0_Real; ///< Initial Richardson number value
+
    /// constructor declaration
    GradRichardsonNum(const HorzMesh *Mesh, const VertCoord *VCoord);
 
@@ -132,7 +134,7 @@ class GradRichardsonNum {
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          GradRichNumNorm[KVec] = 1.0e-12_Real;
-         GradRichNumTmp[KVec]  = 100.0_Real;
+         GradRichNumTmp[KVec]  = RiInitValue;
       }
 
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
@@ -164,9 +166,9 @@ class GradRichardsonNum {
                                         BruntVaisalaFreqSq(JCell, K2))) /
                 (ShearSquared + 1.0e-12_Real);
 
-            Real Weight           = 0.25_Real * DcEdge(JEdge) * DvEdge(JEdge);
-            GradRichNumNorm[KVec] = GradRichNumNorm[KVec] + Weight;
-            GradRichNumTmp[KVec]  = GradRichNumTmp[KVec] + Weight * RiEdge;
+            Real Weight = 0.25_Real * DcEdge(JEdge) * DvEdge(JEdge);
+            GradRichNumNorm[KVec] += Weight;
+            GradRichNumTmp[KVec] += Weight * RiEdge;
          }
       }
 

--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -68,7 +68,7 @@ class ShearMix {
    Real ShearRiCrit = 0.7;      ///< Critical Richardson number of LMG94
    Real ShearExponent =
        3.0; /// Exponent value used interior shear mixing calculation of LMG94
-   I4 RiSmoothLoops = 3; ///< Number of smoothing loops for Richardson number
+   I4 RiSmoothLoops = 2; ///< Number of smoothing loops for Richardson number
 
    /// Constructor for ShearMix
    ShearMix(const VertCoord *VCoord);
@@ -138,9 +138,8 @@ class GradRichardsonNum {
       Real GradRichNumTmp[VecLength];
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
-         const I4 K         = KStart + KVec;
-         GradRichNumNorm[K] = 1.0e-12_Real;
-         GradRichNumTmp[K]  = 100.0_Real;
+         GradRichNumNorm[KVec] = 1.0e-12_Real;
+         GradRichNumTmp[KVec]  = 100.0_Real;
       }
 
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
@@ -151,11 +150,14 @@ class GradRichardsonNum {
             I4 K1      = K - 1;
             I4 K2      = K;
 
-            if (K <= MinLayerCell(ICell)) {
+            if (K < MinLayerCell(ICell) || K > MaxLayerCell(ICell))
+               continue;
+
+            if (K == MinLayerCell(ICell)) {
                K1 = K;
                K2 = K + 1;
             }
-            if (K >= MaxLayerCell(ICell)) {
+            if (K == MaxLayerCell(ICell)) {
                K1 = K - 2;
                K2 = K - 1;
             }
@@ -174,15 +176,15 @@ class GradRichardsonNum {
                                         BruntVaisalaFreqSq(JCell, K2))) /
                 (ShearSquared + 1.0e-12_Real);
 
-            Real Weight        = 0.25_Real * DcEdge(JEdge) * DvEdge(JEdge);
-            GradRichNumNorm[K] = GradRichNumNorm[K] + Weight;
-            GradRichNumTmp[K]  = GradRichNumTmp[K] + Weight * RiEdge;
+            Real Weight           = 0.25_Real * DcEdge(JEdge) * DvEdge(JEdge);
+            GradRichNumNorm[KVec] = GradRichNumNorm[KVec] + Weight;
+            GradRichNumTmp[KVec]  = GradRichNumTmp[KVec] + Weight * RiEdge;
          }
       }
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K            = KStart + KVec;
-         GradRichNum(ICell, K) = GradRichNumTmp[K] / GradRichNumNorm[K];
+         GradRichNum(ICell, K) = GradRichNumTmp[KVec] / GradRichNumNorm[KVec];
       }
    }
 

--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -43,14 +43,12 @@ class ConvectiveMix {
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
-         if (K == 0) {
-            VertVisc(ICell, K) = 0.0_Real;
-            VertDiff(ICell, K) = 0.0_Real;
-         } else {
-            if (BruntVaisalaFreqSq(ICell, K) < ConvTriggerBVF) {
-               VertDiff(ICell, K) += ConvDiff;
-               VertVisc(ICell, K) += ConvDiff;
-            }
+         if (K <= MinLayerCell(ICell) || K >= MaxLayerCell(ICell))
+            continue;
+
+         if (BruntVaisalaFreqSq(ICell, K) < ConvTriggerBVF) {
+            VertDiff(ICell, K) += ConvDiff;
+            VertVisc(ICell, K) += ConvDiff;
          }
       }
    }
@@ -84,33 +82,31 @@ class ShearMix {
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
-         if (K == 0) {
-            VertVisc(ICell, K) = 0.0_Real;
-            VertDiff(ICell, K) = 0.0_Real;
+         if (K <= MinLayerCell(ICell) || K >= MaxLayerCell(ICell))
+            continue;
+
+         if (GradRichNumSmoothed(ICell, K) < 0.0_Real) {
+            VertDiff(ICell, K) += BaseShearValue;
+            VertVisc(ICell, K) += BaseShearValue;
+         } else if (GradRichNumSmoothed(ICell, K) >= 0.0_Real &&
+                    GradRichNumSmoothed(ICell, K) < ShearRiCrit) {
+            VertDiff(ICell, K) +=
+                Kokkos::pow(
+                    1.0_Real -
+                        (GradRichNumSmoothed(ICell, K) / ShearRiCrit) *
+                            (GradRichNumSmoothed(ICell, K) / ShearRiCrit),
+                    ShearExponent) *
+                BaseShearValue;
+            VertVisc(ICell, K) +=
+                Kokkos::pow(
+                    1.0_Real -
+                        (GradRichNumSmoothed(ICell, K) / ShearRiCrit) *
+                            (GradRichNumSmoothed(ICell, K) / ShearRiCrit),
+                    ShearExponent) *
+                BaseShearValue;
          } else {
-            if (GradRichNumSmoothed(ICell, K) < 0.0_Real) {
-               VertDiff(ICell, K) += BaseShearValue;
-               VertVisc(ICell, K) += BaseShearValue;
-            } else if (GradRichNumSmoothed(ICell, K) >= 0.0_Real &&
-                       GradRichNumSmoothed(ICell, K) < ShearRiCrit) {
-               VertDiff(ICell, K) +=
-                   Kokkos::pow(
-                       1.0_Real -
-                           (GradRichNumSmoothed(ICell, K) / ShearRiCrit) *
-                               (GradRichNumSmoothed(ICell, K) / ShearRiCrit),
-                       ShearExponent) *
-                   BaseShearValue;
-               VertVisc(ICell, K) +=
-                   Kokkos::pow(
-                       1.0_Real -
-                           (GradRichNumSmoothed(ICell, K) / ShearRiCrit) *
-                               (GradRichNumSmoothed(ICell, K) / ShearRiCrit),
-                       ShearExponent) *
-                   BaseShearValue;
-            } else {
-               VertDiff(ICell, K) += 0.0_Real;
-               VertVisc(ICell, K) += 0.0_Real;
-            }
+            VertDiff(ICell, K) += 0.0_Real;
+            VertVisc(ICell, K) += 0.0_Real;
          }
       }
    }
@@ -152,21 +148,30 @@ class GradRichardsonNum {
          I4 JCell = CellsOnCell(ICell, J);
          for (int KVec = 0; KVec < KLen; ++KVec) {
             const I4 K = KStart + KVec;
-            if (K < 1 || K >= NVertLayers)
-               continue;
+            I4 K1      = K - 1;
+            I4 K2      = K;
+
+            if (K <= MinLayerCell(ICell)) {
+               K1 = K;
+               K2 = K + 1;
+            }
+            if (K >= MaxLayerCell(ICell)) {
+               K1 = K - 2;
+               K2 = K - 1;
+            }
 
             Real DNormVel =
-                NormalVelocity(JEdge, K - 1) - NormalVelocity(JEdge, K);
+                NormalVelocity(JEdge, K1) - NormalVelocity(JEdge, K2);
             Real DTanVel =
-                TangentialVelocity(JEdge, K - 1) - TangentialVelocity(JEdge, K);
-            Real DzEdge = 0.5_Real * (ZMid(ICell, K - 1) + ZMid(JCell, K - 1) -
-                                      ZMid(ICell, K) - ZMid(JCell, K));
+                TangentialVelocity(JEdge, K1) - TangentialVelocity(JEdge, K2);
+            Real DzEdge = 0.5_Real * (ZMid(ICell, K1) + ZMid(JCell, K1) -
+                                      (ZMid(ICell, K2) + ZMid(JCell, K2)));
             Real ShearSquared =
                 (DNormVel * DNormVel + DTanVel * DTanVel) / (DzEdge * DzEdge);
             Real RiEdge =
                 Kokkos::max(0.0_Real,
-                            0.5_Real * (BruntVaisalaFreqSq(ICell, K) +
-                                        BruntVaisalaFreqSq(JCell, K))) /
+                            0.5_Real * (BruntVaisalaFreqSq(ICell, K2) +
+                                        BruntVaisalaFreqSq(JCell, K2))) /
                 (ShearSquared + 1.0e-12_Real);
 
             Real Weight        = 0.25_Real * DcEdge(JEdge) * DvEdge(JEdge);
@@ -213,14 +218,14 @@ class OneTwoOneFilter {
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
-         if (K < MinLayerCell(ICell) || K > MaxLayerCell(ICell)) {
-            VarOut(ICell, K) = VarIn(ICell, K);
-         } else {
+         if (K > MinLayerCell(ICell) && K < MaxLayerCell(ICell) - 1) {
             // apply 1-2-1 filter
             VarOut(ICell, K) =
                 (VarIn(ICell, K - 1) + 2.0_Real * VarIn(ICell, K) +
                  VarIn(ICell, K + 1)) /
                 4.0_Real;
+         } else {
+            VarOut(ICell, K) = VarIn(ICell, K);
          }
       }
    }

--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -81,10 +81,10 @@ class ShearMix {
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
 
-         if (GradRichNumSmoothed(ICell, K) < 0.0_Real) {
+         if (GradRichNumSmoothed(ICell, K) <= 0.0_Real) {
             VertDiff(ICell, K) += BaseShearValue;
             VertVisc(ICell, K) += BaseShearValue;
-         } else if (GradRichNumSmoothed(ICell, K) >= 0.0_Real &&
+         } else if (GradRichNumSmoothed(ICell, K) > 0.0_Real &&
                     GradRichNumSmoothed(ICell, K) < ShearRiCrit) {
             VertDiff(ICell, K) +=
                 Kokkos::pow(
@@ -153,8 +153,9 @@ class GradRichardsonNum {
                 NormalVelocity(JEdge, K1) - NormalVelocity(JEdge, K2);
             Real DTanVel =
                 TangentialVelocity(JEdge, K1) - TangentialVelocity(JEdge, K2);
-            Real DzEdge = 0.5_Real * (ZMid(ICell, K1) + ZMid(JCell, K1) -
-                                      (ZMid(ICell, K2) + ZMid(JCell, K2)));
+            Real DzEdge =
+                0.5_Real * (GeomZMid(ICell, K1) + GeomZMid(JCell, K1) -
+                            (GeomZMid(ICell, K2) + GeomZMid(JCell, K2)));
             Real ShearSquared =
                 (DNormVel * DNormVel + DTanVel * DTanVel) / (DzEdge * DzEdge);
             Real RiEdge =
@@ -176,7 +177,7 @@ class GradRichardsonNum {
    }
 
  private:
-   Array2DReal ZMid;
+   Array2DReal GeomZMid;
    Array2DI4 EdgesOnCell;
    Array2DI4 CellsOnCell;
    Array2DI4 CellsOnEdge;

--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -65,21 +65,19 @@ class ShearMix {
    bool Enabled = true; ///< Enable shear mixing flag
 
    // Shear mixing parameters
-   Real ShearNuZero =
-       0.005; ///< Numerator of Pacanowski and Philander (1981) Eq (1).
-   Real ShearAlpha = 5.0; ///< Alpha value used in Pacanowski and Philander
-                          ///< (1981) Eqs (1) and (2).
+   Real BaseShearValue = 0.005; ///< Base shear vertical viscosity and
+                                ///< diffusivity (m^2 s^-1) of LMG94
+   Real ShearRiCrit = 0.7;      ///< Critical Richardson number of LMG94
    Real ShearExponent =
-       2.0; /// Exponent value used in Pacanowski and Philander (1981) Eqs (1).
+       3.0; /// Exponent value used interior shear mixing calculation of LMG94
+   I4 RiSmoothLoops = 3; ///< Number of smoothing loops for Richardson number
 
    /// Constructor for ShearMix
-   ShearMix(const HorzMesh *Mesh, const VertCoord *VCoord);
+   ShearMix(const VertCoord *VCoord);
 
    KOKKOS_FUNCTION void
    operator()(Array2DReal VertDiff, Array2DReal VertVisc, I4 ICell, I4 KChunk,
-              const Array2DReal &NormalVelocity,
-              const Array2DReal &TangentialVelocity,
-              const Array2DReal &BruntVaisalaFreqSq) const {
+              const Array2DReal &GradRichNumSmoothed) const {
 
       const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
@@ -90,43 +88,144 @@ class ShearMix {
             VertVisc(ICell, K) = 0.0_Real;
             VertDiff(ICell, K) = 0.0_Real;
          } else {
-            Real ShearViscVal = 0.0;
-            Real InvAreaCell  = 1.0_Real / AreaCell(ICell);
-            Real ShearSquared = 0.0;
-            for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
-               I4 JEdge = EdgesOnCell(ICell, J);
-               Real Factor =
-                   0.5_Real * DcEdge(JEdge) * DvEdge(JEdge) * InvAreaCell;
-               Real DelNormVel =
-                   NormalVelocity(JEdge, K - 1) - NormalVelocity(JEdge, K);
-               Real DelTangVel = TangentialVelocity(JEdge, K - 1) -
-                                 TangentialVelocity(JEdge, K);
-               ShearSquared = ShearSquared + Factor * (DelNormVel * DelNormVel +
-                                                       DelTangVel * DelTangVel);
+            if (GradRichNumSmoothed(ICell, K) < 0.0_Real) {
+               VertDiff(ICell, K) += BaseShearValue;
+               VertVisc(ICell, K) += BaseShearValue;
+            } else if (GradRichNumSmoothed(ICell, K) >= 0.0_Real &&
+                       GradRichNumSmoothed(ICell, K) < ShearRiCrit) {
+               VertDiff(ICell, K) +=
+                   Kokkos::pow(
+                       1.0_Real -
+                           (GradRichNumSmoothed(ICell, K) / ShearRiCrit) *
+                               (GradRichNumSmoothed(ICell, K) / ShearRiCrit),
+                       ShearExponent) *
+                   BaseShearValue;
+               VertVisc(ICell, K) +=
+                   Kokkos::pow(
+                       1.0_Real -
+                           (GradRichNumSmoothed(ICell, K) / ShearRiCrit) *
+                               (GradRichNumSmoothed(ICell, K) / ShearRiCrit),
+                       ShearExponent) *
+                   BaseShearValue;
+            } else {
+               VertDiff(ICell, K) += 0.0_Real;
+               VertVisc(ICell, K) += 0.0_Real;
             }
-            Real DelZMid = GeomZMid(ICell, K - 1) - GeomZMid(ICell, K);
-            ShearSquared = ShearSquared / (DelZMid * DelZMid);
-
-            Real RichardsonNum = BruntVaisalaFreqSq(ICell, K) /
-                                 Kokkos::max(1.0e-12_Real, ShearSquared);
-
-            ShearViscVal =
-                ShearNuZero / Kokkos::pow(1.0_Real + ShearAlpha * RichardsonNum,
-                                          ShearExponent);
-            VertVisc(ICell, K) += ShearViscVal;
-            VertDiff(ICell, K) +=
-                VertVisc(ICell, K) / (1.0_Real + ShearAlpha * RichardsonNum);
          }
       }
    }
 
  private:
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
+};
+
+/// Class for Gradient Richardson Number calculation
+class GradRichardsonNum {
+ public:
+   /// constructor declaration
+   GradRichardsonNum(const HorzMesh *Mesh, const VertCoord *VCoord);
+
+   //   The functor takes the full arrays of Richardson number (inout),
+   //   the index ICell, and normal and tangential velocities as inputs,
+   //   and outputs the Richardson number.
+   KOKKOS_FUNCTION void
+   operator()(Array2DReal GradRichNum, I4 ICell, I4 KChunk,
+              const Array2DReal &NormalVelocity,
+              const Array2DReal &TangentialVelocity,
+              const Array2DReal &BruntVaisalaFreqSq) const {
+
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
+
+      Real GradRichNumNorm[VecLength];
+      Real GradRichNumTmp[VecLength];
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K         = KStart + KVec;
+         GradRichNumNorm[K] = 1.0e-12_Real;
+         GradRichNumTmp[K]  = 100.0_Real;
+      }
+
+      for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
+         I4 JEdge = EdgesOnCell(ICell, J);
+         I4 JCell = CellsOnCell(ICell, J);
+         for (int KVec = 0; KVec < KLen; ++KVec) {
+            const I4 K = KStart + KVec;
+            if (K < 1 || K >= NVertLayers)
+               continue;
+
+            Real DNormVel =
+                NormalVelocity(JEdge, K - 1) - NormalVelocity(JEdge, K);
+            Real DTanVel =
+                TangentialVelocity(JEdge, K - 1) - TangentialVelocity(JEdge, K);
+            Real DzEdge = 0.5_Real * (ZMid(ICell, K - 1) + ZMid(JCell, K - 1) -
+                                      ZMid(ICell, K) - ZMid(JCell, K));
+            Real ShearSquared =
+                (DNormVel * DNormVel + DTanVel * DTanVel) / (DzEdge * DzEdge);
+            Real RiEdge =
+                Kokkos::max(0.0_Real,
+                            0.5_Real * (BruntVaisalaFreqSq(ICell, K) +
+                                        BruntVaisalaFreqSq(JCell, K))) /
+                (ShearSquared + 1.0e-12_Real);
+
+            Real Weight        = 0.25_Real * DcEdge(JEdge) * DvEdge(JEdge);
+            GradRichNumNorm[K] = GradRichNumNorm[K] + Weight;
+            GradRichNumTmp[K]  = GradRichNumTmp[K] + Weight * RiEdge;
+         }
+      }
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K            = KStart + KVec;
+         GradRichNum(ICell, K) = GradRichNumTmp[K] / GradRichNumNorm[K];
+      }
+   }
+
+ private:
+   Array2DReal ZMid;
+   Array2DI4 EdgesOnCell;
+   Array2DI4 CellsOnCell;
+   Array2DI4 CellsOnEdge;
+   Array1DI4 NEdgesOnCell;
+   Array1DI4 MinLayerCell;
+   Array1DI4 MaxLayerCell;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
    Array1DReal DcEdge;
    Array1DReal DvEdge;
-   Array1DReal AreaCell;
-   Array2DReal GeomZMid;
-   Array1DI4 NEdgesOnCell;
-   Array2DI4 EdgesOnCell;
+   I4 NVertLayers;
+   I4 NCellsAll;
+};
+
+/// Class for Gradient Richardson Number calculation
+class OneTwoOneFilter {
+ public:
+   /// constructor declaration
+   OneTwoOneFilter(const VertCoord *VCoord);
+   //   The functor takes the full arrays of Richardson number (inout),
+   //   the index ICell, and normal and tangential velocities as inputs,
+   //   and outputs the Richardson number.
+   KOKKOS_FUNCTION void operator()(Array2DReal VarOut, I4 ICell, I4 KChunk,
+                                   const Array2DReal &VarIn) const {
+
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K = KStart + KVec;
+         if (K < MinLayerCell(ICell) || K > MaxLayerCell(ICell)) {
+            VarOut(ICell, K) = VarIn(ICell, K);
+         } else {
+            // apply 1-2-1 filter
+            VarOut(ICell, K) =
+                (VarIn(ICell, K - 1) + 2.0_Real * VarIn(ICell, K) +
+                 VarIn(ICell, K + 1)) /
+                4.0_Real;
+         }
+      }
+   }
+
+ private:
    Array1DI4 MinLayerCell;
    Array1DI4 MaxLayerCell;
 };
@@ -140,13 +239,20 @@ class VertMix {
    /// Destroy instance (frees Kokkos views)
    static void destroyInstance();
 
-   Array2DReal VertDiff; ///< Vertical diffusivity field (m^2 s^-1)
-   Array2DReal VertVisc; ///< Vertical viscosity field (m^2 s^-1)
+   Array2DReal VertDiff;    ///< Vertical diffusivity field (m^2 s^-1)
+   Array2DReal VertVisc;    ///< Vertical viscosity field (m^2 s^-1)
+   Array2DReal GradRichNum; ///< Gradient Richardson number field
+   Array2DReal
+       GradRichNumSmoothed; ///< Smoothed Gradient Richardson number field
 
-   std::string VertDiffFldName;  ///< Field name for vertical diffusivity
-   std::string VertViscFldName;  ///< Field name for vertical viscosity
-   std::string VertMixGroupName; ///< VertMix group name (for config)
-   std::string Name;             ///< Name of this VertMix instance
+   std::string VertDiffFldName; ///< Field name for vertical diffusivity
+   std::string VertViscFldName; ///< Field name for vertical viscosity
+   std::string
+       GradRichNumFldName; ///< Field name for gradient Richardson number
+   std::string GradRichNumSmoothedFldName; ///< Field name for smoothed gradient
+                                           ///< Richardson number
+   std::string VertMixGroupName;           ///< VertMix group name (for config)
+   std::string Name;                       ///< Name of this VertMix instance
 
    // Background mixing parameters
    Real BackDiff = 1.0e-5; ///< Background vertical diffusivity (m^2 s^-1)
@@ -155,6 +261,10 @@ class VertMix {
    ConvectiveMix
        ComputeVertMixConv;       ///< Functor for Convective VertMix calculation
    ShearMix ComputeVertMixShear; ///< Functor for Shear VertMix calculation
+   GradRichardsonNum
+       ComputeGradRichardsonNum; ///< Functor for Gradient Richardson Number
+                                 ///< calculation
+   OneTwoOneFilter ComputeOneTwoOneFilter; ///< Functor for 1-2-1 filtering
 
    /// Compute vertical diffusivity and viscosity for all cells/layers
    void computeVertMix(const Array2DReal &NormalVelocity,

--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -142,6 +142,7 @@ class GradRichardsonNum {
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
          I4 JEdge = EdgesOnCell(ICell, J);
          I4 JCell = CellsOnCell(ICell, J);
+
          for (int KVec = 0; KVec < KLen; ++KVec) {
             const I4 K = KStart + KVec;
             I4 K1      = K - 1;
@@ -158,6 +159,11 @@ class GradRichardsonNum {
                K1 = K - 2;
                K2 = K - 1;
             }
+
+            // Skip this edge contribution if it would access
+            // invalid edge velocity levels.
+            if (K1 > MaxLayerEdgeBot(JEdge) || K2 > MaxLayerEdgeBot(JEdge))
+               continue;
 
             Real DNormVel =
                 NormalVelocity(JEdge, K1) - NormalVelocity(JEdge, K2);
@@ -195,6 +201,7 @@ class GradRichardsonNum {
    Array1DI4 MaxLayerCell;
    Array1DI4 MinLayerEdgeBot;
    Array1DI4 MaxLayerEdgeTop;
+   Array1DI4 MaxLayerEdgeBot;
    Array1DReal DcEdge;
    Array1DReal DvEdge;
    I4 NVertLayers;

--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -38,13 +38,11 @@ class ConvectiveMix {
    operator()(Array2DReal VertDiff, Array2DReal VertVisc, I4 ICell, I4 KChunk,
               const Array2DReal &BruntVaisalaFreqSq) const {
 
-      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell) + 1);
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
-         if (K <= MinLayerCell(ICell) || K >= MaxLayerCell(ICell))
-            continue;
 
          if (BruntVaisalaFreqSq(ICell, K) < ConvTriggerBVF) {
             VertDiff(ICell, K) += ConvDiff;
@@ -77,13 +75,11 @@ class ShearMix {
    operator()(Array2DReal VertDiff, Array2DReal VertVisc, I4 ICell, I4 KChunk,
               const Array2DReal &GradRichNumSmoothed) const {
 
-      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell) + 1);
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
-         if (K <= MinLayerCell(ICell) || K >= MaxLayerCell(ICell))
-            continue;
 
          if (GradRichNumSmoothed(ICell, K) < 0.0_Real) {
             VertDiff(ICell, K) += BaseShearValue;
@@ -128,7 +124,7 @@ class GradRichardsonNum {
               const Array2DReal &TangentialVelocity,
               const Array2DReal &BruntVaisalaFreqSq) const {
 
-      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell) + 1);
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
 
       Real GradRichNumNorm[VecLength];
@@ -147,18 +143,6 @@ class GradRichardsonNum {
             const I4 K = KStart + KVec;
             I4 K1      = K - 1;
             I4 K2      = K;
-
-            if (K < MinLayerCell(ICell) || K > MaxLayerCell(ICell))
-               continue;
-
-            if (K == MinLayerCell(ICell)) {
-               K1 = K;
-               K2 = K + 1;
-            }
-            if (K == MaxLayerCell(ICell)) {
-               K1 = K - 2;
-               K2 = K - 1;
-            }
 
             // Skip this edge contribution if it would access
             // invalid edge velocity levels.
@@ -220,11 +204,11 @@ class OneTwoOneFilter {
                                    const Array2DReal &VarIn) const {
 
       const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
-      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell) + 1);
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
-         if (K > MinLayerCell(ICell) && K < MaxLayerCell(ICell) - 1) {
+         if (K > MinLayerCell(ICell) && K < MaxLayerCell(ICell)) {
             // apply 1-2-1 filter
             VarOut(ICell, K) =
                 (VarIn(ICell, K - 1) + 2.0_Real * VarIn(ICell, K) +

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -49,7 +49,7 @@ const Real TeosBVFExpValue =
     0.020913834194283325; // Expected value for TEOS-10 squared Brunt-Vaisala
                           // frequency
 const Real LinearBVFExpValue =
-    0.017834796542017275; // Expected value for Linear squared Brunt-Vaisala
+    0.017382842633545097; // Expected value for Linear squared Brunt-Vaisala
                           // frequency
 const Real GswBVFExpValue =
     0.02081197958166906; // Expected value from GSW-C library

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -48,7 +48,7 @@ const Real TeosBVFExpValue =
     0.020913834194283325; // Expected value for TEOS-10 squared Brunt-Vaisala
                           // frequency
 const Real LinearBVFExpValue =
-    0.017834796542017275; // Expected value for Linear squared Brunt-Vaisala
+    0.017382842633545097; // Expected value for Linear squared Brunt-Vaisala
                           // frequency
 const Real GswBVFExpValue =
     0.02081197958166906; // Expected value from GSW-C library

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -121,14 +121,14 @@ void testGradRichNum() {
    VCoord->NVertLayersP1 = NVertLayersP1;
    I4 NCellsSize         = Mesh->NCellsSize;
    I4 NEdgesAll          = Mesh->NEdgesAll;
-   OMEGA_SCOPE(ZMid, VCoord->ZMid);
+   OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
    OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
    OMEGA_SCOPE(EdgesOnCell, Mesh->EdgesOnCell);
    OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
    OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
    OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
    OMEGA_SCOPE(CellsOnCell, Mesh->CellsOnCell);
-   OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
+   // OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
@@ -149,7 +149,7 @@ void testGradRichNum() {
    parallelFor(
        "populateArrays", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
-          ZMid(ICell, K)      = -K;
+          GeomZMid(ICell, K)  = -K;
           NEdgesOnCell(ICell) = 5;
           AreaCell(ICell)     = 3.6e10_Real;
        });
@@ -277,7 +277,7 @@ void testOneTwoOneFilter() {
    VCoord->NVertLayersP1 = NVertLayersP1;
    I4 NCellsSize         = Mesh->NCellsSize;
    I4 NChunks            = VCoord->NVertLayers / VecLength;
-   OMEGA_SCOPE(ZMid, VCoord->ZMid);
+   // OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
@@ -365,13 +365,13 @@ void testOneTwoOneFilter() {
 
 void testBackVertMix() {
    // Get mesh and coordinate info
-   const auto Mesh     = HorzMesh::getDefault();
-   const auto VCoord   = VertCoord::getDefault();
-   VCoord->NVertLayers = NVertLayers;
+   const auto Mesh       = HorzMesh::getDefault();
+   const auto VCoord     = VertCoord::getDefault();
+   VCoord->NVertLayers   = NVertLayers;
    VCoord->NVertLayersP1 = NVertLayersP1;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NEdgesSize       = Mesh->NEdgesSize;
-   I4 NEdgesAll        = Mesh->NEdgesAll;
+   I4 NCellsSize         = Mesh->NCellsSize;
+   I4 NEdgesSize         = Mesh->NEdgesSize;
+   I4 NEdgesAll          = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
 
    /// Get VertMix instance to test
@@ -497,13 +497,13 @@ void testBackVertMix() {
 
 void testConvVertMix() {
    // Get mesh and coordinate info
-   const auto Mesh     = HorzMesh::getDefault();
-   const auto VCoord   = VertCoord::getDefault();
-   VCoord->NVertLayers = NVertLayers;
+   const auto Mesh       = HorzMesh::getDefault();
+   const auto VCoord     = VertCoord::getDefault();
+   VCoord->NVertLayers   = NVertLayers;
    VCoord->NVertLayersP1 = NVertLayersP1;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NEdgesAll        = Mesh->NEdgesAll;
-   OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
+   I4 NCellsSize         = Mesh->NCellsSize;
+   // I4 NEdgesAll          = Mesh->NEdgesAll;
+   // OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
    I4 NChunks = VCoord->NVertLayers / VecLength;
 
    /// Get VertMix instance to test
@@ -770,12 +770,12 @@ void testShearVertMix() {
 /// Test vertical mixing coefficients calculation for all cells/layers
 void testTotalVertMix() {
    /// Get mesh and coordinate info
-   const auto Mesh     = HorzMesh::getDefault();
-   const auto VCoord   = VertCoord::getDefault();
-   VCoord->NVertLayers = NVertLayers;
+   const auto Mesh       = HorzMesh::getDefault();
+   const auto VCoord     = VertCoord::getDefault();
+   VCoord->NVertLayers   = NVertLayers;
    VCoord->NVertLayersP1 = NVertLayersP1;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NEdgesAll        = Mesh->NEdgesAll;
+   I4 NCellsSize         = Mesh->NCellsSize;
+   I4 NEdgesAll          = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
    OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
    OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
@@ -843,7 +843,7 @@ void testTotalVertMix() {
 
    OMEGA_SCOPE(VertDiffP, TestVertMix->VertDiff);
    OMEGA_SCOPE(VertViscP, TestVertMix->VertVisc);
-   OMEGA_SCOPE(GradRichNumSmoothed, TestVertMix->GradRichNumSmoothed);
+   // OMEGA_SCOPE(GradRichNumSmoothed, TestVertMix->GradRichNumSmoothed);
 
    /// Check all VertDiff array values against expected value
    int NumMismatches = 0;

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -115,11 +115,13 @@ void testGradRichNum() {
    /// Get mesh and coordinate info
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
+   auto *MeshHalo      = Halo::getDefault();
    VCoord->NVertLayers = NVertLayers;
    I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(ZMid, VCoord->ZMid);
    OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
+   OMEGA_SCOPE(EdgesOnCell, Mesh->EdgesOnCell);
    OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
    OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
    OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
@@ -150,11 +152,26 @@ void testGradRichNum() {
           AreaCell(ICell)     = 3.6e10_Real;
        });
 
+   // Also test guard is working for skipping layer edge contribution
+   // if it would access invalid edge velocity levels
    parallelFor(
        "setMinMax", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
-          MaxLayerCell(ICell) = NVertLayers - 1;
+          if (ICell % 2 == 0) {
+             MaxLayerCell(ICell) = 10;
+          } else {
+             MaxLayerCell(ICell) = NVertLayers - 2;
+          }
        });
+
+   // Refresh edge layer ranges after overriding MaxLayerCell.
+   VCoord->minMaxLayerEdge(MeshHalo);
+
+   // Rebind GradRichardsonNum so the functor captures refreshed edge ranges.
+   TestVertMix->ComputeGradRichardsonNum = GradRichardsonNum(Mesh, VCoord);
+
+   // Recapture after minMaxLayerEdge since it reallocates edge layer views.
+   OMEGA_SCOPE(MaxLayerEdgeBot, VCoord->MaxLayerEdgeBot);
 
    // filling CellsOnCell with simple mapping for this test
    parallelFor(
@@ -169,19 +186,23 @@ void testGradRichNum() {
    parallelFor(
        "populateArrays", {NEdgesAll, NVertLayers},
        KOKKOS_LAMBDA(I4 IEdge, I4 K) {
-          NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
-          TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
-          DcEdge(IEdge)           = 2.0e5_Real;
-          DvEdge(IEdge)           = 1.45e5_Real;
+          if (K > MaxLayerEdgeBot(IEdge)) {
+             NormalVelEdge(IEdge, K) =
+                 -9.99e30; // Fill value to cause failure if used
+             TangVelEdge(IEdge, K) =
+                 -9.99e30; // Fill value to cause failure if used
+          } else {
+             NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
+             TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
+          }
+          DcEdge(IEdge) = 2.0e5_Real;
+          DvEdge(IEdge) = 1.45e5_Real;
        });
 
    /// Compute gradient Richardson number
    TestVertMix->ComputeVertMixShear.Enabled = true;
    TestVertMix->computeVertMix(NormalVelEdge, TangVelEdge,
                                BruntVaisalaFreqSqCell);
-
-   // const auto &MinLayerCell = VCoord->MinLayerCell;
-   // const auto &MaxLayerCell = VCoord->MaxLayerCell;
 
    /// Check all array values against expected value
    int NumMismatches = 0;
@@ -197,8 +218,39 @@ void testGradRichNum() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (!isApprox(GradRichNum(ICell, K), RiExpValue, RTol))
-                    InnerCount++;
+
+                 // Match the production K1/K2 logic to determine whether
+                 // this layer has any valid edge contributions.
+                 I4 K1 = K - 1;
+                 I4 K2 = K;
+                 if (K == MinLayerCell(ICell)) {
+                    K1 = K;
+                    K2 = K + 1;
+                 }
+                 if (K == MaxLayerCell(ICell)) {
+                    K1 = K - 2;
+                    K2 = K - 1;
+                 }
+
+                 bool HasValidEdge = false;
+                 for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
+                    const I4 JEdge = EdgesOnCell(ICell, J);
+                    if (K1 <= MaxLayerEdgeBot(JEdge) &&
+                        K2 <= MaxLayerEdgeBot(JEdge)) {
+                       HasValidEdge = true;
+                       break;
+                    }
+                 }
+
+                 if (HasValidEdge) {
+                    if (!isApprox(GradRichNum(ICell, K), RiExpValue, RTol))
+                       InnerCount++;
+                 } else {
+                    // With all edges skipped, GradRichNum remains at sentinel
+                    // scale (~1e14) from initialization in the functor.
+                    if (!(GradRichNum(ICell, K) > 1.0e10_Real))
+                       InnerCount++;
+                 }
               },
               NumMismatchesCol);
 
@@ -259,11 +311,12 @@ void testOneTwoOneFilter() {
        });
 
    // Apply the 1-2-1 filter to each cell
+   OMEGA_SCOPE(ComputeOneTwoOneFilter, TestVertMix->ComputeOneTwoOneFilter);
    parallelFor(
        "ApplyOneTwoOneFilter", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
-          TestVertMix->ComputeOneTwoOneFilter(GradRichNumSmoothed, ICell,
-                                              KChunk, GradRichNum);
+          ComputeOneTwoOneFilter(GradRichNumSmoothed, ICell, KChunk,
+                                 GradRichNum);
        });
 
    /// Check all array values against expected value
@@ -478,11 +531,12 @@ void testConvVertMix() {
        });
 
    /// Compute only convective vertical viscosity and diffusivity
+   OMEGA_SCOPE(ComputeVertMixConv, TestVertMix->ComputeVertMixConv);
    parallelFor(
        "ApplyVertMixConv", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
-          TestVertMix->ComputeVertMixConv(VertDiffOut, VertViscOut, ICell,
-                                          KChunk, BruntVaisalaFreqSqIn);
+          ComputeVertMixConv(VertDiffOut, VertViscOut, ICell, KChunk,
+                             BruntVaisalaFreqSqIn);
        });
 
    const auto &MinLayerCell = VCoord->MinLayerCell;
@@ -607,12 +661,13 @@ void testShearVertMix() {
        });
 
    /// Compute only shear vertical viscosity and diffusivity
-   TestVertMix->ComputeVertMixShear.ShearExponent = 3.0;
+   OMEGA_SCOPE(ComputeVertMixShear, TestVertMix->ComputeVertMixShear);
+   ComputeVertMixShear.ShearExponent = 3.0;
    parallelFor(
        "ApplyVertMixShear", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
-          TestVertMix->ComputeVertMixShear(VertDiffOut, VertViscOut, ICell,
-                                           KChunk, GradRichNumSmoothedIn);
+          ComputeVertMixShear(VertDiffOut, VertViscOut, ICell, KChunk,
+                              GradRichNumSmoothedIn);
        });
 
    const auto &MinLayerCell = VCoord->MinLayerCell;

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -153,7 +153,7 @@ void testGradRichNum() {
    parallelFor(
        "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
-          MaxLayerCell(ICell) = VCoord->NVertLayers - 1;
+          MaxLayerCell(ICell) = NVertLayers - 1;
        });
 
    // filling CellsOnCell with simple mapping for this test
@@ -264,7 +264,7 @@ void testOneTwoOneFilter() {
    parallelFor(
        "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
-          MaxLayerCell(ICell) = VCoord->NVertLayers - 1;
+          MaxLayerCell(ICell) = NVertLayers - 1;
        });
 
    // Apply the 1-2-1 filter to each cell
@@ -346,8 +346,7 @@ void testBackVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NEdgesSize       = Mesh->NEdgesSize;
+   I4 NCellsAll        = Mesh->NCellsAll;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
 
@@ -355,10 +354,10 @@ void testBackVertMix() {
    VertMix *TestVertMix = VertMix::getInstance();
 
    /// Create and fill ocean state arrays
-   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesSize, NVertLayers);
-   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesSize, NVertLayers);
+   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
+   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsAll, NVertLayers);
 
    /// Use deep copy initialize with reference or zero values
    deepCopy(NormalVelEdge, NV);

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -128,7 +128,6 @@ void testGradRichNum() {
    OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
    OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
    OMEGA_SCOPE(CellsOnCell, Mesh->CellsOnCell);
-   // OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
@@ -277,7 +276,6 @@ void testOneTwoOneFilter() {
    VCoord->NVertLayersP1 = NVertLayersP1;
    I4 NCellsSize         = Mesh->NCellsSize;
    I4 NChunks            = VCoord->NVertLayers / VecLength;
-   // OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
@@ -502,9 +500,7 @@ void testConvVertMix() {
    VCoord->NVertLayers   = NVertLayers;
    VCoord->NVertLayersP1 = NVertLayersP1;
    I4 NCellsSize         = Mesh->NCellsSize;
-   // I4 NEdgesAll          = Mesh->NEdgesAll;
-   // OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
-   I4 NChunks = VCoord->NVertLayers / VecLength;
+   I4 NChunks            = VCoord->NVertLayers / VecLength;
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
@@ -843,7 +839,6 @@ void testTotalVertMix() {
 
    OMEGA_SCOPE(VertDiffP, TestVertMix->VertDiff);
    OMEGA_SCOPE(VertViscP, TestVertMix->VertVisc);
-   // OMEGA_SCOPE(GradRichNumSmoothed, TestVertMix->GradRichNumSmoothed);
 
    /// Check all VertDiff array values against expected value
    int NumMismatches = 0;

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -113,12 +113,13 @@ void initVertMixTest() {
 
 void testGradRichNum() {
    /// Get mesh and coordinate info
-   const auto Mesh     = HorzMesh::getDefault();
-   const auto VCoord   = VertCoord::getDefault();
-   auto *MeshHalo      = Halo::getDefault();
-   VCoord->NVertLayers = NVertLayers;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NEdgesAll        = Mesh->NEdgesAll;
+   const auto Mesh       = HorzMesh::getDefault();
+   const auto VCoord     = VertCoord::getDefault();
+   auto *MeshHalo        = Halo::getDefault();
+   VCoord->NVertLayers   = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
+   I4 NCellsSize         = Mesh->NCellsSize;
+   I4 NEdgesAll          = Mesh->NEdgesAll;
    OMEGA_SCOPE(ZMid, VCoord->ZMid);
    OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
    OMEGA_SCOPE(EdgesOnCell, Mesh->EdgesOnCell);
@@ -137,7 +138,7 @@ void testGradRichNum() {
    auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
    auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayersP1);
    /// Use deep copy to initialize results
    deepCopy(NormalVelEdge, NV);
    deepCopy(TangVelEdge, TV);
@@ -212,7 +213,7 @@ void testGradRichNum() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -223,11 +224,8 @@ void testGradRichNum() {
                  // this layer has any valid edge contributions.
                  I4 K1 = K - 1;
                  I4 K2 = K;
-                 if (K == MinLayerCell(ICell)) {
-                    K1 = K;
-                    K2 = K + 1;
-                 }
-                 if (K == MaxLayerCell(ICell)) {
+
+                 if (K == MaxLayerCell(ICell) + 1) {
                     K1 = K - 2;
                     K2 = K - 1;
                  }
@@ -272,11 +270,12 @@ void testGradRichNum() {
 
 void testOneTwoOneFilter() {
    /// Get mesh and coordinate info
-   const auto Mesh     = HorzMesh::getDefault();
-   const auto VCoord   = VertCoord::getDefault();
-   VCoord->NVertLayers = NVertLayers;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NChunks          = VCoord->NVertLayers / VecLength;
+   const auto Mesh       = HorzMesh::getDefault();
+   const auto VCoord     = VertCoord::getDefault();
+   VCoord->NVertLayers   = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
+   I4 NCellsSize         = Mesh->NCellsSize;
+   I4 NChunks            = VCoord->NVertLayers / VecLength;
    OMEGA_SCOPE(ZMid, VCoord->ZMid);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
@@ -286,8 +285,8 @@ void testOneTwoOneFilter() {
 
    /// Create and fill ocean state arrays
    auto GradRichNumSmoothed =
-       Array2DReal("GradRichNumSmoothed", NCellsSize, NVertLayers);
-   auto GradRichNum = Array2DReal("GradRichNum", NCellsSize, NVertLayers);
+       Array2DReal("GradRichNumSmoothed", NCellsSize, NVertLayersP1);
+   auto GradRichNum = Array2DReal("GradRichNum", NCellsSize, NVertLayersP1);
    /// Use deep copy to initialize results
    deepCopy(GradRichNumSmoothed, 1.0);
    deepCopy(GradRichNum, 1.0);
@@ -295,7 +294,7 @@ void testOneTwoOneFilter() {
    // Populate GradRichNum with alternating +1.0 and -1.0 values in vertical
    // GradRichNumSmoothed should smooth these to 0.0
    parallelFor(
-       "populateArrays", {Mesh->NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayersP1},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           if (K % 2 == 0) {
              GradRichNum(ICell, K) = 1.0;
@@ -326,19 +325,19 @@ void testOneTwoOneFilter() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K > MinLayerCell(ICell) && K < MaxLayerCell(ICell) - 1) {
+                 if (K > MinLayerCell(ICell) && K < MaxLayerCell(ICell)) {
                     // Interior layers should be smoothed to 0.0
                     if (!isApprox(GradRichNumSmoothed(ICell, K), 0.0_Real,
                                   RTol))
                        InnerCount++;
                  } else {
-                    // Boundary layers (K==0 or K==NVertLayers - 1) should be
+                    // Boundary layers (K==0 or K==NVertLayers) should be
                     // the same as input
                     if (!isApprox(GradRichNumSmoothed(ICell, K),
                                   GradRichNum(ICell, K), RTol))
@@ -368,6 +367,7 @@ void testBackVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
    I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesSize       = Mesh->NEdgesSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
@@ -380,7 +380,7 @@ void testBackVertMix() {
    auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesSize, NVertLayers);
    auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesSize, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayersP1);
 
    /// Use deep copy initialize with reference or zero values
    deepCopy(NormalVelEdge, NV);
@@ -421,7 +421,7 @@ void testBackVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -459,7 +459,7 @@ void testBackVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -499,6 +499,7 @@ void testConvVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
    I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
@@ -509,9 +510,11 @@ void testConvVertMix() {
 
    /// Create and fill ocean state arrays
    auto BruntVaisalaFreqSqIn =
-       Array2DReal("BruntVaisalaFreqSqIn", NCellsSize, NVertLayers);
-   auto VertDiffOut = Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayers);
-   auto VertViscOut = Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqIn", NCellsSize, NVertLayersP1);
+   auto VertDiffOut =
+       Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayersP1);
+   auto VertViscOut =
+       Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayersP1);
 
    /// Use deep copy to initialize with the ref value
    deepCopy(BruntVaisalaFreqSqIn, 0.0);
@@ -521,7 +524,7 @@ void testConvVertMix() {
    // Populate arrays: positive BVF in lower half (conv off),
    // negative in upper half (conv on)
    parallelFor(
-       "populateArrays", {Mesh->NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayersP1},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           if (K < 30) {
              BruntVaisalaFreqSqIn(ICell, K) = -0.2;
@@ -549,7 +552,7 @@ void testConvVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -588,7 +591,7 @@ void testConvVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -625,20 +628,23 @@ void testConvVertMix() {
 
 void testShearVertMix() {
    /// Get mesh and coordinate info
-   const auto Mesh     = HorzMesh::getDefault();
-   const auto VCoord   = VertCoord::getDefault();
-   VCoord->NVertLayers = NVertLayers;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NChunks          = VCoord->NVertLayers / VecLength;
+   const auto Mesh       = HorzMesh::getDefault();
+   const auto VCoord     = VertCoord::getDefault();
+   VCoord->NVertLayers   = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
+   I4 NCellsSize         = Mesh->NCellsSize;
+   I4 NChunks            = VCoord->NVertLayers / VecLength;
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
 
    /// Create and fill ocean state arrays
    auto GradRichNumSmoothedIn =
-       Array2DReal("GradRichNumSmoothedIn", NCellsSize, NVertLayers);
-   auto VertDiffOut = Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayers);
-   auto VertViscOut = Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayers);
+       Array2DReal("GradRichNumSmoothedIn", NCellsSize, NVertLayersP1);
+   auto VertDiffOut =
+       Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayersP1);
+   auto VertViscOut =
+       Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayersP1);
 
    /// Use Kokkos::deep_copy to fill the entire view with the ref value
    deepCopy(GradRichNumSmoothedIn, 0.0);
@@ -649,7 +655,7 @@ void testShearVertMix() {
    // positive in middle third (altered shear value), large positive
    // in lower third (no shear)
    parallelFor(
-       "populateArrays", {Mesh->NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayersP1},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           if (K < 20) {
              GradRichNumSmoothedIn(ICell, K) = -0.2;
@@ -680,7 +686,7 @@ void testShearVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -722,7 +728,7 @@ void testShearVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -766,6 +772,7 @@ void testTotalVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
    I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
@@ -782,7 +789,7 @@ void testTotalVertMix() {
    auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
    auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayersP1);
 
    /// Use deep copy to initialize with the ref value
    deepCopy(NormalVelEdge, NV);
@@ -844,7 +851,7 @@ void testTotalVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -888,7 +895,7 @@ void testTotalVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -943,7 +950,7 @@ void testTotalVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -987,7 +994,7 @@ void testTotalVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -32,29 +32,30 @@ constexpr int NVertLayers = 60;
 
 /// Values to test against
 const Real VertDiffExpValueN =
-    1.0393923290498872; // Expected value for diffusivity for positive BVF
+    1.00501; // Expected value for diffusivity for positive BVF
 const Real VertViscExpValueN =
-    1.0198269656595984; // Expected value for viscosity for positive BVF
+    1.0051; // Expected value for viscosity for positive BVF
 const Real VertDiffExpValueP =
-    0.0015685660274841844; // Expected value for diffusivity for negative BVF
+    0.003882748571163051; // Expected value for diffusivity for negative BVF
 const Real VertViscExpValueP =
-    0.002332474675614262; // Expected value for viscosity for negative BVF
+    0.003972748571163051; // Expected value for viscosity for negative BVF
 const Real VertDiffBackExp =
     1.0e-5; // Expected value for background diffusivity
 const Real VertViscBackExp = 1.0e-4; // Expected value for background viscosity
-const Real VertDiffConvExp =
+const Real VertConvExp =
     1.0; // Expected value for convective diffusivity/viscosity
-const Real VertDiffShearExp =
-    0.039183698912901; // Expected value for shear diffusivity
-const Real VertViscShearExp =
-    0.01972696565959843; // Expected value for shear viscosity
+const Real VertShearExp =
+    0.00387274859; // Expected value for shear diffusivity/viscosity
+const Real VertShearBaseExp =
+    0.005;                   // Expected value for shear diffusivity/viscosity
+const Real RiExpValue = 0.2; // Expected value for gradient Richardson number
 
 /// Test input values
 const Real BVFP = 0.1;  // Positive Brunt-Vaisala frequency in s^-2
 const Real BVFN = -0.1; // Negative Brunt-Vaisala frequency in s^-2
 const Real NV   = 1.0;  // Normal velocity in m/s
 const Real TV   = 1.0;  // Tangential velocity in m/s
-const Real RTol = 1e-8; // Relative tolerance for isApprox checks
+const Real RTol = 1e-7; // Relative tolerance for isApprox checks
 
 /// The initialization routine for VertMix testing. It calls various
 /// init routines, including the creation of the default decomposition.
@@ -110,6 +111,225 @@ void initVertMixTest() {
       ABORT_ERROR("VertMixTest: VertMix retrieval FAIL");
 }
 
+void testGradRichNum() {
+   /// Get mesh and coordinate info
+   const auto Mesh     = HorzMesh::getDefault();
+   const auto VCoord   = VertCoord::getDefault();
+   VCoord->NVertLayers = NVertLayers;
+   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NEdgesAll        = Mesh->NEdgesAll;
+   OMEGA_SCOPE(ZMid, VCoord->ZMid);
+   OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
+   OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
+   OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
+   OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
+   OMEGA_SCOPE(CellsOnCell, Mesh->CellsOnCell);
+
+   /// Get VertMix instance to test
+   VertMix *TestVertMix = VertMix::getInstance();
+
+   /// Create and fill ocean state arrays
+   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
+   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
+   auto BruntVaisalaFreqSqCell =
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsAll, NVertLayers);
+   /// Use deep copy to initialize results
+   deepCopy(NormalVelEdge, NV);
+   deepCopy(TangVelEdge, TV);
+   deepCopy(BruntVaisalaFreqSqCell, BVFP);
+   deepCopy(TestVertMix->GradRichNum, 0.0);
+
+   parallelFor(
+       "populateArrays", {NCellsAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 ICell, I4 K) {
+          ZMid(ICell, K)      = -K;
+          NEdgesOnCell(ICell) = 5;
+          AreaCell(ICell)     = 3.6e10_Real;
+       });
+
+   // filling CellsOnCell with simple mapping for this test
+   parallelFor(
+       "populateArrays", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          CellsOnCell(ICell, 0) = ICell;
+          CellsOnCell(ICell, 1) = ICell;
+          CellsOnCell(ICell, 2) = ICell;
+          CellsOnCell(ICell, 3) = ICell;
+          CellsOnCell(ICell, 4) = ICell;
+       });
+
+   parallelFor(
+       "populateArrays", {NEdgesAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 IEdge, I4 K) {
+          NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
+          TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
+          DcEdge(IEdge)           = 2.0e5_Real;
+          DvEdge(IEdge)           = 1.45e5_Real;
+       });
+
+   /// Compute gradient Richardson number
+   TestVertMix->ComputeVertMixShear.Enabled = true;
+   TestVertMix->computeVertMix(NormalVelEdge, TangVelEdge,
+                               BruntVaisalaFreqSqCell);
+
+   const auto &MinLayerCell = VCoord->MinLayerCell;
+   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+
+   /// Check all array values against expected value
+   int NumMismatches = 0;
+   OMEGA_SCOPE(GradRichNum, TestVertMix->GradRichNum);
+   parallelReduceOuter(
+       "CheckGradRichNum", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (!isApprox(GradRichNum(ICell, K), RiExpValue, RTol))
+                    InnerCount++;
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
+       },
+       NumMismatches);
+
+   // If test fails, print bad values and abort
+   if (NumMismatches != 0) {
+      auto GradRichNumH = createHostMirrorCopy(GradRichNum);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (!isApprox(GradRichNumH(I, K), RiExpValue, RTol))
+               LOG_ERROR("TestVertMix: GradRichNum Bad Value: "
+                         "GradRichNum({},{}) = {}; Expected {}",
+                         I, K, GradRichNumH(I, K), RiExpValue);
+         }
+      }
+      ABORT_ERROR("TestVertMix: GradRichNum FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMix: GradRichNum PASS");
+   }
+
+   return;
+}
+
+void testOneTwoOneFilter() {
+   /// Get mesh and coordinate info
+   const auto Mesh     = HorzMesh::getDefault();
+   const auto VCoord   = VertCoord::getDefault();
+   VCoord->NVertLayers = NVertLayers;
+   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NChunks          = VCoord->NVertLayers / VecLength;
+   OMEGA_SCOPE(ZMid, VCoord->ZMid);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
+   /// Get VertMix instance to test
+   VertMix *TestVertMix = VertMix::getInstance();
+
+   /// Create and fill ocean state arrays
+   auto GradRichNumSmoothed =
+       Array2DReal("GradRichNumSmoothed", NCellsAll, NVertLayers);
+   auto GradRichNum = Array2DReal("GradRichNum", NCellsAll, NVertLayers);
+   /// Use deep copy to initialize results
+   deepCopy(GradRichNumSmoothed, 1.0);
+   deepCopy(GradRichNum, 1.0);
+
+   // Populate GradRichNum with alternating +1.0 and -1.0 values in vertical
+   // GradRichNumSmoothed should smooth these to 0.0
+   parallelFor(
+       "populateArrays", {NCellsAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 ICell, I4 K) {
+          if (K > 0) {
+             GradRichNum(ICell, K) = -1.0 * GradRichNum(ICell, K - 1);
+          }
+       });
+
+   parallelFor(
+       "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          MinLayerCell(ICell) = 1;                       // avoid K=0 boundary
+          MaxLayerCell(ICell) = VCoord->NVertLayers - 2; // avoid top boundary
+       });
+
+   // Apply the 1-2-1 filter to each cell
+   parallelFor(
+       "ApplyOneTwoOneFilter", {NCellsAll, NChunks},
+       KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
+          TestVertMix->ComputeOneTwoOneFilter(GradRichNumSmoothed, ICell,
+                                              KChunk, GradRichNum);
+       });
+
+   /// Check all array values against expected value
+   int NumMismatches = 0;
+   parallelReduceOuter(
+       "CheckGradRichNum", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (K >= 1 && K < NVertLayers - 1) {
+                    // Interior layers should be smoothed to 0.0
+                    if (!isApprox(GradRichNumSmoothed(ICell, K), 0.0_Real,
+                                  RTol))
+                       InnerCount++;
+                 } else {
+                    // Boundary layers (K==0 or K==NVertLayers-1) should be the
+                    // same as input
+                    if (!isApprox(GradRichNumSmoothed(ICell, K),
+                                  GradRichNum(ICell, K), RTol))
+                       InnerCount++;
+                 }
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
+       },
+       NumMismatches);
+
+   // If test fails, print bad values and abort
+   if (NumMismatches != 0) {
+      auto GradRichNumH         = createHostMirrorCopy(GradRichNum);
+      auto GradRichNumSmoothedH = createHostMirrorCopy(GradRichNumSmoothed);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (K >= 1 && K < NVertLayers - 1) {
+               // Interior layers should be smoothed to 0.0
+               if (!isApprox(GradRichNumSmoothedH(I, K), 0.0, RTol))
+                  LOG_ERROR("TestVertMix: GradRichNumSmoothed Bad Value: "
+                            "GradRichNumSmoothed({},{}) = {}; Expected {}",
+                            I, K, GradRichNumSmoothedH(I, K), 0.0);
+            } else {
+               // Boundary layers (K==0 or K==NVertLayers-1) should be copied
+               // from input
+               if (!isApprox(GradRichNumSmoothedH(I, K), GradRichNumH(I, K),
+                             RTol))
+                  LOG_ERROR("TestVertMix: GradRichNumSmoothed Bad Value: "
+                            "GradRichNumSmoothed({},{}) = {}; Expected {}",
+                            I, K, GradRichNumSmoothedH(I, K),
+                            GradRichNumH(I, K));
+            }
+         }
+      }
+      ABORT_ERROR("TestVertMix: GradRichNumSmoothed FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMix: GradRichNumSmoothed PASS");
+   }
+
+   return;
+}
+
 void testBackVertMix() {
    // Get mesh and coordinate info
    const auto Mesh     = HorzMesh::getDefault();
@@ -161,7 +381,7 @@ void testBackVertMix() {
    Array2DReal BackVertVisc = TestVertMix->VertVisc;
    Array2DReal BackVertDiff = TestVertMix->VertDiff;
 
-   /// Check total Visc against linear addition of components
+   /// Check Visc against expected value
    int NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-BackgroundVisc", {Mesh->NCellsAll},
@@ -191,12 +411,15 @@ void testBackVertMix() {
        },
        NumMismatches);
 
-   if (NumMismatches != 0)
+   if (NumMismatches != 0) {
       ABORT_ERROR("TestVertMixBack: VertVisc FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertViscBackExp, BackVertVisc(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixBack: VertVisc PASS");
+   }
 
-   /// Check total Diff against linear addition of components
+   /// Check Diff against expected value
    NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-BackgroundDiff", {Mesh->NCellsAll},
@@ -231,13 +454,14 @@ void testBackVertMix() {
       ABORT_ERROR("TestVertMixBack: VertDiff FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertDiffBackExp, BackVertDiffH(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixBack: VertDiff PASS");
    }
 
    return;
 }
 
 void testConvVertMix() {
-
    // Get mesh and coordinate info
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
@@ -245,49 +469,46 @@ void testConvVertMix() {
    I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
+   I4 NChunks = VCoord->NVertLayers / VecLength;
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
 
    /// Create and fill ocean state arrays
-   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
-   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
-   auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+   auto BruntVaisalaFreqSqIn =
+       Array2DReal("BruntVaisalaFreqSqIn", NCellsAll, NVertLayers);
+   auto VertDiffOut = Array2DReal("VertDiffOut", NCellsAll, NVertLayers);
+   auto VertViscOut = Array2DReal("VertViscOut", NCellsAll, NVertLayers);
 
    /// Use deep copy to initialize with the ref value
-   deepCopy(NormalVelEdge, NV);
-   deepCopy(TangVelEdge, TV);
-   deepCopy(BruntVaisalaFreqSqCell, BVFN);
-   deepCopy(TestVertMix->VertDiff, 0.0);
-   deepCopy(TestVertMix->VertVisc, 0.0);
+   deepCopy(BruntVaisalaFreqSqIn, 0.0);
+   deepCopy(VertDiffOut, 0.0);
+   deepCopy(VertViscOut, 0.0);
 
+   // Populate arrays: positive BVF in lower half (conv off),
+   // negative in upper half (conv on)
    parallelFor(
-       "populateArrays", {Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(I4 ICell, I4 K) { GeomZMid(ICell, K) = -K; });
-
-   parallelFor(
-       "populateArrays", {NEdgesAll, NVertLayers},
-       KOKKOS_LAMBDA(I4 IEdge, I4 K) {
-          NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
-          TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
+       "populateArrays", {NCellsAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 ICell, I4 K) {
+          if (K < 30) {
+             BruntVaisalaFreqSqIn(ICell, K) = -0.2;
+          } else {
+             BruntVaisalaFreqSqIn(ICell, K) = 0.2;
+          }
        });
 
    /// Compute only convective vertical viscosity and diffusivity
-   TestVertMix->BackDiff                    = 0.0;
-   TestVertMix->BackVisc                    = 0.0;
-   TestVertMix->ComputeVertMixConv.Enabled  = true;
-   TestVertMix->ComputeVertMixShear.Enabled = false;
-   TestVertMix->computeVertMix(NormalVelEdge, TangVelEdge,
-                               BruntVaisalaFreqSqCell);
+   parallelFor(
+       "ApplyVertMixConv", {NCellsAll, NChunks},
+       KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
+          TestVertMix->ComputeVertMixConv(VertDiffOut, VertViscOut, ICell,
+                                          KChunk, BruntVaisalaFreqSqIn);
+       });
 
    const auto &MinLayerCell = VCoord->MinLayerCell;
    const auto &MaxLayerCell = VCoord->MaxLayerCell;
 
-   Array2DReal ConvVertVisc = TestVertMix->VertVisc;
-   Array2DReal ConvVertDiff = TestVertMix->VertDiff;
-
-   /// Check total Visc against linear addition of components
+   /// Check Visc against expected value
    int NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-ConvectiveVisc", {Mesh->NCellsAll},
@@ -302,11 +523,13 @@ void testConvVertMix() {
                  const int K = KMin + KOff;
                  if (K == 0) {
                     // Surface layer should be zero
-                    if (ConvVertVisc(ICell, K) != 0.0_Real)
+                    if (VertViscOut(ICell, K) != 0.0_Real)
+                       InnerCount++;
+                 } else if (K < 30) {
+                    if (!isApprox(VertViscOut(ICell, K), VertConvExp, RTol))
                        InnerCount++;
                  } else {
-                    if (!isApprox(ConvVertVisc(ICell, K), VertDiffConvExp,
-                                  RTol))
+                    if (!isApprox(VertViscOut(ICell, K), 0.0_Real, RTol))
                        InnerCount++;
                  }
               },
@@ -318,13 +541,37 @@ void testConvVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto ConvVertViscH = createHostMirrorCopy(ConvVertVisc);
-      ABORT_ERROR("TestVertMixConv: VertVisc FAIL, "
-                  "expected {}, got {} with {} mismatches",
-                  VertDiffConvExp, ConvVertViscH(1, 1), NumMismatches);
+      auto VertViscOutH = createHostMirrorCopy(VertViscOut);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (K == 0) {
+               // Surface should be 0.0
+               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), 0.0_Real);
+            } else if (K < 30) {
+               // Interior layers
+               if (!isApprox(VertViscOutH(I, K), VertConvExp, RTol))
+                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), VertConvExp);
+            } else {
+               // Interior layers
+               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), 0.0_Real);
+            }
+         }
+      }
+      ABORT_ERROR("TestVertMixConv: VertVisc FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixConv: VertVisc PASS");
    }
 
-   /// Check total Diff against linear addition of components
+   /// Check Diff against expected value
    NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-ConvectiveDiff", {Mesh->NCellsAll},
@@ -339,11 +586,13 @@ void testConvVertMix() {
                  const int K = KMin + KOff;
                  if (K == 0) {
                     // Surface layer should be zero
-                    if (ConvVertDiff(ICell, K) != 0.0_Real)
+                    if (VertDiffOut(ICell, K) != 0.0_Real)
+                       InnerCount++;
+                 } else if (K < 30) {
+                    if (!isApprox(VertDiffOut(ICell, K), VertConvExp, RTol))
                        InnerCount++;
                  } else {
-                    if (!isApprox(ConvVertDiff(ICell, K), VertDiffConvExp,
-                                  RTol))
+                    if (!isApprox(VertDiffOut(ICell, K), 0.0_Real, RTol))
                        InnerCount++;
                  }
               },
@@ -355,10 +604,34 @@ void testConvVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto ConvVertDiffH = createHostMirrorCopy(ConvVertDiff);
-      ABORT_ERROR("TestVertMixConv: VertDiff FAIL, "
-                  "expected {}, got {} with {} mismatches",
-                  VertDiffConvExp, ConvVertDiffH(1, 1), NumMismatches);
+      auto VertDiffOutH = createHostMirrorCopy(VertDiffOut);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (K == 0) {
+               // Surface should be 0.0
+               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), 0.0_Real);
+            } else if (K < 30) {
+               // Interior layers
+               if (!isApprox(VertDiffOutH(I, K), VertConvExp, RTol))
+                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), VertConvExp);
+            } else {
+               // Interior layers
+               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), 0.0_Real);
+            }
+         }
+      }
+      ABORT_ERROR("TestVertMixConv: VertDiff FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixConv: VertDiff PASS");
    }
 
    return;
@@ -369,62 +642,51 @@ void testShearVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NEdgesAll        = Mesh->NEdgesAll;
-   OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
-   OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
-   OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
-   OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
-   OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
+   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NChunks          = VCoord->NVertLayers / VecLength;
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
 
    /// Create and fill ocean state arrays
-   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
-   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
-   auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+   auto GradRichNumSmoothedIn =
+       Array2DReal("GradRichNumSmoothedIn", NCellsAll, NVertLayers);
+   auto VertDiffOut = Array2DReal("VertDiffOut", NCellsAll, NVertLayers);
+   auto VertViscOut = Array2DReal("VertViscOut", NCellsAll, NVertLayers);
 
    /// Use Kokkos::deep_copy to fill the entire view with the ref value
-   deepCopy(NormalVelEdge, NV);
-   deepCopy(TangVelEdge, TV);
-   deepCopy(BruntVaisalaFreqSqCell, BVFN);
-   deepCopy(TestVertMix->VertDiff, 0.0);
-   deepCopy(TestVertMix->VertVisc, 0.0);
+   deepCopy(GradRichNumSmoothedIn, 0.0);
+   deepCopy(VertDiffOut, 0.0);
+   deepCopy(VertViscOut, 0.0);
 
+   // Populate arrays: negative Ri in upper third (base shear value),
+   // positive in middle third (altered shear value), large positive
+   // in lower third (no shear)
    parallelFor(
        "populateArrays", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
-          GeomZMid(ICell, K)  = -K;
-          NEdgesOnCell(ICell) = 5;
-          AreaCell(ICell)     = 3.6e10_Real;
-       });
-
-   parallelFor(
-       "populateArrays", {NEdgesAll, NVertLayers},
-       KOKKOS_LAMBDA(I4 IEdge, I4 K) {
-          NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
-          TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
-          DcEdge(IEdge)           = 2.0e5_Real;
-          DvEdge(IEdge)           = 1.45e5_Real;
+          if (K < 20) {
+             GradRichNumSmoothedIn(ICell, K) = -0.2;
+          } else if (K >= 20 && K < 40) {
+             GradRichNumSmoothedIn(ICell, K) = 0.2;
+          } else {
+             GradRichNumSmoothedIn(ICell, K) = 10.0;
+          }
        });
 
    /// Compute only shear vertical viscosity and diffusivity
-   TestVertMix->BackDiff                    = 0.0;
-   TestVertMix->BackVisc                    = 0.0;
-   TestVertMix->ComputeVertMixConv.Enabled  = false;
-   TestVertMix->ComputeVertMixShear.Enabled = true;
-   TestVertMix->computeVertMix(NormalVelEdge, TangVelEdge,
-                               BruntVaisalaFreqSqCell);
+   TestVertMix->ComputeVertMixShear.ShearExponent = 3.0;
+   parallelFor(
+       "ApplyVertMixShear", {NCellsAll, NChunks},
+       KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
+          TestVertMix->ComputeVertMixShear(VertDiffOut, VertViscOut, ICell,
+                                           KChunk, GradRichNumSmoothedIn);
+       });
 
    const auto &MinLayerCell = VCoord->MinLayerCell;
    const auto &MaxLayerCell = VCoord->MaxLayerCell;
 
-   Array2DReal ShearVertVisc = TestVertMix->VertVisc;
-   Array2DReal ShearVertDiff = TestVertMix->VertDiff;
-
-   /// Check total Visc against linear addition of components
+   /// Check Visc against expected value
    int NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-ShearVisc", {Mesh->NCellsAll},
@@ -438,18 +700,17 @@ void testShearVertMix() {
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
                  if (K == 0) {
-                    if (ShearVertVisc(ICell, K) != 0.0_Real)
+                    if (VertViscOut(ICell, K) != 0.0_Real)
                        InnerCount++;
-                    // K = 1 should have ref value
-                 } else if (K == 1) {
-                    if (!isApprox(ShearVertVisc(ICell, K), VertViscShearExp,
+                 } else if (K < 20) {
+                    if (!isApprox(VertViscOut(ICell, K), VertShearBaseExp,
                                   RTol))
                        InnerCount++;
-                    // otherwise check for invalid values
+                 } else if (K >= 20 && K < 40) {
+                    if (!isApprox(VertViscOut(ICell, K), VertShearExp, RTol))
+                       InnerCount++;
                  } else {
-                    if (ShearVertVisc(ICell, K) == 0.0 or
-                        Kokkos::isnan(ShearVertVisc(ICell, K)) or
-                        Kokkos::isinf(ShearVertVisc(ICell, K)))
+                    if (!isApprox(VertViscOut(ICell, K), 0.0_Real, RTol))
                        InnerCount++;
                  }
               },
@@ -461,13 +722,43 @@ void testShearVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto ShearVertViscH = createHostMirrorCopy(ShearVertVisc);
-      ABORT_ERROR("TestVertMixShear: VertVisc FAIL, "
-                  "expected {}, got {} with {} mismatches",
-                  VertViscShearExp, ShearVertViscH(1, 1), NumMismatches);
+      auto VertViscOutH = createHostMirrorCopy(VertViscOut);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (K == 0) {
+               // Surface should be 0.0
+               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), 0.0_Real);
+            } else if (K < 20) {
+               // Interior layers
+               if (!isApprox(VertViscOutH(I, K), VertShearBaseExp, RTol))
+                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), VertShearBaseExp);
+            } else if (K >= 20 && K < 40) {
+               // Interior layers
+               if (!isApprox(VertViscOutH(I, K), VertShearExp, RTol))
+                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), VertShearExp);
+            } else {
+               // Interior layers
+               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), 0.0_Real);
+            }
+         }
+      }
+      ABORT_ERROR("TestVertMixShear: VertVisc FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixShear: VertVisc PASS");
    }
 
-   /// Check total Diff against linear addition of components
+   /// Check Diff against expected value
    NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-ShearVisc", {Mesh->NCellsAll},
@@ -481,18 +772,17 @@ void testShearVertMix() {
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
                  if (K == 0) {
-                    if (ShearVertDiff(ICell, K) != 0.0_Real)
+                    if (VertDiffOut(ICell, K) != 0.0_Real)
                        InnerCount++;
-                    // K = 1 should have ref value
-                 } else if (K == 1) {
-                    if (!isApprox(ShearVertDiff(ICell, K), VertDiffShearExp,
+                 } else if (K < 20) {
+                    if (!isApprox(VertDiffOut(ICell, K), VertShearBaseExp,
                                   RTol))
                        InnerCount++;
-                    // otherwise check for invalid values
+                 } else if (K >= 20 && K < 40) {
+                    if (!isApprox(VertDiffOut(ICell, K), VertShearExp, RTol))
+                       InnerCount++;
                  } else {
-                    if (ShearVertDiff(ICell, K) == 0.0 or
-                        Kokkos::isnan(ShearVertDiff(ICell, K)) or
-                        Kokkos::isinf(ShearVertDiff(ICell, K)))
+                    if (!isApprox(VertDiffOut(ICell, K), 0.0_Real, RTol))
                        InnerCount++;
                  }
               },
@@ -504,10 +794,40 @@ void testShearVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto ShearVertDiffH = createHostMirrorCopy(ShearVertDiff);
-      ABORT_ERROR("TestVertMixShear: VertDiff FAIL, "
-                  "expected {}, got {} with {} mismatches",
-                  VertDiffShearExp, ShearVertDiffH(1, 1), NumMismatches);
+      auto VertDiffOutH = createHostMirrorCopy(VertDiffOut);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (K == 0) {
+               // Surface should be 0.0
+               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), 0.0_Real);
+            } else if (K < 20) {
+               // Interior layers
+               if (!isApprox(VertDiffOutH(I, K), VertShearBaseExp, RTol))
+                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), VertShearBaseExp);
+            } else if (K >= 20 && K < 40) {
+               // Interior layers
+               if (!isApprox(VertDiffOutH(I, K), VertShearExp, RTol))
+                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), VertShearExp);
+            } else {
+               // Interior layers
+               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), 0.0_Real);
+            }
+         }
+      }
+      ABORT_ERROR("TestVertMixShear: VertDiff FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixShear: VertDiff PASS");
    }
 
    return;
@@ -526,6 +846,7 @@ void testTotalVertMix() {
    OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
    OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
    OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
+   OMEGA_SCOPE(CellsOnCell, Mesh->CellsOnCell);
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
@@ -544,6 +865,7 @@ void testTotalVertMix() {
    deepCopy(BruntVaisalaFreqSqCell, BVFP);
    deepCopy(TestVertMix->VertDiff, 0.0);
    deepCopy(TestVertMix->VertVisc, 0.0);
+   deepCopy(TestVertMix->GradRichNumSmoothed, 0.0);
 
    parallelFor(
        "populateArrays", {Mesh->NCellsAll, NVertLayers},
@@ -551,6 +873,17 @@ void testTotalVertMix() {
           GeomZMid(ICell, K)  = -K;
           NEdgesOnCell(ICell) = 5;
           AreaCell(ICell)     = 3.6e10_Real;
+       });
+
+   // current mesh has some CellsOnCell value > NCellsAll, so
+   // filling CellsOnCell with simple mapping for this test
+   parallelFor(
+       "populateArrays", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          CellsOnCell(ICell, 0) = ICell;
+          CellsOnCell(ICell, 1) = ICell;
+          CellsOnCell(ICell, 2) = ICell;
+          CellsOnCell(ICell, 3) = ICell;
+          CellsOnCell(ICell, 4) = ICell;
        });
 
    parallelFor(
@@ -575,6 +908,7 @@ void testTotalVertMix() {
 
    OMEGA_SCOPE(VertDiffP, TestVertMix->VertDiff);
    OMEGA_SCOPE(VertViscP, TestVertMix->VertVisc);
+   OMEGA_SCOPE(GradRichNumSmoothed, TestVertMix->GradRichNumSmoothed);
 
    /// Check all VertDiff array values against expected value
    int NumMismatches = 0;
@@ -616,6 +950,8 @@ void testTotalVertMix() {
       ABORT_ERROR("TestVertMixTotal: VertDiffPositive FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertDiffExpValueP, VertDiffPH(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixTotal: VertDiffPos PASS");
    }
 
    /// Check all VertVisc array values against expected value
@@ -658,6 +994,8 @@ void testTotalVertMix() {
       ABORT_ERROR("TestVertMixTotal: VertViscPositive FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertViscExpValueP, VertViscPH(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixTotal: VertViscPos PASS");
    }
 
    // Now test with negative BVF
@@ -711,6 +1049,8 @@ void testTotalVertMix() {
       ABORT_ERROR("TestVertMix: VertDiffNegative FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertDiffExpValueN, VertDiffNH(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixTotal: VertDiffNeg PASS");
    }
 
    /// Check all VertVisc array values against expected value
@@ -753,6 +1093,8 @@ void testTotalVertMix() {
       ABORT_ERROR("TestVertMix: VertViscNegative FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertViscExpValueN, VertViscNH(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixTotal: VertViscNeg PASS");
    }
 
    return;
@@ -771,12 +1113,14 @@ void finalizeVertMixTest() {
 }
 
 // the main tests (all in one to have the same log):
-// --> one tests the vertical diffusivity and viscosity
+// --> one tests the gradient richardson number calculation
+// --> next tests the 1-2-1 filter (smoothing)
+// --> next tests the vertical diffusivity and viscosity
 // with only background on
 // --> next tests the vertical diffusivity and viscosity
-// with only convective on
+// for only convective
 // --> next tests the vertical diffusivity and viscosity
-// with only shear on
+// for only shear
 // --> next tests the linear superposition of the
 // background, convective, and shear contributions
 void vertMixTest() {
@@ -785,6 +1129,8 @@ void vertMixTest() {
    initVertMixTest();
 
    // test each vertical mix option
+   testGradRichNum();
+   testOneTwoOneFilter();
    testBackVertMix();
    testConvVertMix();
    testShearVertMix();

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -426,8 +426,8 @@ void testBackVertMix() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) {
-                    // Surface layer should be zero
+                 if (K == KMin || K == KMax) {
+                    // Surface and bottom layers should be zero
                     if (BackVertVisc(ICell, K) != 0.0_Real)
                        InnerCount++;
                  } else {
@@ -464,8 +464,8 @@ void testBackVertMix() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) {
-                    // Surface layer should be zero
+                 if (K == KMin || K == KMax) {
+                    // Surface and bottom layers should be zero
                     if (BackVertDiff(ICell, K) != 0.0_Real)
                        InnerCount++;
                  } else {
@@ -555,8 +555,8 @@ void testConvVertMix() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) {
-                    // Surface layer should be zero
+                 if (K == KMin || K == KMax) {
+                    // Surface and bottom layers should be zero
                     if (VertViscOut(ICell, K) != 0.0_Real)
                        InnerCount++;
                  } else if (K < 30) {
@@ -594,8 +594,8 @@ void testConvVertMix() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) {
-                    // Surface layer should be zero
+                 if (K == KMin || K == KMax) {
+                    // Surface and bottom layers should be zero
                     if (VertDiffOut(ICell, K) != 0.0_Real)
                        InnerCount++;
                  } else if (K < 30) {
@@ -689,7 +689,8 @@ void testShearVertMix() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) {
+                 if (K == KMin || K == KMax) {
+                    // Surface and bottom layers should be zero
                     if (VertViscOut(ICell, K) != 0.0_Real)
                        InnerCount++;
                  } else if (K < 20) {
@@ -731,7 +732,8 @@ void testShearVertMix() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) {
+                 if (K == KMin || K == KMax) {
+                    // Surface and bottom layers should be zero
                     if (VertDiffOut(ICell, K) != 0.0_Real)
                        InnerCount++;
                  } else if (K < 20) {
@@ -853,11 +855,12 @@ void testTotalVertMix() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) {
+                 if (K == KMin || K == KMax) {
+                    // Surface and bottom layers should be zero
                     if (VertDiffP(ICell, K) != 0.0_Real)
                        InnerCount++;
                     // K = 1 should have ref value
-                 } else if (K == 1) {
+                 } else if (K == KMin + 1) {
                     if (!isApprox(VertDiffP(ICell, K), VertDiffExpValueP, RTol))
                        InnerCount++;
                     // otherwise check for invalid values
@@ -897,11 +900,11 @@ void testTotalVertMix() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) {
+                 if (K == KMin || K == KMax) {
                     if (VertViscP(ICell, K) != 0.0_Real)
                        InnerCount++;
                     // K = 1 should have ref value
-                 } else if (K == 1) {
+                 } else if (K == KMin + 1) {
                     if (!isApprox(VertViscP(ICell, K), VertViscExpValueP, RTol))
                        InnerCount++;
                     // otherwise check for invalid values
@@ -952,11 +955,11 @@ void testTotalVertMix() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) {
+                 if (K == KMin || K == KMax) {
                     if (VertDiffN(ICell, K) != 0.0_Real)
                        InnerCount++;
                     // K = 1 should have ref value
-                 } else if (K == 1) {
+                 } else if (K == KMin + 1) {
                     if (!isApprox(VertDiffN(ICell, K), VertDiffExpValueN, RTol))
                        InnerCount++;
                     // otherwise check for invalid values
@@ -996,11 +999,11 @@ void testTotalVertMix() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) {
+                 if (K == KMin || K == KMax) {
                     if (VertViscN(ICell, K) != 0.0_Real)
                        InnerCount++;
                     // K = 1 should have ref value
-                 } else if (K == 1) {
+                 } else if (K == KMin + 1) {
                     if (!isApprox(VertViscN(ICell, K), VertViscExpValueN, RTol))
                        InnerCount++;
                     // otherwise check for invalid values

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -116,7 +116,7 @@ void testGradRichNum() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(ZMid, VCoord->ZMid);
    OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
@@ -135,7 +135,7 @@ void testGradRichNum() {
    auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
    auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsAll, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
    /// Use deep copy to initialize results
    deepCopy(NormalVelEdge, NV);
    deepCopy(TangVelEdge, TV);
@@ -143,7 +143,7 @@ void testGradRichNum() {
    deepCopy(TestVertMix->GradRichNum, 0.0);
 
    parallelFor(
-       "populateArrays", {NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           ZMid(ICell, K)      = -K;
           NEdgesOnCell(ICell) = 5;
@@ -151,14 +151,14 @@ void testGradRichNum() {
        });
 
    parallelFor(
-       "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+       "setMinMax", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
           MaxLayerCell(ICell) = NVertLayers - 1;
        });
 
    // filling CellsOnCell with simple mapping for this test
    parallelFor(
-       "populateArrays", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+       "populateArrays", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           CellsOnCell(ICell, 0) = ICell;
           CellsOnCell(ICell, 1) = ICell;
           CellsOnCell(ICell, 2) = ICell;
@@ -209,15 +209,6 @@ void testGradRichNum() {
 
    // If test fails, print bad values and abort
    if (NumMismatches != 0) {
-      auto GradRichNumH = createHostMirrorCopy(GradRichNum);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (!isApprox(GradRichNumH(I, K), RiExpValue, RTol))
-               LOG_ERROR("TestVertMix: GradRichNum Bad Value: "
-                         "GradRichNum({},{}) = {}; Expected {}",
-                         I, K, GradRichNumH(I, K), RiExpValue);
-         }
-      }
       ABORT_ERROR("TestVertMix: GradRichNum FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -232,7 +223,7 @@ void testOneTwoOneFilter() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NCellsSize       = Mesh->NCellsSize;
    I4 NChunks          = VCoord->NVertLayers / VecLength;
    OMEGA_SCOPE(ZMid, VCoord->ZMid);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
@@ -243,8 +234,8 @@ void testOneTwoOneFilter() {
 
    /// Create and fill ocean state arrays
    auto GradRichNumSmoothed =
-       Array2DReal("GradRichNumSmoothed", NCellsAll, NVertLayers);
-   auto GradRichNum = Array2DReal("GradRichNum", NCellsAll, NVertLayers);
+       Array2DReal("GradRichNumSmoothed", NCellsSize, NVertLayers);
+   auto GradRichNum = Array2DReal("GradRichNum", NCellsSize, NVertLayers);
    /// Use deep copy to initialize results
    deepCopy(GradRichNumSmoothed, 1.0);
    deepCopy(GradRichNum, 1.0);
@@ -252,7 +243,7 @@ void testOneTwoOneFilter() {
    // Populate GradRichNum with alternating +1.0 and -1.0 values in vertical
    // GradRichNumSmoothed should smooth these to 0.0
    parallelFor(
-       "populateArrays", {NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           if (K % 2 == 0) {
              GradRichNum(ICell, K) = 1.0;
@@ -262,14 +253,14 @@ void testOneTwoOneFilter() {
        });
 
    parallelFor(
-       "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+       "setMinMax", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
           MaxLayerCell(ICell) = NVertLayers - 1;
        });
 
    // Apply the 1-2-1 filter to each cell
    parallelFor(
-       "ApplyOneTwoOneFilter", {NCellsAll, NChunks},
+       "ApplyOneTwoOneFilter", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
           TestVertMix->ComputeOneTwoOneFilter(GradRichNumSmoothed, ICell,
                                               KChunk, GradRichNum);
@@ -310,28 +301,6 @@ void testOneTwoOneFilter() {
 
    // If test fails, print bad values and abort
    if (NumMismatches != 0) {
-      auto GradRichNumH         = createHostMirrorCopy(GradRichNum);
-      auto GradRichNumSmoothedH = createHostMirrorCopy(GradRichNumSmoothed);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (K > MinLayerCell(I) && K < MaxLayerCell(I) - 1) {
-               // Interior layers should be smoothed to 0.0
-               if (!isApprox(GradRichNumSmoothedH(I, K), 0.0, RTol))
-                  LOG_ERROR("TestVertMix: GradRichNumSmoothed Bad Value: "
-                            "GradRichNumSmoothed({},{}) = {}; Expected {}",
-                            I, K, GradRichNumSmoothedH(I, K), 0.0);
-            } else {
-               // Boundary layers (K==0 or K==NVertLayers-1) should be copied
-               // from input
-               if (!isApprox(GradRichNumSmoothedH(I, K), GradRichNumH(I, K),
-                             RTol))
-                  LOG_ERROR("TestVertMix: GradRichNumSmoothed Bad Value: "
-                            "GradRichNumSmoothed({},{}) = {}; Expected {}",
-                            I, K, GradRichNumSmoothedH(I, K),
-                            GradRichNumH(I, K));
-            }
-         }
-      }
       ABORT_ERROR("TestVertMix: GradRichNumSmoothed FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -346,7 +315,8 @@ void testBackVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NCellsSize       = Mesh->NCellsSize;
+   I4 NEdgesSize       = Mesh->NEdgesSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
 
@@ -354,10 +324,10 @@ void testBackVertMix() {
    VertMix *TestVertMix = VertMix::getInstance();
 
    /// Create and fill ocean state arrays
-   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
-   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
+   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesSize, NVertLayers);
+   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesSize, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsAll, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
 
    /// Use deep copy initialize with reference or zero values
    deepCopy(NormalVelEdge, NV);
@@ -486,9 +456,9 @@ void testConvVertMix() {
 
    /// Create and fill ocean state arrays
    auto BruntVaisalaFreqSqIn =
-       Array2DReal("BruntVaisalaFreqSqIn", NCellsAll, NVertLayers);
-   auto VertDiffOut = Array2DReal("VertDiffOut", NCellsAll, NVertLayers);
-   auto VertViscOut = Array2DReal("VertViscOut", NCellsAll, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqIn", NCellsSize, NVertLayers);
+   auto VertDiffOut = Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayers);
+   auto VertViscOut = Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayers);
 
    /// Use deep copy to initialize with the ref value
    deepCopy(BruntVaisalaFreqSqIn, 0.0);
@@ -498,7 +468,7 @@ void testConvVertMix() {
    // Populate arrays: positive BVF in lower half (conv off),
    // negative in upper half (conv on)
    parallelFor(
-       "populateArrays", {NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           if (K < 30) {
              BruntVaisalaFreqSqIn(ICell, K) = -0.2;
@@ -509,7 +479,7 @@ void testConvVertMix() {
 
    /// Compute only convective vertical viscosity and diffusivity
    parallelFor(
-       "ApplyVertMixConv", {NCellsAll, NChunks},
+       "ApplyVertMixConv", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
           TestVertMix->ComputeVertMixConv(VertDiffOut, VertViscOut, ICell,
                                           KChunk, BruntVaisalaFreqSqIn);
@@ -551,30 +521,6 @@ void testConvVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto VertViscOutH = createHostMirrorCopy(VertViscOut);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (K == 0) {
-               // Surface should be 0.0
-               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), 0.0_Real);
-            } else if (K < 30) {
-               // Interior layers
-               if (!isApprox(VertViscOutH(I, K), VertConvExp, RTol))
-                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), VertConvExp);
-            } else {
-               // Interior layers
-               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), 0.0_Real);
-            }
-         }
-      }
       ABORT_ERROR("TestVertMixConv: VertVisc FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -614,30 +560,6 @@ void testConvVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto VertDiffOutH = createHostMirrorCopy(VertDiffOut);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (K == 0) {
-               // Surface should be 0.0
-               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), 0.0_Real);
-            } else if (K < 30) {
-               // Interior layers
-               if (!isApprox(VertDiffOutH(I, K), VertConvExp, RTol))
-                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), VertConvExp);
-            } else {
-               // Interior layers
-               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), 0.0_Real);
-            }
-         }
-      }
       ABORT_ERROR("TestVertMixConv: VertDiff FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -652,7 +574,7 @@ void testShearVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NCellsSize       = Mesh->NCellsSize;
    I4 NChunks          = VCoord->NVertLayers / VecLength;
 
    /// Get VertMix instance to test
@@ -660,9 +582,9 @@ void testShearVertMix() {
 
    /// Create and fill ocean state arrays
    auto GradRichNumSmoothedIn =
-       Array2DReal("GradRichNumSmoothedIn", NCellsAll, NVertLayers);
-   auto VertDiffOut = Array2DReal("VertDiffOut", NCellsAll, NVertLayers);
-   auto VertViscOut = Array2DReal("VertViscOut", NCellsAll, NVertLayers);
+       Array2DReal("GradRichNumSmoothedIn", NCellsSize, NVertLayers);
+   auto VertDiffOut = Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayers);
+   auto VertViscOut = Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayers);
 
    /// Use Kokkos::deep_copy to fill the entire view with the ref value
    deepCopy(GradRichNumSmoothedIn, 0.0);
@@ -687,7 +609,7 @@ void testShearVertMix() {
    /// Compute only shear vertical viscosity and diffusivity
    TestVertMix->ComputeVertMixShear.ShearExponent = 3.0;
    parallelFor(
-       "ApplyVertMixShear", {NCellsAll, NChunks},
+       "ApplyVertMixShear", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
           TestVertMix->ComputeVertMixShear(VertDiffOut, VertViscOut, ICell,
                                            KChunk, GradRichNumSmoothedIn);
@@ -732,36 +654,6 @@ void testShearVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto VertViscOutH = createHostMirrorCopy(VertViscOut);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (K == 0) {
-               // Surface should be 0.0
-               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), 0.0_Real);
-            } else if (K < 20) {
-               // Interior layers
-               if (!isApprox(VertViscOutH(I, K), VertShearBaseExp, RTol))
-                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), VertShearBaseExp);
-            } else if (K >= 20 && K < 40) {
-               // Interior layers
-               if (!isApprox(VertViscOutH(I, K), VertShearExp, RTol))
-                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), VertShearExp);
-            } else {
-               // Interior layers
-               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), 0.0_Real);
-            }
-         }
-      }
       ABORT_ERROR("TestVertMixShear: VertVisc FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -804,36 +696,6 @@ void testShearVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto VertDiffOutH = createHostMirrorCopy(VertDiffOut);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (K == 0) {
-               // Surface should be 0.0
-               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), 0.0_Real);
-            } else if (K < 20) {
-               // Interior layers
-               if (!isApprox(VertDiffOutH(I, K), VertShearBaseExp, RTol))
-                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), VertShearBaseExp);
-            } else if (K >= 20 && K < 40) {
-               // Interior layers
-               if (!isApprox(VertDiffOutH(I, K), VertShearExp, RTol))
-                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), VertShearExp);
-            } else {
-               // Interior layers
-               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), 0.0_Real);
-            }
-         }
-      }
       ABORT_ERROR("TestVertMixShear: VertDiff FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -888,7 +750,7 @@ void testTotalVertMix() {
    // current mesh has some CellsOnCell value > NCellsAll, so
    // filling CellsOnCell with simple mapping for this test
    parallelFor(
-       "populateArrays", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+       "populateArrays", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           CellsOnCell(ICell, 0) = ICell;
           CellsOnCell(ICell, 1) = ICell;
           CellsOnCell(ICell, 2) = ICell;

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -153,7 +153,7 @@ void testGradRichNum() {
    parallelFor(
        "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
-          MaxLayerCell(ICell) = VCoord->NVertLayers;
+          MaxLayerCell(ICell) = VCoord->NVertLayers - 1;
        });
 
    // filling CellsOnCell with simple mapping for this test

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -28,7 +28,8 @@
 using namespace OMEGA;
 
 /// Test constants and expected values
-constexpr int NVertLayers = 60;
+constexpr int NVertLayers   = 60;
+constexpr int NVertLayersP1 = NVertLayers + 1;
 
 /// Values to test against
 const Real VertDiffExpValueN =

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -124,6 +124,9 @@ void testGradRichNum() {
    OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
    OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
    OMEGA_SCOPE(CellsOnCell, Mesh->CellsOnCell);
+   OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
@@ -145,6 +148,12 @@ void testGradRichNum() {
           ZMid(ICell, K)      = -K;
           NEdgesOnCell(ICell) = 5;
           AreaCell(ICell)     = 3.6e10_Real;
+       });
+
+   parallelFor(
+       "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          MinLayerCell(ICell) = 0;
+          MaxLayerCell(ICell) = VCoord->NVertLayers;
        });
 
    // filling CellsOnCell with simple mapping for this test
@@ -171,8 +180,8 @@ void testGradRichNum() {
    TestVertMix->computeVertMix(NormalVelEdge, TangVelEdge,
                                BruntVaisalaFreqSqCell);
 
-   const auto &MinLayerCell = VCoord->MinLayerCell;
-   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+   // const auto &MinLayerCell = VCoord->MinLayerCell;
+   // const auto &MaxLayerCell = VCoord->MaxLayerCell;
 
    /// Check all array values against expected value
    int NumMismatches = 0;
@@ -245,15 +254,17 @@ void testOneTwoOneFilter() {
    parallelFor(
        "populateArrays", {NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
-          if (K > 0) {
-             GradRichNum(ICell, K) = -1.0 * GradRichNum(ICell, K - 1);
+          if (K % 2 == 0) {
+             GradRichNum(ICell, K) = 1.0;
+          } else {
+             GradRichNum(ICell, K) = -1.0;
           }
        });
 
    parallelFor(
        "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
-          MinLayerCell(ICell) = 1;                       // avoid K=0 boundary
-          MaxLayerCell(ICell) = VCoord->NVertLayers - 2; // avoid top boundary
+          MinLayerCell(ICell) = 0;
+          MaxLayerCell(ICell) = VCoord->NVertLayers - 1;
        });
 
    // Apply the 1-2-1 filter to each cell
@@ -277,14 +288,14 @@ void testOneTwoOneFilter() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K >= 1 && K < NVertLayers - 1) {
+                 if (K > MinLayerCell(ICell) && K < MaxLayerCell(ICell) - 1) {
                     // Interior layers should be smoothed to 0.0
                     if (!isApprox(GradRichNumSmoothed(ICell, K), 0.0_Real,
                                   RTol))
                        InnerCount++;
                  } else {
-                    // Boundary layers (K==0 or K==NVertLayers-1) should be the
-                    // same as input
+                    // Boundary layers (K==0 or K==NVertLayers - 1) should be
+                    // the same as input
                     if (!isApprox(GradRichNumSmoothed(ICell, K),
                                   GradRichNum(ICell, K), RTol))
                        InnerCount++;
@@ -303,7 +314,7 @@ void testOneTwoOneFilter() {
       auto GradRichNumSmoothedH = createHostMirrorCopy(GradRichNumSmoothed);
       for (int I = 0; I < NCellsAll; ++I) {
          for (int K = 0; K < NVertLayers; ++K) {
-            if (K >= 1 && K < NVertLayers - 1) {
+            if (K > MinLayerCell(I) && K < MaxLayerCell(I) - 1) {
                // Interior layers should be smoothed to 0.0
                if (!isApprox(GradRichNumSmoothedH(I, K), 0.0, RTol))
                   LOG_ERROR("TestVertMix: GradRichNumSmoothed Bad Value: "

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -107,11 +107,13 @@ void testGradRichNum() {
    /// Get mesh and coordinate info
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
+   auto *MeshHalo      = Halo::getDefault();
    VCoord->NVertLayers = NVertLayers;
    I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(ZMid, VCoord->ZMid);
    OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
+   OMEGA_SCOPE(EdgesOnCell, Mesh->EdgesOnCell);
    OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
    OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
    OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
@@ -142,11 +144,26 @@ void testGradRichNum() {
           AreaCell(ICell)     = 3.6e10_Real;
        });
 
+   // Also test guard is working for skipping layer edge contribution
+   // if it would access invalid edge velocity levels
    parallelFor(
        "setMinMax", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
-          MaxLayerCell(ICell) = NVertLayers - 1;
+          if (ICell % 2 == 0) {
+             MaxLayerCell(ICell) = 10;
+          } else {
+             MaxLayerCell(ICell) = NVertLayers - 2;
+          }
        });
+
+   // Refresh edge layer ranges after overriding MaxLayerCell.
+   VCoord->minMaxLayerEdge(MeshHalo);
+
+   // Rebind GradRichardsonNum so the functor captures refreshed edge ranges.
+   TestVertMix->ComputeGradRichardsonNum = GradRichardsonNum(Mesh, VCoord);
+
+   // Recapture after minMaxLayerEdge since it reallocates edge layer views.
+   OMEGA_SCOPE(MaxLayerEdgeBot, VCoord->MaxLayerEdgeBot);
 
    // filling CellsOnCell with simple mapping for this test
    parallelFor(
@@ -161,19 +178,23 @@ void testGradRichNum() {
    parallelFor(
        "populateArrays", {NEdgesAll, NVertLayers},
        KOKKOS_LAMBDA(I4 IEdge, I4 K) {
-          NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
-          TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
-          DcEdge(IEdge)           = 2.0e5_Real;
-          DvEdge(IEdge)           = 1.45e5_Real;
+          if (K > MaxLayerEdgeBot(IEdge)) {
+             NormalVelEdge(IEdge, K) =
+                 -9.99e30; // Fill value to cause failure if used
+             TangVelEdge(IEdge, K) =
+                 -9.99e30; // Fill value to cause failure if used
+          } else {
+             NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
+             TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
+          }
+          DcEdge(IEdge) = 2.0e5_Real;
+          DvEdge(IEdge) = 1.45e5_Real;
        });
 
    /// Compute gradient Richardson number
    TestVertMix->ComputeVertMixShear.Enabled = true;
    TestVertMix->computeVertMix(NormalVelEdge, TangVelEdge,
                                BruntVaisalaFreqSqCell);
-
-   // const auto &MinLayerCell = VCoord->MinLayerCell;
-   // const auto &MaxLayerCell = VCoord->MaxLayerCell;
 
    /// Check all array values against expected value
    int NumMismatches = 0;
@@ -189,8 +210,39 @@ void testGradRichNum() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (!isApprox(GradRichNum(ICell, K), RiExpValue, RTol))
-                    InnerCount++;
+
+                 // Match the production K1/K2 logic to determine whether
+                 // this layer has any valid edge contributions.
+                 I4 K1 = K - 1;
+                 I4 K2 = K;
+                 if (K == MinLayerCell(ICell)) {
+                    K1 = K;
+                    K2 = K + 1;
+                 }
+                 if (K == MaxLayerCell(ICell)) {
+                    K1 = K - 2;
+                    K2 = K - 1;
+                 }
+
+                 bool HasValidEdge = false;
+                 for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
+                    const I4 JEdge = EdgesOnCell(ICell, J);
+                    if (K1 <= MaxLayerEdgeBot(JEdge) &&
+                        K2 <= MaxLayerEdgeBot(JEdge)) {
+                       HasValidEdge = true;
+                       break;
+                    }
+                 }
+
+                 if (HasValidEdge) {
+                    if (!isApprox(GradRichNum(ICell, K), RiExpValue, RTol))
+                       InnerCount++;
+                 } else {
+                    // With all edges skipped, GradRichNum remains at sentinel
+                    // scale (~1e14) from initialization in the functor.
+                    if (!(GradRichNum(ICell, K) > 1.0e10_Real))
+                       InnerCount++;
+                 }
               },
               NumMismatchesCol);
 
@@ -251,11 +303,12 @@ void testOneTwoOneFilter() {
        });
 
    // Apply the 1-2-1 filter to each cell
+   OMEGA_SCOPE(ComputeOneTwoOneFilter, TestVertMix->ComputeOneTwoOneFilter);
    parallelFor(
        "ApplyOneTwoOneFilter", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
-          TestVertMix->ComputeOneTwoOneFilter(GradRichNumSmoothed, ICell,
-                                              KChunk, GradRichNum);
+          ComputeOneTwoOneFilter(GradRichNumSmoothed, ICell, KChunk,
+                                 GradRichNum);
        });
 
    /// Check all array values against expected value
@@ -470,11 +523,12 @@ void testConvVertMix() {
        });
 
    /// Compute only convective vertical viscosity and diffusivity
+   OMEGA_SCOPE(ComputeVertMixConv, TestVertMix->ComputeVertMixConv);
    parallelFor(
        "ApplyVertMixConv", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
-          TestVertMix->ComputeVertMixConv(VertDiffOut, VertViscOut, ICell,
-                                          KChunk, BruntVaisalaFreqSqIn);
+          ComputeVertMixConv(VertDiffOut, VertViscOut, ICell, KChunk,
+                             BruntVaisalaFreqSqIn);
        });
 
    const auto &MinLayerCell = VCoord->MinLayerCell;
@@ -599,12 +653,13 @@ void testShearVertMix() {
        });
 
    /// Compute only shear vertical viscosity and diffusivity
-   TestVertMix->ComputeVertMixShear.ShearExponent = 3.0;
+   OMEGA_SCOPE(ComputeVertMixShear, TestVertMix->ComputeVertMixShear);
+   ComputeVertMixShear.ShearExponent = 3.0;
    parallelFor(
        "ApplyVertMixShear", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
-          TestVertMix->ComputeVertMixShear(VertDiffOut, VertViscOut, ICell,
-                                           KChunk, GradRichNumSmoothedIn);
+          ComputeVertMixShear(VertDiffOut, VertViscOut, ICell, KChunk,
+                              GradRichNumSmoothedIn);
        });
 
    const auto &MinLayerCell = VCoord->MinLayerCell;

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -108,7 +108,7 @@ void testGradRichNum() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(ZMid, VCoord->ZMid);
    OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
@@ -127,7 +127,7 @@ void testGradRichNum() {
    auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
    auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsAll, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
    /// Use deep copy to initialize results
    deepCopy(NormalVelEdge, NV);
    deepCopy(TangVelEdge, TV);
@@ -135,7 +135,7 @@ void testGradRichNum() {
    deepCopy(TestVertMix->GradRichNum, 0.0);
 
    parallelFor(
-       "populateArrays", {NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           ZMid(ICell, K)      = -K;
           NEdgesOnCell(ICell) = 5;
@@ -143,14 +143,14 @@ void testGradRichNum() {
        });
 
    parallelFor(
-       "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+       "setMinMax", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
           MaxLayerCell(ICell) = NVertLayers - 1;
        });
 
    // filling CellsOnCell with simple mapping for this test
    parallelFor(
-       "populateArrays", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+       "populateArrays", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           CellsOnCell(ICell, 0) = ICell;
           CellsOnCell(ICell, 1) = ICell;
           CellsOnCell(ICell, 2) = ICell;
@@ -201,15 +201,6 @@ void testGradRichNum() {
 
    // If test fails, print bad values and abort
    if (NumMismatches != 0) {
-      auto GradRichNumH = createHostMirrorCopy(GradRichNum);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (!isApprox(GradRichNumH(I, K), RiExpValue, RTol))
-               LOG_ERROR("TestVertMix: GradRichNum Bad Value: "
-                         "GradRichNum({},{}) = {}; Expected {}",
-                         I, K, GradRichNumH(I, K), RiExpValue);
-         }
-      }
       ABORT_ERROR("TestVertMix: GradRichNum FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -224,7 +215,7 @@ void testOneTwoOneFilter() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NCellsSize       = Mesh->NCellsSize;
    I4 NChunks          = VCoord->NVertLayers / VecLength;
    OMEGA_SCOPE(ZMid, VCoord->ZMid);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
@@ -235,8 +226,8 @@ void testOneTwoOneFilter() {
 
    /// Create and fill ocean state arrays
    auto GradRichNumSmoothed =
-       Array2DReal("GradRichNumSmoothed", NCellsAll, NVertLayers);
-   auto GradRichNum = Array2DReal("GradRichNum", NCellsAll, NVertLayers);
+       Array2DReal("GradRichNumSmoothed", NCellsSize, NVertLayers);
+   auto GradRichNum = Array2DReal("GradRichNum", NCellsSize, NVertLayers);
    /// Use deep copy to initialize results
    deepCopy(GradRichNumSmoothed, 1.0);
    deepCopy(GradRichNum, 1.0);
@@ -244,7 +235,7 @@ void testOneTwoOneFilter() {
    // Populate GradRichNum with alternating +1.0 and -1.0 values in vertical
    // GradRichNumSmoothed should smooth these to 0.0
    parallelFor(
-       "populateArrays", {NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           if (K % 2 == 0) {
              GradRichNum(ICell, K) = 1.0;
@@ -254,14 +245,14 @@ void testOneTwoOneFilter() {
        });
 
    parallelFor(
-       "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+       "setMinMax", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
           MaxLayerCell(ICell) = NVertLayers - 1;
        });
 
    // Apply the 1-2-1 filter to each cell
    parallelFor(
-       "ApplyOneTwoOneFilter", {NCellsAll, NChunks},
+       "ApplyOneTwoOneFilter", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
           TestVertMix->ComputeOneTwoOneFilter(GradRichNumSmoothed, ICell,
                                               KChunk, GradRichNum);
@@ -302,28 +293,6 @@ void testOneTwoOneFilter() {
 
    // If test fails, print bad values and abort
    if (NumMismatches != 0) {
-      auto GradRichNumH         = createHostMirrorCopy(GradRichNum);
-      auto GradRichNumSmoothedH = createHostMirrorCopy(GradRichNumSmoothed);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (K > MinLayerCell(I) && K < MaxLayerCell(I) - 1) {
-               // Interior layers should be smoothed to 0.0
-               if (!isApprox(GradRichNumSmoothedH(I, K), 0.0, RTol))
-                  LOG_ERROR("TestVertMix: GradRichNumSmoothed Bad Value: "
-                            "GradRichNumSmoothed({},{}) = {}; Expected {}",
-                            I, K, GradRichNumSmoothedH(I, K), 0.0);
-            } else {
-               // Boundary layers (K==0 or K==NVertLayers-1) should be copied
-               // from input
-               if (!isApprox(GradRichNumSmoothedH(I, K), GradRichNumH(I, K),
-                             RTol))
-                  LOG_ERROR("TestVertMix: GradRichNumSmoothed Bad Value: "
-                            "GradRichNumSmoothed({},{}) = {}; Expected {}",
-                            I, K, GradRichNumSmoothedH(I, K),
-                            GradRichNumH(I, K));
-            }
-         }
-      }
       ABORT_ERROR("TestVertMix: GradRichNumSmoothed FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -338,7 +307,8 @@ void testBackVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NCellsSize       = Mesh->NCellsSize;
+   I4 NEdgesSize       = Mesh->NEdgesSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
 
@@ -346,10 +316,10 @@ void testBackVertMix() {
    VertMix *TestVertMix = VertMix::getInstance();
 
    /// Create and fill ocean state arrays
-   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
-   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
+   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesSize, NVertLayers);
+   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesSize, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsAll, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
 
    /// Use deep copy initialize with reference or zero values
    deepCopy(NormalVelEdge, NV);
@@ -478,9 +448,9 @@ void testConvVertMix() {
 
    /// Create and fill ocean state arrays
    auto BruntVaisalaFreqSqIn =
-       Array2DReal("BruntVaisalaFreqSqIn", NCellsAll, NVertLayers);
-   auto VertDiffOut = Array2DReal("VertDiffOut", NCellsAll, NVertLayers);
-   auto VertViscOut = Array2DReal("VertViscOut", NCellsAll, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqIn", NCellsSize, NVertLayers);
+   auto VertDiffOut = Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayers);
+   auto VertViscOut = Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayers);
 
    /// Use deep copy to initialize with the ref value
    deepCopy(BruntVaisalaFreqSqIn, 0.0);
@@ -490,7 +460,7 @@ void testConvVertMix() {
    // Populate arrays: positive BVF in lower half (conv off),
    // negative in upper half (conv on)
    parallelFor(
-       "populateArrays", {NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           if (K < 30) {
              BruntVaisalaFreqSqIn(ICell, K) = -0.2;
@@ -501,7 +471,7 @@ void testConvVertMix() {
 
    /// Compute only convective vertical viscosity and diffusivity
    parallelFor(
-       "ApplyVertMixConv", {NCellsAll, NChunks},
+       "ApplyVertMixConv", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
           TestVertMix->ComputeVertMixConv(VertDiffOut, VertViscOut, ICell,
                                           KChunk, BruntVaisalaFreqSqIn);
@@ -543,30 +513,6 @@ void testConvVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto VertViscOutH = createHostMirrorCopy(VertViscOut);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (K == 0) {
-               // Surface should be 0.0
-               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), 0.0_Real);
-            } else if (K < 30) {
-               // Interior layers
-               if (!isApprox(VertViscOutH(I, K), VertConvExp, RTol))
-                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), VertConvExp);
-            } else {
-               // Interior layers
-               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), 0.0_Real);
-            }
-         }
-      }
       ABORT_ERROR("TestVertMixConv: VertVisc FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -606,30 +552,6 @@ void testConvVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto VertDiffOutH = createHostMirrorCopy(VertDiffOut);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (K == 0) {
-               // Surface should be 0.0
-               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), 0.0_Real);
-            } else if (K < 30) {
-               // Interior layers
-               if (!isApprox(VertDiffOutH(I, K), VertConvExp, RTol))
-                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), VertConvExp);
-            } else {
-               // Interior layers
-               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), 0.0_Real);
-            }
-         }
-      }
       ABORT_ERROR("TestVertMixConv: VertDiff FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -644,7 +566,7 @@ void testShearVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NCellsSize       = Mesh->NCellsSize;
    I4 NChunks          = VCoord->NVertLayers / VecLength;
 
    /// Get VertMix instance to test
@@ -652,9 +574,9 @@ void testShearVertMix() {
 
    /// Create and fill ocean state arrays
    auto GradRichNumSmoothedIn =
-       Array2DReal("GradRichNumSmoothedIn", NCellsAll, NVertLayers);
-   auto VertDiffOut = Array2DReal("VertDiffOut", NCellsAll, NVertLayers);
-   auto VertViscOut = Array2DReal("VertViscOut", NCellsAll, NVertLayers);
+       Array2DReal("GradRichNumSmoothedIn", NCellsSize, NVertLayers);
+   auto VertDiffOut = Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayers);
+   auto VertViscOut = Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayers);
 
    /// Use Kokkos::deep_copy to fill the entire view with the ref value
    deepCopy(GradRichNumSmoothedIn, 0.0);
@@ -679,7 +601,7 @@ void testShearVertMix() {
    /// Compute only shear vertical viscosity and diffusivity
    TestVertMix->ComputeVertMixShear.ShearExponent = 3.0;
    parallelFor(
-       "ApplyVertMixShear", {NCellsAll, NChunks},
+       "ApplyVertMixShear", {Mesh->NCellsAll, NChunks},
        KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
           TestVertMix->ComputeVertMixShear(VertDiffOut, VertViscOut, ICell,
                                            KChunk, GradRichNumSmoothedIn);
@@ -724,36 +646,6 @@ void testShearVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto VertViscOutH = createHostMirrorCopy(VertViscOut);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (K == 0) {
-               // Surface should be 0.0
-               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), 0.0_Real);
-            } else if (K < 20) {
-               // Interior layers
-               if (!isApprox(VertViscOutH(I, K), VertShearBaseExp, RTol))
-                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), VertShearBaseExp);
-            } else if (K >= 20 && K < 40) {
-               // Interior layers
-               if (!isApprox(VertViscOutH(I, K), VertShearExp, RTol))
-                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), VertShearExp);
-            } else {
-               // Interior layers
-               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
-                            "VertVisc({},{}) = {}; Expected {}",
-                            I, K, VertViscOutH(I, K), 0.0_Real);
-            }
-         }
-      }
       ABORT_ERROR("TestVertMixShear: VertVisc FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -796,36 +688,6 @@ void testShearVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto VertDiffOutH = createHostMirrorCopy(VertDiffOut);
-      for (int I = 0; I < NCellsAll; ++I) {
-         for (int K = 0; K < NVertLayers; ++K) {
-            if (K == 0) {
-               // Surface should be 0.0
-               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), 0.0_Real);
-            } else if (K < 20) {
-               // Interior layers
-               if (!isApprox(VertDiffOutH(I, K), VertShearBaseExp, RTol))
-                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), VertShearBaseExp);
-            } else if (K >= 20 && K < 40) {
-               // Interior layers
-               if (!isApprox(VertDiffOutH(I, K), VertShearExp, RTol))
-                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), VertShearExp);
-            } else {
-               // Interior layers
-               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
-                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
-                            "VertDiff({},{}) = {}; Expected {}",
-                            I, K, VertDiffOutH(I, K), 0.0_Real);
-            }
-         }
-      }
       ABORT_ERROR("TestVertMixShear: VertDiff FAIL with {} bad values",
                   NumMismatches);
    } else {
@@ -880,7 +742,7 @@ void testTotalVertMix() {
    // current mesh has some CellsOnCell value > NCellsAll, so
    // filling CellsOnCell with simple mapping for this test
    parallelFor(
-       "populateArrays", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+       "populateArrays", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           CellsOnCell(ICell, 0) = ICell;
           CellsOnCell(ICell, 1) = ICell;
           CellsOnCell(ICell, 2) = ICell;

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -145,7 +145,7 @@ void testGradRichNum() {
    parallelFor(
        "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
-          MaxLayerCell(ICell) = VCoord->NVertLayers;
+          MaxLayerCell(ICell) = VCoord->NVertLayers - 1;
        });
 
    // filling CellsOnCell with simple mapping for this test

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -105,12 +105,13 @@ void initVertMixTest() {
 
 void testGradRichNum() {
    /// Get mesh and coordinate info
-   const auto Mesh     = HorzMesh::getDefault();
-   const auto VCoord   = VertCoord::getDefault();
-   auto *MeshHalo      = Halo::getDefault();
-   VCoord->NVertLayers = NVertLayers;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NEdgesAll        = Mesh->NEdgesAll;
+   const auto Mesh       = HorzMesh::getDefault();
+   const auto VCoord     = VertCoord::getDefault();
+   auto *MeshHalo        = Halo::getDefault();
+   VCoord->NVertLayers   = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
+   I4 NCellsSize         = Mesh->NCellsSize;
+   I4 NEdgesAll          = Mesh->NEdgesAll;
    OMEGA_SCOPE(ZMid, VCoord->ZMid);
    OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
    OMEGA_SCOPE(EdgesOnCell, Mesh->EdgesOnCell);
@@ -129,7 +130,7 @@ void testGradRichNum() {
    auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
    auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayersP1);
    /// Use deep copy to initialize results
    deepCopy(NormalVelEdge, NV);
    deepCopy(TangVelEdge, TV);
@@ -204,7 +205,7 @@ void testGradRichNum() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -215,11 +216,8 @@ void testGradRichNum() {
                  // this layer has any valid edge contributions.
                  I4 K1 = K - 1;
                  I4 K2 = K;
-                 if (K == MinLayerCell(ICell)) {
-                    K1 = K;
-                    K2 = K + 1;
-                 }
-                 if (K == MaxLayerCell(ICell)) {
+
+                 if (K == MaxLayerCell(ICell) + 1) {
                     K1 = K - 2;
                     K2 = K - 1;
                  }
@@ -264,11 +262,12 @@ void testGradRichNum() {
 
 void testOneTwoOneFilter() {
    /// Get mesh and coordinate info
-   const auto Mesh     = HorzMesh::getDefault();
-   const auto VCoord   = VertCoord::getDefault();
-   VCoord->NVertLayers = NVertLayers;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NChunks          = VCoord->NVertLayers / VecLength;
+   const auto Mesh       = HorzMesh::getDefault();
+   const auto VCoord     = VertCoord::getDefault();
+   VCoord->NVertLayers   = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
+   I4 NCellsSize         = Mesh->NCellsSize;
+   I4 NChunks            = VCoord->NVertLayers / VecLength;
    OMEGA_SCOPE(ZMid, VCoord->ZMid);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
@@ -278,8 +277,8 @@ void testOneTwoOneFilter() {
 
    /// Create and fill ocean state arrays
    auto GradRichNumSmoothed =
-       Array2DReal("GradRichNumSmoothed", NCellsSize, NVertLayers);
-   auto GradRichNum = Array2DReal("GradRichNum", NCellsSize, NVertLayers);
+       Array2DReal("GradRichNumSmoothed", NCellsSize, NVertLayersP1);
+   auto GradRichNum = Array2DReal("GradRichNum", NCellsSize, NVertLayersP1);
    /// Use deep copy to initialize results
    deepCopy(GradRichNumSmoothed, 1.0);
    deepCopy(GradRichNum, 1.0);
@@ -287,7 +286,7 @@ void testOneTwoOneFilter() {
    // Populate GradRichNum with alternating +1.0 and -1.0 values in vertical
    // GradRichNumSmoothed should smooth these to 0.0
    parallelFor(
-       "populateArrays", {Mesh->NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayersP1},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           if (K % 2 == 0) {
              GradRichNum(ICell, K) = 1.0;
@@ -318,19 +317,19 @@ void testOneTwoOneFilter() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K > MinLayerCell(ICell) && K < MaxLayerCell(ICell) - 1) {
+                 if (K > MinLayerCell(ICell) && K < MaxLayerCell(ICell)) {
                     // Interior layers should be smoothed to 0.0
                     if (!isApprox(GradRichNumSmoothed(ICell, K), 0.0_Real,
                                   RTol))
                        InnerCount++;
                  } else {
-                    // Boundary layers (K==0 or K==NVertLayers - 1) should be
+                    // Boundary layers (K==0 or K==NVertLayers) should be
                     // the same as input
                     if (!isApprox(GradRichNumSmoothed(ICell, K),
                                   GradRichNum(ICell, K), RTol))
@@ -360,6 +359,7 @@ void testBackVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
    I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesSize       = Mesh->NEdgesSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
@@ -372,7 +372,7 @@ void testBackVertMix() {
    auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesSize, NVertLayers);
    auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesSize, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayersP1);
 
    /// Use deep copy initialize with reference or zero values
    deepCopy(NormalVelEdge, NV);
@@ -413,7 +413,7 @@ void testBackVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -451,7 +451,7 @@ void testBackVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -491,6 +491,7 @@ void testConvVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
    I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
@@ -501,9 +502,11 @@ void testConvVertMix() {
 
    /// Create and fill ocean state arrays
    auto BruntVaisalaFreqSqIn =
-       Array2DReal("BruntVaisalaFreqSqIn", NCellsSize, NVertLayers);
-   auto VertDiffOut = Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayers);
-   auto VertViscOut = Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqIn", NCellsSize, NVertLayersP1);
+   auto VertDiffOut =
+       Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayersP1);
+   auto VertViscOut =
+       Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayersP1);
 
    /// Use deep copy to initialize with the ref value
    deepCopy(BruntVaisalaFreqSqIn, 0.0);
@@ -513,7 +516,7 @@ void testConvVertMix() {
    // Populate arrays: positive BVF in lower half (conv off),
    // negative in upper half (conv on)
    parallelFor(
-       "populateArrays", {Mesh->NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayersP1},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           if (K < 30) {
              BruntVaisalaFreqSqIn(ICell, K) = -0.2;
@@ -541,7 +544,7 @@ void testConvVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -580,7 +583,7 @@ void testConvVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -617,20 +620,23 @@ void testConvVertMix() {
 
 void testShearVertMix() {
    /// Get mesh and coordinate info
-   const auto Mesh     = HorzMesh::getDefault();
-   const auto VCoord   = VertCoord::getDefault();
-   VCoord->NVertLayers = NVertLayers;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NChunks          = VCoord->NVertLayers / VecLength;
+   const auto Mesh       = HorzMesh::getDefault();
+   const auto VCoord     = VertCoord::getDefault();
+   VCoord->NVertLayers   = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
+   I4 NCellsSize         = Mesh->NCellsSize;
+   I4 NChunks            = VCoord->NVertLayers / VecLength;
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
 
    /// Create and fill ocean state arrays
    auto GradRichNumSmoothedIn =
-       Array2DReal("GradRichNumSmoothedIn", NCellsSize, NVertLayers);
-   auto VertDiffOut = Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayers);
-   auto VertViscOut = Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayers);
+       Array2DReal("GradRichNumSmoothedIn", NCellsSize, NVertLayersP1);
+   auto VertDiffOut =
+       Array2DReal("VertDiffOut", Mesh->NCellsAll, NVertLayersP1);
+   auto VertViscOut =
+       Array2DReal("VertViscOut", Mesh->NCellsAll, NVertLayersP1);
 
    /// Use Kokkos::deep_copy to fill the entire view with the ref value
    deepCopy(GradRichNumSmoothedIn, 0.0);
@@ -641,7 +647,7 @@ void testShearVertMix() {
    // positive in middle third (altered shear value), large positive
    // in lower third (no shear)
    parallelFor(
-       "populateArrays", {Mesh->NCellsAll, NVertLayers},
+       "populateArrays", {Mesh->NCellsAll, NVertLayersP1},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
           if (K < 20) {
              GradRichNumSmoothedIn(ICell, K) = -0.2;
@@ -672,7 +678,7 @@ void testShearVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -714,7 +720,7 @@ void testShearVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -758,6 +764,7 @@ void testTotalVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayersP1;
    I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
@@ -774,7 +781,7 @@ void testTotalVertMix() {
    auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
    auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayersP1);
 
    /// Use deep copy to initialize with the ref value
    deepCopy(NormalVelEdge, NV);
@@ -836,7 +843,7 @@ void testTotalVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -880,7 +887,7 @@ void testTotalVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -935,7 +942,7 @@ void testTotalVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
@@ -979,7 +986,7 @@ void testTotalVertMix() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -145,7 +145,7 @@ void testGradRichNum() {
    parallelFor(
        "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
-          MaxLayerCell(ICell) = VCoord->NVertLayers - 1;
+          MaxLayerCell(ICell) = NVertLayers - 1;
        });
 
    // filling CellsOnCell with simple mapping for this test
@@ -256,7 +256,7 @@ void testOneTwoOneFilter() {
    parallelFor(
        "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
-          MaxLayerCell(ICell) = VCoord->NVertLayers - 1;
+          MaxLayerCell(ICell) = NVertLayers - 1;
        });
 
    // Apply the 1-2-1 filter to each cell
@@ -338,8 +338,7 @@ void testBackVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NEdgesSize       = Mesh->NEdgesSize;
+   I4 NCellsAll        = Mesh->NCellsAll;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
 
@@ -347,10 +346,10 @@ void testBackVertMix() {
    VertMix *TestVertMix = VertMix::getInstance();
 
    /// Create and fill ocean state arrays
-   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesSize, NVertLayers);
-   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesSize, NVertLayers);
+   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
+   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
    auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsAll, NVertLayers);
 
    /// Use deep copy initialize with reference or zero values
    deepCopy(NormalVelEdge, NV);

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -32,29 +32,30 @@ constexpr int NVertLayers = 60;
 
 /// Values to test against
 const Real VertDiffExpValueN =
-    1.0393923290498872; // Expected value for diffusivity for positive BVF
+    1.00501; // Expected value for diffusivity for positive BVF
 const Real VertViscExpValueN =
-    1.0198269656595984; // Expected value for viscosity for positive BVF
+    1.0051; // Expected value for viscosity for positive BVF
 const Real VertDiffExpValueP =
-    0.0015685660274841844; // Expected value for diffusivity for negative BVF
+    0.003882748571163051; // Expected value for diffusivity for negative BVF
 const Real VertViscExpValueP =
-    0.002332474675614262; // Expected value for viscosity for negative BVF
+    0.003972748571163051; // Expected value for viscosity for negative BVF
 const Real VertDiffBackExp =
     1.0e-5; // Expected value for background diffusivity
 const Real VertViscBackExp = 1.0e-4; // Expected value for background viscosity
-const Real VertDiffConvExp =
+const Real VertConvExp =
     1.0; // Expected value for convective diffusivity/viscosity
-const Real VertDiffShearExp =
-    0.039183698912901; // Expected value for shear diffusivity
-const Real VertViscShearExp =
-    0.01972696565959843; // Expected value for shear viscosity
+const Real VertShearExp =
+    0.00387274859; // Expected value for shear diffusivity/viscosity
+const Real VertShearBaseExp =
+    0.005;                   // Expected value for shear diffusivity/viscosity
+const Real RiExpValue = 0.2; // Expected value for gradient Richardson number
 
 /// Test input values
 const Real BVFP = 0.1;  // Positive Brunt-Vaisala frequency in s^-2
 const Real BVFN = -0.1; // Negative Brunt-Vaisala frequency in s^-2
 const Real NV   = 1.0;  // Normal velocity in m/s
 const Real TV   = 1.0;  // Tangential velocity in m/s
-const Real RTol = 1e-8; // Relative tolerance for isApprox checks
+const Real RTol = 1e-7; // Relative tolerance for isApprox checks
 
 /// The initialization routine for VertMix testing. It calls various
 /// init routines, including the creation of the default decomposition.
@@ -100,6 +101,225 @@ void initVertMixTest() {
    VertMix *DefVertMix = VertMix::getInstance();
    if (!DefVertMix)
       ABORT_ERROR("VertMixTest: VertMix retrieval FAIL");
+}
+
+void testGradRichNum() {
+   /// Get mesh and coordinate info
+   const auto Mesh     = HorzMesh::getDefault();
+   const auto VCoord   = VertCoord::getDefault();
+   VCoord->NVertLayers = NVertLayers;
+   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NEdgesAll        = Mesh->NEdgesAll;
+   OMEGA_SCOPE(ZMid, VCoord->ZMid);
+   OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
+   OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
+   OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
+   OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
+   OMEGA_SCOPE(CellsOnCell, Mesh->CellsOnCell);
+
+   /// Get VertMix instance to test
+   VertMix *TestVertMix = VertMix::getInstance();
+
+   /// Create and fill ocean state arrays
+   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
+   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
+   auto BruntVaisalaFreqSqCell =
+       Array2DReal("BruntVaisalaFreqSqCell", NCellsAll, NVertLayers);
+   /// Use deep copy to initialize results
+   deepCopy(NormalVelEdge, NV);
+   deepCopy(TangVelEdge, TV);
+   deepCopy(BruntVaisalaFreqSqCell, BVFP);
+   deepCopy(TestVertMix->GradRichNum, 0.0);
+
+   parallelFor(
+       "populateArrays", {NCellsAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 ICell, I4 K) {
+          ZMid(ICell, K)      = -K;
+          NEdgesOnCell(ICell) = 5;
+          AreaCell(ICell)     = 3.6e10_Real;
+       });
+
+   // filling CellsOnCell with simple mapping for this test
+   parallelFor(
+       "populateArrays", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          CellsOnCell(ICell, 0) = ICell;
+          CellsOnCell(ICell, 1) = ICell;
+          CellsOnCell(ICell, 2) = ICell;
+          CellsOnCell(ICell, 3) = ICell;
+          CellsOnCell(ICell, 4) = ICell;
+       });
+
+   parallelFor(
+       "populateArrays", {NEdgesAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 IEdge, I4 K) {
+          NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
+          TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
+          DcEdge(IEdge)           = 2.0e5_Real;
+          DvEdge(IEdge)           = 1.45e5_Real;
+       });
+
+   /// Compute gradient Richardson number
+   TestVertMix->ComputeVertMixShear.Enabled = true;
+   TestVertMix->computeVertMix(NormalVelEdge, TangVelEdge,
+                               BruntVaisalaFreqSqCell);
+
+   const auto &MinLayerCell = VCoord->MinLayerCell;
+   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+
+   /// Check all array values against expected value
+   int NumMismatches = 0;
+   OMEGA_SCOPE(GradRichNum, TestVertMix->GradRichNum);
+   parallelReduceOuter(
+       "CheckGradRichNum", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (!isApprox(GradRichNum(ICell, K), RiExpValue, RTol))
+                    InnerCount++;
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
+       },
+       NumMismatches);
+
+   // If test fails, print bad values and abort
+   if (NumMismatches != 0) {
+      auto GradRichNumH = createHostMirrorCopy(GradRichNum);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (!isApprox(GradRichNumH(I, K), RiExpValue, RTol))
+               LOG_ERROR("TestVertMix: GradRichNum Bad Value: "
+                         "GradRichNum({},{}) = {}; Expected {}",
+                         I, K, GradRichNumH(I, K), RiExpValue);
+         }
+      }
+      ABORT_ERROR("TestVertMix: GradRichNum FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMix: GradRichNum PASS");
+   }
+
+   return;
+}
+
+void testOneTwoOneFilter() {
+   /// Get mesh and coordinate info
+   const auto Mesh     = HorzMesh::getDefault();
+   const auto VCoord   = VertCoord::getDefault();
+   VCoord->NVertLayers = NVertLayers;
+   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NChunks          = VCoord->NVertLayers / VecLength;
+   OMEGA_SCOPE(ZMid, VCoord->ZMid);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
+   /// Get VertMix instance to test
+   VertMix *TestVertMix = VertMix::getInstance();
+
+   /// Create and fill ocean state arrays
+   auto GradRichNumSmoothed =
+       Array2DReal("GradRichNumSmoothed", NCellsAll, NVertLayers);
+   auto GradRichNum = Array2DReal("GradRichNum", NCellsAll, NVertLayers);
+   /// Use deep copy to initialize results
+   deepCopy(GradRichNumSmoothed, 1.0);
+   deepCopy(GradRichNum, 1.0);
+
+   // Populate GradRichNum with alternating +1.0 and -1.0 values in vertical
+   // GradRichNumSmoothed should smooth these to 0.0
+   parallelFor(
+       "populateArrays", {NCellsAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 ICell, I4 K) {
+          if (K > 0) {
+             GradRichNum(ICell, K) = -1.0 * GradRichNum(ICell, K - 1);
+          }
+       });
+
+   parallelFor(
+       "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          MinLayerCell(ICell) = 1;                       // avoid K=0 boundary
+          MaxLayerCell(ICell) = VCoord->NVertLayers - 2; // avoid top boundary
+       });
+
+   // Apply the 1-2-1 filter to each cell
+   parallelFor(
+       "ApplyOneTwoOneFilter", {NCellsAll, NChunks},
+       KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
+          TestVertMix->ComputeOneTwoOneFilter(GradRichNumSmoothed, ICell,
+                                              KChunk, GradRichNum);
+       });
+
+   /// Check all array values against expected value
+   int NumMismatches = 0;
+   parallelReduceOuter(
+       "CheckGradRichNum", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (K >= 1 && K < NVertLayers - 1) {
+                    // Interior layers should be smoothed to 0.0
+                    if (!isApprox(GradRichNumSmoothed(ICell, K), 0.0_Real,
+                                  RTol))
+                       InnerCount++;
+                 } else {
+                    // Boundary layers (K==0 or K==NVertLayers-1) should be the
+                    // same as input
+                    if (!isApprox(GradRichNumSmoothed(ICell, K),
+                                  GradRichNum(ICell, K), RTol))
+                       InnerCount++;
+                 }
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
+       },
+       NumMismatches);
+
+   // If test fails, print bad values and abort
+   if (NumMismatches != 0) {
+      auto GradRichNumH         = createHostMirrorCopy(GradRichNum);
+      auto GradRichNumSmoothedH = createHostMirrorCopy(GradRichNumSmoothed);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (K >= 1 && K < NVertLayers - 1) {
+               // Interior layers should be smoothed to 0.0
+               if (!isApprox(GradRichNumSmoothedH(I, K), 0.0, RTol))
+                  LOG_ERROR("TestVertMix: GradRichNumSmoothed Bad Value: "
+                            "GradRichNumSmoothed({},{}) = {}; Expected {}",
+                            I, K, GradRichNumSmoothedH(I, K), 0.0);
+            } else {
+               // Boundary layers (K==0 or K==NVertLayers-1) should be copied
+               // from input
+               if (!isApprox(GradRichNumSmoothedH(I, K), GradRichNumH(I, K),
+                             RTol))
+                  LOG_ERROR("TestVertMix: GradRichNumSmoothed Bad Value: "
+                            "GradRichNumSmoothed({},{}) = {}; Expected {}",
+                            I, K, GradRichNumSmoothedH(I, K),
+                            GradRichNumH(I, K));
+            }
+         }
+      }
+      ABORT_ERROR("TestVertMix: GradRichNumSmoothed FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMix: GradRichNumSmoothed PASS");
+   }
+
+   return;
 }
 
 void testBackVertMix() {
@@ -153,7 +373,7 @@ void testBackVertMix() {
    Array2DReal BackVertVisc = TestVertMix->VertVisc;
    Array2DReal BackVertDiff = TestVertMix->VertDiff;
 
-   /// Check total Visc against linear addition of components
+   /// Check Visc against expected value
    int NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-BackgroundVisc", {Mesh->NCellsAll},
@@ -183,12 +403,15 @@ void testBackVertMix() {
        },
        NumMismatches);
 
-   if (NumMismatches != 0)
+   if (NumMismatches != 0) {
       ABORT_ERROR("TestVertMixBack: VertVisc FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertViscBackExp, BackVertVisc(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixBack: VertVisc PASS");
+   }
 
-   /// Check total Diff against linear addition of components
+   /// Check Diff against expected value
    NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-BackgroundDiff", {Mesh->NCellsAll},
@@ -223,13 +446,14 @@ void testBackVertMix() {
       ABORT_ERROR("TestVertMixBack: VertDiff FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertDiffBackExp, BackVertDiffH(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixBack: VertDiff PASS");
    }
 
    return;
 }
 
 void testConvVertMix() {
-
    // Get mesh and coordinate info
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
@@ -237,49 +461,46 @@ void testConvVertMix() {
    I4 NCellsSize       = Mesh->NCellsSize;
    I4 NEdgesAll        = Mesh->NEdgesAll;
    OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
+   I4 NChunks = VCoord->NVertLayers / VecLength;
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
 
    /// Create and fill ocean state arrays
-   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
-   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
-   auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+   auto BruntVaisalaFreqSqIn =
+       Array2DReal("BruntVaisalaFreqSqIn", NCellsAll, NVertLayers);
+   auto VertDiffOut = Array2DReal("VertDiffOut", NCellsAll, NVertLayers);
+   auto VertViscOut = Array2DReal("VertViscOut", NCellsAll, NVertLayers);
 
    /// Use deep copy to initialize with the ref value
-   deepCopy(NormalVelEdge, NV);
-   deepCopy(TangVelEdge, TV);
-   deepCopy(BruntVaisalaFreqSqCell, BVFN);
-   deepCopy(TestVertMix->VertDiff, 0.0);
-   deepCopy(TestVertMix->VertVisc, 0.0);
+   deepCopy(BruntVaisalaFreqSqIn, 0.0);
+   deepCopy(VertDiffOut, 0.0);
+   deepCopy(VertViscOut, 0.0);
 
+   // Populate arrays: positive BVF in lower half (conv off),
+   // negative in upper half (conv on)
    parallelFor(
-       "populateArrays", {Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(I4 ICell, I4 K) { GeomZMid(ICell, K) = -K; });
-
-   parallelFor(
-       "populateArrays", {NEdgesAll, NVertLayers},
-       KOKKOS_LAMBDA(I4 IEdge, I4 K) {
-          NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
-          TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
+       "populateArrays", {NCellsAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 ICell, I4 K) {
+          if (K < 30) {
+             BruntVaisalaFreqSqIn(ICell, K) = -0.2;
+          } else {
+             BruntVaisalaFreqSqIn(ICell, K) = 0.2;
+          }
        });
 
    /// Compute only convective vertical viscosity and diffusivity
-   TestVertMix->BackDiff                    = 0.0;
-   TestVertMix->BackVisc                    = 0.0;
-   TestVertMix->ComputeVertMixConv.Enabled  = true;
-   TestVertMix->ComputeVertMixShear.Enabled = false;
-   TestVertMix->computeVertMix(NormalVelEdge, TangVelEdge,
-                               BruntVaisalaFreqSqCell);
+   parallelFor(
+       "ApplyVertMixConv", {NCellsAll, NChunks},
+       KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
+          TestVertMix->ComputeVertMixConv(VertDiffOut, VertViscOut, ICell,
+                                          KChunk, BruntVaisalaFreqSqIn);
+       });
 
    const auto &MinLayerCell = VCoord->MinLayerCell;
    const auto &MaxLayerCell = VCoord->MaxLayerCell;
 
-   Array2DReal ConvVertVisc = TestVertMix->VertVisc;
-   Array2DReal ConvVertDiff = TestVertMix->VertDiff;
-
-   /// Check total Visc against linear addition of components
+   /// Check Visc against expected value
    int NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-ConvectiveVisc", {Mesh->NCellsAll},
@@ -294,11 +515,13 @@ void testConvVertMix() {
                  const int K = KMin + KOff;
                  if (K == 0) {
                     // Surface layer should be zero
-                    if (ConvVertVisc(ICell, K) != 0.0_Real)
+                    if (VertViscOut(ICell, K) != 0.0_Real)
+                       InnerCount++;
+                 } else if (K < 30) {
+                    if (!isApprox(VertViscOut(ICell, K), VertConvExp, RTol))
                        InnerCount++;
                  } else {
-                    if (!isApprox(ConvVertVisc(ICell, K), VertDiffConvExp,
-                                  RTol))
+                    if (!isApprox(VertViscOut(ICell, K), 0.0_Real, RTol))
                        InnerCount++;
                  }
               },
@@ -310,13 +533,37 @@ void testConvVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto ConvVertViscH = createHostMirrorCopy(ConvVertVisc);
-      ABORT_ERROR("TestVertMixConv: VertVisc FAIL, "
-                  "expected {}, got {} with {} mismatches",
-                  VertDiffConvExp, ConvVertViscH(1, 1), NumMismatches);
+      auto VertViscOutH = createHostMirrorCopy(VertViscOut);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (K == 0) {
+               // Surface should be 0.0
+               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), 0.0_Real);
+            } else if (K < 30) {
+               // Interior layers
+               if (!isApprox(VertViscOutH(I, K), VertConvExp, RTol))
+                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), VertConvExp);
+            } else {
+               // Interior layers
+               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixConv: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), 0.0_Real);
+            }
+         }
+      }
+      ABORT_ERROR("TestVertMixConv: VertVisc FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixConv: VertVisc PASS");
    }
 
-   /// Check total Diff against linear addition of components
+   /// Check Diff against expected value
    NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-ConvectiveDiff", {Mesh->NCellsAll},
@@ -331,11 +578,13 @@ void testConvVertMix() {
                  const int K = KMin + KOff;
                  if (K == 0) {
                     // Surface layer should be zero
-                    if (ConvVertDiff(ICell, K) != 0.0_Real)
+                    if (VertDiffOut(ICell, K) != 0.0_Real)
+                       InnerCount++;
+                 } else if (K < 30) {
+                    if (!isApprox(VertDiffOut(ICell, K), VertConvExp, RTol))
                        InnerCount++;
                  } else {
-                    if (!isApprox(ConvVertDiff(ICell, K), VertDiffConvExp,
-                                  RTol))
+                    if (!isApprox(VertDiffOut(ICell, K), 0.0_Real, RTol))
                        InnerCount++;
                  }
               },
@@ -347,10 +596,34 @@ void testConvVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto ConvVertDiffH = createHostMirrorCopy(ConvVertDiff);
-      ABORT_ERROR("TestVertMixConv: VertDiff FAIL, "
-                  "expected {}, got {} with {} mismatches",
-                  VertDiffConvExp, ConvVertDiffH(1, 1), NumMismatches);
+      auto VertDiffOutH = createHostMirrorCopy(VertDiffOut);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (K == 0) {
+               // Surface should be 0.0
+               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), 0.0_Real);
+            } else if (K < 30) {
+               // Interior layers
+               if (!isApprox(VertDiffOutH(I, K), VertConvExp, RTol))
+                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), VertConvExp);
+            } else {
+               // Interior layers
+               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixConv: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), 0.0_Real);
+            }
+         }
+      }
+      ABORT_ERROR("TestVertMixConv: VertDiff FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixConv: VertDiff PASS");
    }
 
    return;
@@ -361,62 +634,51 @@ void testShearVertMix() {
    const auto Mesh     = HorzMesh::getDefault();
    const auto VCoord   = VertCoord::getDefault();
    VCoord->NVertLayers = NVertLayers;
-   I4 NCellsSize       = Mesh->NCellsSize;
-   I4 NEdgesAll        = Mesh->NEdgesAll;
-   OMEGA_SCOPE(GeomZMid, VCoord->GeomZMid);
-   OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
-   OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
-   OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
-   OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
+   I4 NCellsAll        = Mesh->NCellsAll;
+   I4 NChunks          = VCoord->NVertLayers / VecLength;
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
 
    /// Create and fill ocean state arrays
-   auto NormalVelEdge = Array2DReal("NormalVelEdge", NEdgesAll, NVertLayers);
-   auto TangVelEdge   = Array2DReal("TangVelEdge", NEdgesAll, NVertLayers);
-   auto BruntVaisalaFreqSqCell =
-       Array2DReal("BruntVaisalaFreqSqCell", NCellsSize, NVertLayers);
+   auto GradRichNumSmoothedIn =
+       Array2DReal("GradRichNumSmoothedIn", NCellsAll, NVertLayers);
+   auto VertDiffOut = Array2DReal("VertDiffOut", NCellsAll, NVertLayers);
+   auto VertViscOut = Array2DReal("VertViscOut", NCellsAll, NVertLayers);
 
    /// Use Kokkos::deep_copy to fill the entire view with the ref value
-   deepCopy(NormalVelEdge, NV);
-   deepCopy(TangVelEdge, TV);
-   deepCopy(BruntVaisalaFreqSqCell, BVFN);
-   deepCopy(TestVertMix->VertDiff, 0.0);
-   deepCopy(TestVertMix->VertVisc, 0.0);
+   deepCopy(GradRichNumSmoothedIn, 0.0);
+   deepCopy(VertDiffOut, 0.0);
+   deepCopy(VertViscOut, 0.0);
 
+   // Populate arrays: negative Ri in upper third (base shear value),
+   // positive in middle third (altered shear value), large positive
+   // in lower third (no shear)
    parallelFor(
        "populateArrays", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
-          GeomZMid(ICell, K)  = -K;
-          NEdgesOnCell(ICell) = 5;
-          AreaCell(ICell)     = 3.6e10_Real;
-       });
-
-   parallelFor(
-       "populateArrays", {NEdgesAll, NVertLayers},
-       KOKKOS_LAMBDA(I4 IEdge, I4 K) {
-          NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
-          TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
-          DcEdge(IEdge)           = 2.0e5_Real;
-          DvEdge(IEdge)           = 1.45e5_Real;
+          if (K < 20) {
+             GradRichNumSmoothedIn(ICell, K) = -0.2;
+          } else if (K >= 20 && K < 40) {
+             GradRichNumSmoothedIn(ICell, K) = 0.2;
+          } else {
+             GradRichNumSmoothedIn(ICell, K) = 10.0;
+          }
        });
 
    /// Compute only shear vertical viscosity and diffusivity
-   TestVertMix->BackDiff                    = 0.0;
-   TestVertMix->BackVisc                    = 0.0;
-   TestVertMix->ComputeVertMixConv.Enabled  = false;
-   TestVertMix->ComputeVertMixShear.Enabled = true;
-   TestVertMix->computeVertMix(NormalVelEdge, TangVelEdge,
-                               BruntVaisalaFreqSqCell);
+   TestVertMix->ComputeVertMixShear.ShearExponent = 3.0;
+   parallelFor(
+       "ApplyVertMixShear", {NCellsAll, NChunks},
+       KOKKOS_LAMBDA(I4 ICell, I4 KChunk) {
+          TestVertMix->ComputeVertMixShear(VertDiffOut, VertViscOut, ICell,
+                                           KChunk, GradRichNumSmoothedIn);
+       });
 
    const auto &MinLayerCell = VCoord->MinLayerCell;
    const auto &MaxLayerCell = VCoord->MaxLayerCell;
 
-   Array2DReal ShearVertVisc = TestVertMix->VertVisc;
-   Array2DReal ShearVertDiff = TestVertMix->VertDiff;
-
-   /// Check total Visc against linear addition of components
+   /// Check Visc against expected value
    int NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-ShearVisc", {Mesh->NCellsAll},
@@ -430,18 +692,17 @@ void testShearVertMix() {
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
                  if (K == 0) {
-                    if (ShearVertVisc(ICell, K) != 0.0_Real)
+                    if (VertViscOut(ICell, K) != 0.0_Real)
                        InnerCount++;
-                    // K = 1 should have ref value
-                 } else if (K == 1) {
-                    if (!isApprox(ShearVertVisc(ICell, K), VertViscShearExp,
+                 } else if (K < 20) {
+                    if (!isApprox(VertViscOut(ICell, K), VertShearBaseExp,
                                   RTol))
                        InnerCount++;
-                    // otherwise check for invalid values
+                 } else if (K >= 20 && K < 40) {
+                    if (!isApprox(VertViscOut(ICell, K), VertShearExp, RTol))
+                       InnerCount++;
                  } else {
-                    if (ShearVertVisc(ICell, K) == 0.0 or
-                        Kokkos::isnan(ShearVertVisc(ICell, K)) or
-                        Kokkos::isinf(ShearVertVisc(ICell, K)))
+                    if (!isApprox(VertViscOut(ICell, K), 0.0_Real, RTol))
                        InnerCount++;
                  }
               },
@@ -453,13 +714,43 @@ void testShearVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto ShearVertViscH = createHostMirrorCopy(ShearVertVisc);
-      ABORT_ERROR("TestVertMixShear: VertVisc FAIL, "
-                  "expected {}, got {} with {} mismatches",
-                  VertViscShearExp, ShearVertViscH(1, 1), NumMismatches);
+      auto VertViscOutH = createHostMirrorCopy(VertViscOut);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (K == 0) {
+               // Surface should be 0.0
+               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), 0.0_Real);
+            } else if (K < 20) {
+               // Interior layers
+               if (!isApprox(VertViscOutH(I, K), VertShearBaseExp, RTol))
+                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), VertShearBaseExp);
+            } else if (K >= 20 && K < 40) {
+               // Interior layers
+               if (!isApprox(VertViscOutH(I, K), VertShearExp, RTol))
+                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), VertShearExp);
+            } else {
+               // Interior layers
+               if (!isApprox(VertViscOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixShear: VertVisc Bad Value: "
+                            "VertVisc({},{}) = {}; Expected {}",
+                            I, K, VertViscOutH(I, K), 0.0_Real);
+            }
+         }
+      }
+      ABORT_ERROR("TestVertMixShear: VertVisc FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixShear: VertVisc PASS");
    }
 
-   /// Check total Diff against linear addition of components
+   /// Check Diff against expected value
    NumMismatches = 0;
    parallelReduceOuter(
        "CheckVertMixMatrix-ShearVisc", {Mesh->NCellsAll},
@@ -473,18 +764,17 @@ void testShearVertMix() {
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
                  if (K == 0) {
-                    if (ShearVertDiff(ICell, K) != 0.0_Real)
+                    if (VertDiffOut(ICell, K) != 0.0_Real)
                        InnerCount++;
-                    // K = 1 should have ref value
-                 } else if (K == 1) {
-                    if (!isApprox(ShearVertDiff(ICell, K), VertDiffShearExp,
+                 } else if (K < 20) {
+                    if (!isApprox(VertDiffOut(ICell, K), VertShearBaseExp,
                                   RTol))
                        InnerCount++;
-                    // otherwise check for invalid values
+                 } else if (K >= 20 && K < 40) {
+                    if (!isApprox(VertDiffOut(ICell, K), VertShearExp, RTol))
+                       InnerCount++;
                  } else {
-                    if (ShearVertDiff(ICell, K) == 0.0 or
-                        Kokkos::isnan(ShearVertDiff(ICell, K)) or
-                        Kokkos::isinf(ShearVertDiff(ICell, K)))
+                    if (!isApprox(VertDiffOut(ICell, K), 0.0_Real, RTol))
                        InnerCount++;
                  }
               },
@@ -496,10 +786,40 @@ void testShearVertMix() {
        NumMismatches);
 
    if (NumMismatches != 0) {
-      auto ShearVertDiffH = createHostMirrorCopy(ShearVertDiff);
-      ABORT_ERROR("TestVertMixShear: VertDiff FAIL, "
-                  "expected {}, got {} with {} mismatches",
-                  VertDiffShearExp, ShearVertDiffH(1, 1), NumMismatches);
+      auto VertDiffOutH = createHostMirrorCopy(VertDiffOut);
+      for (int I = 0; I < NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (K == 0) {
+               // Surface should be 0.0
+               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), 0.0_Real);
+            } else if (K < 20) {
+               // Interior layers
+               if (!isApprox(VertDiffOutH(I, K), VertShearBaseExp, RTol))
+                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), VertShearBaseExp);
+            } else if (K >= 20 && K < 40) {
+               // Interior layers
+               if (!isApprox(VertDiffOutH(I, K), VertShearExp, RTol))
+                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), VertShearExp);
+            } else {
+               // Interior layers
+               if (!isApprox(VertDiffOutH(I, K), 0.0_Real, RTol))
+                  LOG_ERROR("TestVertMixShear: VertDiff Bad Value: "
+                            "VertDiff({},{}) = {}; Expected {}",
+                            I, K, VertDiffOutH(I, K), 0.0_Real);
+            }
+         }
+      }
+      ABORT_ERROR("TestVertMixShear: VertDiff FAIL with {} bad values",
+                  NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixShear: VertDiff PASS");
    }
 
    return;
@@ -518,6 +838,7 @@ void testTotalVertMix() {
    OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
    OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
    OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
+   OMEGA_SCOPE(CellsOnCell, Mesh->CellsOnCell);
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
@@ -536,6 +857,7 @@ void testTotalVertMix() {
    deepCopy(BruntVaisalaFreqSqCell, BVFP);
    deepCopy(TestVertMix->VertDiff, 0.0);
    deepCopy(TestVertMix->VertVisc, 0.0);
+   deepCopy(TestVertMix->GradRichNumSmoothed, 0.0);
 
    parallelFor(
        "populateArrays", {Mesh->NCellsAll, NVertLayers},
@@ -543,6 +865,17 @@ void testTotalVertMix() {
           GeomZMid(ICell, K)  = -K;
           NEdgesOnCell(ICell) = 5;
           AreaCell(ICell)     = 3.6e10_Real;
+       });
+
+   // current mesh has some CellsOnCell value > NCellsAll, so
+   // filling CellsOnCell with simple mapping for this test
+   parallelFor(
+       "populateArrays", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          CellsOnCell(ICell, 0) = ICell;
+          CellsOnCell(ICell, 1) = ICell;
+          CellsOnCell(ICell, 2) = ICell;
+          CellsOnCell(ICell, 3) = ICell;
+          CellsOnCell(ICell, 4) = ICell;
        });
 
    parallelFor(
@@ -567,6 +900,7 @@ void testTotalVertMix() {
 
    OMEGA_SCOPE(VertDiffP, TestVertMix->VertDiff);
    OMEGA_SCOPE(VertViscP, TestVertMix->VertVisc);
+   OMEGA_SCOPE(GradRichNumSmoothed, TestVertMix->GradRichNumSmoothed);
 
    /// Check all VertDiff array values against expected value
    int NumMismatches = 0;
@@ -608,6 +942,8 @@ void testTotalVertMix() {
       ABORT_ERROR("TestVertMixTotal: VertDiffPositive FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertDiffExpValueP, VertDiffPH(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixTotal: VertDiffPos PASS");
    }
 
    /// Check all VertVisc array values against expected value
@@ -650,6 +986,8 @@ void testTotalVertMix() {
       ABORT_ERROR("TestVertMixTotal: VertViscPositive FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertViscExpValueP, VertViscPH(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixTotal: VertViscPos PASS");
    }
 
    // Now test with negative BVF
@@ -703,6 +1041,8 @@ void testTotalVertMix() {
       ABORT_ERROR("TestVertMix: VertDiffNegative FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertDiffExpValueN, VertDiffNH(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixTotal: VertDiffNeg PASS");
    }
 
    /// Check all VertVisc array values against expected value
@@ -745,6 +1085,8 @@ void testTotalVertMix() {
       ABORT_ERROR("TestVertMix: VertViscNegative FAIL, "
                   "expected {}, got {} with {} mismatches",
                   VertViscExpValueN, VertViscNH(1, 1), NumMismatches);
+   } else {
+      LOG_INFO("TestVertMixTotal: VertViscNeg PASS");
    }
 
    return;
@@ -763,12 +1105,14 @@ void finalizeVertMixTest() {
 }
 
 // the main tests (all in one to have the same log):
-// --> one tests the vertical diffusivity and viscosity
+// --> one tests the gradient richardson number calculation
+// --> next tests the 1-2-1 filter (smoothing)
+// --> next tests the vertical diffusivity and viscosity
 // with only background on
 // --> next tests the vertical diffusivity and viscosity
-// with only convective on
+// for only convective
 // --> next tests the vertical diffusivity and viscosity
-// with only shear on
+// for only shear
 // --> next tests the linear superposition of the
 // background, convective, and shear contributions
 void vertMixTest() {
@@ -777,6 +1121,8 @@ void vertMixTest() {
    initVertMixTest();
 
    // test each vertical mix option
+   testGradRichNum();
+   testOneTwoOneFilter();
    testBackVertMix();
    testConvVertMix();
    testShearVertMix();

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -116,6 +116,9 @@ void testGradRichNum() {
    OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
    OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
    OMEGA_SCOPE(CellsOnCell, Mesh->CellsOnCell);
+   OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
    /// Get VertMix instance to test
    VertMix *TestVertMix = VertMix::getInstance();
@@ -137,6 +140,12 @@ void testGradRichNum() {
           ZMid(ICell, K)      = -K;
           NEdgesOnCell(ICell) = 5;
           AreaCell(ICell)     = 3.6e10_Real;
+       });
+
+   parallelFor(
+       "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          MinLayerCell(ICell) = 0;
+          MaxLayerCell(ICell) = VCoord->NVertLayers;
        });
 
    // filling CellsOnCell with simple mapping for this test
@@ -163,8 +172,8 @@ void testGradRichNum() {
    TestVertMix->computeVertMix(NormalVelEdge, TangVelEdge,
                                BruntVaisalaFreqSqCell);
 
-   const auto &MinLayerCell = VCoord->MinLayerCell;
-   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+   // const auto &MinLayerCell = VCoord->MinLayerCell;
+   // const auto &MaxLayerCell = VCoord->MaxLayerCell;
 
    /// Check all array values against expected value
    int NumMismatches = 0;
@@ -237,15 +246,17 @@ void testOneTwoOneFilter() {
    parallelFor(
        "populateArrays", {NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
-          if (K > 0) {
-             GradRichNum(ICell, K) = -1.0 * GradRichNum(ICell, K - 1);
+          if (K % 2 == 0) {
+             GradRichNum(ICell, K) = 1.0;
+          } else {
+             GradRichNum(ICell, K) = -1.0;
           }
        });
 
    parallelFor(
        "setMinMax", {NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
-          MinLayerCell(ICell) = 1;                       // avoid K=0 boundary
-          MaxLayerCell(ICell) = VCoord->NVertLayers - 2; // avoid top boundary
+          MinLayerCell(ICell) = 0;
+          MaxLayerCell(ICell) = VCoord->NVertLayers - 1;
        });
 
    // Apply the 1-2-1 filter to each cell
@@ -269,14 +280,14 @@ void testOneTwoOneFilter() {
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K >= 1 && K < NVertLayers - 1) {
+                 if (K > MinLayerCell(ICell) && K < MaxLayerCell(ICell) - 1) {
                     // Interior layers should be smoothed to 0.0
                     if (!isApprox(GradRichNumSmoothed(ICell, K), 0.0_Real,
                                   RTol))
                        InnerCount++;
                  } else {
-                    // Boundary layers (K==0 or K==NVertLayers-1) should be the
-                    // same as input
+                    // Boundary layers (K==0 or K==NVertLayers - 1) should be
+                    // the same as input
                     if (!isApprox(GradRichNumSmoothed(ICell, K),
                                   GradRichNum(ICell, K), RTol))
                        InnerCount++;
@@ -295,7 +306,7 @@ void testOneTwoOneFilter() {
       auto GradRichNumSmoothedH = createHostMirrorCopy(GradRichNumSmoothed);
       for (int I = 0; I < NCellsAll; ++I) {
          for (int K = 0; K < NVertLayers; ++K) {
-            if (K >= 1 && K < NVertLayers - 1) {
+            if (K > MinLayerCell(I) && K < MaxLayerCell(I) - 1) {
                // Interior layers should be smoothed to 0.0
                if (!isApprox(GradRichNumSmoothedH(I, K), 0.0, RTol))
                   LOG_ERROR("TestVertMix: GradRichNumSmoothed Bad Value: "


### PR DESCRIPTION
This PR changes the shear vertical mixing formulation from Pacanowski and Philander (1981) to Large et al (1994), adds in vertical smoothing to the gradient Richardson number, and updates the tests and docs to reflect these changes.

Passes all CTests on PM-CPU and PM-GPU and the polaris `omega_pr` suite on PM.

Checklist
* [x] Documentation
  * [x] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [x] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests
    * [x] Document testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] New tests:
    * [x] CTest unit tests for new features have been added per the approved design.

## Testing

### CTest unit tests
- Machine: PM-CPU, PM-GPU
- Compiler: gnu, gnugpu
- Build type: Relase
- Result: All tests passed

### Polaris `omega_pr` suite
- Baseline workdir: `/pscratch/sd/k/katsmith/polaris_testing_vert_mixing//baseline_omega_pr`
- Baseline build: `/pscratch/sd/k/katsmith/polaris-main/e3sm_submodules/Omega`
- PR build: `/pscratch/sd/k/katsmith/polaris-pr352/e3sm_submodules/Omega`
- PR workdir: `/pscratch/sd/k/katsmith/polaris_testing_vert_mixing/pr352_omega_pr`
- Machine: `pm-cpu`
- Compiler: `gnu`
- Build type: `Release`
- Log: not found
- Result: All tests passed

Tests added/modified/impacted
- CTest: in VertMixTest added tests: `testGradRichNum` and `testOneTwoOneFilter`, and modified: `testShearVertMix` and `testTotalVertMix`. 

## Documentation

Documentation has be built locally here and charges are as expected: https://portal.nersc.gov/project/e3sm/katsmith/omega_docs/html/devGuide/VerticalMixingCoeff.html



