### PR TITLE
fix IO define mode errors and clean up formats

### DIFF
--- a/components/omega/doc/devGuide/IO.md
+++ b/components/omega/doc/devGuide/IO.md
@@ -44,32 +44,36 @@ As mentioned above, most I/O operations will take place within the IOStreams
 module, but the base IO functions can be accessed directly. To open and close
 files for reading/writing, use:
 ```c++
-   IO::openFile(FileID, Filename, Mode);
+   IO::openFileRead(FileID, Filename, FileFormat(optional));
    IO::closeFile(FileID);
 ```
 or
 ```c++
-   IO::openFile(FileID, Filename, Mode, Format, IfExists);
+   bool NewFile;
+   IO::openFileWrite(FileID, Filename, NewFile, IfExists, FileFormat(opt));
    IO::closeFile(FileID);
 ```
 In both case, an integer FileID is assigned to the open file which is then
 used by all subsequent operations. The Filename is a ``std::string`` that
-should include the full path and name of the file. The mode can be either
-``OMEGA::IO::ModeRead`` or ``OMEGA::IO::ModeWrite``. The shorter interface
-uses default values for the file format, overwrite behavior and precision.
-In the longer interface, the user must supply these values using the enums:
+should include the full path and name of the file. If the optional FileFormat
+is not supplied, the default file format (currently pnetcdf) is used. Supported
+file formats are shown below. The IfExists argument specifies the behavior
+for writing a file when the file already exists. It is an optional argument
+except when the FileFormat argument is needed; in that case, both must be
+supplied. The available options for IfExists are also shown below.
 ```c++
 /// Supported file formats
 enum FileFmt {
+   FmtPnetCDF  = PIO_IOTYPE_PNETCDF,  ///< Parallel NetCDF
    FmtNetCDF3  = PIO_IOTYPE_NETCDF,   ///< NetCDF3 classic format
-   FmtPnetCDF  = PIO_IOTYPE_PNETCDF,  ///< Parallel NetCDF3
-   FmtNetCDF4c = PIO_IOTYPE_NETCDF4C, ///< NetCDF4 (HDF5-compatible) cmpressed
+   FmtNetCDF4c = PIO_IOTYPE_NETCDF4C, ///< NetCDF4 (HDF5-compatible) compressed
    FmtNetCDF4p = PIO_IOTYPE_NETCDF4P, ///< NetCDF4 (HDF5-compatible) parallel
-   FmtNetCDF4  = PIO_IOTYPE_NETCDF4P, ///< NetCDF4 (HDF5-compatible) parallel
-   FmtHDF5     = PIO_IOTYPE_HDF5,     ///< native HDF5 format
-   FmtADIOS    = PIO_IOTYPE_ADIOS,    ///< ADIOS format
-   FmtUnknown  = -1,                  ///< Unknown or undefined
-   FmtDefault  = PIO_IOTYPE_NETCDF4C, ///< NetCDF4 is default
+   FmtNetCDF4z = PIO_IOTYPE_NETCDF4P_NCZARR, ///< NetCDF4 (HDF5) NCZarr
+   FmtADIOS    = PIO_IOTYPE_ADIOS,           ///< ADIOS parallel
+   FmtADIOSC   = PIO_IOTYPE_ADIOSC,  ///< ADIOS parallel with compression
+   FmtHDF5     = PIO_IOTYPE_HDF5,    ///< native HDF5 parallel
+   FmtHDF5C    = PIO_IOTYPE_HDF5C,   ///< native HDF5 parallel w compression
+   FmtDefault  = PIO_IOTYPE_PNETCDF, ///< PNETCDF is default
 };
 
 /// Behavior (for output files) when a file already exists
@@ -80,10 +84,9 @@ enum class IfExists {
 };
 
 ```
-with the defaults for each being ``IO::FmtDefault``, and
-``IO::IfExists::Fail``. The E3SM standard format is currently
-NetCDF4. Earlier NetCDF formats should be avoided, but are provided in
-case an input file is in an earlier format.
+The defaults for each are ``IO::FmtDefault`` for file format and
+``IO::IfExists::Fail`` for IfExists. Earlier NetCDF formats should be avoided,
+but are provided in case an input file is in an earlier format.
 
 Once the file is open, data is read/written using one of two interfaces,
 depending on whether the array is decomposed across MPI tasks or not. For

--- a/components/omega/doc/userGuide/IO.md
+++ b/components/omega/doc/userGuide/IO.md
@@ -27,7 +27,7 @@ IO:
     IOStride: 1
     IOBaseTask: 0
     IORearranger: box
-    IODefaultFormat: NetCDF4
+    IODefaultFormat: pnetcdf
 ```
 where ``IOTasks`` is the total number of IOTasks to assign to reading
 and writing. The default is 1 (serial IO) for safety but this number
@@ -53,8 +53,8 @@ See SCORPIO documentation for details.
 
 Finally, the user can specify the file format. The SCORPIO library
 supports all the various NetCDF formats, though the use of older
-NetCDF formats is strongly discouraged. NetCDF-4 is currently the E3SM
-default and is the default for Omega. In addition, SCORPIO supports
+NetCDF formats is strongly discouraged. PNetCDF is currently the
+default for Omega. In addition, SCORPIO supports
 native HDF5 files (note that the latest NetCDF formats are all implemented
 with HDF5 and are mostly compatible with HDF5) The ADIOS format is different
 since ADIOS writes each chunk of data to a separate file and these files must

--- a/components/omega/doc/userGuide/IOStreams.md
+++ b/components/omega/doc/userGuide/IOStreams.md
@@ -38,6 +38,7 @@ Omega:
       Filename: ocn.hist.$SimTime
       Mode: write
       IfExists: replace
+      #FileFormat: adios (optional format if different from default pnetcdf)
       Precision: double
       Freq: 1
       FreqUnits: months
@@ -97,6 +98,9 @@ a template can be:
    - Append if you want to append (eg multiple time slices) to the existing
      file. When re-running an interval, this will also over-write existing
      slices corresponding to the simulation time if they exist in the file.
+- **FileFormat:** An optional field that can be used if the file has a format
+   incompatible with the default IO format. If not supplied, the stream
+   will use the default format.
 - **Precision:** A field that determines whether floating point numbers are
    written in full (double) precision or reduced (single). Acceptable values
    are double or single. If not present, double is assumed, but a warning

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -461,7 +461,7 @@ Decomp::Decomp(
    TimerFlag = Pacer::start("Decomp read mesh", 2) && TimerFlag;
    int FileID;
    MeshFileName = MeshFileName_;
-   IO::openFile(FileID, MeshFileName, IO::ModeRead);
+   IO::openFileRead(FileID, MeshFileName);
 
    // Read mesh size and connectivity information
    std::vector<I4> CellsOnCellInit;

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -36,31 +36,18 @@ Rearranger DefaultRearr = RearrDefault;
 Rearranger
 RearrFromString(const std::string &Rearr // [in] choice of IO rearranger
 ) {
-   // Set default return value
-   Rearranger ReturnRearr = RearrUnknown;
-
    // Convert input string to lowercase for easier comparison
    std::string RearrComp = Rearr;
    std::transform(RearrComp.begin(), RearrComp.end(), RearrComp.begin(),
                   [](unsigned char c) { return std::tolower(c); });
 
-   // Determine the appropriate enum to use based on the name
-   // Check most likely options first
-
-   if (RearrComp == "box") { // Box rearranger
-      ReturnRearr = RearrBox;
-
-   } else if (RearrComp == "subset") { // Subset rearranger
-      ReturnRearr = RearrSubset;
-
-   } else if (RearrComp == "default") { // Default
-      ReturnRearr = RearrDefault;
-
-   } else {
+   // Find the enum corresponding to the string choice
+   auto RearrFound = RearrMap.find(RearrComp);
+   if (RearrFound == RearrMap.end()) // no entry found
       ABORT_ERROR("IO: Unknown data rearranger {}", RearrComp);
-   }
 
-   return ReturnRearr;
+   // Extract and return enum corresponding to string
+   return RearrFound->second;
 
 } // End RearrFromString
 
@@ -69,46 +56,29 @@ RearrFromString(const std::string &Rearr // [in] choice of IO rearranger
 FileFmt
 FileFmtFromString(const std::string &Format // [in] choice of IO file format
 ) {
-   // Set default return value
-   FileFmt ReturnFileFmt = FmtUnknown;
+   // In special case of blank option, return default. This is often the
+   // case when no explicit format is supplied by an IOStream and the default
+   // is desired
+   if (Format.empty())
+      return FmtDefault;
 
    // Convert input string to lowercase for easier comparison
    std::string FmtCompare = Format;
    std::transform(FmtCompare.begin(), FmtCompare.end(), FmtCompare.begin(),
                   [](unsigned char c) { return std::tolower(c); });
 
-   // Determine the appropriate enum to use based on the input string
-   // Check most likely options first
+   // Find the map entry corresponding to the string choice
+   auto FmtFound = FmtMap.find(FmtCompare);
 
-   if (FmtCompare == "netcdf4") { // NetCDF4 variants
-      ReturnFileFmt = FmtNetCDF4;
-
-   } else if (FmtCompare == "adios") { // ADIOS
-      ReturnFileFmt = FmtADIOS;
-
-   } else if (FmtCompare == "netcdf4c") { // netcdf4 variant - compressed
-      ReturnFileFmt = FmtNetCDF4c;
-
-   } else if (FmtCompare == "netcdf4p") { // netcdf4 variant - parallel
-      ReturnFileFmt = FmtNetCDF4p;
-
-   } else if (FmtCompare == "netcdf3") { // Older netcdf
-      ReturnFileFmt = FmtNetCDF3;
-
-   } else if (FmtCompare == "pnetcdf") { // pnetcdf
-      ReturnFileFmt = FmtPnetCDF;
-
-   } else if (FmtCompare == "hdf5") { // native HDF5
-      ReturnFileFmt = FmtHDF5;
-
-   } else if (FmtCompare == "default") {
-      ReturnFileFmt = FmtDefault;
-
-   } else {
-      ABORT_ERROR("IO: Unknown default file format {}", FmtCompare);
+   // if no entry found int the map, then a bad format has been supplied and we
+   // try to use the default anyway after printing a warning
+   if (FmtFound == FmtMap.end()) {
+      LOG_WARN("IO: Unknown file format {}; using default instead", FmtCompare);
+      return FmtDefault;
    }
 
-   return ReturnFileFmt;
+   // Extract and return enum corresponding to string
+   return FmtFound->second;
 
 } // end of FileFmtFromString
 
@@ -117,27 +87,18 @@ FileFmtFromString(const std::string &Format // [in] choice of IO file format
 Mode ModeFromString(
     const std::string &ModeChoice // [in] IO mode choice (read/write)
 ) {
-   // Set default return value
-   Mode ReturnMode = ModeUnknown;
-
    // Convert input string to lowercase for easier comparison
    std::string ModeComp = ModeChoice;
    std::transform(ModeComp.begin(), ModeComp.end(), ModeComp.begin(),
                   [](unsigned char c) { return std::tolower(c); });
 
-   // Determine the appropriate enum to use based on the input string
-
-   if (ModeComp == "read") { // Read only
-      ReturnMode = ModeRead;
-
-   } else if (ModeComp == "write") { // Write only
-      ReturnMode = ModeWrite;
-
-   } else {
+   // Find the map entry corresponding to the string choice
+   auto ModeFound = ModeMap.find(ModeComp);
+   if (ModeFound == ModeMap.end()) // no entry found
       ABORT_ERROR("IO: Unknown file mode {}: Must be read or write", ModeComp);
-   }
 
-   return ReturnMode;
+   // Extract and return enum corresponding to string
+   return ModeFound->second;
 
 } // End ModeFromString
 
@@ -146,30 +107,18 @@ Mode ModeFromString(
 IfExists IfExistsFromString(
     const std::string &InIfExists // [in] choice of behavior on file existence
 ) {
-   // Set default return value
-   IfExists ReturnIfExists = IfExists::Fail;
-
    // Convert input string to lowercase for easier comparison
    std::string IECompare = InIfExists;
    std::transform(IECompare.begin(), IECompare.end(), IECompare.begin(),
                   [](unsigned char c) { return std::tolower(c); });
 
-   // Determine the appropriate enum to use based on the input string
+   // Find the map entry corresponding to the string choice
+   auto IfExistsFound = IfExistsMap.find(IECompare);
+   if (IfExistsFound == IfExistsMap.end()) // no entry found, default to Fail
+      return IfExists::Fail;
 
-   if (IECompare == "fail") { // Fail with error
-      ReturnIfExists = IfExists::Fail;
-
-   } else if (IECompare == "replace") { // Replace existing file
-      ReturnIfExists = IfExists::Replace;
-
-   } else if (IECompare == "append") { // Append or insert into existing file
-      ReturnIfExists = IfExists::Append;
-
-   } else {
-      ReturnIfExists = IfExists::Fail;
-   }
-
-   return ReturnIfExists;
+   // Extract and return enum corresponding to string
+   return IfExistsFound->second;
 
 } // End IfExistsFromString
 
@@ -233,98 +182,110 @@ void init(const MPI_Comm &InComm // [in] MPI communicator to use
 } // end init
 
 //------------------------------------------------------------------------------
-// This routine opens a file for reading or writing, depending on the
-// Mode argument. The filename with full path must be supplied and
-// a FileID is returned to be used by other IO functions.
+// This routine opens a file for reading. The filename with full path must be
+// supplied and a FileID is returned to be used by other IO functions.
 // The format of the file is assumed to be the default defined on init
 // but can be optionally changed through this open function.
-// For files to be written, optional arguments govern the behavior to be
-// used if the file already exists, and the precision of any floating point
-// variables.
-void openFile(
+void openFileRead(
     int &FileID,                 // [out] returned fileID for this file
     const std::string &Filename, // [in] name (incl path) of file to open
-    Mode InMode,                 // [in] mode (read or write)
-    FileFmt InFormat,            // [in] (optional) file format
-    IfExists InIfExists          // [in] (for writes) behavior if file exists
+    FileFmt InFormat             // [in] (optional) file format
 ) {
 
    int PIOErr = 0;        // internal SCORPIO/PIO return call
    int Format = InFormat; // coerce to integer for PIO calls
-   int IsCDF5 = (InFormat == PIO_IOTYPE_PNETCDF) ? PIO_64BIT_DATA : 0;
 
-   switch (InMode) {
+   // Open the file for read-only
+   PIOErr = PIOc_openfile(SysID, &FileID, &Format, Filename.c_str(), ModeRead);
+   if (PIOErr != PIO_NOERR)
+      ABORT_ERROR("IO::openFile: PIO error opening file {} for read", Filename);
 
-   // If reading, open the file for read-only
-   case ModeRead:
-      PIOErr = PIOc_openfile(SysID, &FileID, &Format, Filename.c_str(), InMode);
+   return;
+
+} // End openFileRead
+//------------------------------------------------------------------------------
+// This routine opens a file for writing. The filename with full path must be
+// supplied and a FileID is returned to be used by other IO functions.
+// A flag is returned to note whether a new file has been created and is
+// therefore in define mode. The first optional argument determines what
+// action to take if the file already exists (default Fail). The second
+// optional argument allows the user to specify a file format other than
+// the default.
+void openFileWrite(
+    int &FileID,                 // [out] returned fileID for this file
+    const std::string &Filename, // [in] name (incl path) of file to open
+    bool &NewFile,               // [out] flag to note whether new file created
+    IfExists InIfExists,         // [in] (optional) behavior if file exists
+    FileFmt InFormat             // [in] (optional) file format
+) {
+
+   int PIOErr     = 0;                  // internal SCORPIO/PIO return call
+   int Format     = InFormat;           // coerce to integer for PIO calls
+   int TmpPnetcdf = PIO_IOTYPE_PNETCDF; // coerce to int for comparison
+   int IsCDF5     = (Format == TmpPnetcdf) ? PIO_64BIT_DATA : 0;
+
+   switch (InIfExists) {
+   // If the write should be a new file and fail if the
+   // file exists, we use create and fail with an error
+   case IfExists::Fail:
+      PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
+                               NC_NOCLOBBER | IsCDF5 | ModeWrite);
       if (PIOErr != PIO_NOERR)
-         ABORT_ERROR("IO::openFile: PIO error opening file {} for read",
+         ABORT_ERROR("IO::openFileWrite: PIO error creating new file {}"
+                     " file already exists and fail mode requested",
                      Filename);
+      NewFile = true;
       break;
 
-   // If writing, the open will depend on what to do if the file
-   // exists.
-   case ModeWrite:
-
-      switch (InIfExists) {
-      // If the write should be a new file and fail if the
-      // file exists, we use create and fail with an error
-      case IfExists::Fail:
-         PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
-                                  NC_NOCLOBBER | IsCDF5 | InMode);
-         if (PIOErr != PIO_NOERR)
-            ABORT_ERROR("IO::openFile: PIO error opening file {} for writing",
-                        Filename);
-         break;
-
-      // If the write should replace any existing file
-      // we use create with the CLOBBER option
-      case IfExists::Replace:
-         PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
-                                  NC_CLOBBER | IsCDF5 | InMode);
-         if (PIOErr != PIO_NOERR)
-            ABORT_ERROR("IO::openFile: PIO error opening file {} for writing",
-                        Filename);
-         break;
-
-      // If the write should append or add to an existing file
-      // we open the file for reading and writing, but also must create
-      // the file if it doesn't already exist
-      case IfExists::Append: {
-         // Check for existence with one task and then broadcast to avoid
-         // the case where some tasks create and some open
-         bool FileExists;
-         MachEnv *DefEnv = MachEnv::getDefault();
-         if (DefEnv->isMasterTask()) {
-            FileExists = std::filesystem::exists(Filename);
-         }
-         Broadcast(FileExists);
-
-         if (FileExists) {
-            PIOErr = PIOc_openfile(SysID, &FileID, &Format, Filename.c_str(),
-                                   IsCDF5 | InMode);
-         } else {
-            PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
-                                     IsCDF5 | InMode);
-         }
-
-         if (PIOErr != PIO_NOERR)
-            ABORT_ERROR("IO::openFile: PIO error opening file {} for writing",
-                        Filename);
-      } break;
-
-      default:
-         ABORT_ERROR("IO::openFile: unknown IfExists option for writing");
-
-      } // end switch IfExists
+   // If the write should replace any existing file
+   // we use create with the CLOBBER option
+   case IfExists::Replace:
+      PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
+                               NC_CLOBBER | IsCDF5 | ModeWrite);
+      if (PIOErr != PIO_NOERR)
+         ABORT_ERROR("IO::openFileWrite: PIO error creating new file {}"
+                     " in replace mode",
+                     Filename);
+      NewFile = true;
       break;
 
-   // Unknown mode
+   // If the write should append or add to an existing file
+   // we open the file for reading and writing, but also must create
+   // the file if it doesn't already exist
+   case IfExists::Append: {
+      // Check for existence with one task and then broadcast to avoid
+      // the case where some tasks create and some open
+      bool FileExists;
+      MachEnv *DefEnv = MachEnv::getDefault();
+      if (DefEnv->isMasterTask()) {
+         FileExists = std::filesystem::exists(Filename);
+      }
+      Broadcast(FileExists);
+
+      if (FileExists) {
+         PIOErr = PIOc_openfile(SysID, &FileID, &Format, Filename.c_str(),
+                                IsCDF5 | ModeWrite);
+         if (PIOErr != PIO_NOERR)
+            ABORT_ERROR("IO::openFileWrite: PIO error opening existing file"
+                        " {} in append mode",
+                        Filename);
+         NewFile = false;
+      } else {
+         PIOErr = PIOc_createfile(SysID, &FileID, &Format, Filename.c_str(),
+                                  IsCDF5 | ModeWrite);
+         if (PIOErr != PIO_NOERR)
+            ABORT_ERROR("IO::openFileWrite: PIO error creating new file {}"
+                        " in append mode",
+                        Filename);
+         NewFile = true;
+      }
+
+   } break;
+
    default:
-      ABORT_ERROR("IO::fileOpen: Unknown Mode for file");
+      ABORT_ERROR("IO::openFileWrite: unknown IfExists option for writing");
 
-   } // End switch on Mode
+   } // end switch IfExists
 
    return;
 

--- a/components/omega/src/base/IO.h
+++ b/components/omega/src/base/IO.h
@@ -61,21 +61,38 @@ enum Rearranger {
    RearrBox     = PIO_REARR_BOX,    ///< box rearranger (default)
    RearrSubset  = PIO_REARR_SUBSET, ///< subset rearranger
    RearrDefault = PIO_REARR_BOX,    ///< default value (Box)
-   RearrUnknown = -1                ///< unknown or undefined
+   RearrUnknown = PIO_REARR_ANY,    ///< Lets PIO choose the rearranger
 };
+
+/// Map of string option name to enum. This is only used in the string
+/// conversion utility but is placed here so that options can all be changed
+/// in one place.
+static const std::map<std::string, Rearranger> RearrMap = {
+    {"box", RearrBox}, {"subset", RearrSubset}, {"default", RearrDefault}};
 
 /// Supported file formats
 enum FileFmt {
+   FmtPnetCDF  = PIO_IOTYPE_PNETCDF,  ///< Parallel NetCDF
    FmtNetCDF3  = PIO_IOTYPE_NETCDF,   ///< NetCDF3 classic format
-   FmtPnetCDF  = PIO_IOTYPE_PNETCDF,  ///< Parallel NetCDF3
-   FmtNetCDF4c = PIO_IOTYPE_NETCDF4C, ///< NetCDF4 (HDF5-compatible) cmpressed
+   FmtNetCDF4c = PIO_IOTYPE_NETCDF4C, ///< NetCDF4 (HDF5-compatible) compressed
    FmtNetCDF4p = PIO_IOTYPE_NETCDF4P, ///< NetCDF4 (HDF5-compatible) parallel
-   FmtNetCDF4  = PIO_IOTYPE_NETCDF4P, ///< NetCDF4 (HDF5-compatible) parallel
-   FmtHDF5     = PIO_IOTYPE_HDF5,     ///< native HDF5 format
-   FmtADIOS    = PIO_IOTYPE_ADIOS,    ///< ADIOS format
-   FmtUnknown  = -1,                  ///< Unknown or undefined
-   FmtDefault  = PIO_IOTYPE_PNETCDF,  ///< PNETCDF is default
+   FmtNetCDF4z = PIO_IOTYPE_NETCDF4P_NCZARR, ///< NetCDF4 (HDF5) NCZarr
+   FmtADIOS    = PIO_IOTYPE_ADIOS,           ///< ADIOS parallel
+   FmtADIOSC   = PIO_IOTYPE_ADIOSC,  ///< ADIOS parallel with compression
+   FmtHDF5     = PIO_IOTYPE_HDF5,    ///< native HDF5 parallel
+   FmtHDF5C    = PIO_IOTYPE_HDF5C,   ///< native HDF5 parallel w compression
+   FmtDefault  = PIO_IOTYPE_PNETCDF, ///< PNETCDF is default
 };
+
+/// Map of string file format option name to enum. This is only used in the
+/// string conversion utility but is placed here so that options can all be
+/// changed in one place.
+static const std::map<std::string, FileFmt> FmtMap = {
+    {"pnetcdf", FmtPnetCDF},   {"netcdf3", FmtNetCDF3},
+    {"netcdf4c", FmtNetCDF4c}, {"netcdf4p", FmtNetCDF4p},
+    {"netcdf4z", FmtNetCDF4z}, {"adios", FmtADIOS},
+    {"adiosc", FmtADIOSC},     {"hdf5", FmtHDF5},
+    {"hdf5c", FmtHDF5C},       {"default", FmtDefault}};
 
 /// File operations
 enum Mode {
@@ -84,12 +101,26 @@ enum Mode {
    ModeUnknown,             /// Unknown or undefined
 };
 
+/// Map of string file format option name to enum. This is only used in the
+/// string conversion utility but is placed here so that options can all be
+/// changed in one place.
+static const std::map<std::string, Mode> ModeMap = {{"read", ModeRead},
+                                                    {"write", ModeWrite}};
+
 /// Behavior (for output files) when a file already exists
 enum class IfExists {
    Fail,    /// Fail with an error
    Replace, /// Replace the file
    Append,  /// Append to the existing file
 };
+
+/// Map of string file format option name to enum. This is only used in the
+/// string conversion utility but is placed here so that options can all be
+/// changed in one place.
+static const std::map<std::string, IfExists> IfExistsMap = {
+    {"fail", IfExists::Fail},
+    {"replace", IfExists::Replace},
+    {"append", IfExists::Append}};
 
 /// Data types for PIO corresponding to Omega types
 enum IODataType {
@@ -139,20 +170,28 @@ IfExists IfExistsFromString(
 void init(const MPI_Comm &InComm ///< [in] MPI communicator to use
 );
 
-/// This routine opens a file for reading or writing, depending on the
-/// Mode argument. The filename with full path must be supplied and
-/// a FileID is returned to be used by other IO functions.
+/// This routine opens a file for reading. The filename with full path must be
+/// supplied and a FileID is returned to be used by other IO functions.
 /// The format of the file is assumed to be the default defined on init
 /// but can be optionally changed through this open function.
-/// For files to be written, optional arguments govern the behavior to be
-/// used if the file already exists, and the precision of any floating point
-/// variables.
-void openFile(
-    int &FileID,                    ///< [out] returned fileID for this file
-    const std::string &Filename,    ///< [in] name (incl path) of file to open
-    Mode Mode,                      ///< [in] mode (read or write)
-    FileFmt Format    = FmtDefault, ///< [in] (optional) file format
-    IfExists IfExists = IfExists::Fail ///< [in] behavior if file exists
+void openFileRead(
+    int &FileID,                 ///< [out] returned fileID for this file
+    const std::string &Filename, ///< [in] name (incl path) of file to open
+    FileFmt Format = FmtDefault  ///< [in] (optional) file format
+);
+
+/// This routine opens a file for writing. The filename with full path must be
+/// supplied and a FileID is returned to be used by other IO functions.
+/// A flag is returned to note whether a new file has been created and is
+/// therefore in define mode. The first optional argument determines what
+/// action to take if the file already exists. The second optional argument
+/// allows the user to specify a file format other than the default.
+void openFileWrite(
+    int &FileID,                 ///< [out] returned fileID for this file
+    const std::string &Filename, ///< [in] name (incl path) of file to open
+    bool &NewFile,               ///< [out] true if new file created
+    IfExists InIfExists = IfExists::Fail, ///< [in] behavior if file exists
+    FileFmt Format      = FmtDefault      ///< [in] (optional) file format
 );
 
 /// Closes an open file using the fileID, returns an error code

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -407,6 +407,12 @@ void IOStream::create(const std::string &StreamName, //< [in] name of stream
    // Add filename to stream
    NewStream->Filename = StreamFilename;
 
+   // Set file format - the FileFmtFromString will return the
+   // default file format if it was unknown or absent from config
+   std::string InFormatStr;
+   Error FmtErr          = StreamConfig.get("FileFormat", InFormatStr);
+   NewStream->FileFormat = IO::FileFmtFromString(InFormatStr);
+
    // Set flag to reduce precision for double precision reals. If no flag
    // present, assume full (double) precision
    std::string PrecisionString;
@@ -622,15 +628,16 @@ void IOStream::create(const std::string &StreamName, //< [in] name of stream
 } // End IOStream create
 
 //------------------------------------------------------------------------------
-// Define all dimensions used. Returns a map of dimension names to defined
-// dimension IDs.
-void IOStream::defineAllDims(
+// Read all dimensions in an existing file and assigs the dimension ID
+// The input file must be in data mode.
+void IOStream::readAllDims(
     int FileID,                           ///< [in] id assigned to the IO file
     std::map<std::string, int> &AllDimIDs ///< [out] dim name, assigned ID
 ) {
 
    Error Err;
 
+   // loop over all expected dimensions
    for (auto IDim = Dimension::begin(); IDim != Dimension::end(); ++IDim) {
       std::string DimName = IDim->first;
       // For back compatibility, we also allow an older name (typically
@@ -645,7 +652,7 @@ void IOStream::defineAllDims(
       I4 Length = IDim->second->getLengthGlobal();
       I4 DimID;
 
-      // First check to see if the dimension already exists in the file
+      // Read the dimension from the file
       I4 InLength;
       Err = IO::getDimFromFile(FileID, DimName, DimID, InLength);
       if (Err.isFail()) { // dim not found
@@ -654,24 +661,46 @@ void IOStream::defineAllDims(
       }
 
       // If dim is found, use this DimID and check the length for consistency
+      // If dim is not found, skip the dimension and it will be added later
+      // if needed.
       if (Err.isSuccess()) {
+         AllDimIDs[DimName] = DimID;
          if (InLength != Length and Length != IO::Unlimited)
             ABORT_ERROR("Inconsistent length for dimension {} in stream {}",
                         DimName, Name);
+      }
 
-         // If dim is not found, define the dimension from the dim class if
-         // it is a write operation, otherwise assume the dimension is not
-         // needed
-      } else {
+   } // end loop over all dims
 
-         if (Mode == IO::Mode::ModeWrite) {
-            DimID = IO::defineDim(FileID, DimName, Length);
-         }
+   return;
 
-      } // end if found in file
+} // End readAllDims
 
-      // Add the DimID to map for later use
-      AllDimIDs[DimName] = DimID;
+//------------------------------------------------------------------------------
+// Define all dimensions used. If some dimensions have already be read
+// from the file (ie when appending to an existing file), only the dims
+// not already read will be defined. The file must be in define mode.
+// A map of all dimension IDs is returned.
+void IOStream::defineAllDims(
+    int FileID,                           ///< [in] id assigned to the IO file
+    std::map<std::string, int> &AllDimIDs ///< [out] dim name, assigned ID
+) {
+
+   Error Err;
+
+   // Loop over all dimensions to be defined
+   for (auto IDim = Dimension::begin(); IDim != Dimension::end(); ++IDim) {
+      std::string DimName = IDim->first;
+
+      // First check to see if the dimension already exists in the dim map
+      auto DimFound = AllDimIDs.find(DimName);
+
+      // If it doesn't already exist, define the new dimension and add the ID.
+      if (DimFound == AllDimIDs.end()) {
+         I4 Length          = IDim->second->getLengthGlobal();
+         I4 DimID           = IO::defineDim(FileID, DimName, Length);
+         AllDimIDs[DimName] = DimID;
+      }
 
    } // end loop over all dims
 
@@ -2285,7 +2314,7 @@ Error IOStream::readStream(
 
    // Open input file
    int InFileID;
-   IO::openFile(InFileID, InFileName, Mode, IO::DefaultFileFmt, ExistAction);
+   IO::openFileRead(InFileID, InFileName, FileFormat);
 
    // Read any requested global metadata
    for (auto Iter = ReqMetadata.begin(); Iter != ReqMetadata.end(); ++Iter) {
@@ -2343,7 +2372,7 @@ Error IOStream::readStream(
 
    // Get dimensions from file and check that file has same dimension lengths
    std::map<std::string, int> AllDimIDs;
-   defineAllDims(InFileID, AllDimIDs);
+   readAllDims(InFileID, AllDimIDs);
 
    // For each field in the contents, define field and read field data
    for (auto IFld = Contents.begin(); IFld != Contents.end(); ++IFld) {
@@ -2438,8 +2467,15 @@ void IOStream::writeStream(
 
    // Open output file
    int OutFileID;
-   IO::openFile(OutFileID, OutFileName, Mode, IO::DefaultFileFmt, ExistAction);
-   bool NeedEndDef = false; // check if we need to call end-define-mode
+   bool DefineMode;
+   IO::openFileWrite(OutFileID, OutFileName, DefineMode, ExistAction,
+                     FileFormat);
+
+   // If this is an existing file, read and check dimensions from current file
+   // and assign dimIDs. Otherwise, dimensions will be added later.
+   std::map<std::string, int> AllDimIDs;
+   if (!DefineMode)
+      readAllDims(OutFileID, AllDimIDs);
 
    // For files with multiple frames or time slices, we need to determine the
    // default Frame number for time-dependent fields. If the frame/time already
@@ -2448,51 +2484,56 @@ void IOStream::writeStream(
    // next frame in the sequence.
    Frame = 0; // default is one frame in file
    if (Multiframe) {
-      // Get the current number of frames in the file - the length of the
-      // unlimited time dimension
-      I4 TimeDimID;
-      I4 NFrames;
-      Err = IO::getDimFromFile(OutFileID, "time", TimeDimID, NFrames);
-      if (Err.isFail() or NFrames == 0) {
-         // If there is an error, we assume this is a new file in which
-         // the dimension has not yet been written. Similarly, if NFrames is 0,
-         // no frames have yet been written. In both cases, this is the first
-         // frame in the file.
+      // If a new file was created (and is in define mode), this must be the
+      // first frame
+      if (DefineMode) {
          Frame = 0;
       } else {
-         // If there are frames in the file, we read the elapsed time for each
-         // frame to determine whether the current slice already exists. If
-         // equal (within roundoff), the slice exists and we overwrite with
-         // the current frame. Otherwise, increment to the next frame
-         R8 FrameTime;
-         int TmpID;
-         std::vector<int> TmpDimLengths; // empty dim length for scalar time
-         for (int IFrame = 0; IFrame < NFrames; ++IFrame) {
-            Err = IO::readNDVar(&FrameTime, "time", OutFileID, TmpID, IFrame,
-                                &TmpDimLengths);
-            CHECK_ERROR_ABORT(Err, "Error reading frame time in {}",
+         // Otherwise get the current number of frames in the file - the length
+         // the unlimited time dimension
+         I4 TimeDimID;
+         I4 NFrames;
+         Err = IO::getDimFromFile(OutFileID, "time", TimeDimID, NFrames);
+         // If time was not found, we assume the dimension has not yet been
+         // written to the old file and Frame should be 0.
+         // Similarly, if NFrames is 0, no frames have yet been
+         // written. In both cases, this is the first frame in the file.
+         if (Err.isFail() or NFrames == 0) {
+            Frame = 0;
+         } else {
+            // If there are frames in the file, we read the elapsed time for
+            // each frame to determine whether the current slice already exists.
+            // If equal (within roundoff), the slice exists and we overwrite
+            // with the current frame. Otherwise, increment to the next frame
+            R8 FrameTime;
+            int TmpID;
+            std::vector<int> TmpDimLengths; // empty dim length for scalar time
+            for (int IFrame = 0; IFrame < NFrames; ++IFrame) {
+               Err = IO::readNDVar(&FrameTime, "time", OutFileID, TmpID, IFrame,
+                                   &TmpDimLengths);
+               CHECK_ERROR_ABORT(Err, "Error reading frame time in {}",
+                                 OutFileName);
+               if (std::abs(ElapsedTimeR8 - FrameTime) < 1.e-5) { // overwrite
+                  Frame = IFrame;
+                  break;
+               } else if (ElapsedTimeR8 > FrameTime) { // move to next frame
+                  Frame = IFrame + 1;
+               } else { // time is earlier but doesn't match any frames
+                  ABORT_ERROR("Existing multiframe file {} appears to be using "
+                              "different time intervals or is from the wrong "
+                              "time period",
                               OutFileName);
-            if (std::abs(ElapsedTimeR8 - FrameTime) < 1.e-5) { // overwrite
-               Frame = IFrame;
-               break;
-            } else if (ElapsedTimeR8 > FrameTime) { // move to next frame
-               Frame = IFrame + 1;
-            } else { // time is earlier but doesn't match any frames
-               ABORT_ERROR("Existing multiframe file {} appears to be using "
-                           "different time intervals or is from the wrong "
-                           "time period",
-                           OutFileName);
-            } // end if elapsed time matches
-         } // end loop over existing frames
-      } // end if nframes
+               } // end if elapsed time matches
+            } // end loop over existing frames
+         } // end if nframes
+      } // end if DefineMode/NewFile
    } // end if multiframe
 
    // Write Metadata for global metadata (Code and Simulation)
    // Only needs to be written for a new file
-   if (Frame < 1) {
+   if (DefineMode) {
       writeFieldMeta(CodeMeta, OutFileID, IO::GlobalID);
       writeFieldMeta(SimMeta, OutFileID, IO::GlobalID);
-      NeedEndDef = true;
    }
 
    // Create and write a field for any global data that is file or time
@@ -2507,16 +2548,19 @@ void IOStream::writeStream(
       SimTimeName = SimTimeName + std::to_string(Frame);
       FileField->addMetadata(SimTimeName, SimTimeStr);
    }
-   // Write and then destroy temporary field
-   if (!NeedEndDef) { // in data-mode, need to redef
+
+   // Must be in define mode to write metadata
+   if (!DefineMode) {
       PIOc_redef(OutFileID);
-      NeedEndDef = true;
+      DefineMode = true;
    }
+
+   // Write and then destroy temporary field
    writeFieldMeta("FileField", OutFileID, IO::GlobalID);
    Field::destroy("FileField");
 
-   // Assign dimension IDs for all defined dimensions
-   std::map<std::string, int> AllDimIDs;
+   // Assign dimension IDs for all defined dimensions that have not been read
+   // from the file.
    defineAllDims(OutFileID, AllDimIDs);
 
    // Define each field and write field metadata
@@ -2563,12 +2607,12 @@ void IOStream::writeStream(
       // Now we can write the field metadata
       if (Frame < 1) { // only write if it's the first time
          writeFieldMeta(FieldName, OutFileID, FieldID);
-         NeedEndDef = true;
       }
    }
-   if (NeedEndDef) {
-      IO::endDefinePhase(OutFileID);
-   }
+
+   // We need to exit define mode before writing data
+   IO::endDefinePhase(OutFileID);
+   DefineMode = false;
 
    // Now write data arrays for all fields in contents
    for (auto IFld = Contents.begin(); IFld != Contents.end(); ++IFld) {
@@ -2801,8 +2845,7 @@ std::string IOStream::buildFilename(
       Outfile.replace(Pos, 2, SSec);
    }
 
-   // Add netcdf suffix
-   Outfile = Outfile + ".nc";
+   // Suffix should be added by PIO
 
    return Outfile;
 

--- a/components/omega/src/infra/IOStream.h
+++ b/components/omega/src/infra/IOStream.h
@@ -62,6 +62,8 @@
 ///      UsePointerFile: false
 ///      Filename: ocn.hist.$SimTime
 ///      Mode: write
+///      # File format is only needed if differs from default (pnetcdf)
+///      # FileFormat: adios
 ///      IfExists: replace
 ///      Precision: double
 ///      Freq: 1
@@ -76,6 +78,8 @@
 ///      UsePointerFile: false
 ///      Filename: ocn.hifreq.$Y-$M
 ///      Mode: write
+///      # File format is only needed if differs from default (pnetcdf)
+///      # FileFormat: adios
 ///      IfExists: append
 ///      Precision: single
 ///      Freq: 10
@@ -116,6 +120,7 @@ class IOStream {
    std::string Filename;     ///< filename or filename template (with path)
    bool FilenameIsTemplate;  ///< true if the filename is a template
    IO::IfExists ExistAction; ///< action if file exists (write only)
+   IO::FileFmt FileFormat;   ///< file format (eg pnetcdf, hdf5, adios)
 
    IO::Mode Mode;        ///< mode (read or write)
    bool ReducePrecision; ///< flag to use 32-bit precision for 64-bit floats
@@ -155,8 +160,17 @@ class IOStream {
                       Clock *&ModelClock    ///< [inout] Omega model clock
    );
 
-   /// Define all dimensions used. Returns a map of dimension names to defined
-   /// dimension IDs.
+   /// Read all dimensions from an input file and determine the dimension ID.
+   /// The file must be in data mode.
+   void readAllDims(
+       int FileID, ///< [in] id assigned to the IO file
+       std::map<std::string, int> &AllDimIDs ///< [out] dim name, assigned ID
+   );
+
+   /// Define all dimensions used. If some dimensions have already be read
+   /// from the file (ie when appending to an existing file), only the dims
+   /// not already read will be defined. The file must be in define mode.
+   /// A map of all dimension IDs is returned.
    void defineAllDims(
        int FileID, ///< [in] id assigned to the IO file
        std::map<std::string, int> &AllDimIDs ///< [out] dim name, assigned ID

--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -101,7 +101,7 @@ HorzMesh::HorzMesh(const std::string &Name, //< [in] Name for new mesh
    EdgesOnVertex  = MeshDecomp->EdgesOnVertex;
 
    // Open the mesh file for reading (assume IO has already been initialized)
-   IO::openFile(MeshFileID, MeshFileName, IO::ModeRead);
+   IO::openFileRead(MeshFileID, MeshFileName);
 
    // Create Omega Dimensions associated with this mesh
    createDimensions(MeshDecomp);

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -104,7 +104,7 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
       std::string MPASDimName  = "nVertLevels";
 
       // Open the mesh file for reading (assume IO has already been initialized)
-      IO::openFile(MeshFileID, MeshFileName, IO::ModeRead);
+      IO::openFileRead(MeshFileID, MeshFileName);
 
       // Set NVertLayers
       I4 NVertLayersID;

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -216,8 +216,9 @@ int main(int argc, char *argv[]) {
 
       // Open a file for output
       int OutFileID;
-      IO::openFile(OutFileID, "IOTest.nc", IO::ModeWrite, IO::FmtDefault,
-                   IO::IfExists::Replace);
+      bool NewFile;
+      IO::openFileWrite(OutFileID, "IOTest.nc", NewFile, IO::IfExists::Replace,
+                        IO::FmtDefault);
 
       // Define array dimensions
       int DimCellID;
@@ -366,8 +367,8 @@ int main(int argc, char *argv[]) {
 
       // Re-open to write additional frames for multi-frame fields
       // Open a file for output
-      IO::openFile(OutFileID, "IOTest.nc", IO::ModeWrite, IO::FmtDefault,
-                   IO::IfExists::Append);
+      IO::openFileWrite(OutFileID, "IOTest.nc", NewFile, IO::IfExists::Append,
+                        IO::FmtDefault);
 
       // write second frame data
       IO::writeNDVar(RefR8Time.data(), OutFileID, VarIDR8Time, 1, &DimLengths);
@@ -379,7 +380,7 @@ int main(int argc, char *argv[]) {
 
       // Open a file for reading to verify read/write
       int InFileID;
-      IO::openFile(InFileID, "IOTest.nc", IO::ModeRead);
+      IO::openFileRead(InFileID, "IOTest.nc");
 
       // Get dimension lengths to verify read/write of dimension info
       I4 NVertLayersID;


### PR DESCRIPTION
Some IO fixes and format changes, including
  - adding fixes to eliminate IO define mode errors
  - adding a per-stream optional file format option
  - updating IO format options to match SCORPIO
  - creating string-to-enum maps to consolidate IO option definitions in IO.h (instead of the various string-to-enum conversion routines) so that various IO format and other options can be changed in one place

Checklist
* [x] Documentation:
  * [x] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
  * [x] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [x] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [ ] Indicate "All tests passed" or document failing tests
    * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.
    * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.

Fixes #356
Fixes #331 
