### PR TITLE
Fix Perlmutter build with gnugpu

### DIFF
--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -135,6 +135,7 @@ endif()
 
 # Add the cpptrace library
 if (NOT TARGET cpptrace::cpptrace)
+	option(CPPTRACE_INHERIT_HOST_STANDARD "" ON)
 	add_subdirectory(
 	  ${E3SM_EXTERNALS_ROOT}/cpptrace
 	  ${CMAKE_CURRENT_BINARY_DIR}/cpptrace


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

This PR:
- updates `cpptrace` submodule
- sets a CMake variable to make `cpptrace` inherit Omega C++ standard

This is done to fix a configure issue on Perlmutter with gnugpu. Fixes #364.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


