### PR TITLE
Replacing config->Rho0 with constant RhoSw

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -32,7 +32,6 @@ Omega:
   WindStress:
     InterpType: Isotropic
   VertCoord:
-    Density0: 1026.0
     MovementWeightType: Uniform
   Tendencies:
     ThicknessFluxTendencyEnable: true

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -62,7 +62,7 @@ VelocityHyperDiffOnEdge::VelocityHyperDiffOnEdge(const HorzMesh *Mesh,
 
 WindForcingOnEdge::WindForcingOnEdge(const HorzMesh *Mesh,
                                      const VertCoord *VCoord)
-    : Enabled(false), LocRhoSw(RhoSw), EdgeMask(VCoord->EdgeMask),
+    : Enabled(false), EdgeMask(VCoord->EdgeMask),
       MinLayerEdgeBot(VCoord->MinLayerEdgeBot) {}
 
 BottomDragOnEdge::BottomDragOnEdge(const HorzMesh *Mesh,

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -305,7 +305,6 @@ class VelocityHyperDiffOnEdge {
 class WindForcingOnEdge {
  public:
    bool Enabled = false;
-   Real LocRhoSw;
 
    /// constructor declaration
    WindForcingOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord);
@@ -320,7 +319,7 @@ class WindForcingOnEdge {
 
          const Real InvThickEdge = 1._Real / LayerThickEdge(IEdge, K);
          Tend(IEdge, K) += EdgeMask(IEdge, K) * InvThickEdge *
-                           NormalStressEdge(IEdge) / LocRhoSw;
+                           NormalStressEdge(IEdge) / RhoSw;
       }
    }
 

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -834,9 +834,8 @@ void VertCoord::computePressure(
           LocPressInterf(ICell, KMin) = SurfacePressure(ICell);
           parallelScanInner(
               Team, KRange, INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
-                 const I4 KLyr = K + KMin;
-                 Real Increment =
-                     Gravity * RhoSw * LayerThickness(ICell, KLyr);
+                 const I4 KLyr  = K + KMin;
+                 Real Increment = Gravity * RhoSw * LayerThickness(ICell, KLyr);
                  Accum += Increment;
 
                  if (IsFinal) {

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -83,11 +83,6 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
       ABORT_ERROR("VertCoord: Unknown MovementWeightType requested");
    }
 
-   // Fetch reference density from Config
-   Err.reset();
-   Err += VCoordConfig.get("Density0", Rho0);
-   CHECK_ERROR_ABORT(Err, "VertCoord: Density0 not found in VertCoord");
-
    // Store name suffix
    Name = Name_;
 
@@ -824,7 +819,7 @@ void VertCoord::computePressure(
     const Array1DReal &SurfacePressure // [in] surface pressure
 ) {
 
-   OMEGA_SCOPE(LocRho0, Rho0);
+   OMEGA_SCOPE(LocRhoSw, RhoSw);
    OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocPressInterf, PressureInterface);
@@ -842,7 +837,7 @@ void VertCoord::computePressure(
               Team, KRange, INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
                  const I4 KLyr = K + KMin;
                  Real Increment =
-                     Gravity * LocRho0 * LayerThickness(ICell, KLyr);
+                     Gravity * LocRhoSw * LayerThickness(ICell, KLyr);
                  Accum += Increment;
 
                  if (IsFinal) {
@@ -866,7 +861,7 @@ void VertCoord::computeZHeight(
     const Array2DReal &SpecVol         // [in] specific volume
 ) {
 
-   OMEGA_SCOPE(LocRho0, Rho0);
+   OMEGA_SCOPE(LocRhoSw, RhoSw);
    OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocZInterf, ZInterface);
@@ -884,7 +879,7 @@ void VertCoord::computeZHeight(
           parallelScanInner(
               Team, KRange, INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
                  const I4 KLyr = KMax - K;
-                 Real DZ       = LocRho0 * SpecVol(ICell, KLyr) *
+                 Real DZ       = LocRhoSw * SpecVol(ICell, KLyr) *
                            LayerThickness(ICell, KLyr);
                  Accum += DZ;
                  if (IsFinal) {
@@ -939,7 +934,7 @@ void VertCoord::computeGeopotential(
 // reductions and a parallel_for over the active layers within a column.
 void VertCoord::computeTargetThickness() {
 
-   OMEGA_SCOPE(LocRho0, Rho0);
+   OMEGA_SCOPE(LocRhoSw, RhoSw);
    OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocLayerThickTarget, LayerThicknessTarget);
@@ -956,7 +951,7 @@ void VertCoord::computeTargetThickness() {
 
           Real Coeff =
               (LocPressInterf(ICell, KMax + 1) - LocPressInterf(ICell, KMin)) /
-              (Gravity * LocRho0);
+              (Gravity * LocRhoSw);
 
           Real SumWh   = 0;
           Real SumRefH = 0;

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -819,7 +819,6 @@ void VertCoord::computePressure(
     const Array1DReal &SurfacePressure // [in] surface pressure
 ) {
 
-   OMEGA_SCOPE(LocRhoSw, RhoSw);
    OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocPressInterf, PressureInterface);
@@ -837,7 +836,7 @@ void VertCoord::computePressure(
               Team, KRange, INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
                  const I4 KLyr = K + KMin;
                  Real Increment =
-                     Gravity * LocRhoSw * LayerThickness(ICell, KLyr);
+                     Gravity * RhoSw * LayerThickness(ICell, KLyr);
                  Accum += Increment;
 
                  if (IsFinal) {
@@ -861,7 +860,6 @@ void VertCoord::computeZHeight(
     const Array2DReal &SpecVol         // [in] specific volume
 ) {
 
-   OMEGA_SCOPE(LocRhoSw, RhoSw);
    OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocZInterf, ZInterface);
@@ -879,8 +877,8 @@ void VertCoord::computeZHeight(
           parallelScanInner(
               Team, KRange, INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
                  const I4 KLyr = KMax - K;
-                 Real DZ       = LocRhoSw * SpecVol(ICell, KLyr) *
-                           LayerThickness(ICell, KLyr);
+                 Real DZ =
+                     RhoSw * SpecVol(ICell, KLyr) * LayerThickness(ICell, KLyr);
                  Accum += DZ;
                  if (IsFinal) {
                     LocZInterf(ICell, KLyr) = -LocBotDepth(ICell) + Accum;
@@ -934,7 +932,6 @@ void VertCoord::computeGeopotential(
 // reductions and a parallel_for over the active layers within a column.
 void VertCoord::computeTargetThickness() {
 
-   OMEGA_SCOPE(LocRhoSw, RhoSw);
    OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocLayerThickTarget, LayerThicknessTarget);
@@ -951,7 +948,7 @@ void VertCoord::computeTargetThickness() {
 
           Real Coeff =
               (LocPressInterf(ICell, KMax + 1) - LocPressInterf(ICell, KMin)) /
-              (Gravity * LocRhoSw);
+              (Gravity * RhoSw);
 
           Real SumWh   = 0;
           Real SumRefH = 0;

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -164,8 +164,6 @@ class VertCoord {
 
    HostArray1DReal BottomDepthH;
 
-   Real Rho0; // reference density
-
    // VertCoord instance name and FieldGroup names
    std::string Name;
    std::string InitGroupName;

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -154,18 +154,16 @@ struct TestSetupPlane {
               std::cos(2 * TwoPi * Y / Ly) / Ly / Ly);
    }
 
-   KOKKOS_FUNCTION Real windForcingX(Real X, Real Y,
-                                     Real SaltWaterDensity) const {
+   KOKKOS_FUNCTION Real windForcingX(Real X, Real Y) const {
       const Real StressU = vectorX(X, Y);
       const Real Thick   = scalarB(X, Y);
-      return StressU / (Thick * SaltWaterDensity);
+      return StressU / (Thick * RhoSw);
    }
 
-   KOKKOS_FUNCTION Real windForcingY(Real X, Real Y,
-                                     Real SaltWaterDensity) const {
+   KOKKOS_FUNCTION Real windForcingY(Real X, Real Y) const {
       const Real StressV = vectorY(X, Y);
       const Real Thick   = scalarB(X, Y);
-      return StressV / (Thick * SaltWaterDensity);
+      return StressV / (Thick * RhoSw);
    }
 
    KOKKOS_FUNCTION Real bottomDragX(Real X, Real Y, Real Coeff) const {
@@ -297,18 +295,16 @@ struct TestSetupSphere {
       return std::sqrt(3. / 2. / Pi) * std::cos(Lat) * std::cos(Lon) / Radius;
    }
 
-   KOKKOS_FUNCTION Real windForcingX(Real Lon, Real Lat,
-                                     Real SaltWaterDensity) const {
+   KOKKOS_FUNCTION Real windForcingX(Real Lon, Real Lat) const {
       const Real StressU = vectorX(Lon, Lat);
       const Real Thick   = scalarB(Lon, Lat);
-      return StressU / (Thick * SaltWaterDensity);
+      return StressU / (Thick * RhoSw);
    }
 
-   KOKKOS_FUNCTION Real windForcingY(Real Lon, Real Lat,
-                                     Real SaltWaterDensity) const {
+   KOKKOS_FUNCTION Real windForcingY(Real Lon, Real Lat) const {
       const Real StressV = vectorY(Lon, Lat);
       const Real Thick   = scalarB(Lon, Lat);
-      return StressV / (Thick * SaltWaterDensity);
+      return StressV / (Thick * RhoSw);
    }
 
    KOKKOS_FUNCTION Real bottomDragX(Real Lon, Real Lat, Real Coeff) const {
@@ -706,8 +702,6 @@ int testWindForcing(int NVertLayers) {
    const auto Mesh   = HorzMesh::getDefault();
    const auto VCoord = VertCoord::getDefault();
 
-   const Real SaltWaterDensity = 0.987654321;
-
    // Compute exact result
    Array2DReal ExactWindForcing("ExactWindForcing", Mesh->NEdgesOwned,
                                 NVertLayers);
@@ -715,8 +709,8 @@ int testWindForcing(int NVertLayers) {
    // Note: this computes wind forcing at every layer
    Err += setVectorEdge(
        KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
-          VecField[0] = Setup.windForcingX(X, Y, SaltWaterDensity);
-          VecField[1] = Setup.windForcingY(X, Y, SaltWaterDensity);
+          VecField[0] = Setup.windForcingX(X, Y);
+          VecField[1] = Setup.windForcingY(X, Y);
        },
        ExactWindForcing, EdgeComponent::Normal, Geom, Mesh, ExchangeHalos::No);
 
@@ -745,7 +739,6 @@ int testWindForcing(int NVertLayers) {
    Array2DReal NumWindForcing("NumWindForcing", Mesh->NEdgesOwned, NVertLayers);
 
    WindForcingOnEdge WindForcingOnE(Mesh, VCoord);
-   WindForcingOnE.LocRhoSw = SaltWaterDensity;
 
    parallelFor(
        {Mesh->NEdgesOwned, NVertLayers}, KOKKOS_LAMBDA(int IEdge, int KLayer) {

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -131,7 +131,7 @@ int main(int argc, char *argv[]) {
 
       /// Initialize layer thickness and surface pressure so that resulting
       /// interface pressure is the number of layers above plus one
-      Real Rho0 = DefVertCoord->Rho0;
+      Real Rho0 = RhoSw;
       parallelFor(
           {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
              SurfacePressure(ICell) = 1.0_Real;


### PR DESCRIPTION
This PR aims to address issue #357 by removing mentions of Rho0 (from the user config file) and using a single reference density RhoSw, currently set in GlobalConstants.h. 
This will be later set in PCD. 

I did not see any docs that required updating but let me know if I forgot something. 

Checklist
* [ ] Documentation:
  * [ ] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
  * [ ] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [ ] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] All ctests passed on PM-CPU and PM-GPU with `Debug` version. 
  * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline - on `pm-cpu/gnu`

Closes #357

