### PR TITLE
Fixes to support Aurora GPU

### DIFF
--- a/components/omega/src/ocn/HorzOperators.h
+++ b/components/omega/src/ocn/HorzOperators.h
@@ -420,7 +420,15 @@ class MasksAndCoefficients {
    // (recursive device calls are rejected by DPC++).
    KOKKOS_INLINE_FUNCTION static void sort_by_key(Array2DI4 &vec, const I4 low,
                                                   const I4 high) {
-      if (low >= high)
+      if (low > high) {
+         printf(
+             "Error: MasksAndCoefficients::sort_by_key called with invalid "
+             "bounds (low=%d, high=%d)\n",
+             low, high);
+         return;
+      }
+
+      if (low == high)
          return;
 
       for (I4 i = low + 1; i <= high; ++i) {

--- a/components/omega/src/ocn/HorzOperators.h
+++ b/components/omega/src/ocn/HorzOperators.h
@@ -211,9 +211,8 @@ class SecondDerivativeOnCell {
                                    const int ICell) const {
       const int NEdges = NEdgesOnCell(ICell);
       if (MaxMaxEdges < NEdges)
-         printf("Error: Number of edges on cell:%d exceeds maximum "
-                "expected:%d for cell:%d",
-                NEdges, MaxMaxEdges, ICell);
+         Kokkos::abort("SecondDerivativeOnCell: number of edges on cell "
+                       "exceeds MaxMaxEdges");
 
       // check to see if we are reaching outside the halo
       auto CellList = Kokkos::subview(CellListCell, ICell, Kokkos::ALL);
@@ -421,11 +420,8 @@ class MasksAndCoefficients {
    KOKKOS_INLINE_FUNCTION static void sort_by_key(Array2DI4 &vec, const I4 low,
                                                   const I4 high) {
       if (low > high) {
-         printf(
-             "Error: MasksAndCoefficients::sort_by_key called with invalid "
-             "bounds (low=%d, high=%d)\n",
-             low, high);
-         return;
+         Kokkos::abort("MasksAndCoefficients::sort_by_key called with invalid "
+                       "bounds");
       }
 
       if (low == high)

--- a/components/omega/src/ocn/HorzOperators.h
+++ b/components/omega/src/ocn/HorzOperators.h
@@ -416,35 +416,19 @@ class MasksAndCoefficients {
    // Sort the second dimension (values) of vec based on the first (keys):
    // Array1DI4 keys   = Kokkos::subview(vec, 0, Kokkos::ALL);
    // Array1DI4 values = Kokkos::subview(vec, 1, Kokkos::ALL);
-   KOKKOS_INLINE_FUNCTION static int partition(Array2DI4 &vec, const int low,
-                                               const int high) {
-      // Selecting last element as the pivot
-      const I4 pivot = vec(0, high);
-      int i          = (low - 1);
-      for (int j = low; j < high; ++j) {
-         if (vec(0, j) <= pivot) {
-            i++;
-            swap(vec, i, j);
-         }
-      }
-      // Put pivot to its position
-      swap(vec, i + 1, high);
-      // Return the point of partition
-      return (i + 1);
-   }
-
+   // Use iterative insertion sort to keep this SYCL-device compatible
+   // (recursive device calls are rejected by DPC++).
    KOKKOS_INLINE_FUNCTION static void sort_by_key(Array2DI4 &vec, const I4 low,
                                                   const I4 high) {
-      // Base case: This part will be executed till the starting
-      // index low is lesser than the ending index high
-      if (low < high) {
-         // pi is Partitioning Index, vec[pi] is now at
-         // right place
-         const I4 pi = partition(vec, low, high);
-         // Separately sort elements before and after the
-         // Partition Index pi
-         sort_by_key(vec, low, pi - 1);
-         sort_by_key(vec, pi + 1, high);
+      if (low >= high)
+         return;
+
+      for (I4 i = low + 1; i <= high; ++i) {
+         I4 j = i;
+         while (j > low && vec(0, j - 1) > vec(0, j)) {
+            swap(vec, j - 1, j);
+            --j;
+         }
       }
    }
    KOKKOS_INLINE_FUNCTION static bool is_sorted(Array2DI4 &vec) {

--- a/components/omega/src/ocn/HorzUtil.h
+++ b/components/omega/src/ocn/HorzUtil.h
@@ -183,7 +183,7 @@ KOKKOS_INLINE_FUNCTION void arc_bisect(const Real ax, const Real ay,
    cy = 0.5_Real * (ay + by);
    cz = 0.5_Real * (az + bz);
    if (cx == 0. && cy == 0. && cz == 0.) {
-      printf("arc_bisect: A and B are diametrically opposite");
+      Kokkos::abort("arc_bisect: A and B are diametrically opposite");
    } else {
       const Real d = Kokkos::sqrt(cx * cx + cy * cy + cz * cz);
       const Real r = Kokkos::sqrt(ax * ax + ay * ay + az * az);


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

This merge fixes various issues that were preventing GPU builds on Aurora:
* Switches the `sort_by_key()` method in horizontal operators to use non-recursive insertion sort.  SYCL on Aurora doesn't allow recursive functions on the GPU.
* Switches from `printf()` to `kokkos::abort()` calls in two methods in horizontal operators. This is required in kokkos functions to support SYCL on Aurora.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


