### PR TITLE
Ykim/omega/cpptrace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -83,12 +83,12 @@
 	path = components/gcam/src
 	url = git@github.com:E3SM-Project/giac
 	branch = aldivi/iac_gcam6_merge_co2
-[submodule "externals/cpptrace"]
-	path = externals/cpptrace
-	url = git@github.com:jeremy-rifkin/cpptrace
 [submodule "components/omega/external/yaml-cpp"]
 	path = components/omega/external/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp.git
 [submodule "components/omega/external/GSW-C"]
 	path = components/omega/external/GSW-C
 	url = git@github.com:E3SM-Project/GSW-C.git
+[submodule "components/omega/external/cpptrace"]
+	path = components/omega/external/cpptrace
+	url = https://github.com/jeremy-rifkin/cpptrace.git

--- a/components/omega/doc/devGuide/CMakeBuild.md
+++ b/components/omega/doc/devGuide/CMakeBuild.md
@@ -124,7 +124,6 @@ git submodule update --init --recursive \
 	externals/YAKL \
 	externals/ekat \
 	externals/scorpio \
-	externals/cpptrace \
 	components/omega/external \
 	cime
 ```

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -137,7 +137,7 @@ endif()
 if (NOT TARGET cpptrace::cpptrace)
 	option(CPPTRACE_INHERIT_HOST_STANDARD "" ON)
 	add_subdirectory(
-	  ${E3SM_EXTERNALS_ROOT}/cpptrace
-	  ${CMAKE_CURRENT_BINARY_DIR}/cpptrace
+	  ${OMEGA_SOURCE_DIR}/external/cpptrace
+	  ${CMAKE_CURRENT_BINARY_DIR}/external/cpptrace
 	)
 endif()


### PR DESCRIPTION
Moves `cpptrace` from `E3SM/externals` to `E3SM/compoments/omega/external`.

CTests are passed on `PM-GPU`, `PM-CPU`, and `Chrysalis`.

Checklist
* [X] Documentation:
  * [X] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
* [X] Building
  * [X] CMake build does not produce any new warnings from changes in this PR
* [X] Testing
  * [X] Add a comment to the PR titled `Testing` with the following:
    * [X] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.

