### PR TITLE
Port sphere transport time-varying prescribed velocity fields

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -22,6 +22,8 @@ Omega:
     IODefaultFormat: pnetcdf
   State:
     NTimeLevels: 2
+    PrescribeThicknessType: None
+    PrescribeVelocityType: None
   Advection:
     Coef3rdOrder: 0.25
     FluxThicknessType: Center

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -45,7 +45,7 @@ void ForwardBackwardStepper::doStep(
    if (AuxState == nullptr)
       LOG_CRITICAL("Invalid AuxState");
 
-   prescribeVelocity(State, CurLevel, State, CurLevel,SimTime);
+   prescribeVelocity(State, CurLevel, State, CurLevel, SimTime);
 
    // R_u^{n} = RHS_u(u^{n}, h^{n}, t^{n})
    Tend->computeVelocityTendencies(State, AuxState, CurTracerArray,

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -45,6 +45,8 @@ void ForwardBackwardStepper::doStep(
    if (AuxState == nullptr)
       LOG_CRITICAL("Invalid AuxState");
 
+   prescribeVelocity(State, CurLevel, State, CurLevel,SimTime);
+
    // R_u^{n} = RHS_u(u^{n}, h^{n}, t^{n})
    Tend->computeVelocityTendencies(State, AuxState, CurTracerArray,
                                    ThickCurLevel, VelCurLevel, TracerCurLevel,
@@ -60,6 +62,8 @@ void ForwardBackwardStepper::doStep(
    // h^{n+1} = h^{n} + R_h^{n}
    updateThicknessByTend(State, ThickNextLevel, State, ThickCurLevel, TimeStep);
 
+   prescribeThickness(State, CurLevel, State, CurLevel);
+
    // R_phi^{n} = RHS_phi(u^{n+1}, h^{n+1}, phi^{n}, t^{n})
    Tend->computeTracerTendencies(State, AuxState, CurTracerArray,
                                  ThickNextLevel, VelNextLevel, SimTime);
@@ -67,10 +71,6 @@ void ForwardBackwardStepper::doStep(
    // phi^{n+1} = (phi^{n} * h^{n} + R_phi^{n}) / h^{n+1}
    updateTracersByTend(NextTracerArray, CurTracerArray, State, ThickNextLevel,
                        State, ThickCurLevel, TimeStep);
-
-   prescribeThickness(State, NextLevel, State, CurLevel);
-   prescribeVelocity(State, NextLevel, State, CurLevel,
-                     SimTime + TimeStep);
 
    // Update time levels (New -> Old) of prognostic variables with halo
    // exchanges

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -69,7 +69,8 @@ void ForwardBackwardStepper::doStep(
                        State, ThickCurLevel, TimeStep);
 
    prescribeThickness(State, NextLevel, State, CurLevel);
-   prescribeVelocity(State, NextLevel, State, CurLevel);
+   prescribeVelocity(State, NextLevel, State, CurLevel,
+                     SimTime + TimeStep);
 
    // Update time levels (New -> Old) of prognostic variables with halo
    // exchanges

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -68,6 +68,9 @@ void ForwardBackwardStepper::doStep(
    updateTracersByTend(NextTracerArray, CurTracerArray, State, ThickNextLevel,
                        State, ThickCurLevel, TimeStep);
 
+   prescribeThickness(State, NextLevel, State, CurLevel);
+   prescribeVelocity(State, NextLevel, State, CurLevel);
+
    // Update time levels (New -> Old) of prognostic variables with halo
    // exchanges
    const MPI_Comm Comm = MeshHalo->getComm();

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -45,7 +45,7 @@ void ForwardBackwardStepper::doStep(
    if (AuxState == nullptr)
       LOG_CRITICAL("Invalid AuxState");
 
-   prescribeVelocity(State, CurLevel, State, CurLevel, SimTime);
+   prescribeVelocity(State, VelCurLevel, State, VelCurLevel, SimTime);
 
    // R_u^{n} = RHS_u(u^{n}, h^{n}, t^{n})
    Tend->computeVelocityTendencies(State, AuxState, CurTracerArray,
@@ -55,6 +55,11 @@ void ForwardBackwardStepper::doStep(
    // u^{n+1} = u^{n} + R_u^{n}
    updateVelocityByTend(State, VelNextLevel, State, VelCurLevel, TimeStep);
 
+   updateVelocityByTend(State, VelNextLevel, State, VelCurLevel, TimeStep);
+
+   prescribeVelocity(State, VelNextLevel, State, VelCurLevel,
+                     SimTime + TimeStep);
+
    // R_h^{n} = RHS_h(u^{n+1}, h^{n}, t^{n})
    Tend->computeThicknessTendencies(State, AuxState, ThickCurLevel,
                                     VelNextLevel, SimTime);
@@ -62,7 +67,7 @@ void ForwardBackwardStepper::doStep(
    // h^{n+1} = h^{n} + R_h^{n}
    updateThicknessByTend(State, ThickNextLevel, State, ThickCurLevel, TimeStep);
 
-   prescribeThickness(State, CurLevel, State, CurLevel);
+   prescribeThickness(State, ThickNextLevel, State, ThickCurLevel);
 
    // R_phi^{n} = RHS_phi(u^{n+1}, h^{n+1}, phi^{n}, t^{n})
    Tend->computeTracerTendencies(State, AuxState, CurTracerArray,

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -34,6 +34,8 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    Array3DReal CurTracerArray  = Tracers::getAll(CurLevel);
    Array3DReal NextTracerArray = Tracers::getAll(NextLevel);
 
+   prescribeState(State, CurLevel, State, CurLevel, SimTime);
+
    // q = (h,u,phi)
    // R_q^{n} = RHS_q(u^{n}, h^{n}, phi^{n}, t^{n})
    Tend->computeAllTendencies(State, AuxState, CurTracerArray, CurLevel,
@@ -47,6 +49,8 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    State->exchangeHalo(NextLevel);
    MeshHalo->exchangeFullArrayHalo(NextTracerArray, OnCell);
 
+   prescribeState(State, NextLevel, State, CurLevel, SimTime + 0.5 * TimeStep);
+
    // R_q^{n+0.5} = RHS_q(u^{n+0.5}, h^{n+0.5}, phi^{n+0.5}, t^{n+0.5})
    Tend->computeAllTendencies(State, AuxState, NextTracerArray, NextLevel,
                               NextLevel, NextLevel, SimTime + 0.5 * TimeStep);
@@ -55,8 +59,6 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    updateStateByTend(State, NextLevel, State, CurLevel, TimeStep);
    updateTracersByTend(NextTracerArray, CurTracerArray, State, NextLevel, State,
                        CurLevel, TimeStep);
-
-   prescribeState(State, NextLevel, State, CurLevel, SimTime + TimeStep);
 
    // Update time levels (New -> Old) of prognostic variables with halo
    // exchanges

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -56,6 +56,8 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    updateTracersByTend(NextTracerArray, CurTracerArray, State, NextLevel, State,
                        CurLevel, TimeStep);
 
+   prescribeState(State, NextLevel, State, CurLevel);
+
    // Update time levels (New -> Old) of prognostic variables with halo
    // exchanges
    const MPI_Comm Comm = MeshHalo->getComm();

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -56,7 +56,7 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    updateTracersByTend(NextTracerArray, CurTracerArray, State, NextLevel, State,
                        CurLevel, TimeStep);
 
-   prescribeState(State, NextLevel, State, CurLevel);
+   prescribeState(State, NextLevel, State, CurLevel, SimTime + TimeStep);
 
    // Update time levels (New -> Old) of prognostic variables with halo
    // exchanges

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -74,8 +74,8 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
    const int CurLevel  = 0;
    const int NextLevel = 1;
 
-   Array3DReal CurTracerArray  = Tracers::getAll(CurLevel);
-   Array3DReal NextTracerArray = Tracers::getAll(NextLevel);
+   Array3DReal CurTracerArray   = Tracers::getAll(CurLevel);
+   Array3DReal NextTracerArray  = Tracers::getAll(NextLevel);
    TimeInstant ForcingStageTime = SimTime;
 
    for (int Stage = 0; Stage < NStages; ++Stage) {
@@ -99,7 +99,8 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
          updateStateByTend(ProvisState, CurLevel, State, CurLevel,
                            RKA[Stage] * TimeStep);
          ForcingStageTime += RKA[Stage] * TimeStep;
-         prescribeState(ProvisState, CurLevel, ProvisState, CurLevel, ForcingStageTime);
+         prescribeState(ProvisState, CurLevel, ProvisState, CurLevel,
+                        ForcingStageTime);
          updateTracersByTend(ProvisTracers, CurTracerArray, ProvisState,
                              CurLevel, State, CurLevel, RKA[Stage] * TimeStep);
 

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -76,6 +76,7 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
 
    Array3DReal CurTracerArray  = Tracers::getAll(CurLevel);
    Array3DReal NextTracerArray = Tracers::getAll(NextLevel);
+   TimeInstant ForcingStageTime = SimTime;
 
    for (int Stage = 0; Stage < NStages; ++Stage) {
       const TimeInstant StageTime = SimTime + RKC[Stage] * TimeStep;
@@ -84,11 +85,11 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
       // q^{n+1} = q^{n} + dt * RKB[0] * R^{(0)}
       if (Stage == 0) {
          weightTracers(NextTracerArray, CurTracerArray, State, CurLevel);
+         prescribeState(State, CurLevel, State, CurLevel, ForcingStageTime);
          Tend->computeAllTendencies(State, AuxState, CurTracerArray, CurLevel,
                                     CurLevel, CurLevel, StageTime);
          updateStateByTend(State, NextLevel, State, CurLevel,
                            RKB[Stage] * TimeStep);
-         prescribeState(State, NextLevel, State, CurLevel, StageTime);
          accumulateTracersUpdate(NextTracerArray, RKB[Stage] * TimeStep);
       } else {
          // every other stage does:
@@ -97,7 +98,8 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
          // q^{n+1} += RKB[stage] * dt * R^{(s)}
          updateStateByTend(ProvisState, CurLevel, State, CurLevel,
                            RKA[Stage] * TimeStep);
-         prescribeState(State, NextLevel, State, CurLevel, StageTime);
+         ForcingStageTime += RKA[Stage] * TimeStep;
+         prescribeState(ProvisState, CurLevel, ProvisState, CurLevel, ForcingStageTime);
          updateTracersByTend(ProvisTracers, CurTracerArray, ProvisState,
                              CurLevel, State, CurLevel, RKA[Stage] * TimeStep);
 
@@ -111,7 +113,6 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
                                     CurLevel, CurLevel, CurLevel, StageTime);
          updateStateByTend(State, NextLevel, State, NextLevel,
                            RKB[Stage] * TimeStep);
-         prescribeState(State, NextLevel, State, CurLevel, StageTime);
          accumulateTracersUpdate(NextTracerArray, RKB[Stage] * TimeStep);
       }
    }

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -88,7 +88,7 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
                                     CurLevel, CurLevel, StageTime);
          updateStateByTend(State, NextLevel, State, CurLevel,
                            RKB[Stage] * TimeStep);
-         prescribeState(State, NextLevel, State, CurLevel);
+         prescribeState(State, NextLevel, State, CurLevel, StageTime);
          accumulateTracersUpdate(NextTracerArray, RKB[Stage] * TimeStep);
       } else {
          // every other stage does:
@@ -97,7 +97,7 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
          // q^{n+1} += RKB[stage] * dt * R^{(s)}
          updateStateByTend(ProvisState, CurLevel, State, CurLevel,
                            RKA[Stage] * TimeStep);
-         prescribeState(State, NextLevel, State, CurLevel);
+         prescribeState(State, NextLevel, State, CurLevel, StageTime);
          updateTracersByTend(ProvisTracers, CurTracerArray, ProvisState,
                              CurLevel, State, CurLevel, RKA[Stage] * TimeStep);
 
@@ -111,7 +111,7 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
                                     CurLevel, CurLevel, CurLevel, StageTime);
          updateStateByTend(State, NextLevel, State, NextLevel,
                            RKB[Stage] * TimeStep);
-         prescribeState(State, NextLevel, State, CurLevel);
+         prescribeState(State, NextLevel, State, CurLevel, StageTime);
          accumulateTracersUpdate(NextTracerArray, RKB[Stage] * TimeStep);
       }
    }

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -88,6 +88,7 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
                                     CurLevel, CurLevel, StageTime);
          updateStateByTend(State, NextLevel, State, CurLevel,
                            RKB[Stage] * TimeStep);
+         prescribeState(State, NextLevel, State, CurLevel);
          accumulateTracersUpdate(NextTracerArray, RKB[Stage] * TimeStep);
       } else {
          // every other stage does:
@@ -96,6 +97,7 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
          // q^{n+1} += RKB[stage] * dt * R^{(s)}
          updateStateByTend(ProvisState, CurLevel, State, CurLevel,
                            RKA[Stage] * TimeStep);
+         prescribeState(State, NextLevel, State, CurLevel);
          updateTracersByTend(ProvisTracers, CurTracerArray, ProvisState,
                              CurLevel, State, CurLevel, RKA[Stage] * TimeStep);
 
@@ -109,6 +111,7 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
                                     CurLevel, CurLevel, CurLevel, StageTime);
          updateStateByTend(State, NextLevel, State, NextLevel,
                            RKB[Stage] * TimeStep);
+         prescribeState(State, NextLevel, State, CurLevel);
          accumulateTracersUpdate(NextTracerArray, RKB[Stage] * TimeStep);
       }
    }

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -8,9 +8,9 @@
 #include "Config.h"
 #include "Error.h"
 #include "ForwardBackwardStepper.h"
+#include "Logging.h"
 #include "RungeKutta2Stepper.h"
 #include "RungeKutta4Stepper.h"
-#include "Logging.h"
 
 namespace OMEGA {
 //------------------------------------------------------------------------------
@@ -21,9 +21,9 @@ TimeStepper *TimeStepper::DefaultTimeStepper = nullptr;
 std::map<std::string, std::unique_ptr<TimeStepper>>
     TimeStepper::AllTimeSteppers;
 PrescribeStateType TimeStepper::DefaultPrescribeThicknessMode =
-   PrescribeStateType::None;
+    PrescribeStateType::None;
 PrescribeStateType TimeStepper::DefaultPrescribeVelocityMode =
-   PrescribeStateType::None;
+    PrescribeStateType::None;
 
 //------------------------------------------------------------------------------
 // utility functions
@@ -48,7 +48,8 @@ TimeStepperType getTimeStepperFromStr(const std::string &InString) {
    return TimeStepperChoice;
 }
 
-PrescribeStateType getPrescribeThicknessTypeFromStr(const std::string &InString) {
+PrescribeStateType
+getPrescribeThicknessTypeFromStr(const std::string &InString) {
 
    if (InString == "None") {
       return PrescribeStateType::None;
@@ -57,23 +58,26 @@ PrescribeStateType getPrescribeThicknessTypeFromStr(const std::string &InString)
       return PrescribeStateType::Init;
    }
 
-   ABORT_ERROR("PrescribeStateType should be 'None' or 'Init' for thickness but got {}",
-               InString);
+   ABORT_ERROR(
+       "PrescribeStateType should be 'None' or 'Init' for thickness but got {}",
+       InString);
    return PrescribeStateType::Invalid;
 }
-PrescribeStateType getPrescribeVelocityTypeFromStr(const std::string &InString) {
+PrescribeStateType
+getPrescribeVelocityTypeFromStr(const std::string &InString) {
 
    if (InString == "None") {
       return PrescribeStateType::None;
-   }else if (InString == "Init") {
+   } else if (InString == "Init") {
       return PrescribeStateType::Init;
-   }else if (InString == "NonDivergent") {
+   } else if (InString == "NonDivergent") {
       return PrescribeStateType::NonDivergent;
-   }else if (InString == "Divergent") {
+   } else if (InString == "Divergent") {
       return PrescribeStateType::Divergent;
    }
 
-   ABORT_ERROR("PrescribeStateType should be 'None', 'Init', 'NonDivergent' or 'Divergent' for velocity but got {}",
+   ABORT_ERROR("PrescribeStateType should be 'None', 'Init', 'NonDivergent' or "
+               "'Divergent' for velocity but got {}",
                InString);
    return PrescribeStateType::Invalid;
 }
@@ -153,10 +157,8 @@ TimeStepper *TimeStepper::create(
       ABORT_ERROR("Unknown time stepping method");
    }
 
-   NewTimeStepper->PrescribeThicknessMode =
-      DefaultPrescribeThicknessMode;
-   NewTimeStepper->PrescribeVelocityMode =
-      DefaultPrescribeVelocityMode;
+   NewTimeStepper->PrescribeThicknessMode = DefaultPrescribeThicknessMode;
+   NewTimeStepper->PrescribeVelocityMode  = DefaultPrescribeVelocityMode;
 
    // Attach data pointers
    NewTimeStepper->attachData(InTend, InAuxState, InMesh, InVCoord, InMeshHalo);
@@ -209,10 +211,8 @@ TimeStepper *TimeStepper::create(
       ABORT_ERROR("Unknown time stepping method");
    }
 
-   NewTimeStepper->PrescribeThicknessMode =
-      DefaultPrescribeThicknessMode;
-   NewTimeStepper->PrescribeVelocityMode =
-      DefaultPrescribeVelocityMode;
+   NewTimeStepper->PrescribeThicknessMode = DefaultPrescribeThicknessMode;
+   NewTimeStepper->PrescribeVelocityMode  = DefaultPrescribeVelocityMode;
 
    // Store instance
    AllTimeSteppers.emplace(InName, NewTimeStepper);
@@ -346,7 +346,8 @@ void TimeStepper::init1() {
    Error StateErr = OmegaConfig->get(StateConfig);
    if (StateErr.isSuccess()) {
       std::string ThicknessMode;
-      if (StateConfig.get("PrescribeThicknessType", ThicknessMode).isSuccess()) {
+      if (StateConfig.get("PrescribeThicknessType", ThicknessMode)
+              .isSuccess()) {
          TimeStepper::DefaultPrescribeThicknessMode =
              getPrescribeThicknessTypeFromStr(ThicknessMode);
       }
@@ -545,7 +546,7 @@ void TimeStepper::prescribeThickness(OceanState *State1, int TimeLevel1,
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    const int K = KMin + KChunk;
+                    const int K           = KMin + KChunk;
                     LayerThick1(ICell, K) = LayerThick2(ICell, K);
                  });
           });
@@ -555,8 +556,8 @@ void TimeStepper::prescribeThickness(OceanState *State1, int TimeLevel1,
 
 //------------------------------------------------------------------------------
 void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
-                           OceanState *State2, int TimeLevel2,
-                           const TimeInstant &SimTime) const {
+                                    OceanState *State2, int TimeLevel2,
+                                    const TimeInstant &SimTime) const {
 
    if (PrescribeVelocityMode == PrescribeStateType::None) {
       return;
@@ -578,7 +579,7 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    const int K = KMin + KChunk;
+                    const int K          = KMin + KChunk;
                     NormalVel2(IEdge, K) = NormalVel1(IEdge, K);
                  });
           });
@@ -597,8 +598,8 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
       TimeInterval ElapsedTimeInterval = SimTime - ModelClock->getStartTime();
       ElapsedTimeInterval.get(ElapsedTimeSec, TimeUnits::Seconds);
 
-      const R8 Tau     = 12. * Day2Sec; // 12 days in seconds
-      const R8 TSim    = ElapsedTimeSec;
+      const R8 Tau  = 12. * Day2Sec; // 12 days in seconds
+      const R8 TSim = ElapsedTimeSec;
 
       parallelForOuter(
           "prescribeVelocityNonDivergent", {Mesh->NEdgesAll},
@@ -607,21 +608,19 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
              const int KMax   = MaxLayerEdgeTop(IEdge);
              const int KRange = vertRange(KMin, KMax);
 
-             const R8 lon_p =
-                 LonEdge(IEdge) - 2.0 * Pi * TSim / Tau;
-             const R8 u = (1 / Tau) *
-                          (10.0 * Kokkos::pow(sin(lon_p), 2) *
-                           sin(2.0 * LatEdge(IEdge)) *
-                           cos(Pi * TSim / Tau) +
-                           2.0 * Pi * cos(LatEdge(IEdge)));
-             const R8 v = (10.0 / Tau) * sin(2.0 * lon_p) *
+             const R8 lon_p = LonEdge(IEdge) - 2.0 * Pi * TSim / Tau;
+             const R8 u     = (1 / Tau) * (10.0 * Kokkos::pow(sin(lon_p), 2) *
+                                           sin(2.0 * LatEdge(IEdge)) *
+                                           cos(Pi * TSim / Tau) +
+                                       2.0 * Pi * cos(LatEdge(IEdge)));
+             const R8 v     = (10.0 / Tau) * sin(2.0 * lon_p) *
                           cos(LatEdge(IEdge)) * cos(Pi * TSim / Tau);
-             const R8 normalVel = REarth * (
-                 u * cos(AngleEdge(IEdge)) + v * sin(AngleEdge(IEdge)));
+             const R8 normalVel = REarth * (u * cos(AngleEdge(IEdge)) +
+                                            v * sin(AngleEdge(IEdge)));
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    const int K = KMin + KChunk;
+                    const int K          = KMin + KChunk;
                     NormalVel2(IEdge, K) = normalVel;
                  });
           });
@@ -640,8 +639,8 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
       TimeInterval ElapsedTimeInterval = SimTime - ModelClock->getStartTime();
       ElapsedTimeInterval.get(ElapsedTimeSec, TimeUnits::Seconds);
 
-      const R8 Tau     = 12. * Day2Sec; // 14 days in seconds
-      const R8 TSim    = ElapsedTimeSec;
+      const R8 Tau  = 12. * Day2Sec; // 14 days in seconds
+      const R8 TSim = ElapsedTimeSec;
 
       parallelForOuter(
           "prescribeVelocityDivergent", {Mesh->NEdgesAll},
@@ -650,24 +649,22 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
              const int KMax   = MaxLayerEdgeTop(IEdge);
              const int KRange = vertRange(KMin, KMax);
 
-             const R8 lon_p =
-                 LonEdge(IEdge) - 2.0 * Pi * TSim / Tau;
-             const R8 u = (1.0 / Tau) *
-                          (-5.0 * Kokkos::pow(sin(lon_p / 2), 2) *
-                          sin(2.0 * LatEdge(IEdge)) *
-                          Kokkos::pow(cos(LatEdge(IEdge)), 2) *
-                          cos(Pi * TSim / Tau) +
-                          2.0 * Pi * cos(LatEdge(IEdge)));
-             const R8 v = ((2.5 / Tau) *
-                           sin(lon_p) *
-                           Kokkos::pow(cos(LatEdge(IEdge)), 3) *
-                           cos(Pi * TSim / Tau));
-             const R8 normalVel = REarth * (
-                 u * cos(AngleEdge(IEdge)) + v * sin(AngleEdge(IEdge)));
+             const R8 lon_p = LonEdge(IEdge) - 2.0 * Pi * TSim / Tau;
+             const R8 u =
+                 (1.0 / Tau) * (-5.0 * Kokkos::pow(sin(lon_p / 2), 2) *
+                                    sin(2.0 * LatEdge(IEdge)) *
+                                    Kokkos::pow(cos(LatEdge(IEdge)), 2) *
+                                    cos(Pi * TSim / Tau) +
+                                2.0 * Pi * cos(LatEdge(IEdge)));
+             const R8 v =
+                 ((2.5 / Tau) * sin(lon_p) *
+                  Kokkos::pow(cos(LatEdge(IEdge)), 3) * cos(Pi * TSim / Tau));
+             const R8 normalVel = REarth * (u * cos(AngleEdge(IEdge)) +
+                                            v * sin(AngleEdge(IEdge)));
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    const int K = KMin + KChunk;
+                    const int K          = KMin + KChunk;
                     NormalVel2(IEdge, K) = normalVel;
                  });
           });

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -551,7 +551,8 @@ void TimeStepper::prescribeThickness(OceanState *State1, int TimeLevel1,
 
 //------------------------------------------------------------------------------
 void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
-                                    OceanState *State2, int TimeLevel2) const {
+                           OceanState *State2, int TimeLevel2,
+                           const TimeInstant &SimTime) const {
 
    if (PrescribeVelocityMode == PrescribeStateType::None) {
       return;
@@ -583,9 +584,10 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
 
 //------------------------------------------------------------------------------
 void TimeStepper::prescribeState(OceanState *State1, int TimeLevel1,
-                                 OceanState *State2, int TimeLevel2) const {
+                                 OceanState *State2, int TimeLevel2,
+                                 const TimeInstant &SimTime) const {
    prescribeThickness(State1, TimeLevel1, State2, TimeLevel2);
-   prescribeVelocity(State1, TimeLevel1, State2, TimeLevel2);
+   prescribeVelocity(State1, TimeLevel1, State2, TimeLevel2, SimTime);
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -653,14 +653,15 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
              const R8 lon_p =
                  LonEdge(IEdge) - 2.0 * Pi * TSim / Tau;
              const R8 u = (1.0 / Tau) *
-                          (-10.0 * Kokkos::pow(sin(lon_p / 2), 2) *
+                          (-5.0 * Kokkos::pow(sin(lon_p / 2), 2) *
                           sin(2.0 * LatEdge(IEdge)) *
                           Kokkos::pow(cos(LatEdge(IEdge)), 2) *
-                          cos(Pi * TSim / Tau)) +
-                          2.0 * Pi * cos(LatEdge(IEdge));
-             const R8 v = (10.0 / (2 * Tau)) *
-                          (sin(lon_p) * Kokkos::pow(cos(LatEdge(IEdge)), 3) *
-                          cos(Pi * TSim / Tau));
+                          cos(Pi * TSim / Tau) +
+                          2.0 * Pi * cos(LatEdge(IEdge)));
+             const R8 v = ((2.5 / Tau) *
+                           sin(lon_p) *
+                           Kokkos::pow(cos(LatEdge(IEdge)), 3) *
+                           cos(Pi * TSim / Tau));
              const R8 normalVel = REarth * (
                  u * cos(AngleEdge(IEdge)) + v * sin(AngleEdge(IEdge)));
 

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -461,6 +461,64 @@ void TimeStepper::updateStateByTend(OceanState *State1, int TimeLevel1,
 }
 
 //------------------------------------------------------------------------------
+// Reset state variables to their initial values
+void TimeStepper::prescribeThickness(OceanState *State1, int TimeLevel1,
+                                     OceanState *State2, int TimeLevel2) const {
+
+   Array2DReal LayerThick1 = State1->getLayerThickness(TimeLevel1);
+   Array2DReal LayerThick2 = State2->getLayerThickness(TimeLevel2);
+
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
+   parallelForOuter(
+       "prescribeThickness", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K = KMin + KChunk;
+                 LayerThick1(ICell, K) = LayerThick2(ICell, K);
+              });
+       });
+}
+
+//------------------------------------------------------------------------------
+void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
+                                    OceanState *State2, int TimeLevel2) const {
+
+   Array2DReal NormalVel1 = State1->getNormalVelocity(TimeLevel1);
+   Array2DReal NormalVel2 = State2->getNormalVelocity(TimeLevel2);
+
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   parallelForOuter(
+       "prescribeVelocity", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRange(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int K = KMin + KChunk;
+                 NormalVel1(IEdge, K) = NormalVel2(IEdge, K);
+              });
+       });
+}
+
+//------------------------------------------------------------------------------
+void TimeStepper::prescribeState(OceanState *State1, int TimeLevel1,
+                                 OceanState *State2, int TimeLevel2) const {
+   prescribeThickness(State1, TimeLevel1, State2, TimeLevel2);
+   prescribeVelocity(State1, TimeLevel1, State2, TimeLevel2);
+}
+
+//------------------------------------------------------------------------------
 // Updates tracers
 // NextTracers = (CurTracers * LayerThickness2(TimeLevel2)) +
 //               Coeff * TracersTend) / LayerThickness1(TimeLevel1)

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -609,8 +609,8 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
 
              const R8 lon_p =
                  LonEdge(IEdge) - 2.0 * Pi * TSim / Tau;
-             const R8 u = (10.0 / Tau) *
-                          (Kokkos::pow(sin(lon_p), 2) *
+             const R8 u = (1 / Tau) *
+                          (10.0 * Kokkos::pow(sin(lon_p), 2) *
                            sin(2.0 * LatEdge(IEdge)) *
                            cos(Pi * TSim / Tau) +
                            2.0 * Pi * cos(LatEdge(IEdge)));
@@ -653,14 +653,14 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
              const R8 lon_p =
                  LonEdge(IEdge) - 2.0 * Pi * TSim / Tau;
              const R8 u = (1.0 / Tau) *
-                          (-10.0 / 2.0) * Kokkos::pow(sin(lon_p / 2), 2) *
+                          (-10.0 * Kokkos::pow(sin(lon_p / 2), 2) *
                           sin(2.0 * LatEdge(IEdge)) *
                           Kokkos::pow(cos(LatEdge(IEdge)), 2) *
-                          cos(Pi * TSim / Tau) +
+                          cos(Pi * TSim / Tau)) +
                           2.0 * Pi * cos(LatEdge(IEdge));
-             const R8 v = (10.0 / (4 * Tau)) *
-                          sin(lon_p) * Kokkos::pow(cos(LatEdge(IEdge)), 3) *
-                          cos(Pi * TSim / Tau);
+             const R8 v = (10.0 / (2 * Tau)) *
+                          (sin(lon_p) * Kokkos::pow(cos(LatEdge(IEdge)), 3) *
+                          cos(Pi * TSim / Tau));
              const R8 normalVel = REarth * (
                  u * cos(AngleEdge(IEdge)) + v * sin(AngleEdge(IEdge)));
 

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -12,7 +12,6 @@
 #include "RungeKutta4Stepper.h"
 
 namespace OMEGA {
-
 //------------------------------------------------------------------------------
 // create the static class members
 // Default model time stepper
@@ -20,6 +19,10 @@ TimeStepper *TimeStepper::DefaultTimeStepper = nullptr;
 // All defined time steppers
 std::map<std::string, std::unique_ptr<TimeStepper>>
     TimeStepper::AllTimeSteppers;
+PrescribeStateType TimeStepper::DefaultPrescribeThicknessMode =
+   PrescribeStateType::None;
+PrescribeStateType TimeStepper::DefaultPrescribeVelocityMode =
+   PrescribeStateType::None;
 
 //------------------------------------------------------------------------------
 // utility functions
@@ -42,6 +45,33 @@ TimeStepperType getTimeStepperFromStr(const std::string &InString) {
    }
 
    return TimeStepperChoice;
+}
+
+PrescribeStateType getPrescribeThicknessTypeFromStr(const std::string &InString) {
+
+   if (InString == "None") {
+      return PrescribeStateType::None;
+   }
+   if (InString == "Init") {
+      return PrescribeStateType::Init;
+   }
+
+   ABORT_ERROR("PrescribeStateType should be 'None' or 'Init' for thickness but got {}",
+               InString);
+   return PrescribeStateType::Invalid;
+}
+PrescribeStateType getPrescribeVelocityTypeFromStr(const std::string &InString) {
+
+   if (InString == "None") {
+      return PrescribeStateType::None;
+   }
+   if (InString == "Init") {
+      return PrescribeStateType::Init;
+   }
+
+   ABORT_ERROR("PrescribeStateType should be 'None' or 'Init' for velocity but got {}",
+               InString);
+   return PrescribeStateType::Invalid;
 }
 
 //------------------------------------------------------------------------------
@@ -119,6 +149,11 @@ TimeStepper *TimeStepper::create(
       ABORT_ERROR("Unknown time stepping method");
    }
 
+   NewTimeStepper->PrescribeThicknessMode =
+      DefaultPrescribeThicknessMode;
+   NewTimeStepper->PrescribeVelocityMode =
+      DefaultPrescribeVelocityMode;
+
    // Attach data pointers
    NewTimeStepper->attachData(InTend, InAuxState, InMesh, InVCoord, InMeshHalo);
 
@@ -169,6 +204,11 @@ TimeStepper *TimeStepper::create(
    default:
       ABORT_ERROR("Unknown time stepping method");
    }
+
+   NewTimeStepper->PrescribeThicknessMode =
+      DefaultPrescribeThicknessMode;
+   NewTimeStepper->PrescribeVelocityMode =
+      DefaultPrescribeVelocityMode;
 
    // Store instance
    AllTimeSteppers.emplace(InName, NewTimeStepper);
@@ -296,6 +336,22 @@ void TimeStepper::init1() {
    } else { // only valid StopTime supplied
       TimeInstant StopTime2(StopTimeStr);
       StopTime = StopTime2;
+   }
+
+   Config StateConfig("State");
+   Error StateErr = OmegaConfig->get(StateConfig);
+   if (StateErr.isSuccess()) {
+      std::string ThicknessMode;
+      if (StateConfig.get("PrescribeThicknessType", ThicknessMode).isSuccess()) {
+         TimeStepper::DefaultPrescribeThicknessMode =
+             getPrescribeThicknessTypeFromStr(ThicknessMode);
+      }
+
+      std::string VelocityMode;
+      if (StateConfig.get("PrescribeVelocityType", VelocityMode).isSuccess()) {
+         TimeStepper::DefaultPrescribeVelocityMode =
+             getPrescribeVelocityTypeFromStr(VelocityMode);
+      }
    }
 
    // Now that all the inputs are defined, create the default time stepper
@@ -465,50 +521,64 @@ void TimeStepper::updateStateByTend(OceanState *State1, int TimeLevel1,
 void TimeStepper::prescribeThickness(OceanState *State1, int TimeLevel1,
                                      OceanState *State2, int TimeLevel2) const {
 
-   Array2DReal LayerThick1 = State1->getLayerThickness(TimeLevel1);
-   Array2DReal LayerThick2 = State2->getLayerThickness(TimeLevel2);
+   if (PrescribeThicknessMode == PrescribeStateType::None) {
+      return;
+   }
 
-   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
-   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+   if (PrescribeThicknessMode == PrescribeStateType::Init) {
+      Array2DReal LayerThick1 = State1->getLayerThickness(TimeLevel1);
+      Array2DReal LayerThick2 = State2->getLayerThickness(TimeLevel2);
 
-   parallelForOuter(
-       "prescribeThickness", {Mesh->NCellsAll},
-       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRange(KMin, KMax);
+      OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+      OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
-          parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K = KMin + KChunk;
-                 LayerThick1(ICell, K) = LayerThick2(ICell, K);
-              });
-       });
+      parallelForOuter(
+          "prescribeThickness", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRange(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    const int K = KMin + KChunk;
+                    LayerThick1(ICell, K) = LayerThick2(ICell, K);
+                 });
+          });
+      return;
+   }
 }
 
 //------------------------------------------------------------------------------
 void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
                                     OceanState *State2, int TimeLevel2) const {
 
-   Array2DReal NormalVel1 = State1->getNormalVelocity(TimeLevel1);
-   Array2DReal NormalVel2 = State2->getNormalVelocity(TimeLevel2);
+   if (PrescribeVelocityMode == PrescribeStateType::None) {
+      return;
+   }
 
-   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
-   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+   if (PrescribeVelocityMode == PrescribeStateType::Init) {
+      Array2DReal NormalVel1 = State1->getNormalVelocity(TimeLevel1);
+      Array2DReal NormalVel2 = State2->getNormalVelocity(TimeLevel2);
 
-   parallelForOuter(
-       "prescribeVelocity", {Mesh->NEdgesAll},
-       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-          const int KMin   = MinLayerEdgeBot(IEdge);
-          const int KMax   = MaxLayerEdgeTop(IEdge);
-          const int KRange = vertRange(KMin, KMax);
+      OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+      OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
-          parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K = KMin + KChunk;
-                 NormalVel1(IEdge, K) = NormalVel2(IEdge, K);
-              });
-       });
+      parallelForOuter(
+          "prescribeVelocity", {Mesh->NEdgesAll},
+          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRange(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    const int K = KMin + KChunk;
+                    NormalVel1(IEdge, K) = NormalVel2(IEdge, K);
+                 });
+          });
+      return;
+   }
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -594,7 +594,7 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
 
       const Clock *ModelClock = StepClock.get();
       R8 ElapsedTimeSec;
-      TimeInterval ElapsedTimeInterval = SimTime - ModelClock->getCurrentTime();
+      TimeInterval ElapsedTimeInterval = SimTime - ModelClock->getStartTime();
       ElapsedTimeInterval.get(ElapsedTimeSec, TimeUnits::Seconds);
 
       const R8 Tau     = 12. * Day2Sec; // 12 days in seconds
@@ -637,7 +637,7 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
 
       const Clock *ModelClock = StepClock.get();
       R8 ElapsedTimeSec;
-      TimeInterval ElapsedTimeInterval = SimTime - ModelClock->getCurrentTime();
+      TimeInterval ElapsedTimeInterval = SimTime - ModelClock->getStartTime();
       ElapsedTimeInterval.get(ElapsedTimeSec, TimeUnits::Seconds);
 
       const R8 Tau     = 12. * Day2Sec; // 14 days in seconds

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -10,6 +10,7 @@
 #include "ForwardBackwardStepper.h"
 #include "RungeKutta2Stepper.h"
 #include "RungeKutta4Stepper.h"
+#include "Logging.h"
 
 namespace OMEGA {
 //------------------------------------------------------------------------------
@@ -64,12 +65,15 @@ PrescribeStateType getPrescribeVelocityTypeFromStr(const std::string &InString) 
 
    if (InString == "None") {
       return PrescribeStateType::None;
-   }
-   if (InString == "Init") {
+   }else if (InString == "Init") {
       return PrescribeStateType::Init;
+   }else if (InString == "NonDivergent") {
+      return PrescribeStateType::NonDivergent;
+   }else if (InString == "Divergent") {
+      return PrescribeStateType::Divergent;
    }
 
-   ABORT_ERROR("PrescribeStateType should be 'None' or 'Init' for velocity but got {}",
+   ABORT_ERROR("PrescribeStateType should be 'None', 'Init', 'NonDivergent' or 'Divergent' for velocity but got {}",
                InString);
    return PrescribeStateType::Invalid;
 }
@@ -576,6 +580,94 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
                  Team, KRange, INNER_LAMBDA(int KChunk) {
                     const int K = KMin + KChunk;
                     NormalVel2(IEdge, K) = NormalVel1(IEdge, K);
+                 });
+          });
+      return;
+   } else if (PrescribeVelocityMode == PrescribeStateType::NonDivergent) {
+      Array2DReal NormalVel2 = State2->getNormalVelocity(TimeLevel2);
+
+      OMEGA_SCOPE(LatEdge, Mesh->LatEdgeH);
+      OMEGA_SCOPE(LonEdge, Mesh->LonEdgeH);
+      OMEGA_SCOPE(AngleEdge, Mesh->AngleEdgeH);
+      OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBotH);
+      OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTopH);
+
+      const Clock *ModelClock = StepClock.get();
+      R8 ElapsedTimeSec;
+      TimeInterval ElapsedTimeInterval = SimTime - ModelClock->getCurrentTime();
+      ElapsedTimeInterval.get(ElapsedTimeSec, TimeUnits::Seconds);
+
+      const R8 Tau     = 12. * Day2Sec; // 12 days in seconds
+      const R8 TSim    = ElapsedTimeSec;
+
+      parallelForOuter(
+          "prescribeVelocityNonDivergent", {Mesh->NEdgesAll},
+          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRange(KMin, KMax);
+
+             const R8 lon_p =
+                 LonEdge(IEdge) - 2.0 * Pi * TSim / Tau;
+             const R8 u = (10.0 / Tau) *
+                          (Kokkos::pow(sin(lon_p), 2) *
+                           sin(2.0 * LatEdge(IEdge)) *
+                           cos(Pi * TSim / Tau) +
+                           2.0 * Pi * cos(LatEdge(IEdge)));
+             const R8 v = (10.0 / Tau) * sin(2.0 * lon_p) *
+                          cos(LatEdge(IEdge)) * cos(Pi * TSim / Tau);
+             const R8 normalVel = REarth * (
+                 u * cos(AngleEdge(IEdge)) + v * sin(AngleEdge(IEdge)));
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    const int K = KMin + KChunk;
+                    NormalVel2(IEdge, K) = normalVel;
+                 });
+          });
+      return;
+   } else if (PrescribeVelocityMode == PrescribeStateType::Divergent) {
+      Array2DReal NormalVel2 = State2->getNormalVelocity(TimeLevel2);
+
+      OMEGA_SCOPE(LatEdge, Mesh->LatEdgeH);
+      OMEGA_SCOPE(LonEdge, Mesh->LonEdgeH);
+      OMEGA_SCOPE(AngleEdge, Mesh->AngleEdgeH);
+      OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBotH);
+      OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTopH);
+
+      const Clock *ModelClock = StepClock.get();
+      R8 ElapsedTimeSec;
+      TimeInterval ElapsedTimeInterval = SimTime - ModelClock->getCurrentTime();
+      ElapsedTimeInterval.get(ElapsedTimeSec, TimeUnits::Seconds);
+
+      const R8 Tau     = 12. * Day2Sec; // 14 days in seconds
+      const R8 TSim    = ElapsedTimeSec;
+
+      parallelForOuter(
+          "prescribeVelocityDivergent", {Mesh->NEdgesAll},
+          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRange(KMin, KMax);
+
+             const R8 lon_p =
+                 LonEdge(IEdge) - 2.0 * Pi * TSim / Tau;
+             const R8 u = (1.0 / Tau) *
+                          (-10.0 / 2.0) * Kokkos::pow(sin(lon_p / 2), 2) *
+                          sin(2.0 * LatEdge(IEdge)) *
+                          Kokkos::pow(cos(LatEdge(IEdge)), 2) *
+                          cos(Pi * TSim / Tau) +
+                          2.0 * Pi * cos(LatEdge(IEdge));
+             const R8 v = (10.0 / (4 * Tau)) *
+                          sin(lon_p) * Kokkos::pow(cos(LatEdge(IEdge)), 3) *
+                          cos(Pi * TSim / Tau);
+             const R8 normalVel = REarth * (
+                 u * cos(AngleEdge(IEdge)) + v * sin(AngleEdge(IEdge)));
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    const int K = KMin + KChunk;
+                    NormalVel2(IEdge, K) = normalVel;
                  });
           });
       return;

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -575,7 +575,7 @@ void TimeStepper::prescribeVelocity(OceanState *State1, int TimeLevel1,
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
                     const int K = KMin + KChunk;
-                    NormalVel1(IEdge, K) = NormalVel2(IEdge, K);
+                    NormalVel2(IEdge, K) = NormalVel1(IEdge, K);
                  });
           });
       return;

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -204,6 +204,31 @@ class TimeStepper {
        TimeInterval Coeff  ///< [in] time-related coeff for tendency
    ) const;
 
+       /// Resets the layer thickness at the working time level to the initial
+       /// condition stored at the reference time level.
+       void prescribeThickness(
+           OceanState *State1, ///< [out] destination state
+           int TimeLevel1,     ///< [in] time level index of the reference data
+           OceanState *State2, ///< [in] source state (initial condition)
+           int TimeLevel2      ///< [in] time level index of the destination data
+       ) const;
+
+       /// Resets the velocity at the working time level to the initial condition.
+       void prescribeVelocity(
+           OceanState *State1, ///< [out] destination state
+           int TimeLevel1,     ///< [in] time level index of the reference data
+           OceanState *State2, ///< [in] source state (initial condition)
+           int TimeLevel2      ///< [in] time level index of the destination data
+       ) const;
+
+       /// Reset thickness and velocity to their initial values
+       void prescribeState(
+           OceanState *State1, ///< [out] destination state
+           int TimeLevel1,     ///< [in] time level index of the reference data
+           OceanState *State2, ///< [in] source state (initial condition)
+           int TimeLevel2      ///< [in] time level index of the destination data
+       ) const;
+
    /// Updates tracers
    /// NextTracers = (CurTracers * LayerThickness2(TimeLevel2)) +
    ///               Coeff * TracersTend) / LayerThickness1(TimeLevel1)

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -228,18 +228,20 @@ class TimeStepper {
 
        /// Resets the velocity at the working time level to the initial condition.
        void prescribeVelocity(
-           OceanState *State1, ///< [out] destination state
-           int TimeLevel1,     ///< [in] time level index of the reference data
-           OceanState *State2, ///< [in] source state (initial condition)
-           int TimeLevel2      ///< [in] time level index of the destination data
+           OceanState *State1,        ///< [out] destination state
+           int TimeLevel1,            ///< [in] time level index of the reference data
+           OceanState *State2,        ///< [in] source state (initial condition)
+           int TimeLevel2,            ///< [in] time level index of the destination data
+           const TimeInstant &SimTime ///< [in] current simulation time
        ) const;
 
        /// Reset thickness and velocity to their initial values
        void prescribeState(
-           OceanState *State1, ///< [out] destination state
-           int TimeLevel1,     ///< [in] time level index of the reference data
-           OceanState *State2, ///< [in] source state (initial condition)
-           int TimeLevel2      ///< [in] time level index of the destination data
+           OceanState *State1,        ///< [out] destination state
+           int TimeLevel1,            ///< [in] time level index of the reference data
+           OceanState *State2,        ///< [in] source state (initial condition)
+           int TimeLevel2,            ///< [in] time level index of the destination data
+           const TimeInstant &SimTime ///< [in] current simulation time
        ) const;
 
    /// Updates tracers

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -67,6 +67,8 @@ enum class TimeStepperType {
 enum class PrescribeStateType {
     None,
     Init,
+    NonDivergent,
+    Divergent,
     Invalid
 };
 

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -64,13 +64,7 @@ enum class TimeStepperType {
 
 /// An enum describing how a state variable should be prescribed from the
 /// reference time level
-enum class PrescribeStateType {
-    None,
-    Init,
-    NonDivergent,
-    Divergent,
-    Invalid
-};
+enum class PrescribeStateType { None, Init, NonDivergent, Divergent, Invalid };
 
 //------------------------------------------------------------------------------
 // Utility routine
@@ -219,32 +213,32 @@ class TimeStepper {
        TimeInterval Coeff  ///< [in] time-related coeff for tendency
    ) const;
 
-       /// Resets the layer thickness at the working time level to the initial
-       /// condition stored at the reference time level.
-       void prescribeThickness(
-           OceanState *State1, ///< [out] destination state
-           int TimeLevel1,     ///< [in] time level index of the reference data
-           OceanState *State2, ///< [in] source state (initial condition)
-           int TimeLevel2      ///< [in] time level index of the destination data
-       ) const;
+   /// Resets the layer thickness at the working time level to the initial
+   /// condition stored at the reference time level.
+   void prescribeThickness(
+       OceanState *State1, ///< [out] destination state
+       int TimeLevel1,     ///< [in] time level index of the reference data
+       OceanState *State2, ///< [in] source state (initial condition)
+       int TimeLevel2      ///< [in] time level index of the destination data
+   ) const;
 
-       /// Resets the velocity at the working time level to the initial condition.
-       void prescribeVelocity(
-           OceanState *State1,        ///< [out] destination state
-           int TimeLevel1,            ///< [in] time level index of the reference data
-           OceanState *State2,        ///< [in] source state (initial condition)
-           int TimeLevel2,            ///< [in] time level index of the destination data
-           const TimeInstant &SimTime ///< [in] current simulation time
-       ) const;
+   /// Resets the velocity at the working time level to the initial condition.
+   void prescribeVelocity(
+       OceanState *State1, ///< [out] destination state
+       int TimeLevel1,     ///< [in] time level index of the reference data
+       OceanState *State2, ///< [in] source state (initial condition)
+       int TimeLevel2,     ///< [in] time level index of the destination data
+       const TimeInstant &SimTime ///< [in] current simulation time
+   ) const;
 
-       /// Reset thickness and velocity to their initial values
-       void prescribeState(
-           OceanState *State1,        ///< [out] destination state
-           int TimeLevel1,            ///< [in] time level index of the reference data
-           OceanState *State2,        ///< [in] source state (initial condition)
-           int TimeLevel2,            ///< [in] time level index of the destination data
-           const TimeInstant &SimTime ///< [in] current simulation time
-       ) const;
+   /// Reset thickness and velocity to their initial values
+   void prescribeState(
+       OceanState *State1, ///< [out] destination state
+       int TimeLevel1,     ///< [in] time level index of the reference data
+       OceanState *State2, ///< [in] source state (initial condition)
+       int TimeLevel2,     ///< [in] time level index of the destination data
+       const TimeInstant &SimTime ///< [in] current simulation time
+   ) const;
 
    /// Updates tracers
    /// NextTracers = (CurTracers * LayerThickness2(TimeLevel2)) +
@@ -294,9 +288,9 @@ class TimeStepper {
    /// Time step
    TimeInterval TimeStep;
 
-    /// Prescribe state configuration
-    PrescribeStateType PrescribeThicknessMode;
-    PrescribeStateType PrescribeVelocityMode;
+   /// Prescribe state configuration
+   PrescribeStateType PrescribeThicknessMode;
+   PrescribeStateType PrescribeVelocityMode;
 
    /// Start time
    TimeInstant StartTime;
@@ -341,9 +335,9 @@ class TimeStepper {
    static TimeStepper *DefaultTimeStepper;
    /// All defined time steppers
    static std::map<std::string, std::unique_ptr<TimeStepper>> AllTimeSteppers;
-    /// Prescribe modes parsed from config
-    static PrescribeStateType DefaultPrescribeThicknessMode;
-    static PrescribeStateType DefaultPrescribeVelocityMode;
+   /// Prescribe modes parsed from config
+   static PrescribeStateType DefaultPrescribeThicknessMode;
+   static PrescribeStateType DefaultPrescribeVelocityMode;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -62,11 +62,24 @@ enum class TimeStepperType {
    Invalid
 };
 
+/// An enum describing how a state variable should be prescribed from the
+/// reference time level
+enum class PrescribeStateType {
+    None,
+    Init,
+    Invalid
+};
+
 //------------------------------------------------------------------------------
 // Utility routine
 /// Translate string for time stepper type into enum
 TimeStepperType getTimeStepperFromStr(
     const std::string &InString ///< [in] choice of time stepping method
+);
+
+/// Translate string for prescribe state type into enum
+PrescribeStateType getPrescribeStateTypeFromStr(
+    const std::string &InString ///< [in] choice of prescribe method
 );
 
 //------------------------------------------------------------------------------
@@ -277,6 +290,10 @@ class TimeStepper {
    /// Time step
    TimeInterval TimeStep;
 
+    /// Prescribe state configuration
+    PrescribeStateType PrescribeThicknessMode;
+    PrescribeStateType PrescribeVelocityMode;
+
    /// Start time
    TimeInstant StartTime;
 
@@ -320,6 +337,9 @@ class TimeStepper {
    static TimeStepper *DefaultTimeStepper;
    /// All defined time steppers
    static std::map<std::string, std::unique_ptr<TimeStepper>> AllTimeSteppers;
+    /// Prescribe modes parsed from config
+    static PrescribeStateType DefaultPrescribeThicknessMode;
+    static PrescribeStateType DefaultPrescribeVelocityMode;
 };
 
 } // namespace OMEGA


### PR DESCRIPTION
This PR ports time-varying prescribed velocity fields for the sphere transport cases:

- https://docs.e3sm.org/polaris/main/users_guide/ocean/tasks/correlated_tracers_2d.html
- https://docs.e3sm.org/polaris/main/users_guide/ocean/tasks/divergent_2d.html
- https://docs.e3sm.org/polaris/main/users_guide/ocean/tasks/nondivergent_2d.html

and provides an option for the constant prescribed velocity field in the sphere transport case:

- https://docs.e3sm.org/polaris/main/users_guide/ocean/tasks/rotation_2d.html

Checklist
* [N/A] Documentation:
  * [N/A] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
  * [N/A] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [N/A] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [N/A] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [X] Linting
  * [X] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [X] Building
  * [X] CMake build does not produce any new warnings from changes in this PR
* [X] Testing
  * [X] Add a comment to the PR titled `Testing` with the following:
    * [X] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [X] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [X] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [X] Indicate "All tests passed" or document failing tests
    * [X] Document testing used to verify the changes including any tests that are added/modified/impacted.
    * [N/A] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
  * [N/A] New tests:
    * [N/A] CTest unit tests for new features have been added per the approved design.
    * [X] Polaris tests for new features have been added per the approved design (and included in a test suite) See https://github.com/E3SM-Project/polaris/pull/500
* [X] Stealth Features
  * [N/A] If any stealth features are included in the PR, please confirm that they have been documented.
