### PR TITLE
Set vertical bounds to prevent accesses outside of halo region

### DIFF
--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -142,10 +142,12 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    NCellsSize  = Decomp->NCellsSize;
 
    NEdgesOwned = Decomp->NEdgesOwned;
+   NEdgesHalo0 = Decomp->NEdgesHaloH(0);
    NEdgesAll   = Decomp->NEdgesAll;
    NEdgesSize  = Decomp->NEdgesSize;
 
    NVerticesOwned = Decomp->NVerticesOwned;
+   NVerticesHalo0 = Decomp->NVerticesHaloH(0);
    NVerticesAll   = Decomp->NVerticesAll;
    NVerticesSize  = Decomp->NVerticesSize;
    VertexDegree   = Decomp->VertexDegree;
@@ -626,6 +628,22 @@ void VertCoord::minMaxLayerEdge(Halo *MeshHalo) {
           LocMaxLayerEdgeBot(LocNEdgesAll) = -1;
        });
 
+   // Set the [MinLayerEdgeBot, MaxLayerEdgeTop] range to be invalid
+   // on the outermost edges of the halo layer.
+   OMEGA_SCOPE(LocNEdgesHalo0, NEdgesHalo0);
+   // start from NEdgesHalo(0) to exclude any edges of the owned cells
+   parallelFor(
+       {NEdgesAll - NEdgesHalo0}, KOKKOS_LAMBDA(int EdgeOffset) {
+          const int IEdge = LocNEdgesHalo0 + EdgeOffset;
+
+          // Is any cell on this edge an invalid (remote) cell ?
+          if (LocCellsOnEdge(IEdge, 0) == LocNEdgesAll ||
+              LocCellsOnEdge(IEdge, 1) == LocNEdgesAll) {
+             LocMinLayerEdgeBot(IEdge) = LocNVertLayersP1;
+             LocMaxLayerEdgeTop(IEdge) = -1;
+          }
+       });
+
    MinLayerEdgeTopH = createHostMirrorCopy(MinLayerEdgeTop);
    MinLayerEdgeBotH = createHostMirrorCopy(MinLayerEdgeBot);
    MaxLayerEdgeTopH = createHostMirrorCopy(MaxLayerEdgeTop);
@@ -706,6 +724,27 @@ void VertCoord::minMaxLayerVertex(Halo *MeshHalo) {
           LocMinLayerVertexBot(LocNVerticesAll) = LocNVertLayersP1;
           LocMaxLayerVertexTop(LocNVerticesAll) = -1;
           LocMaxLayerVertexBot(LocNVerticesAll) = -1;
+       });
+
+   // Set the [MinLayerVertexBot, MaxLayerVertexTop] range to be invalid
+   // on the outermost vertices of the halo layer.
+   OMEGA_SCOPE(LocNVerticesHalo0, NVerticesHalo0);
+   // start from NVerticesHalo(0) to exclude any vertices of the owned cells
+   parallelFor(
+       {NVerticesAll - NVerticesHalo0}, KOKKOS_LAMBDA(int VertexOffset) {
+          const int IVertex = LocNVerticesHalo0 + VertexOffset;
+
+          // Is any cell on this vertex an invalid (remote) cell ?
+          bool IsOuterMost = LocCellsOnVertex(IVertex, 0) == LocNVerticesAll;
+          for (int I = 1; I < LocVertexDegree; ++I) {
+             IsOuterMost =
+                 IsOuterMost || LocCellsOnVertex(IVertex, I) == LocNVerticesAll;
+          }
+
+          if (IsOuterMost) {
+             LocMinLayerVertexBot(IVertex) = LocNVertLayersP1;
+             LocMaxLayerVertexTop(IVertex) = -1;
+          }
        });
 
    MinLayerVertexTopH = createHostMirrorCopy(MinLayerVertexTop);

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -631,14 +631,15 @@ void VertCoord::minMaxLayerEdge(Halo *MeshHalo) {
    // Set the [MinLayerEdgeBot, MaxLayerEdgeTop] range to be invalid
    // on the outermost edges of the halo layer.
    OMEGA_SCOPE(LocNEdgesHalo0, NEdgesHalo0);
+   OMEGA_SCOPE(LocNCellsAll, NCellsAll);
    // start from NEdgesHalo(0) to exclude any edges of the owned cells
    parallelFor(
        {NEdgesAll - NEdgesHalo0}, KOKKOS_LAMBDA(int EdgeOffset) {
           const int IEdge = LocNEdgesHalo0 + EdgeOffset;
 
           // Is any cell on this edge an invalid (remote) cell ?
-          if (LocCellsOnEdge(IEdge, 0) == LocNEdgesAll ||
-              LocCellsOnEdge(IEdge, 1) == LocNEdgesAll) {
+          if (LocCellsOnEdge(IEdge, 0) == LocNCellsAll ||
+              LocCellsOnEdge(IEdge, 1) == LocNCellsAll) {
              LocMinLayerEdgeBot(IEdge) = LocNVertLayersP1;
              LocMaxLayerEdgeTop(IEdge) = -1;
           }
@@ -729,16 +730,17 @@ void VertCoord::minMaxLayerVertex(Halo *MeshHalo) {
    // Set the [MinLayerVertexBot, MaxLayerVertexTop] range to be invalid
    // on the outermost vertices of the halo layer.
    OMEGA_SCOPE(LocNVerticesHalo0, NVerticesHalo0);
+   OMEGA_SCOPE(LocNCellsAll, NCellsAll);
    // start from NVerticesHalo(0) to exclude any vertices of the owned cells
    parallelFor(
        {NVerticesAll - NVerticesHalo0}, KOKKOS_LAMBDA(int VertexOffset) {
           const int IVertex = LocNVerticesHalo0 + VertexOffset;
 
           // Is any cell on this vertex an invalid (remote) cell ?
-          bool IsOuterMost = LocCellsOnVertex(IVertex, 0) == LocNVerticesAll;
+          bool IsOuterMost = LocCellsOnVertex(IVertex, 0) == LocNCellsAll;
           for (int I = 1; I < LocVertexDegree; ++I) {
              IsOuterMost =
-                 IsOuterMost || LocCellsOnVertex(IVertex, I) == LocNVerticesAll;
+                 IsOuterMost || LocCellsOnVertex(IVertex, I) == LocNCellsAll;
           }
 
           if (IsOuterMost) {

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -59,9 +59,11 @@ class VertCoord {
    I4 NCellsAll;
    I4 NCellsSize;
    I4 NEdgesOwned;
+   I4 NEdgesHalo0;
    I4 NEdgesAll;
    I4 NEdgesSize;
    I4 NVerticesOwned;
+   I4 NVerticesHalo0;
    I4 NVerticesAll;
    I4 NVerticesSize;
    I4 VertexDegree;


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
This PR changes how the `[MinLayerEdgeBot, MaxLayerEdgeTop]` and `[MinLayerVertexBot, MaxLayerVertexTop]` index ranges are defined for the outermost edges and vertices of the halo layer. In this PR they are set to be invalid (empty) ranges to prevent accesses outside the halo.

Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


