### PR TITLE
Exchange state halos at every Runge-Kutta stage

### DIFF
--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -44,7 +44,7 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    updateTracersByTend(NextTracerArray, CurTracerArray, State, NextLevel, State,
                        CurLevel, 0.5 * TimeStep);
 
-   // We need to exchange tracer halos at every stage for high-order advection
+   State->exchangeHalo(NextLevel);
    MeshHalo->exchangeFullArrayHalo(NextTracerArray, OnCell);
 
    // R_q^{n+0.5} = RHS_q(u^{n+0.5}, h^{n+0.5}, phi^{n+0.5}, t^{n+0.5})

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -101,12 +101,7 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
 
          Pacer::timingBarrier("RK4:haloExchProvisBarrier", 3, Comm);
          Pacer::start("RK4:haloExchProvis", 3);
-         // TODO(mwarusz) this depends on halo width actually
-         if (Stage == 2) {
-            ProvisState->exchangeHalo(CurLevel);
-         }
-         // We need to exchange tracer halos at every stage for high-order
-         // advection
+         ProvisState->exchangeHalo(CurLevel);
          MeshHalo->exchangeFullArrayHalo(ProvisTracers, OnCell);
          Pacer::stop("RK4:haloExchProvis", 3);
 


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

 #354 added a halo exchange for tracers at every Runge-Kutta stage. To have valid halo data for the del4 velocity tendency, we also need to perform it at every stage for the state variables.

Fixes #376.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests
    * [x] Document testing used to verify the changes including any tests that are added/modified/impacted.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


