### PR TITLE
Refactor hierarchical parallelism wrappers

### DIFF
--- a/components/omega/doc/devGuide/ParallelLoops.md
+++ b/components/omega/doc/devGuide/ParallelLoops.md
@@ -358,7 +358,7 @@ To enable scratch memory, the outer loops needs to be launched with the `LaunchC
 configured with the requested number of scratch values.
 Inside the outer loop, unmanaged scratch arrays can be created from a pool of memory accessible
 by calling the `teamScratch(Team)` function.
-Scratch arrays have a different type than normal Omega arrays, for example `ArrayScratch1DReal` is the
+Scratch arrays have a different type than normal Omega arrays, for example `ScratchArray1DReal` is the
 type of a 1D scratch array of Reals. They also cannot have labels.
 
 As an example, the following code uses scratch memory to compute an expensive function on elements of a 2D array `A`.
@@ -370,7 +370,7 @@ By using scratch memory, the expensive function is only computed once for every 
        LaunchConfig({N1}, TeamScratch<Real>(N2)),
        KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
 
-        ArrayScratch1DReal SA(teamScratch(Team), N2);
+        ScratchArray1DReal SA(teamScratch(Team), N2);
 
         parallelForInner(Team, N2, INNER_LAMBDA (int J2) {
             SA(J2) = expensiveFunc(A(J1, J2));
@@ -392,8 +392,8 @@ You can create multiple scratch arrays of different types, as in the following c
    parallelForOuter(
        LaunchConfig({N1}, TeamScratch<Real, I4>(4, 8)),
        KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
-        ArrayScratch1DI4 ScratchI4(teamScratch(Team), 8);
-        ArrayScratch1DReal ScratchReal(teamScratch(Team), 4);
+        ScratchArray1DI4 ScratchI4(teamScratch(Team), 8);
+        ScratchArray1DReal ScratchReal(teamScratch(Team), 4);
    });
 ```
 As the above example illustrates, the order in which the arrays are created inside the outer region

--- a/components/omega/doc/devGuide/ParallelLoops.md
+++ b/components/omega/doc/devGuide/ParallelLoops.md
@@ -192,7 +192,7 @@ a 3D array in parallel using hierarchical parallelism.
    Array3DReal A("A", N1, N2, N3);
    parallelForOuter(
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
-        parallelForInner(Team, N3, INNER_LAMBDA(Int J3) {
+        parallelForInner(Team, N3, INNER_LAMBDA(int J3) {
           A(J1, J2, J3) = J1 + J2 + J3;
         });
     });
@@ -204,7 +204,7 @@ diagonal of a square matrix one can do:
    Array2DReal M("M", N, N);
    parallelForOuter(
        {N}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
-        parallelForInner(Team, J1, INNER_LAMBDA(Int J2) {
+        parallelForInner(Team, J1, INNER_LAMBDA(int J2) {
           M(J1, J2) = J1 + J2;
         });
     });
@@ -220,7 +220,7 @@ in a 2D array might be done as follows.
    parallelForOuter(
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
         Real SumD3;
-        parallelReduceInner(Team, N3, INNER_LAMBDA(Int J3, Real &Accum) {
+        parallelReduceInner(Team, N3, INNER_LAMBDA(int J3, Real &Accum) {
             Accum += A(J1, J2, J3);
         }, SumD3);
         B(J1, J2) = SumD3;
@@ -234,10 +234,10 @@ For example, to additionally compute and store maxima along the third dimension 
    parallelForOuter(
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
         Real SumD3, MaxD3;
-        parallelReduceInner(Team, N3, INNER_LAMBDA(Int J3, Real &AccumSum, Real &AccumMax) {
+        parallelReduceInner(Team, N3, INNER_LAMBDA(int J3, Real &AccumSum, Real &AccumMax) {
             AccumSum += A(J1, J2, J3);
-            AccumMax = Kokkos::Max(AccumMax, A(J1, J2, J3));
-        }, SumN3, MaxN3);
+            AccumMax = Kokkos::max(AccumMax, A(J1, J2, J3));
+        }, SumD3, Kokkos::Max<Real>(MaxD3));
         B(J1, J2) = SumD3;
         C(J1, J2) = MaxD3;
     });
@@ -254,7 +254,7 @@ be done as follows.
    Array3DReal D("D", N1, N2, N3);
    parallelForOuter(
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
-       parallelScanInner(Team, N1, INNER_LAMBDA(Int J3, Real &Accum, bool IsFinal) {
+       parallelScanInner(Team, N3, INNER_LAMBDA(int J3, Real &Accum, bool IsFinal) {
             Accum += A(J1, J2, J3);
             if (IsFinal) {
               D(J1, J2, J3) = Accum;
@@ -267,7 +267,7 @@ before the `if` statement. That is, it performs an inclusive scan. To compute an
 simply move the addition after the `if` statement.
 ```c++
   Real FinalScanValue;
-  parallelScanInner(Team, N1, INNER_LAMBDA(Int J3, Real &Accum, bool IsFinal) {
+  parallelScanInner(Team, N3, INNER_LAMBDA(int J3, Real &Accum, bool IsFinal) {
        if (IsFinal) {
          D(J1, J2, J3) = Accum;
        }
@@ -280,19 +280,20 @@ and only one-dimensional index range can be used. In contrast to `parallelReduce
 `parallelScanInner` supports only sum-based scans and only one scan variable.
 
 ### parallelSearchInner
-To search an index range in parallel for the first index where a given condition occurs Omega
-provides the `parallelSearchInner` function.
+To search an index range in parallel for the first index at which a given condition occurs,
+Omega provides the `parallelSearchInner` function.
 For example, the following code finds, for each row of a matrix, the first column index where
 the matrix element is above a certain threshold. If no element matches the condition then
 `parallelSearchInner` returns `-1`.
 ```c++
    Array2DReal M("M", N1, N2);
-   Array1DI3 ThresholdIdx("ThresholdIdx", N1);
+   Array1DI4 ThresholdIdx("ThresholdIdx", N1);
+   const Real Threshold = 0.5;
    parallelForOuter(
        {N1}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
 
        int Idx;
-       parallelSearchInner(Team, N2, INNER_LAMBDA(Int J2) {
+       parallelSearchInner(Team, N2, INNER_LAMBDA(int J2) {
             return M(J1, J2) > Threshold;
        }, Idx);
 

--- a/components/omega/doc/devGuide/ParallelLoops.md
+++ b/components/omega/doc/devGuide/ParallelLoops.md
@@ -165,9 +165,9 @@ The second way uses a helper struct `Range` to provide a range of valid indices
    });
 ```
 Note that this range is inclusive, i.e. the loop index `K` takes values from `N1` up to and including `N2`.
-This means that `Range{0, N}` specifies a diffrent range than the first example.
-For simplicity, most examples in this document use the first way of specyfying the range,
-but a `Range` argument can be passed to all inner iteration patters.
+This means that `Range{0, N}` specifies a different range than the first example.
+For simplicity, most examples in this document use the first way of specifying the range,
+but a `Range` argument can be passed to all inner iteration patterns.
 
 
 ### parallelForOuter
@@ -324,7 +324,7 @@ Labels are not supported by `parallelSearchInner` and only one-dimensional index
 
 ### Launch Config
 
-While specyfing loop bounds is enough to start an outer parallel loop, sometimes more control over the underlaying
+While specifying loop bounds is enough to start an outer parallel loop, sometimes more control over the underlying
 Kokkos `TeamPolicy` is desired. The most common use case is utilizing scratch memory, a concept discussed more
 thoroughly in the next sub-section. To enable more control, outer loops can be launched by providing
 a `LaunchConfig` struct as the first argument, which is composed of three parts:
@@ -341,7 +341,7 @@ with team size of 32 and enough scratch memory for 8 `Real` values and 4 `I4` va
    });
 ```
 It is not necessary to provide all three arguments to `LaunchConfig`. If you want the default team size,
-or you don't need any scratch memory, you can use the follwing constructors.
+or you don't need any scratch memory, you can use the following constructors.
 ```c++
    auto LConfig1 = LaunchConfig({N1, N2}, TeamScratch<Real, I4>(8, 4));
    auto LConfig2 = LaunchConfig({N1, N2}, 32);
@@ -356,7 +356,7 @@ In hierarchical code, it is often useful to have some amount of scratch memory p
 Scratch memory enables reuse of expensive to compute data in inner loops.
 To enable scratch memory, the outer loops needs to be launched with the `LaunchConfig` parameter described above,
 configured with the requested number of scratch values.
-Inside the outer loop, unmanaged scratch arrays can be created from a pool of memory accesible
+Inside the outer loop, unmanaged scratch arrays can be created from a pool of memory accessible
 by calling the `teamScratch(Team)` function.
 Scratch arrays have a different type than normal Omega arrays, for example `ArrayScratch1DReal` is the
 type of a 1D scratch array of Reals. They also cannot have labels.

--- a/components/omega/doc/devGuide/ParallelLoops.md
+++ b/components/omega/doc/devGuide/ParallelLoops.md
@@ -115,6 +115,7 @@ The following inner iteration patterns are supported in Omega:
 - `parallelForInner`
 - `parallelReduceInner`
 - `parallelScanInner`
+- `parallelSearchInner`
 
 To provide even more flexibility, the outer loops support iterating over a multi-dimensional range.
 Currently, the inner loops are limited to one dimension.
@@ -277,3 +278,25 @@ Moreover, this example illustrates that the final scan value can be obtained by 
 an additional argument `FinalScanValue`. Labels are not supported by `parallelScanInner`
 and only one-dimensional index range can be used. In contrast to `parallelReduceInner`,
 `parallelScanInner` supports only sum-based scans and only one scan variable.
+
+### parallelSearchInner
+To search an index range in parallel for the first index where a given condition occurs Omega
+provides the `parallelSearchInner` function.
+For example, the following code finds, for each row of a matrix, the first column index where
+the matrix element is above a certain threshold. If no element matches the condition then
+`parallelSearchInner` returns `-1`.
+```c++
+   Array2DReal M("M", N1, N2);
+   Array1DI3 ThresholdIdx("ThresholdIdx", N1);
+   parallelForOuter(
+       {N1}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+
+       int Idx;
+       parallelSearchInner(Team, N2, INNER_LAMBDA(Int J2) {
+            return M(J1, J2) > Threshold;
+       }, Idx);
+
+       ThresholdIdx(J1) = Idx;
+   });
+```
+Labels are not supported by `parallelSearchInner` and only one-dimensional index range can be used.

--- a/components/omega/doc/devGuide/ParallelLoops.md
+++ b/components/omega/doc/devGuide/ParallelLoops.md
@@ -150,6 +150,26 @@ To do that Kokkos provides the `single` function. To execute a statement once pe
   });
 ```
 
+### Inner Iteration Ranges
+
+There are two ways of specifying the iteration range of an inner loop.
+The first takes the total number of iterations `N` as the second argument
+```c++
+   parallelForInner(Team, N, INNER_LAMBDA (int K) {
+   });
+```
+and the loop index `K` takes values from `0` up to and including `N - 1`.
+The second way uses a helper struct `Range` to provide a range of valid indices
+```c++
+   parallelForInner(Team, Range{N1, N2}, INNER_LAMBDA (int K) {
+   });
+```
+Note that this range is inclusive, i.e. the loop index `K` takes values from `N1` up to and including `N2`.
+This means that `Range{0, N}` specifies a diffrent range than the first example.
+For simplicity, most examples in this document use the first way of specyfying the range,
+but a `Range` argument can be passed to all inner iteration patters.
+
+
 ### parallelForOuter
 To start outer iterations over a multidimensional index range the `parallelForOuter` wrapper is available.
 A call to `parallelForOuter` might look as follows.
@@ -301,3 +321,80 @@ the matrix element is above a certain threshold. If no element matches the condi
    });
 ```
 Labels are not supported by `parallelSearchInner` and only one-dimensional index range can be used.
+
+### Launch Config
+
+While specyfing loop bounds is enough to start an outer parallel loop, sometimes more control over the underlaying
+Kokkos `TeamPolicy` is desired. The most common use case is utilizing scratch memory, a concept discussed more
+thoroughly in the next sub-section. To enable more control, outer loops can be launched by providing
+a `LaunchConfig` struct as the first argument, which is composed of three parts:
+- loop bounds,
+- team size,
+- amount of scratch memory.
+
+For example, the following snippet launches a loop iterating over a two-dimensional index range
+with team size of 32 and enough scratch memory for 8 `Real` values and 4 `I4` values per team.
+```c++
+   auto LConfig = LaunchConfig({N1, N2}, 32, TeamScratch<Real, I4>(8, 4));
+   parallelForOuter(LConfig,
+       KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
+   });
+```
+It is not necessary to provide all three arguments to `LaunchConfig`. If you want the default team size,
+or you don't need any scratch memory, you can use the follwing constructors.
+```c++
+   auto LConfig1 = LaunchConfig({N1, N2}, TeamScratch<Real, I4>(8, 4));
+   auto LConfig2 = LaunchConfig({N1, N2}, 32);
+```
+For simplicity, most examples in this document use the simple form of launching outer loops with just the bounds,
+but `LaunchConfig` can be used for all types of outer parallel loops.
+Inner parallel loops cannot use `LaunchConfig`.
+
+### Team Scratch Memory
+
+In hierarchical code, it is often useful to have some amount of scratch memory private to each team.
+Scratch memory enables reuse of expensive to compute data in inner loops.
+To enable scratch memory, the outer loops needs to be launched with the `LaunchConfig` parameter described above,
+configured with the requested number of scratch values.
+Inside the outer loop, unmanaged scratch arrays can be created from a pool of memory accesible
+by calling the `teamScratch(Team)` function.
+Scratch arrays have a different type than normal Omega arrays, for example `ArrayScratch1DReal` is the
+type of a 1D scratch array of Reals. They also cannot have labels.
+
+As an example, the following code uses scratch memory to compute an expensive function on elements of a 2D array `A`.
+It then computes finite differences along the second dimension of the scratch array, and stores them in `A`.
+By using scratch memory, the expensive function is only computed once for every element, and there is no need for global memory allocation.
+```c++
+   Array2DReal A("A", N1, N2);
+   parallelForOuter(
+       LaunchConfig({N1}, TeamScratch<Real>(N2)),
+       KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+
+        ArrayScratch1DReal SA(teamScratch(Team), N2);
+
+        parallelForInner(Team, N2, INNER_LAMBDA (int J2) {
+            SA(J2) = expensiveFunc(A(J1, J2));
+        });
+
+        teamBarrier(Team);
+
+        parallelForInner(Team, N2, INNER_LAMBDA (int J2) {
+
+            const int J2M1 = Kokkos::max(J2 - 1, 0);
+            const int J2P1 = Kokkos::min(J2 + 1, N2 - 1);
+
+            A(J1, J2) = SA(J2P1) - SA(J2M1);
+        });
+   });
+```
+You can create multiple scratch arrays of different types, as in the following code.
+```c++
+   parallelForOuter(
+       LaunchConfig({N1}, TeamScratch<Real, I4>(4, 8)),
+       KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+        ArrayScratch1DI4 ScratchI4(teamScratch(Team), 8);
+        ArrayScratch1DReal ScratchReal(teamScratch(Team), 4);
+   });
+```
+As the above example illustrates, the order in which the arrays are created inside the outer region
+doesn't need to match the order of arguments to `TeamScratch`.

--- a/components/omega/src/base/TriDiagSolvers.h
+++ b/components/omega/src/base/TriDiagSolvers.h
@@ -57,11 +57,10 @@ struct ThomasSolver {
 
    // Create a Kokkos team policy for solving NBatch systems of size NRow
    // and set scratch size
-   static TeamPolicy makeTeamPolicy(int NBatch, int NRow) {
-      TeamPolicy Policy((NBatch + VecLength - 1) / VecLength, 1, 1);
-      Policy.set_scratch_size(
-          0, Kokkos::PerTeam(4 * NRow * VecLength * sizeof(Real)));
-      return Policy;
+   static LaunchConfig<1> makeLaunchConfig(int NBatch, int NRow) {
+      const int NTeams   = (NBatch + VecLength - 1) / VecLength;
+      const int NScratch = 4 * NRow * VecLength;
+      return LaunchConfig({NTeams}, 1, TeamScratch<Real>(NScratch));
    }
 
    // Solve the system defined in the scratch data argument `Scratch`
@@ -101,11 +100,11 @@ struct ThomasSolver {
       const int NBatch = X.extent_int(0);
       const int NRow   = X.extent_int(1);
 
-      TeamPolicy Policy = makeTeamPolicy(NBatch, NRow);
+      auto LConfig = makeLaunchConfig(NBatch, NRow);
 
-      Kokkos::parallel_for(
-          Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
-             const int IStart = Member.league_rank() * VecLength;
+      parallelForOuter(
+          LConfig, KOKKOS_LAMBDA(const int IChunk, const TeamMember &Member) {
+             const int IStart = IChunk * VecLength;
 
              TriDiagScratch Scratch(Member, NRow);
 
@@ -140,11 +139,9 @@ struct PCRSolver {
 
    // Create a Kokkos team policy for solving NBatch systems of size NRow
    // and set scratch size
-   static TeamPolicy makeTeamPolicy(int NBatch, int NRow) {
-      TeamPolicy Policy(NBatch, NRow, 1);
-      Policy.set_scratch_size(
-          0, Kokkos::PerTeam(4 * NRow * VecLength * sizeof(Real)));
-      return Policy;
+   static LaunchConfig<1> makeLaunchConfig(int NBatch, int NRow) {
+      const int NScratch = 4 * NRow * VecLength;
+      return LaunchConfig({NBatch}, NRow, TeamScratch<Real>(NScratch));
    }
 
    // Solve the system defined in the scratch data argument `Scratch`
@@ -218,13 +215,12 @@ struct PCRSolver {
    static void solve(const Array2DReal &DL, const Array2DReal &D,
                      const Array2DReal &DU, const Array2DReal &X) {
 
-      const int NBatch  = X.extent_int(0);
-      const int NRow    = X.extent_int(1);
-      TeamPolicy Policy = makeTeamPolicy(NBatch, NRow);
+      const int NBatch = X.extent_int(0);
+      const int NRow   = X.extent_int(1);
+      auto LConfig     = makeLaunchConfig(NBatch, NRow);
 
-      Kokkos::parallel_for(
-          Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
-             const int I = Member.league_rank();
+      parallelForOuter(
+          LConfig, KOKKOS_LAMBDA(int I, const TeamMember &Member) {
              const int K = Member.team_rank();
 
              TriDiagScratch Scratch(Member, NRow);
@@ -264,11 +260,10 @@ struct ThomasDiffusionSolver {
 
    // Create a Kokkos team policy for solving NBatch systems of size NRow
    // and set scratch size
-   static TeamPolicy makeTeamPolicy(int NBatch, int NRow) {
-      TeamPolicy Policy((NBatch + VecLength - 1) / VecLength, 1, 1);
-      Policy.set_scratch_size(
-          0, Kokkos::PerTeam(4 * NRow * VecLength * sizeof(Real)));
-      return Policy;
+   static LaunchConfig<1> makeLaunchConfig(int NBatch, int NRow) {
+      const int NTeams   = (NBatch + VecLength - 1) / VecLength;
+      const int NScratch = 4 * NRow * VecLength;
+      return LaunchConfig({NTeams}, 1, TeamScratch<Real>(NScratch));
    }
 
    // Solve the system defined in the scratch data argument `Scratch`
@@ -327,11 +322,11 @@ struct ThomasDiffusionSolver {
       const int NBatch = X.extent_int(0);
       const int NRow   = X.extent_int(1);
 
-      TeamPolicy Policy = makeTeamPolicy(NBatch, NRow);
+      auto LConfig = makeLaunchConfig(NBatch, NRow);
 
-      Kokkos::parallel_for(
-          Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
-             const int IStart = Member.league_rank() * VecLength;
+      parallelForOuter(
+          LConfig, KOKKOS_LAMBDA(int IChunk, const TeamMember &Member) {
+             const int IStart = IChunk * VecLength;
 
              TriDiagDiffScratch Scratch(Member, NRow);
 
@@ -365,11 +360,9 @@ struct PCRDiffusionSolver {
 
    // Create a Kokkos team policy for solving NBatch systems of size NRow
    // and set scratch size
-   static TeamPolicy makeTeamPolicy(int NBatch, int NRow) {
-      TeamPolicy Policy(NBatch, NRow, 1);
-      Policy.set_scratch_size(
-          0, Kokkos::PerTeam(4 * NRow * VecLength * sizeof(Real)));
-      return Policy;
+   static LaunchConfig<1> makeLaunchConfig(int NBatch, int NRow) {
+      const int NScratch = 4 * NRow * VecLength;
+      return LaunchConfig({NBatch}, NRow, TeamScratch<Real>(NScratch));
    }
 
    // Solve the system defined in the scratch data argument `Scratch`
@@ -461,10 +454,9 @@ struct PCRDiffusionSolver {
       const int NBatch = X.extent_int(0);
       const int NRow   = X.extent_int(1);
 
-      TeamPolicy Policy = makeTeamPolicy(NBatch, NRow);
-      Kokkos::parallel_for(
-          Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
-             const int I = Member.league_rank();
+      auto LConfig = makeLaunchConfig(NBatch, NRow);
+      parallelForOuter(
+          LConfig, KOKKOS_LAMBDA(int I, const TeamMember &Member) {
              const int K = Member.team_rank();
 
              TriDiagDiffScratch Scratch(Member, NRow);

--- a/components/omega/src/base/TriDiagSolvers.h
+++ b/components/omega/src/base/TriDiagSolvers.h
@@ -47,9 +47,9 @@ struct TriDiagScratch {
    TriDiagScratchArray X; // rhs on input, contains solution after calling solve
 
    // Constructor takes team member and system size
-   KOKKOS_FUNCTION TriDiagScratch(const TeamMember &Member, int NRow)
-       : DL(Member.team_scratch(0), NRow), D(Member.team_scratch(0), NRow),
-         DU(Member.team_scratch(0), NRow), X(Member.team_scratch(0), NRow) {}
+   KOKKOS_FUNCTION TriDiagScratch(const TeamMember &Team, int NRow)
+       : DL(teamScratch(Team), NRow), D(teamScratch(Team), NRow),
+         DU(teamScratch(Team), NRow), X(teamScratch(Team), NRow) {}
 };
 
 // Thomas algorithm solver for general tridiagonal systems
@@ -66,7 +66,7 @@ struct ThomasSolver {
    // Solve the system defined in the scratch data argument `Scratch`
    // This a team-level function that needs to be called inside a
    // parallel loop using TeamPolicy, hence it has a team member argument
-   static void KOKKOS_FUNCTION solve(const TeamMember &Member,
+   static void KOKKOS_FUNCTION solve(const TeamMember &Team,
                                      const TriDiagScratch &Scratch) {
       const int NRow = Scratch.X.extent_int(0);
 
@@ -103,10 +103,10 @@ struct ThomasSolver {
       auto LConfig = makeLaunchConfig(NBatch, NRow);
 
       parallelForOuter(
-          LConfig, KOKKOS_LAMBDA(const int IChunk, const TeamMember &Member) {
+          LConfig, KOKKOS_LAMBDA(const int IChunk, const TeamMember &Team) {
              const int IStart = IChunk * VecLength;
 
-             TriDiagScratch Scratch(Member, NRow);
+             TriDiagScratch Scratch(Team, NRow);
 
              for (int K = 0; K < NRow; ++K) {
                 for (int IVec = 0; IVec < VecLength; ++IVec) {
@@ -120,7 +120,7 @@ struct ThomasSolver {
                 }
              }
 
-             solve(Member, Scratch);
+             solve(Team, Scratch);
 
              for (int IVec = 0; IVec < VecLength; ++IVec) {
                 for (int K = 0; K < NRow; ++K) {
@@ -147,12 +147,12 @@ struct PCRSolver {
    // Solve the system defined in the scratch data argument `Scratch`
    // This a team-level function that needs to be called inside a
    // parallel loop using TeamPolicy, hence it has a team member argument
-   static void KOKKOS_FUNCTION solve(const TeamMember &Member,
+   static void KOKKOS_FUNCTION solve(const TeamMember &Team,
                                      const TriDiagScratch &Scratch) {
       const int NRow = Scratch.X.extent_int(0);
 
       // Row index = Thread index
-      const int K = Member.team_rank();
+      const int K = Team.team_rank();
 
       // Number of reduction levels
       const int NLevels = Kokkos::ceil(Kokkos::log2(NRow));
@@ -178,7 +178,7 @@ struct PCRSolver {
          const Real NewDL = alpha * Scratch.DL(Kmh, 0);
          const Real NewDU = gamma * Scratch.DU(Kph, 0);
 
-         Member.team_barrier();
+         teamBarrier(Team);
 
          // Store new system coefficients
          Scratch.D(K, 0)  = NewD;
@@ -186,7 +186,7 @@ struct PCRSolver {
          Scratch.DL(K, 0) = NewDL;
          Scratch.DU(K, 0) = NewDU;
 
-         Member.team_barrier();
+         teamBarrier(Team);
       }
 
       const int Stride = 1 << (NLevels - 1);
@@ -220,21 +220,21 @@ struct PCRSolver {
       auto LConfig     = makeLaunchConfig(NBatch, NRow);
 
       parallelForOuter(
-          LConfig, KOKKOS_LAMBDA(int I, const TeamMember &Member) {
-             const int K = Member.team_rank();
+          LConfig, KOKKOS_LAMBDA(int I, const TeamMember &Team) {
+             const int K = Team.team_rank();
 
-             TriDiagScratch Scratch(Member, NRow);
+             TriDiagScratch Scratch(Team, NRow);
 
              Scratch.DL(K, 0) = DL(I, K);
              Scratch.D(K, 0)  = D(I, K);
              Scratch.DU(K, 0) = DU(I, K);
              Scratch.X(K, 0)  = X(I, K);
 
-             Member.team_barrier();
+             teamBarrier(Team);
 
-             solve(Member, Scratch);
+             solve(Team, Scratch);
 
-             Member.team_barrier();
+             teamBarrier(Team);
 
              X(I, K) = Scratch.X(K, 0);
           });
@@ -250,9 +250,9 @@ struct TriDiagDiffScratch {
    TriDiagScratchArray X; // rhs on input, contains solution after calling solve
    TriDiagScratchArray Alpha; // internal workspace
 
-   KOKKOS_FUNCTION TriDiagDiffScratch(const TeamMember &Member, int NRow)
-       : G(Member.team_scratch(0), NRow), H(Member.team_scratch(0), NRow),
-         X(Member.team_scratch(0), NRow), Alpha(Member.team_scratch(0), NRow) {}
+   KOKKOS_FUNCTION TriDiagDiffScratch(const TeamMember &Team, int NRow)
+       : G(teamScratch(Team), NRow), H(teamScratch(Team), NRow),
+         X(teamScratch(Team), NRow), Alpha(teamScratch(Team), NRow) {}
 };
 
 // Thomas algorithm solver for diffusion-type tridiagonal systems
@@ -269,7 +269,7 @@ struct ThomasDiffusionSolver {
    // Solve the system defined in the scratch data argument `Scratch`
    // This a team-level function that needs to be called inside a
    // parallel loop using TeamPolicy, hence it has a team member argument
-   static void KOKKOS_FUNCTION solve(const TeamMember &Member,
+   static void KOKKOS_FUNCTION solve(const TeamMember &Team,
                                      const TriDiagDiffScratch &Scratch) {
       const int NRow = Scratch.X.extent_int(0);
 
@@ -325,10 +325,10 @@ struct ThomasDiffusionSolver {
       auto LConfig = makeLaunchConfig(NBatch, NRow);
 
       parallelForOuter(
-          LConfig, KOKKOS_LAMBDA(int IChunk, const TeamMember &Member) {
+          LConfig, KOKKOS_LAMBDA(int IChunk, const TeamMember &Team) {
              const int IStart = IChunk * VecLength;
 
-             TriDiagDiffScratch Scratch(Member, NRow);
+             TriDiagDiffScratch Scratch(Team, NRow);
 
              for (int K = 0; K < NRow; ++K) {
                 for (int IVec = 0; IVec < VecLength; ++IVec) {
@@ -341,7 +341,7 @@ struct ThomasDiffusionSolver {
                 }
              }
 
-             solve(Member, Scratch);
+             solve(Team, Scratch);
 
              for (int IVec = 0; IVec < VecLength; ++IVec) {
                 for (int K = 0; K < NRow; ++K) {
@@ -368,12 +368,12 @@ struct PCRDiffusionSolver {
    // Solve the system defined in the scratch data argument `Scratch`
    // This a team-level function that needs to be called inside a
    // parallel loop using TeamPolicy, hence it has a team member argument
-   static void KOKKOS_FUNCTION solve(const TeamMember &Member,
+   static void KOKKOS_FUNCTION solve(const TeamMember &Team,
                                      const TriDiagDiffScratch &Scratch) {
       const int NRow = Scratch.X.extent_int(0);
 
       // Row index = Thread index
-      const int K = Member.team_rank();
+      const int K = Team.team_rank();
 
       // Number of reduction levels
       const int NLevels = Kokkos::ceil(Kokkos::log2(NRow));
@@ -406,14 +406,14 @@ struct PCRDiffusionSolver {
          const Real NewH = Scratch.H(K, 0) + Alpha * Scratch.H(Kmh, 0) +
                            Beta * Scratch.H(Kph, 0);
 
-         Member.team_barrier();
+         teamBarrier(Team);
 
          // Store new system coefficients
          Scratch.H(K, 0) = NewH;
          Scratch.G(K, 0) = NewG;
          Scratch.X(K, 0) = NewX;
 
-         Member.team_barrier();
+         teamBarrier(Team);
       }
 
       const int Stride = 1 << (NLevels - 1);
@@ -456,20 +456,20 @@ struct PCRDiffusionSolver {
 
       auto LConfig = makeLaunchConfig(NBatch, NRow);
       parallelForOuter(
-          LConfig, KOKKOS_LAMBDA(int I, const TeamMember &Member) {
-             const int K = Member.team_rank();
+          LConfig, KOKKOS_LAMBDA(int I, const TeamMember &Team) {
+             const int K = Team.team_rank();
 
-             TriDiagDiffScratch Scratch(Member, NRow);
+             TriDiagDiffScratch Scratch(Team, NRow);
 
              Scratch.G(K, 0) = G(I, K);
              Scratch.H(K, 0) = H(I, K);
              Scratch.X(K, 0) = X(I, K);
 
-             Member.team_barrier();
+             teamBarrier(Team);
 
-             solve(Member, Scratch);
+             solve(Team, Scratch);
 
-             Member.team_barrier();
+             teamBarrier(Team);
 
              X(I, K) = Scratch.X(K, 0);
           });

--- a/components/omega/src/base/TriDiagSolvers.h
+++ b/components/omega/src/base/TriDiagSolvers.h
@@ -35,8 +35,9 @@ using TriDiagDiffSolver = ThomasDiffusionSolver;
 #endif
 
 // Type of real array of size (NRow, VecLength) in the scratch memory space
-using TriDiagScratchArray = Kokkos::View<Real *[VecLength], MemLayout,
-                                         ScratchMemSpace, MemoryUnmanaged>;
+using TriDiagScratchArray =
+    Kokkos::View<Real *[VecLength], MemLayout, ScratchMemSpace,
+                 Kokkos::MemoryUnmanaged>;
 
 // Scratch data for general tridiagonal solver
 struct TriDiagScratch {

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -1,13 +1,13 @@
 #ifndef OMEGA_KOKKOS_H
 #define OMEGA_KOKKOS_H
-//===-- base/OmegaKokkos.h - Omega extension of Kokkos ------*- C++ -*-===//
+//===-- infra/OmegaKokkos.h - Omega extension of Kokkos ------*- C++ -*-===//
 //
 /// \file
 /// \brief Extends Kokkos for Omega
 ///
 /// This header extends Kokkos for Omega.
 //
-//===----------------------------------------------------------------------===//
+//===-------------------------------------------------------------------===//
 
 #include "DataTypes.h"
 #include "Error.h"
@@ -18,6 +18,9 @@
 namespace OMEGA {
 
 #define OMEGA_SCOPE(a, b) auto &a = b
+
+using ExecSpace     = MemSpace::execution_space;
+using HostExecSpace = HostMemSpace::execution_space;
 
 /// An enum is used to provide a shorthand for determining the type of
 /// field. These correspond to the supported Omega data types (Real will be
@@ -70,23 +73,50 @@ template <class T> struct ArrayRank {
    static constexpr bool Is5D = T::rank == 5;
 };
 
-using ExecSpace       = MemSpace::execution_space;
-using HostExecSpace   = HostMemSpace::execution_space;
-using TeamPolicy      = Kokkos::TeamPolicy<ExecSpace>;
-using TeamMember      = TeamPolicy::member_type;
-using ScratchMemSpace = ExecSpace::scratch_memory_space;
-using Kokkos::MemoryUnmanaged;
-using Kokkos::PerTeam;
-using Kokkos::TeamThreadRange;
-using RealScratchArray =
-    Kokkos::View<Real *, ScratchMemSpace, Kokkos::MemoryUnmanaged>;
+template <typename V>
+auto createHostMirrorCopy(const V &View)
+    -> Kokkos::View<typename V::data_type, HostMemLayout, HostMemSpace> {
+   return Kokkos::create_mirror_view_and_copy(HostExecSpace(), View);
+}
 
-/// team_size for hierarchical parallelism
-#ifdef OMEGA_TARGET_DEVICE
-constexpr int OMEGA_TEAMSIZE = 64;
-#else
-constexpr int OMEGA_TEAMSIZE = 1;
-#endif
+template <typename V>
+auto createDeviceMirrorCopy(const V &View)
+    -> Kokkos::View<typename V::data_type, MemLayout, MemSpace> {
+   return Kokkos::create_mirror_view_and_copy(ExecSpace(), View);
+}
+
+// function alias to follow Camel Naming Convention
+template <typename D, typename S> void deepCopy(D &&Dst, S &&Src) {
+   Kokkos::deep_copy(std::forward<D>(Dst), std::forward<S>(Src));
+}
+
+template <typename E, typename D, typename S>
+void deepCopy(E &Space, D &Dst, const S &Src) {
+   Kokkos::deep_copy(Space, Dst, Src);
+}
+
+// Check if two arrays are identical
+template <class ArrayTypeA, class ArrayTypeB>
+bool arraysEqual(const ArrayTypeA &A, const ArrayTypeB &B) {
+   OMEGA_REQUIRE(A.span_is_contiguous() && B.span_is_contiguous(),
+                 "arraysEqual works only for contiguous arrays");
+   OMEGA_REQUIRE(A.size() == B.size(),
+                 "arrayEqual can only compare arrays of equal size");
+
+   // This is a debug utility and not performance critical
+   // so just copy to the host and compare there
+   const auto AH = createHostMirrorCopy(A);
+   const auto BH = createHostMirrorCopy(B);
+
+   bool Equal = true;
+   for (size_t I = 0; I < AH.size(); I++) {
+      if (AH.data()[I] != BH.data()[I]) {
+         Equal = false;
+         break;
+      }
+   }
+   return Equal;
+}
 
 // Takes a functor that uses multidimensional indexing
 // and converts it into one that also accepts linear index
@@ -169,293 +199,13 @@ template <class F, int Rank> struct LinearIdxWrapper : F {
 #endif
 };
 
-template <typename V>
-auto createHostMirrorCopy(const V &View)
-    -> Kokkos::View<typename V::data_type, HostMemLayout, HostMemSpace> {
-   return Kokkos::create_mirror_view_and_copy(HostExecSpace(), View);
-}
-
-template <typename V>
-auto createDeviceMirrorCopy(const V &View)
-    -> Kokkos::View<typename V::data_type, MemLayout, MemSpace> {
-   return Kokkos::create_mirror_view_and_copy(ExecSpace(), View);
-}
-
-// function alias to follow Camel Naming Convention
-template <typename D, typename S> void deepCopy(D &&Dst, S &&Src) {
-   Kokkos::deep_copy(std::forward<D>(Dst), std::forward<S>(Src));
-}
-
-template <typename E, typename D, typename S>
-void deepCopy(E &Space, D &Dst, const S &Src) {
-   Kokkos::deep_copy(Space, Dst, Src);
-}
-
-// Check if two arrays are identical
-template <class ArrayTypeA, class ArrayTypeB>
-bool arraysEqual(const ArrayTypeA &A, const ArrayTypeB &B) {
-   OMEGA_REQUIRE(A.span_is_contiguous() && B.span_is_contiguous(),
-                 "arraysEqual works only for contiguous arrays");
-   OMEGA_REQUIRE(A.size() == B.size(),
-                 "arrayEqual can only compare arrays of equal size");
-
-   // This is a debug utility and not performance critical
-   // so just copy to the host and compare there
-   const auto AH = createHostMirrorCopy(A);
-   const auto BH = createHostMirrorCopy(B);
-
-   bool Equal = true;
-   for (size_t I = 0; I < AH.size(); I++) {
-      if (AH.data()[I] != BH.data()[I]) {
-         Equal = false;
-         break;
-      }
-   }
-   return Equal;
-}
-
-using Bounds1D = Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<int>>;
-
-#if OMEGA_LAYOUT_RIGHT
-
-template <int N>
-using Bounds = Kokkos::MDRangePolicy<
-    ExecSpace, Kokkos::Rank<N, Kokkos::Iterate::Right, Kokkos::Iterate::Right>,
-    Kokkos::IndexType<int>>;
-
-#elif OMEGA_LAYOUT_LEFT
-
-template <int N>
-using Bounds = Kokkos::MDRangePolicy<
-    ExecSpace, Kokkos::Rank<N, Kokkos::Iterate::Left, Kokkos::Iterate::Left>,
-    Kokkos::IndexType<int>>;
-
-#else
-
-#error "OMEGA Memory Layout is not defined."
-
-#endif
-
-// parallelFor: with label
-template <int N, class F>
-inline void parallelFor(const std::string &Label, const int (&UpperBounds)[N],
-                        F &&Functor) {
-   if constexpr (N == 1) {
-      const auto Policy = Bounds1D(0, UpperBounds[0]);
-      Kokkos::parallel_for(Label, Policy, std::forward<F>(Functor));
-
-   } else {
-#ifdef OMEGA_TARGET_DEVICE
-      // On device convert the functor to use one dimensional indexing and use
-      // 1D RangePolicy
-      auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
-      int LinBound    = 1;
-      for (int Rank = 0; Rank < N; ++Rank) {
-         LinBound *= UpperBounds[Rank];
-      }
-      const auto Policy = Bounds1D(0, LinBound);
-      Kokkos::parallel_for(Label, Policy, std::move(LinFunctor));
-#else
-      // On host use MDRangePolicy
-      const int LowerBounds[N] = {0};
-      const auto Policy        = Bounds<N>(LowerBounds, UpperBounds);
-      Kokkos::parallel_for(Label, Policy, std::forward<F>(Functor));
-#endif
-   }
-}
-
-// parallelFor: without label
-template <int N, class F>
-inline void parallelFor(const int (&UpperBounds)[N], F &&Functor) {
-   parallelFor("", UpperBounds, std::forward<F>(Functor));
-}
-
-// parallelReduce: with label
-template <int N, class F, class... R>
-inline void parallelReduce(const std::string &Label,
-                           const int (&UpperBounds)[N], F &&Functor,
-                           R &&...Reducers) {
-   if constexpr (N == 1) {
-      const auto Policy = Bounds1D(0, UpperBounds[0]);
-      Kokkos::parallel_reduce(Label, Policy, std::forward<F>(Functor),
-                              std::forward<R>(Reducers)...);
-
-   } else {
-
-#ifdef OMEGA_TARGET_DEVICE
-      // On device convert the functor to use one dimensional indexing and use
-      // 1D RangePolicy
-      auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
-      int LinBound    = 1;
-      for (int Rank = 0; Rank < N; ++Rank) {
-         LinBound *= UpperBounds[Rank];
-      }
-      const auto Policy = Bounds1D(0, LinBound);
-      Kokkos::parallel_reduce(Label, Policy, std::move(LinFunctor),
-                              std::forward<R>(Reducers)...);
-#else
-      // On host use MDRangePolicy
-      const int LowerBounds[N] = {0};
-      const auto Policy        = Bounds<N>(LowerBounds, UpperBounds);
-      Kokkos::parallel_reduce(Label, Policy, std::forward<F>(Functor),
-                              std::forward<R>(Reducers)...);
-#endif
-   }
-}
-
-// parallelReduce: without label
-template <int N, class F, class... R>
-inline void parallelReduce(const int (&UpperBounds)[N], F &&Functor,
-                           R &&...Reducers) {
-   parallelReduce("", UpperBounds, std::forward<F>(Functor),
-                  std::forward<R>(Reducers)...);
-}
-
-/// Hierarchical parallelism wrappers
-
-#define INNER_LAMBDA [=]
-// #define INNER_LAMBDA [&]
-
-KOKKOS_INLINE_FUNCTION void teamBarrier(const TeamMember &Team) {
-   Team.team_barrier();
-}
-
-// parallelForOuter: with label
-template <int N, class F>
-inline void parallelForOuter(const std::string &Label,
-                             const int (&UpperBounds)[N], F &&Functor,
-                             int ScratchValsPerTeam = 0) {
-
-   auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
-   int LinBound    = 1;
-   for (int Rank = 0; Rank < N; ++Rank) {
-      LinBound *= UpperBounds[Rank];
-   }
-
-   auto Policy = TeamPolicy(LinBound, OMEGA_TEAMSIZE);
-
-   if (ScratchValsPerTeam > 0) {
-      Policy.set_scratch_size(
-          0, Kokkos::PerTeam(ScratchValsPerTeam * sizeof(Real)));
-   }
-
-   Kokkos::parallel_for(
-       Label, Policy, KOKKOS_LAMBDA(const TeamMember &Team) {
-          const int TeamId = Team.league_rank();
-          LinFunctor(TeamId, Team);
-       });
-}
-
-// parallelForOuter: without label
-template <int N, class F>
-inline void parallelForOuter(const int (&UpperBounds)[N], F &&Functor,
-                             int ScratchValsPerTeam = 0) {
-   parallelForOuter("", UpperBounds, std::forward<F>(Functor),
-                    ScratchValsPerTeam);
-}
-
-// parallelForInner
-
-template <class F>
-KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int MinIndex,
-                                      int MaxIndex, F &&Functor) {
-   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
-   Kokkos::parallel_for(Policy, std::forward<F>(Functor));
-}
-
-template <class F>
-KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int UpperBound,
-                                      F &&Functor) {
-   parallelForInner(Team, 0, UpperBound - 1, std::forward<F>(Functor));
-}
-
-// This struct is used to get the right accumulator type to be used in
-// the outer parallel lambda based on the final reduction variable type.
-// The final reduction variable can be either a reference to
-// an arithmetic type (int&, Real&) or a Kokkos reducer (Kokkos::Max<Real>).
-// We need to know this type because nvcc does not allow generic lambdas.
-template <class T, class Enable = void> struct AccumTypeHelper;
-
-template <class T>
-struct AccumTypeHelper<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
-   using Type = T;
-};
-
-template <class T>
-struct AccumTypeHelper<T, std::enable_if_t<Kokkos::is_reducer_v<T>>> {
-   using Type = typename T::value_type;
-};
-
-template <class T> using AccumType = typename AccumTypeHelper<T>::Type;
-
-// parallelReduceOuter: with label
-template <int N, class F, class... R>
-inline void parallelReduceOuter(const std::string &Label,
-                                const int (&UpperBounds)[N], F &&Functor,
-                                R &&...Reducers) {
-
-   auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
-   int LinBound    = 1;
-   for (int Rank = 0; Rank < N; ++Rank) {
-      LinBound *= UpperBounds[Rank];
-   }
-
-   auto Policy = TeamPolicy(LinBound, OMEGA_TEAMSIZE);
-   Kokkos::parallel_reduce(
-       Label, Policy,
-       KOKKOS_LAMBDA(const TeamMember &Team,
-                     AccumType<std::remove_reference_t<R>> &...Accums) {
-          const int TeamId = Team.league_rank();
-          LinFunctor(TeamId, Team, Accums...);
-       },
-       std::forward<R>(Reducers)...);
-}
-
-// parallelReduceOuter: without label
-template <int N, class F, class... R>
-inline void parallelReduceOuter(const int (&UpperBounds)[N], F &&Functor,
-                                R &&...Reducers) {
-   parallelReduceOuter("", UpperBounds, std::forward<F>(Functor),
-                       std::forward<R>(Reducers)...);
-}
-
-// parallelReduceInner
-
-template <class F, class... R>
-KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int MinIndex,
-                                         int MaxIndex, F &&Functor,
-                                         R &&...Reducers) {
-   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
-   Kokkos::parallel_reduce(Policy, std::forward<F>(Functor),
-                           std::forward<R>(Reducers)...);
-}
-
-template <class F, class... R>
-KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int UpperBound,
-                                         F &&Functor, R &&...Reducers) {
-   parallelReduceInner(Team, 0, UpperBound - 1, std::forward<F>(Functor),
-                       std::forward<R>(Reducers)...);
-}
-
-// parallelScanInner
-
-template <class F, class... R>
-KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int MinIndex,
-                                       int MaxIndex, F &&Functor,
-                                       R &&...Reducers) {
-   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
-   Kokkos::parallel_scan(Policy, std::forward<F>(Functor),
-                         std::forward<R>(Reducers)...);
-}
-
-template <class F, class... R>
-KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int UpperBound,
-                                       F &&Functor, R &&...Reducers) {
-   parallelScanInner(Team, 0, UpperBound - 1, std::forward<F>(Functor),
-                     std::forward<R>(Reducers)...);
-}
-
 } // end namespace OMEGA
+
+// Flat parallelism wrappers
+#include "OmegaKokkosFlatPar.h"
+
+// Hierarchical parallelism wrappers
+#include "OmegaKokkosHiPar.h"
 
 //===----------------------------------------------------------------------===//
 #endif

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -355,11 +355,18 @@ inline void parallelForOuter(const int (&UpperBounds)[N], F &&Functor,
 }
 
 // parallelForInner
+
+template <class F>
+KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int MinIndex,
+                                      int MaxIndex, F &&Functor) {
+   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
+   Kokkos::parallel_for(Policy, std::forward<F>(Functor));
+}
+
 template <class F>
 KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int UpperBound,
                                       F &&Functor) {
-   const auto Policy = TeamThreadRange(Team, UpperBound);
-   Kokkos::parallel_for(Policy, std::forward<F>(Functor));
+   parallelForInner(Team, 0, UpperBound - 1, std::forward<F>(Functor));
 }
 
 // This struct is used to get the right accumulator type to be used in
@@ -413,21 +420,39 @@ inline void parallelReduceOuter(const int (&UpperBounds)[N], F &&Functor,
 }
 
 // parallelReduceInner
+
 template <class F, class... R>
-KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int UpperBound,
-                                         F &&Functor, R &&...Reducers) {
-   const auto Policy = TeamThreadRange(Team, UpperBound);
+KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int MinIndex,
+                                         int MaxIndex, F &&Functor,
+                                         R &&...Reducers) {
+   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
    Kokkos::parallel_reduce(Policy, std::forward<F>(Functor),
                            std::forward<R>(Reducers)...);
 }
 
+template <class F, class... R>
+KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int UpperBound,
+                                         F &&Functor, R &&...Reducers) {
+   parallelReduceInner(Team, 0, UpperBound - 1, std::forward<F>(Functor),
+                       std::forward<R>(Reducers)...);
+}
+
 // parallelScanInner
+
+template <class F, class... R>
+KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int MinIndex,
+                                       int MaxIndex, F &&Functor,
+                                       R &&...Reducers) {
+   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
+   Kokkos::parallel_scan(Policy, std::forward<F>(Functor),
+                         std::forward<R>(Reducers)...);
+}
+
 template <class F, class... R>
 KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int UpperBound,
                                        F &&Functor, R &&...Reducers) {
-   const auto Policy = TeamThreadRange(Team, UpperBound);
-   Kokkos::parallel_scan(Policy, std::forward<F>(Functor),
-                         std::forward<R>(Reducers)...);
+   parallelScanInner(Team, 0, UpperBound - 1, std::forward<F>(Functor),
+                     std::forward<R>(Reducers)...);
 }
 
 } // end namespace OMEGA

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -11,6 +11,8 @@
 
 #include "DataTypes.h"
 #include "Error.h"
+#include <algorithm>
+#include <array>
 #include <functional>
 #include <type_traits>
 #include <utility>
@@ -101,7 +103,7 @@ bool arraysEqual(const ArrayTypeA &A, const ArrayTypeB &B) {
    OMEGA_REQUIRE(A.span_is_contiguous() && B.span_is_contiguous(),
                  "arraysEqual works only for contiguous arrays");
    OMEGA_REQUIRE(A.size() == B.size(),
-                 "arrayEqual can only compare arrays of equal size");
+                 "arraysEqual can only compare arrays of equal size");
 
    // This is a debug utility and not performance critical
    // so just copy to the host and compare there

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -124,16 +124,17 @@ template <class F, int Rank> struct LinearIdxWrapper : F {
    static_assert(Rank >= 1 && Rank <= 5, "LinearIdxWrapper supports ranks 1-5");
    using F::operator();
 
-   LinearIdxWrapper(F &&Functor, const int (&Bounds)[Rank])
-       : F(std::move(Functor)) {
-      computeStrides(Bounds);
+   template <class Array>
+   LinearIdxWrapper(F &&Functor, Array &&Bounds) : F(std::move(Functor)) {
+      computeStrides(std::forward<Array>(Bounds));
    }
 
-   LinearIdxWrapper(const F &Functor, const int (&Bounds)[Rank]) : F(Functor) {
-      computeStrides(Bounds);
+   template <class Array>
+   LinearIdxWrapper(const F &Functor, Array &&Bounds) : F(Functor) {
+      computeStrides(std::forward<Array>(Bounds));
    }
 
-   void computeStrides(const int (&Bounds)[Rank]) {
+   template <class Array> void computeStrides(Array &&Bounds) {
       if constexpr (Rank > 1) {
          Strides[Rank - 2] = Bounds[Rank - 1];
          for (int I = Rank - 3; I >= 0; --I) {
@@ -198,6 +199,12 @@ template <class F, int Rank> struct LinearIdxWrapper : F {
    int Strides[Rank - 1];
 #endif
 };
+
+// Deduction guides for deducing Rank
+template <class F, int Rank>
+LinearIdxWrapper(F, const int (&)[Rank]) -> LinearIdxWrapper<F, Rank>;
+template <class F, size_t Rank>
+LinearIdxWrapper(F, std::array<int, Rank>) -> LinearIdxWrapper<F, Rank>;
 
 } // end namespace OMEGA
 

--- a/components/omega/src/infra/OmegaKokkosFlatPar.h
+++ b/components/omega/src/infra/OmegaKokkosFlatPar.h
@@ -1,0 +1,115 @@
+#ifndef OMEGA_KOKKOS_FLATPAR_H
+#define OMEGA_KOKKOS_FLATPAR_H
+//===-- infra/OmegaKokkosFlatPar.h - Omega flat parallelism wrappers ------*-
+// C++ -*-===//
+//
+/// \file
+/// \brief Omega flat parallelism wrappers
+///
+/// INTERNAL HEADER NOT MEANT TO BE INCLUDED DIRECTLY
+//
+//===--------------------------------------------------------------------------------===//
+
+namespace OMEGA {
+
+using Bounds1D = Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<int>>;
+
+#if OMEGA_LAYOUT_RIGHT
+
+template <int N>
+using Bounds = Kokkos::MDRangePolicy<
+    ExecSpace, Kokkos::Rank<N, Kokkos::Iterate::Right, Kokkos::Iterate::Right>,
+    Kokkos::IndexType<int>>;
+
+#elif OMEGA_LAYOUT_LEFT
+
+template <int N>
+using Bounds = Kokkos::MDRangePolicy<
+    ExecSpace, Kokkos::Rank<N, Kokkos::Iterate::Left, Kokkos::Iterate::Left>,
+    Kokkos::IndexType<int>>;
+
+#else
+
+#error "OMEGA Memory Layout is not defined."
+
+#endif
+
+// parallelFor: with label
+template <int N, class F>
+inline void parallelFor(const std::string &Label, const int (&UpperBounds)[N],
+                        F &&Functor) {
+   if constexpr (N == 1) {
+      const auto Policy = Bounds1D(0, UpperBounds[0]);
+      Kokkos::parallel_for(Label, Policy, std::forward<F>(Functor));
+
+   } else {
+#ifdef OMEGA_TARGET_DEVICE
+      // On device convert the functor to use one dimensional indexing and use
+      // 1D RangePolicy
+      auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
+      int LinBound    = 1;
+      for (int Rank = 0; Rank < N; ++Rank) {
+         LinBound *= UpperBounds[Rank];
+      }
+      const auto Policy = Bounds1D(0, LinBound);
+      Kokkos::parallel_for(Label, Policy, std::move(LinFunctor));
+#else
+      // On host use MDRangePolicy
+      const int LowerBounds[N] = {0};
+      const auto Policy        = Bounds<N>(LowerBounds, UpperBounds);
+      Kokkos::parallel_for(Label, Policy, std::forward<F>(Functor));
+#endif
+   }
+}
+
+// parallelFor: without label
+template <int N, class F>
+inline void parallelFor(const int (&UpperBounds)[N], F &&Functor) {
+   parallelFor("", UpperBounds, std::forward<F>(Functor));
+}
+
+// parallelReduce: with label
+template <int N, class F, class... R>
+inline void parallelReduce(const std::string &Label,
+                           const int (&UpperBounds)[N], F &&Functor,
+                           R &&...Reducers) {
+   if constexpr (N == 1) {
+      const auto Policy = Bounds1D(0, UpperBounds[0]);
+      Kokkos::parallel_reduce(Label, Policy, std::forward<F>(Functor),
+                              std::forward<R>(Reducers)...);
+
+   } else {
+
+#ifdef OMEGA_TARGET_DEVICE
+      // On device convert the functor to use one dimensional indexing and use
+      // 1D RangePolicy
+      auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
+      int LinBound    = 1;
+      for (int Rank = 0; Rank < N; ++Rank) {
+         LinBound *= UpperBounds[Rank];
+      }
+      const auto Policy = Bounds1D(0, LinBound);
+      Kokkos::parallel_reduce(Label, Policy, std::move(LinFunctor),
+                              std::forward<R>(Reducers)...);
+#else
+      // On host use MDRangePolicy
+      const int LowerBounds[N] = {0};
+      const auto Policy        = Bounds<N>(LowerBounds, UpperBounds);
+      Kokkos::parallel_reduce(Label, Policy, std::forward<F>(Functor),
+                              std::forward<R>(Reducers)...);
+#endif
+   }
+}
+
+// parallelReduce: without label
+template <int N, class F, class... R>
+inline void parallelReduce(const int (&UpperBounds)[N], F &&Functor,
+                           R &&...Reducers) {
+   parallelReduce("", UpperBounds, std::forward<F>(Functor),
+                  std::forward<R>(Reducers)...);
+}
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -31,18 +31,18 @@ constexpr int OMEGA_TEAMSIZE = 1;
 #define INNER_LAMBDA [=]
 // #define INNER_LAMBDA [&]
 
+// Helper struct for providing information about scratch memory requirements
+// TeamScratch<Real, I4>(4, 8) stores the number of bytes needed for
+// 4 values of type Real and 8 vals of type I4
 template <class... T> struct TeamScratch {
    size_t BytesPerTeam = 0;
 
    TeamScratch() = default;
 
-   template <int N> TeamScratch(const int (&NVals)[N]) {
-      static_assert(N == sizeof...(T));
-      int I = 0;
-      ((BytesPerTeam += sizeof(T) * NVals[I++]), ...);
+   template <class... ArgT> TeamScratch(ArgT... Args) {
+      static_assert(sizeof...(ArgT) == sizeof...(T));
+      ((BytesPerTeam += sizeof(T) * Args), ...);
    }
-
-   TeamScratch(int NVals) : TeamScratch({{NVals}}) {}
 };
 
 template <int N> struct LaunchConfig {

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -249,7 +249,7 @@ KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int UpperBound,
 // returns the first index in the range [0, UpperBound) for which the input
 // functor returns true. If no such index is found it returns -1
 template <class F>
-KOKKOS_FUNCTION void parallelSearchInner(const TeamMember &Team, int UpperBound,
+KOKKOS_FUNCTION void parallelSearchInner(const TeamMember &Team, Range Rng,
                                          F &&Functor, int &Idx) {
    static_assert(std::is_same_v<std::invoke_result_t<F, int>, bool>,
                  "parallelSearchInner requires a functor that takes an int and "
@@ -260,14 +260,14 @@ KOKKOS_FUNCTION void parallelSearchInner(const TeamMember &Team, int UpperBound,
    // on CPUs
 #ifndef OMEGA_TARGET_DEVICE
    Idx = -1;
-   for (int I = 0; I < UpperBound; ++I) {
+   for (int I = Rng.First; I <= Rng.Last; ++I) {
       if (Functor(I)) {
          Idx = I;
          break;
       }
    }
 #else
-   const auto Policy = TeamThreadRange(Team, UpperBound);
+   const auto Policy = TeamThreadRange(Team, Rng.First, Rng.Last + 1);
    Kokkos::parallel_reduce(
        Policy,
        INNER_LAMBDA(int I, int &Accum) {
@@ -280,6 +280,13 @@ KOKKOS_FUNCTION void parallelSearchInner(const TeamMember &Team, int UpperBound,
       Idx = -1;
    }
 #endif
+}
+
+template <class F>
+KOKKOS_FUNCTION void parallelSearchInner(const TeamMember &Team, int UpperBound,
+                                         F &&Functor, int &Idx) {
+   parallelSearchInner(Team, Range{0, UpperBound - 1}, std::forward<F>(Functor),
+                       Idx);
 }
 
 } // end namespace OMEGA

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -18,7 +18,7 @@ using ScratchMemSpace = ExecSpace::scratch_memory_space;
 using Kokkos::MemoryUnmanaged;
 using Kokkos::PerTeam;
 using Kokkos::TeamThreadRange;
-using RealScratchArray =
+using ArrayScratch1DReal =
     Kokkos::View<Real *, ScratchMemSpace, Kokkos::MemoryUnmanaged>;
 
 /// team_size for hierarchical parallelism

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -165,28 +165,33 @@ inline void parallelReduceOuter(const int (&UpperBounds)[N], F &&Functor,
                        std::forward<R>(Reducers)...);
 }
 
+// Inclusive range of indices
+struct Range {
+   int First;
+   int Last;
+};
+
 // parallelForInner
 
 template <class F>
-KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int MinIndex,
-                                      int MaxIndex, F &&Functor) {
-   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
+KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, Range Rng,
+                                      F &&Functor) {
+   const auto Policy = TeamThreadRange(Team, Rng.First, Rng.Last + 1);
    Kokkos::parallel_for(Policy, std::forward<F>(Functor));
 }
 
 template <class F>
 KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int UpperBound,
                                       F &&Functor) {
-   parallelForInner(Team, 0, UpperBound - 1, std::forward<F>(Functor));
+   parallelForInner(Team, Range{0, UpperBound - 1}, std::forward<F>(Functor));
 }
 
 // parallelReduceInner
 
 template <class F, class... R>
-KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int MinIndex,
-                                         int MaxIndex, F &&Functor,
-                                         R &&...Reducers) {
-   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
+KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, Range Rng,
+                                         F &&Functor, R &&...Reducers) {
+   const auto Policy = TeamThreadRange(Team, Rng.First, Rng.Last + 1);
    Kokkos::parallel_reduce(Policy, std::forward<F>(Functor),
                            std::forward<R>(Reducers)...);
 }
@@ -194,17 +199,16 @@ KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int MinIndex,
 template <class F, class... R>
 KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int UpperBound,
                                          F &&Functor, R &&...Reducers) {
-   parallelReduceInner(Team, 0, UpperBound - 1, std::forward<F>(Functor),
+   parallelReduceInner(Team, Range{0, UpperBound - 1}, std::forward<F>(Functor),
                        std::forward<R>(Reducers)...);
 }
 
 // parallelScanInner
 
 template <class F, class... R>
-KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int MinIndex,
-                                       int MaxIndex, F &&Functor,
-                                       R &&...Reducers) {
-   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
+KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, Range Rng,
+                                       F &&Functor, R &&...Reducers) {
+   const auto Policy = TeamThreadRange(Team, Rng.First, Rng.Last + 1);
    Kokkos::parallel_scan(Policy, std::forward<F>(Functor),
                          std::forward<R>(Reducers)...);
 }
@@ -212,7 +216,7 @@ KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int MinIndex,
 template <class F, class... R>
 KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int UpperBound,
                                        F &&Functor, R &&...Reducers) {
-   parallelScanInner(Team, 0, UpperBound - 1, std::forward<F>(Functor),
+   parallelScanInner(Team, Range{0, UpperBound - 1}, std::forward<F>(Functor),
                      std::forward<R>(Reducers)...);
 }
 

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -18,6 +18,8 @@ using ScratchMemSpace = ExecSpace::scratch_memory_space;
 using Kokkos::PerTeam;
 using ArrayScratch1DReal =
     Kokkos::View<Real *, ScratchMemSpace, Kokkos::MemoryUnmanaged>;
+using ArrayScratch1DI4 =
+    Kokkos::View<I4 *, ScratchMemSpace, Kokkos::MemoryUnmanaged>;
 
 /// team_size for hierarchical parallelism
 #ifdef OMEGA_TARGET_DEVICE

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -1,0 +1,176 @@
+#ifndef OMEGA_KOKKOS_HIPAR_H
+#define OMEGA_KOKKOS_HIPAR_H
+//===-- infra/OmegaKokkosHiPar.h - Omega hierarchical parallelism wrappers
+//------*- C++ -*-===//
+//
+/// \file
+/// \brief Omega hierarchical parallelism wrappers
+///
+/// INTERNAL HEADER NOT MEANT TO BE INCLUDED DIRECTLY
+//
+//===--------------------------------------------------------------------------------------===//
+
+namespace OMEGA {
+
+using TeamPolicy      = Kokkos::TeamPolicy<ExecSpace>;
+using TeamMember      = TeamPolicy::member_type;
+using ScratchMemSpace = ExecSpace::scratch_memory_space;
+using Kokkos::MemoryUnmanaged;
+using Kokkos::PerTeam;
+using Kokkos::TeamThreadRange;
+using RealScratchArray =
+    Kokkos::View<Real *, ScratchMemSpace, Kokkos::MemoryUnmanaged>;
+
+/// team_size for hierarchical parallelism
+#ifdef OMEGA_TARGET_DEVICE
+constexpr int OMEGA_TEAMSIZE = 64;
+#else
+constexpr int OMEGA_TEAMSIZE = 1;
+#endif
+
+#define INNER_LAMBDA [=]
+// #define INNER_LAMBDA [&]
+
+KOKKOS_INLINE_FUNCTION void teamBarrier(const TeamMember &Team) {
+   Team.team_barrier();
+}
+
+// parallelForOuter: with label
+template <int N, class F>
+inline void parallelForOuter(const std::string &Label,
+                             const int (&UpperBounds)[N], F &&Functor,
+                             int ScratchValsPerTeam = 0) {
+
+   auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
+   int LinBound    = 1;
+   for (int Rank = 0; Rank < N; ++Rank) {
+      LinBound *= UpperBounds[Rank];
+   }
+
+   auto Policy = TeamPolicy(LinBound, OMEGA_TEAMSIZE);
+
+   if (ScratchValsPerTeam > 0) {
+      Policy.set_scratch_size(
+          0, Kokkos::PerTeam(ScratchValsPerTeam * sizeof(Real)));
+   }
+
+   Kokkos::parallel_for(
+       Label, Policy, KOKKOS_LAMBDA(const TeamMember &Team) {
+          const int TeamId = Team.league_rank();
+          LinFunctor(TeamId, Team);
+       });
+}
+
+// parallelForOuter: without label
+template <int N, class F>
+inline void parallelForOuter(const int (&UpperBounds)[N], F &&Functor,
+                             int ScratchValsPerTeam = 0) {
+   parallelForOuter("", UpperBounds, std::forward<F>(Functor),
+                    ScratchValsPerTeam);
+}
+
+// This struct is used to get the right accumulator type to be used in
+// the outer parallel lambda based on the final reduction variable type.
+// The final reduction variable can be either a reference to
+// an arithmetic type (int&, Real&) or a Kokkos reducer (Kokkos::Max<Real>).
+// We need to know this type because nvcc does not allow generic lambdas.
+template <class T, class Enable = void> struct AccumTypeHelper;
+
+template <class T>
+struct AccumTypeHelper<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
+   using Type = T;
+};
+
+template <class T>
+struct AccumTypeHelper<T, std::enable_if_t<Kokkos::is_reducer_v<T>>> {
+   using Type = typename T::value_type;
+};
+
+template <class T> using AccumType = typename AccumTypeHelper<T>::Type;
+
+// parallelReduceOuter: with label
+template <int N, class F, class... R>
+inline void parallelReduceOuter(const std::string &Label,
+                                const int (&UpperBounds)[N], F &&Functor,
+                                R &&...Reducers) {
+
+   auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
+   int LinBound    = 1;
+   for (int Rank = 0; Rank < N; ++Rank) {
+      LinBound *= UpperBounds[Rank];
+   }
+
+   auto Policy = TeamPolicy(LinBound, OMEGA_TEAMSIZE);
+   Kokkos::parallel_reduce(
+       Label, Policy,
+       KOKKOS_LAMBDA(const TeamMember &Team,
+                     AccumType<std::remove_reference_t<R>> &...Accums) {
+          const int TeamId = Team.league_rank();
+          LinFunctor(TeamId, Team, Accums...);
+       },
+       std::forward<R>(Reducers)...);
+}
+
+// parallelReduceOuter: without label
+template <int N, class F, class... R>
+inline void parallelReduceOuter(const int (&UpperBounds)[N], F &&Functor,
+                                R &&...Reducers) {
+   parallelReduceOuter("", UpperBounds, std::forward<F>(Functor),
+                       std::forward<R>(Reducers)...);
+}
+
+// parallelForInner
+
+template <class F>
+KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int MinIndex,
+                                      int MaxIndex, F &&Functor) {
+   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
+   Kokkos::parallel_for(Policy, std::forward<F>(Functor));
+}
+
+template <class F>
+KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int UpperBound,
+                                      F &&Functor) {
+   parallelForInner(Team, 0, UpperBound - 1, std::forward<F>(Functor));
+}
+
+// parallelReduceInner
+
+template <class F, class... R>
+KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int MinIndex,
+                                         int MaxIndex, F &&Functor,
+                                         R &&...Reducers) {
+   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
+   Kokkos::parallel_reduce(Policy, std::forward<F>(Functor),
+                           std::forward<R>(Reducers)...);
+}
+
+template <class F, class... R>
+KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int UpperBound,
+                                         F &&Functor, R &&...Reducers) {
+   parallelReduceInner(Team, 0, UpperBound - 1, std::forward<F>(Functor),
+                       std::forward<R>(Reducers)...);
+}
+
+// parallelScanInner
+
+template <class F, class... R>
+KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int MinIndex,
+                                       int MaxIndex, F &&Functor,
+                                       R &&...Reducers) {
+   const auto Policy = TeamThreadRange(Team, MinIndex, MaxIndex + 1);
+   Kokkos::parallel_scan(Policy, std::forward<F>(Functor),
+                         std::forward<R>(Reducers)...);
+}
+
+template <class F, class... R>
+KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int UpperBound,
+                                       F &&Functor, R &&...Reducers) {
+   parallelScanInner(Team, 0, UpperBound - 1, std::forward<F>(Functor),
+                     std::forward<R>(Reducers)...);
+}
+
+} // end namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -16,10 +16,13 @@ using TeamPolicy      = Kokkos::TeamPolicy<ExecSpace>;
 using TeamMember      = TeamPolicy::member_type;
 using ScratchMemSpace = ExecSpace::scratch_memory_space;
 using Kokkos::PerTeam;
-using ArrayScratch1DReal =
-    Kokkos::View<Real *, ScratchMemSpace, Kokkos::MemoryUnmanaged>;
-using ArrayScratch1DI4 =
-    Kokkos::View<I4 *, ScratchMemSpace, Kokkos::MemoryUnmanaged>;
+
+template <class T>
+using ArrayScratch1D =
+    Kokkos::View<T *, ScratchMemSpace, Kokkos::MemoryUnmanaged>;
+
+using ArrayScratch1DReal = ArrayScratch1D<Real>;
+using ArrayScratch1DI4   = ArrayScratch1D<I4>;
 
 /// team_size for hierarchical parallelism
 #ifdef OMEGA_TARGET_DEVICE
@@ -41,7 +44,7 @@ template <class... T> struct TeamScratch {
 
    template <class... ArgT> TeamScratch(ArgT... Args) {
       static_assert(sizeof...(ArgT) == sizeof...(T));
-      ((BytesPerTeam += sizeof(T) * Args), ...);
+      ((BytesPerTeam += ArrayScratch1D<T>::shmem_size(Args)), ...);
    }
 };
 

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -73,6 +73,10 @@ KOKKOS_INLINE_FUNCTION void teamBarrier(const TeamMember &Team) {
    Team.team_barrier();
 }
 
+KOKKOS_INLINE_FUNCTION decltype(auto) teamScratch(const TeamMember &Team) {
+   return Team.team_scratch(0);
+}
+
 // parallelForOuter: with label and with launch config
 template <int N, class F>
 inline void parallelForOuter(const std::string &Label,

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -18,11 +18,11 @@ using ScratchMemSpace = ExecSpace::scratch_memory_space;
 using Kokkos::PerTeam;
 
 template <class T>
-using ArrayScratch1D =
+using ScratchArray1D =
     Kokkos::View<T *, ScratchMemSpace, Kokkos::MemoryUnmanaged>;
 
-using ArrayScratch1DReal = ArrayScratch1D<Real>;
-using ArrayScratch1DI4   = ArrayScratch1D<I4>;
+using ScratchArray1DReal = ScratchArray1D<Real>;
+using ScratchArray1DI4   = ScratchArray1D<I4>;
 
 /// team_size for hierarchical parallelism
 #ifdef OMEGA_TARGET_DEVICE
@@ -44,7 +44,7 @@ template <class... T> struct TeamScratch {
 
    template <class... ArgT> TeamScratch(ArgT... Args) {
       static_assert(sizeof...(ArgT) == sizeof...(T));
-      ((BytesPerTeam += ArrayScratch1D<T>::shmem_size(Args)), ...);
+      ((BytesPerTeam += ScratchArray1D<T>::shmem_size(Args)), ...);
    }
 };
 

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -74,19 +74,19 @@ KOKKOS_INLINE_FUNCTION void teamBarrier(const TeamMember &Team) {
 // parallelForOuter: with label and with launch config
 template <int N, class F>
 inline void parallelForOuter(const std::string &Label,
-                             const LaunchConfig<N> &Config, F &&Functor) {
+                             const LaunchConfig<N> &LConfig, F &&Functor) {
 
    auto LinFunctor =
-       LinearIdxWrapper{std::forward<F>(Functor), Config.UpperBounds};
+       LinearIdxWrapper{std::forward<F>(Functor), LConfig.UpperBounds};
    int LinBound = 1;
    for (int Rank = 0; Rank < N; ++Rank) {
-      LinBound *= Config.UpperBounds[Rank];
+      LinBound *= LConfig.UpperBounds[Rank];
    }
 
-   auto Policy = TeamPolicy(LinBound, Config.TeamSize);
+   auto Policy = TeamPolicy(LinBound, LConfig.TeamSize);
 
-   if (Config.ScratchBytesPerTeam > 0) {
-      Policy.set_scratch_size(0, Kokkos::PerTeam(Config.ScratchBytesPerTeam));
+   if (LConfig.ScratchBytesPerTeam > 0) {
+      Policy.set_scratch_size(0, Kokkos::PerTeam(LConfig.ScratchBytesPerTeam));
    }
 
    Kokkos::parallel_for(
@@ -98,8 +98,8 @@ inline void parallelForOuter(const std::string &Label,
 
 // parallelForOuter: without label and with launch config
 template <int N, class F>
-inline void parallelForOuter(const LaunchConfig<N> &Config, F &&Functor) {
-   parallelForOuter("", Config, std::forward<F>(Functor));
+inline void parallelForOuter(const LaunchConfig<N> &LConfig, F &&Functor) {
+   parallelForOuter("", LConfig, std::forward<F>(Functor));
 }
 
 // parallelForOuter: with label and with array bounds
@@ -134,19 +134,24 @@ struct AccumTypeHelper<T, std::enable_if_t<Kokkos::is_reducer_v<T>>> {
 
 template <class T> using AccumType = typename AccumTypeHelper<T>::Type;
 
-// parallelReduceOuter: with label
+// parallelReduceOuter: with label and with launch config
 template <int N, class F, class... R>
 inline void parallelReduceOuter(const std::string &Label,
-                                const int (&UpperBounds)[N], F &&Functor,
+                                const LaunchConfig<N> &LConfig, F &&Functor,
                                 R &&...Reducers) {
 
-   auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
-   int LinBound    = 1;
+   auto LinFunctor =
+       LinearIdxWrapper{std::forward<F>(Functor), LConfig.UpperBounds};
+   int LinBound = 1;
    for (int Rank = 0; Rank < N; ++Rank) {
-      LinBound *= UpperBounds[Rank];
+      LinBound *= LConfig.UpperBounds[Rank];
    }
 
-   auto Policy = TeamPolicy(LinBound, OMEGA_TEAMSIZE);
+   auto Policy = TeamPolicy(LinBound, LConfig.TeamSize);
+   if (LConfig.ScratchBytesPerTeam > 0) {
+      Policy.set_scratch_size(0, Kokkos::PerTeam(LConfig.ScratchBytesPerTeam));
+   }
+
    Kokkos::parallel_reduce(
        Label, Policy,
        KOKKOS_LAMBDA(const TeamMember &Team,
@@ -157,11 +162,28 @@ inline void parallelReduceOuter(const std::string &Label,
        std::forward<R>(Reducers)...);
 }
 
-// parallelReduceOuter: without label
+// parallelReduceOuter: without label and with launch config
+template <int N, class F, class... R>
+inline void parallelReduceOuter(const LaunchConfig<N> &LConfig, F &&Functor,
+                                R &&...Reducers) {
+   parallelReduceOuter("", LConfig, std::forward<F>(Functor),
+                       std::forward<R>(Reducers)...);
+}
+
+// parallelReduceOuter: with label and with array bounds
+template <int N, class F, class... R>
+inline void parallelReduceOuter(const std::string Label,
+                                const int (&UpperBounds)[N], F &&Functor,
+                                R &&...Reducers) {
+   parallelReduceOuter(Label, LaunchConfig(UpperBounds),
+                       std::forward<F>(Functor), std::forward<R>(Reducers)...);
+}
+
+// parallelReduceOuter: without label and with array bounds
 template <int N, class F, class... R>
 inline void parallelReduceOuter(const int (&UpperBounds)[N], F &&Functor,
                                 R &&...Reducers) {
-   parallelReduceOuter("", UpperBounds, std::forward<F>(Functor),
+   parallelReduceOuter("", LaunchConfig(UpperBounds), std::forward<F>(Functor),
                        std::forward<R>(Reducers)...);
 }
 

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -242,6 +242,44 @@ KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, int UpperBound,
                      std::forward<R>(Reducers)...);
 }
 
+// parallelSearchInner
+// Given a functor taking an index and returning a bool this function
+// returns the first index in the range [0, UpperBound) for which the input
+// functor returns true. If no such index is found it returns -1
+template <class F>
+KOKKOS_FUNCTION void parallelSearchInner(const TeamMember &Team, int UpperBound,
+                                         F &&Functor, int &Idx) {
+   static_assert(std::is_same_v<std::invoke_result_t<F, int>, bool>,
+                 "parallelSearchInner requires a functor that takes an int and "
+                 "returns bool");
+
+   // There are different implementations for host and device since the
+   // parallel_reduce version doesn't return early leading to performance loss
+   // on CPUs
+#ifndef OMEGA_TARGET_DEVICE
+   Idx = -1;
+   for (int I = 0; I < UpperBound; ++I) {
+      if (Functor(I)) {
+         Idx = I;
+         break;
+      }
+   }
+#else
+   const auto Policy = TeamThreadRange(Team, UpperBound);
+   Kokkos::parallel_reduce(
+       Policy,
+       INNER_LAMBDA(int I, int &Accum) {
+          if (I <= Accum && Functor(I)) {
+             Accum = I;
+          }
+       },
+       Kokkos::Min<int>(Idx));
+   if (Idx == Kokkos::reduction_identity<int>::min()) {
+      Idx = -1;
+   }
+#endif
+}
+
 } // end namespace OMEGA
 
 //===----------------------------------------------------------------------===//

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -204,7 +204,7 @@ struct Range {
 template <class F>
 KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, Range Rng,
                                       F &&Functor) {
-   const auto Policy = TeamThreadRange(Team, Rng.First, Rng.Last + 1);
+   const auto Policy = Kokkos::TeamThreadRange(Team, Rng.First, Rng.Last + 1);
    Kokkos::parallel_for(Policy, std::forward<F>(Functor));
 }
 
@@ -219,7 +219,7 @@ KOKKOS_FUNCTION void parallelForInner(const TeamMember &Team, int UpperBound,
 template <class F, class... R>
 KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, Range Rng,
                                          F &&Functor, R &&...Reducers) {
-   const auto Policy = TeamThreadRange(Team, Rng.First, Rng.Last + 1);
+   const auto Policy = Kokkos::TeamThreadRange(Team, Rng.First, Rng.Last + 1);
    Kokkos::parallel_reduce(Policy, std::forward<F>(Functor),
                            std::forward<R>(Reducers)...);
 }
@@ -236,7 +236,7 @@ KOKKOS_FUNCTION void parallelReduceInner(const TeamMember &Team, int UpperBound,
 template <class F, class... R>
 KOKKOS_FUNCTION void parallelScanInner(const TeamMember &Team, Range Rng,
                                        F &&Functor, R &&...Reducers) {
-   const auto Policy = TeamThreadRange(Team, Rng.First, Rng.Last + 1);
+   const auto Policy = Kokkos::TeamThreadRange(Team, Rng.First, Rng.Last + 1);
    Kokkos::parallel_scan(Policy, std::forward<F>(Functor),
                          std::forward<R>(Reducers)...);
 }
@@ -271,7 +271,7 @@ KOKKOS_FUNCTION void parallelSearchInner(const TeamMember &Team, Range Rng,
       }
    }
 #else
-   const auto Policy = TeamThreadRange(Team, Rng.First, Rng.Last + 1);
+   const auto Policy = Kokkos::TeamThreadRange(Team, Rng.First, Rng.Last + 1);
    Kokkos::parallel_reduce(
        Policy,
        INNER_LAMBDA(int I, int &Accum) {

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -30,27 +30,64 @@ constexpr int OMEGA_TEAMSIZE = 1;
 #define INNER_LAMBDA [=]
 // #define INNER_LAMBDA [&]
 
+template <class... T> struct TeamScratch {
+   size_t BytesPerTeam = 0;
+
+   TeamScratch() = default;
+
+   template <int N> TeamScratch(const int (&NVals)[N]) {
+      static_assert(N == sizeof...(T));
+      int I = 0;
+      ((BytesPerTeam += sizeof(T) * NVals[I++]), ...);
+   }
+
+   TeamScratch(int NVals) : TeamScratch({{NVals}}) {}
+};
+
+template <int N> struct LaunchConfig {
+   std::array<int, N> UpperBounds;
+   int TeamSize;
+   size_t ScratchBytesPerTeam;
+
+   template <class... T>
+   LaunchConfig(const int (&UpperBoundsIn)[N], int TeamSize,
+                const TeamScratch<T...> &Scratch)
+       : TeamSize(TeamSize), ScratchBytesPerTeam(Scratch.BytesPerTeam) {
+      std::copy(std::begin(UpperBoundsIn), std::end(UpperBoundsIn),
+                std::begin(UpperBounds));
+   }
+
+   template <class... T>
+   LaunchConfig(const int (&UpperBounds)[N], const TeamScratch<T...> &Scratch)
+       : LaunchConfig(UpperBounds, OMEGA_TEAMSIZE, Scratch) {}
+
+   LaunchConfig(const int (&UpperBounds)[N], int TeamSize)
+       : LaunchConfig(UpperBounds, TeamSize, TeamScratch<>{}) {}
+
+   LaunchConfig(const int (&UpperBounds)[N])
+       : LaunchConfig(UpperBounds, OMEGA_TEAMSIZE, TeamScratch<>{}) {}
+};
+
 KOKKOS_INLINE_FUNCTION void teamBarrier(const TeamMember &Team) {
    Team.team_barrier();
 }
 
-// parallelForOuter: with label
+// parallelForOuter: with label and with launch config
 template <int N, class F>
 inline void parallelForOuter(const std::string &Label,
-                             const int (&UpperBounds)[N], F &&Functor,
-                             int ScratchValsPerTeam = 0) {
+                             const LaunchConfig<N> &Config, F &&Functor) {
 
-   auto LinFunctor = LinearIdxWrapper{std::forward<F>(Functor), UpperBounds};
-   int LinBound    = 1;
+   auto LinFunctor =
+       LinearIdxWrapper{std::forward<F>(Functor), Config.UpperBounds};
+   int LinBound = 1;
    for (int Rank = 0; Rank < N; ++Rank) {
-      LinBound *= UpperBounds[Rank];
+      LinBound *= Config.UpperBounds[Rank];
    }
 
-   auto Policy = TeamPolicy(LinBound, OMEGA_TEAMSIZE);
+   auto Policy = TeamPolicy(LinBound, Config.TeamSize);
 
-   if (ScratchValsPerTeam > 0) {
-      Policy.set_scratch_size(
-          0, Kokkos::PerTeam(ScratchValsPerTeam * sizeof(Real)));
+   if (Config.ScratchBytesPerTeam > 0) {
+      Policy.set_scratch_size(0, Kokkos::PerTeam(Config.ScratchBytesPerTeam));
    }
 
    Kokkos::parallel_for(
@@ -60,12 +97,23 @@ inline void parallelForOuter(const std::string &Label,
        });
 }
 
-// parallelForOuter: without label
+// parallelForOuter: without label and with launch config
 template <int N, class F>
-inline void parallelForOuter(const int (&UpperBounds)[N], F &&Functor,
-                             int ScratchValsPerTeam = 0) {
-   parallelForOuter("", UpperBounds, std::forward<F>(Functor),
-                    ScratchValsPerTeam);
+inline void parallelForOuter(const LaunchConfig<N> &Config, F &&Functor) {
+   parallelForOuter("", Config, std::forward<F>(Functor));
+}
+
+// parallelForOuter: with label and with array bounds
+template <int N, class F>
+inline void parallelForOuter(const std::string &Label,
+                             const int (&UpperBounds)[N], F &&Functor) {
+   parallelForOuter(Label, LaunchConfig(UpperBounds), std::forward<F>(Functor));
+}
+
+// parallelForOuter: without label and with array bounds
+template <int N, class F>
+inline void parallelForOuter(const int (&UpperBounds)[N], F &&Functor) {
+   parallelForOuter("", LaunchConfig(UpperBounds), std::forward<F>(Functor));
 }
 
 // This struct is used to get the right accumulator type to be used in

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -200,6 +200,10 @@ inline void parallelReduceOuter(const int (&UpperBounds)[N], F &&Functor,
 struct Range {
    int First;
    int Last;
+
+   // Clamp Last to ensure zero iterations if First > Last.
+   KOKKOS_FUNCTION Range(int First, int Last)
+       : First(First), Last(Kokkos::max(Last, First - 1)) {}
 };
 
 // parallelForInner

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -181,7 +181,7 @@ inline void parallelReduceOuter(const LaunchConfig<N> &LConfig, F &&Functor,
 
 // parallelReduceOuter: with label and with array bounds
 template <int N, class F, class... R>
-inline void parallelReduceOuter(const std::string Label,
+inline void parallelReduceOuter(const std::string &Label,
                                 const int (&UpperBounds)[N], F &&Functor,
                                 R &&...Reducers) {
    parallelReduceOuter(Label, LaunchConfig(UpperBounds),

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -16,7 +16,6 @@ using TeamPolicy      = Kokkos::TeamPolicy<ExecSpace>;
 using TeamMember      = TeamPolicy::member_type;
 using ScratchMemSpace = ExecSpace::scratch_memory_space;
 using Kokkos::PerTeam;
-using Kokkos::TeamThreadRange;
 using ArrayScratch1DReal =
     Kokkos::View<Real *, ScratchMemSpace, Kokkos::MemoryUnmanaged>;
 

--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -15,7 +15,6 @@ namespace OMEGA {
 using TeamPolicy      = Kokkos::TeamPolicy<ExecSpace>;
 using TeamMember      = TeamPolicy::member_type;
 using ScratchMemSpace = ExecSpace::scratch_memory_space;
-using Kokkos::MemoryUnmanaged;
 using Kokkos::PerTeam;
 using Kokkos::TeamThreadRange;
 using ArrayScratch1DReal =

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -434,15 +434,12 @@ void Tendencies::computeThicknessTendenciesOnly(
 
    parallelForOuter(
        {Mesh->NCellsAll}, KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRange(KMin, KMax);
+          const int KMin = MinLayerCell(ICell);
+          const int KMax = MaxLayerCell(ICell);
 
           parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K                     = KMin + KChunk;
-                 LocLayerThicknessTend(ICell, K) = 0;
-              });
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(int K) { LocLayerThicknessTend(ICell, K) = 0; });
        });
 
    // Compute thickness flux divergence
@@ -510,15 +507,12 @@ void Tendencies::computeVelocityTendenciesOnly(
 
    parallelForOuter(
        {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-          const int KMin   = MinLayerEdgeBot(IEdge);
-          const int KMax   = MaxLayerEdgeTop(IEdge);
-          const int KRange = vertRange(KMin, KMax);
+          const int KMin = MinLayerEdgeBot(IEdge);
+          const int KMax = MaxLayerEdgeTop(IEdge);
 
           parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K                     = KMin + KChunk;
-                 LocNormalVelocityTend(IEdge, K) = 0;
-              });
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(int K) { LocNormalVelocityTend(IEdge, K) = 0; });
        });
 
    // Compute potential vorticity horizontal advection
@@ -704,14 +698,11 @@ void Tendencies::computeTracerTendenciesOnly(
    parallelForOuter(
        {NTracers, Mesh->NCellsAll},
        KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRange(KMin, KMax);
+          const int KMin = MinLayerCell(ICell);
+          const int KMax = MaxLayerCell(ICell);
           parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K                = KMin + KChunk;
-                 LocTracerTend(L, ICell, K) = 0;
-              });
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(int K) { LocTracerTend(L, ICell, K) = 0; });
        });
 
    // compute tracer horizotal advection

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -385,7 +385,7 @@ void VertAdv::computeVerticalVelocity(
        "computeVerticalVelocity",
        LaunchConfig({NCellsHalo0}, TeamScratch<Real>(NVertLayers)),
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          ArrayScratch1DReal DivHU(teamScratch(Team), LocNVertLayers);
+          ScratchArray1DReal DivHU(teamScratch(Team), LocNVertLayers);
 
           const Real InvAreaCell = 1._Real / LocAreaCell(ICell);
 
@@ -537,7 +537,7 @@ void VertAdv::computeVelocityVAdvTend(
 
           // Allocate scratch space for W times Du/Dz at vertical interfaces
           // between edges
-          ArrayScratch1DReal WDuDzEdge(teamScratch(Team), LocNVertLayersP1);
+          ScratchArray1DReal WDuDzEdge(teamScratch(Team), LocNVertLayersP1);
 
           // Flux is zero at top and bottom
           Kokkos::single(
@@ -847,11 +847,11 @@ void VertAdv::computeFCTVAdvTend(
           const I4 KMax = MaxLayerCell(ICell);
           I4 KRange     = vertRangeChunked(KMin, KMax);
 
-          ArrayScratch1DReal InvNewProvThick(teamScratch(Team), LocNVertLayers);
-          ArrayScratch1DReal WorkTend(teamScratch(Team), LocNVertLayers);
-          ArrayScratch1DReal FlxIn(teamScratch(Team), LocNVertLayers);
-          ArrayScratch1DReal FlxOut(teamScratch(Team), LocNVertLayers);
-          ArrayScratch1DReal RescaledFlux(teamScratch(Team),
+          ScratchArray1DReal InvNewProvThick(teamScratch(Team), LocNVertLayers);
+          ScratchArray1DReal WorkTend(teamScratch(Team), LocNVertLayers);
+          ScratchArray1DReal FlxIn(teamScratch(Team), LocNVertLayers);
+          ScratchArray1DReal FlxOut(teamScratch(Team), LocNVertLayers);
+          ScratchArray1DReal RescaledFlux(teamScratch(Team),
                                           LocNVertLayers + 1);
 
           parallelForInner(

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -384,7 +384,7 @@ void VertAdv::computeVerticalVelocity(
    parallelForOuter(
        "computeVerticalVelocity", {NCellsHalo0},
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          RealScratchArray DivHU(Team.team_scratch(0), LocNVertLayers);
+          ArrayScratch1DReal DivHU(Team.team_scratch(0), LocNVertLayers);
 
           const Real InvAreaCell = 1._Real / LocAreaCell(ICell);
 
@@ -536,7 +536,7 @@ void VertAdv::computeVelocityVAdvTend(
 
           // Allocate scratch space for W times Du/Dz at vertical interfaces
           // between edges
-          RealScratchArray WDuDzEdge(Team.team_scratch(0), LocNVertLayersP1);
+          ArrayScratch1DReal WDuDzEdge(Team.team_scratch(0), LocNVertLayersP1);
 
           // Flux is zero at top and bottom
           Kokkos::single(
@@ -845,13 +845,13 @@ void VertAdv::computeFCTVAdvTend(
           const I4 KMax = MaxLayerCell(ICell);
           I4 KRange     = vertRangeChunked(KMin, KMax);
 
-          RealScratchArray InvNewProvThick(Team.team_scratch(0),
-                                           LocNVertLayers);
-          RealScratchArray WorkTend(Team.team_scratch(0), LocNVertLayers);
-          RealScratchArray FlxIn(Team.team_scratch(0), LocNVertLayers);
-          RealScratchArray FlxOut(Team.team_scratch(0), LocNVertLayers);
-          RealScratchArray RescaledFlux(Team.team_scratch(0),
-                                        LocNVertLayers + 1);
+          ArrayScratch1DReal InvNewProvThick(Team.team_scratch(0),
+                                             LocNVertLayers);
+          ArrayScratch1DReal WorkTend(Team.team_scratch(0), LocNVertLayers);
+          ArrayScratch1DReal FlxIn(Team.team_scratch(0), LocNVertLayers);
+          ArrayScratch1DReal FlxOut(Team.team_scratch(0), LocNVertLayers);
+          ArrayScratch1DReal RescaledFlux(Team.team_scratch(0),
+                                          LocNVertLayers + 1);
 
           parallelForInner(
               Team, KRange, INNER_LAMBDA(int KChunk) {

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -385,7 +385,7 @@ void VertAdv::computeVerticalVelocity(
        "computeVerticalVelocity",
        LaunchConfig({NCellsHalo0}, TeamScratch<Real>(NVertLayers)),
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          ArrayScratch1DReal DivHU(Team.team_scratch(0), LocNVertLayers);
+          ArrayScratch1DReal DivHU(teamScratch(Team), LocNVertLayers);
 
           const Real InvAreaCell = 1._Real / LocAreaCell(ICell);
 
@@ -416,7 +416,7 @@ void VertAdv::computeVerticalVelocity(
                  }
               });
 
-          Team.team_barrier();
+          teamBarrier(Team);
 
           // Set velocity through top and bottom interfaces to zero
           Kokkos::single(
@@ -537,7 +537,7 @@ void VertAdv::computeVelocityVAdvTend(
 
           // Allocate scratch space for W times Du/Dz at vertical interfaces
           // between edges
-          ArrayScratch1DReal WDuDzEdge(Team.team_scratch(0), LocNVertLayersP1);
+          ArrayScratch1DReal WDuDzEdge(teamScratch(Team), LocNVertLayersP1);
 
           // Flux is zero at top and bottom
           Kokkos::single(
@@ -567,7 +567,7 @@ void VertAdv::computeVelocityVAdvTend(
                  }
               });
 
-          Team.team_barrier();
+          teamBarrier(Team);
 
           KRange = vertRangeChunked(KMin, KMax);
           // Average W*Du/Dz from interfaces to layer midpoints
@@ -847,12 +847,11 @@ void VertAdv::computeFCTVAdvTend(
           const I4 KMax = MaxLayerCell(ICell);
           I4 KRange     = vertRangeChunked(KMin, KMax);
 
-          ArrayScratch1DReal InvNewProvThick(Team.team_scratch(0),
-                                             LocNVertLayers);
-          ArrayScratch1DReal WorkTend(Team.team_scratch(0), LocNVertLayers);
-          ArrayScratch1DReal FlxIn(Team.team_scratch(0), LocNVertLayers);
-          ArrayScratch1DReal FlxOut(Team.team_scratch(0), LocNVertLayers);
-          ArrayScratch1DReal RescaledFlux(Team.team_scratch(0),
+          ArrayScratch1DReal InvNewProvThick(teamScratch(Team), LocNVertLayers);
+          ArrayScratch1DReal WorkTend(teamScratch(Team), LocNVertLayers);
+          ArrayScratch1DReal FlxIn(teamScratch(Team), LocNVertLayers);
+          ArrayScratch1DReal FlxOut(teamScratch(Team), LocNVertLayers);
+          ArrayScratch1DReal RescaledFlux(teamScratch(Team),
                                           LocNVertLayers + 1);
 
           parallelForInner(
@@ -930,7 +929,7 @@ void VertAdv::computeFCTVAdvTend(
                  }
               });
 
-          Team.team_barrier();
+          teamBarrier(Team);
 
           KRange = vertRangeChunked(KMin + 1, KMax);
 
@@ -953,7 +952,7 @@ void VertAdv::computeFCTVAdvTend(
                  }
               });
 
-          Team.team_barrier();
+          teamBarrier(Team);
 
           // Accumulate total FCT vertical advection tendency
           KRange = vertRangeChunked(KMin, KMax);

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -382,7 +382,8 @@ void VertAdv::computeVerticalVelocity(
 
    // Loop over all cells owned by the task
    parallelForOuter(
-       "computeVerticalVelocity", {NCellsHalo0},
+       "computeVerticalVelocity",
+       LaunchConfig({NCellsHalo0}, TeamScratch<Real>(NVertLayers)),
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
           ArrayScratch1DReal DivHU(Team.team_scratch(0), LocNVertLayers);
 
@@ -454,8 +455,7 @@ void VertAdv::computeVerticalVelocity(
                     LocTotVertVel(ICell, KRev) = Accum;
                  }
               });
-       },
-       NVertLayers);
+       });
 
 } // end computeVerticalVelocity
 
@@ -526,7 +526,8 @@ void VertAdv::computeVelocityVAdvTend(
 
    // Loop over every owned edge
    parallelForOuter(
-       "computeVelocityVAdvTend", {NEdgesOwned},
+       "computeVelocityVAdvTend",
+       LaunchConfig({NEdgesOwned}, TeamScratch<Real>(NVertLayersP1)),
        KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
           const I4 Cell1 = LocCOnE(IEdge, 0);
           const I4 Cell2 = LocCOnE(IEdge, 1);
@@ -581,8 +582,7 @@ void VertAdv::computeVelocityVAdvTend(
                                          (WDuDzEdge(K) + WDuDzEdge(K + 1));
                  }
               });
-       },
-       NVertLayersP1);
+       });
 
 } // end computeVelocityVAdvTend
 
@@ -839,7 +839,9 @@ void VertAdv::computeFCTVAdvTend(
    OMEGA_SCOPE(LocEps, Eps);
 
    parallelForOuter(
-       "computeFCTVAdvTend", {NTracers, NCellsOwned},
+       "computeFCTVAdvTend",
+       LaunchConfig({NTracers, NCellsOwned},
+                    TeamScratch<Real>(5 * NVertLayers + 1)),
        KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
           const I4 KMin = MinLayerCell(ICell);
           const I4 KMax = MaxLayerCell(ICell);
@@ -967,8 +969,7 @@ void VertAdv::computeFCTVAdvTend(
                  }
               });
           // TODO: Monotonicity and diagnostic checks
-       },
-       5 * NVertLayers + 1);
+       });
 
 } // end computeFTCVAdvTend
 

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -938,7 +938,8 @@ void VertCoord::computePressure(
           const I4 KMax               = LocMaxLayerCell(ICell);
           LocPressInterf(ICell, KMin) = SurfacePressure(ICell);
           parallelScanInner(
-              Team, Range{KMin, KMax}, INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
                  Real Increment = Gravity * RhoSw * LayerThickness(ICell, K);
                  Accum += Increment;
 

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -866,11 +866,8 @@ void VertCoord::setMasks() {
           const I4 KMax = LocMaxLyrEdgeTop(IEdge);
 
           parallelForInner(
-              Team, KMax - KMin + 1, INNER_LAMBDA(int K) {
-                 I4 KLyr = KMin + K;
-
-                 LocEdgeMask(IEdge, KLyr) = 1._Real;
-              });
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(int K) { LocEdgeMask(IEdge, K) = 1._Real; });
        });
 
    EdgeMaskH = createHostMirrorCopy(EdgeMask);
@@ -889,11 +886,8 @@ void VertCoord::setMasks() {
           const I4 KMax = LocMaxLyrCell(ICell);
 
           parallelForInner(
-              Team, KMax - KMin + 1, INNER_LAMBDA(int K) {
-                 I4 KLyr = KMin + K;
-
-                 LocCellMask(ICell, KLyr) = 1._Real;
-              });
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(int K) { LocCellMask(ICell, K) = 1._Real; });
        });
 
    CellMaskH = createHostMirrorCopy(CellMask);
@@ -913,11 +907,8 @@ void VertCoord::setMasks() {
           const I4 KMax = LocMaxLyrVrtxBot(IVertex);
 
           parallelForInner(
-              Team, KMax - KMin + 1, INNER_LAMBDA(int K) {
-                 I4 KLyr = KMin + K;
-
-                 LocVrtxMask(IVertex, KLyr) = 1._Real;
-              });
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(int K) { LocVrtxMask(IVertex, K) = 1._Real; });
        });
 
    VertexMaskH = createHostMirrorCopy(VertexMask);
@@ -943,21 +934,18 @@ void VertCoord::computePressure(
    parallelForOuter(
        "computePressure", {NCellsAll},
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          const I4 KMin   = LocMinLayerCell(ICell);
-          const I4 KMax   = LocMaxLayerCell(ICell);
-          const I4 KRange = vertRange(KMin, KMax);
-
+          const I4 KMin               = LocMinLayerCell(ICell);
+          const I4 KMax               = LocMaxLayerCell(ICell);
           LocPressInterf(ICell, KMin) = SurfacePressure(ICell);
           parallelScanInner(
-              Team, KRange, INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
-                 const I4 KLyr  = K + KMin;
-                 Real Increment = Gravity * RhoSw * LayerThickness(ICell, KLyr);
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
+                 Real Increment = Gravity * RhoSw * LayerThickness(ICell, K);
                  Accum += Increment;
 
                  if (IsFinal) {
-                    LocPressInterf(ICell, KLyr + 1) =
+                    LocPressInterf(ICell, K + 1) =
                         SurfacePressure(ICell) + Accum;
-                    LocPressMid(ICell, KLyr) =
+                    LocPressMid(ICell, K) =
                         SurfacePressure(ICell) + Accum - 0.5 * Increment;
                  }
               });
@@ -1061,10 +1049,8 @@ void VertCoord::computeTargetThickness() {
    parallelForOuter(
        "computeTargetThickness", {NCellsAll},
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          const I4 KMin   = LocMinLayerCell(ICell);
-          const I4 KMax   = LocMaxLayerCell(ICell);
-          const I4 KRange = vertRange(KMin, KMax);
-
+          const I4 KMin = LocMinLayerCell(ICell);
+          const I4 KMax = LocMaxLayerCell(ICell);
           Real Coeff =
               (LocPressInterf(ICell, KMax + 1) - LocPressInterf(ICell, KMin)) /
               (Gravity * RhoSw);
@@ -1072,11 +1058,10 @@ void VertCoord::computeTargetThickness() {
           Real SumWh   = 0;
           Real SumRefH = 0;
           parallelReduceInner(
-              Team, KRange,
+              Team, Range{KMin, KMax},
               INNER_LAMBDA(const int K, Real &LocalWh, Real &LocalSum) {
-                 const I4 KLyr             = K + KMin;
-                 const Real RefPseudoThick = LocRefPseudoThick(ICell, KLyr);
-                 LocalWh += LocVertCoordMvmtWgts(KLyr) * RefPseudoThick;
+                 const Real RefPseudoThick = LocRefPseudoThick(ICell, K);
+                 LocalWh += LocVertCoordMvmtWgts(K) * RefPseudoThick;
                  LocalSum += RefPseudoThick;
               },
               SumWh, SumRefH);

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -463,13 +463,11 @@ void TimeStepper::updateThicknessByTend(OceanState *State1, int TimeLevel1,
    parallelForOuter(
        "updateThickByTend", {Mesh->NCellsAll},
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRange(KMin, KMax);
+          const int KMin = MinLayerCell(ICell);
+          const int KMax = MaxLayerCell(ICell);
 
           parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K = KMin + KChunk;
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
                  LayerThick1(ICell, K) =
                      LayerThick2(ICell, K) +
                      CoeffSeconds * LayerThickTend(ICell, K);
@@ -498,13 +496,11 @@ void TimeStepper::updateVelocityByTend(OceanState *State1, int TimeLevel1,
    parallelForOuter(
        "updateVelByTend", {Mesh->NEdgesAll},
        KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-          const int KMin   = MinLayerEdgeBot(IEdge);
-          const int KMax   = MaxLayerEdgeTop(IEdge);
-          const int KRange = vertRange(KMin, KMax);
+          const int KMin = MinLayerEdgeBot(IEdge);
+          const int KMax = MaxLayerEdgeTop(IEdge);
 
           parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K          = KMin + KChunk;
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
                  NormalVel1(IEdge, K) = NormalVel2(IEdge, K) +
                                         CoeffSeconds * NormalVelTend(IEdge, K);
               });
@@ -704,12 +700,10 @@ void TimeStepper::updateTracersByTend(const Array3DReal &NextTracers,
    parallelForOuter(
        "updateTracersByTend", {NTracers, Mesh->NCellsAll},
        KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRange(KMin, KMax);
+          const int KMin = MinLayerCell(ICell);
+          const int KMax = MaxLayerCell(ICell);
           parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K = KMin + KChunk;
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
                  NextTracers(L, ICell, K) =
                      (CurTracers(L, ICell, K) * LayerThick2(ICell, K) +
                       CoeffSeconds * TracerTend(L, ICell, K)) /
@@ -732,12 +726,10 @@ void TimeStepper::weightTracers(const Array3DReal &NextTracers,
    parallelForOuter(
        "weightTracers", {NTracers, Mesh->NCellsAll},
        KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRange(KMin, KMax);
+          const int KMin = MinLayerCell(ICell);
+          const int KMax = MaxLayerCell(ICell);
           parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K = KMin + KChunk;
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
                  NextTracers(L, ICell, K) =
                      CurTracers(L, ICell, K) * CurThickness(ICell, K);
               });
@@ -761,12 +753,10 @@ void TimeStepper::accumulateTracersUpdate(const Array3DReal &AccumTracer,
    parallelForOuter(
        "accumulateTracersUpdate", {NTracers, Mesh->NCellsAll},
        KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRange(KMin, KMax);
+          const int KMin = MinLayerCell(ICell);
+          const int KMax = MaxLayerCell(ICell);
           parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K = KMin + KChunk;
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
                  AccumTracer(L, ICell, K) +=
                      CoeffSeconds * TracerTend(L, ICell, K);
               });
@@ -787,12 +777,10 @@ void TimeStepper::finalizeTracersUpdate(const Array3DReal &NextTracers,
    parallelForOuter(
        "finalizeTracersUpdate", {NTracers, Mesh->NCellsAll},
        KOKKOS_LAMBDA(int L, int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRange(KMin, KMax);
+          const int KMin = MinLayerCell(ICell);
+          const int KMax = MaxLayerCell(ICell);
           parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 const int K = KMin + KChunk;
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
                  NextTracers(L, ICell, K) /= NextThick(ICell, K);
               });
        });

--- a/components/omega/test/base/TriDiagSolversTest.cpp
+++ b/components/omega/test/base/TriDiagSolversTest.cpp
@@ -165,46 +165,44 @@ Real runDiffManufactured(int NCells) {
           U(ICell)          = manufacturedSolution(XCell(ICell), 0);
        });
 
-   TeamPolicy Policy = TriDiagDiffSolver::makeTeamPolicy(1, NCells);
+   auto LConfig = TriDiagDiffSolver::makeLaunchConfig(1, NCells);
 
    // Integrate in time with backward Euler
    for (int Step = 0; Step < NSteps; ++Step) {
       const Real Time     = Step * TimeStep;
       const Real TimeNext = (Step + 1) * TimeStep;
 
-      Kokkos::parallel_for(
-          Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+      parallelForOuter(
+          LConfig, KOKKOS_LAMBDA(int, const TeamMember &Member) {
              TriDiagDiffScratch Scratch(Member, NCells);
 
              // Setup the system to be solved
-             Kokkos::parallel_for(
-                 TeamThreadRange(Member, NCells), [=](int ICell) {
-                    for (int IVec = 0; IVec < VecLength; ++IVec) {
+             parallelForInner(Member, NCells, [=](int ICell) {
+                for (int IVec = 0; IVec < VecLength; ++IVec) {
 
-                       // Forcing term from the manufactured solution
-                       const Real F =
-                           manufacturedForcing(XCell(ICell), TimeNext);
+                   // Forcing term from the manufactured solution
+                   const Real F = manufacturedForcing(XCell(ICell), TimeNext);
 
-                       Scratch.H(ICell, IVec) = LayerThick(ICell);
+                   Scratch.H(ICell, IVec) = LayerThick(ICell);
 
-                       if (ICell == NCells - 1) {
-                          // Boundary condition
-                          const Real XBnd = XVertex(ICell + 1);
-                          const Real BoundaryCoeff =
-                              -(2 + Kokkos::sin(XBnd)) * Kokkos::tan(XBnd);
-                          Scratch.H(ICell, IVec) -= TimeStep * BoundaryCoeff;
-                          Scratch.G(ICell, IVec) = 0;
-                       } else {
-                          const Real AvgLayerThick =
-                              (LayerThick(ICell + 1) + LayerThick(ICell)) / 2;
-                          Scratch.G(ICell, IVec) =
-                              Diffusivity(ICell + 1) * TimeStep / AvgLayerThick;
-                       }
-                       // RHS
-                       Scratch.X(ICell, IVec) =
-                           LayerThick(ICell) * (U(ICell) + TimeStep * F);
-                    }
-                 });
+                   if (ICell == NCells - 1) {
+                      // Boundary condition
+                      const Real XBnd = XVertex(ICell + 1);
+                      const Real BoundaryCoeff =
+                          -(2 + Kokkos::sin(XBnd)) * Kokkos::tan(XBnd);
+                      Scratch.H(ICell, IVec) -= TimeStep * BoundaryCoeff;
+                      Scratch.G(ICell, IVec) = 0;
+                   } else {
+                      const Real AvgLayerThick =
+                          (LayerThick(ICell + 1) + LayerThick(ICell)) / 2;
+                      Scratch.G(ICell, IVec) =
+                          Diffusivity(ICell + 1) * TimeStep / AvgLayerThick;
+                   }
+                   // RHS
+                   Scratch.X(ICell, IVec) =
+                       LayerThick(ICell) * (U(ICell) + TimeStep * F);
+                }
+             });
 
              // Solve the system
              Member.team_barrier();
@@ -212,9 +210,9 @@ Real runDiffManufactured(int NCells) {
              Member.team_barrier();
 
              // Store the solution
-             Kokkos::parallel_for(
-                 TeamThreadRange(Member, NCells),
-                 [=](int ICell) { U(ICell) = Scratch.X(ICell, 0); });
+             parallelForInner(Member, NCells, [=](int ICell) {
+                U(ICell) = Scratch.X(ICell, 0);
+             });
           });
    }
 
@@ -318,45 +316,42 @@ Real runDiffusionStability(bool UseGeneralSolver, Real DiffValue) {
    for (int Step = 0; Step < NSteps; ++Step) {
 
       if (UseGeneralSolver) {
-         TeamPolicy Policy = TriDiagSolver::makeTeamPolicy(1, NCells);
+         auto LConfig = TriDiagSolver::makeLaunchConfig(1, NCells);
 
-         Kokkos::parallel_for(
-             Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+         parallelForOuter(
+             LConfig, KOKKOS_LAMBDA(int, const TeamMember &Member) {
                 TriDiagScratch Scratch(Member, NCells);
 
                 // Setup the system to be solved in the form expected by the
                 // general tridiagonal solver
-                Kokkos::parallel_for(
-                    TeamThreadRange(Member, NCells), [=](int ICell) {
-                       for (int IVec = 0; IVec < VecLength; ++IVec) {
+                parallelForInner(Member, NCells, [=](int ICell) {
+                   for (int IVec = 0; IVec < VecLength; ++IVec) {
 
-                          if (ICell < NCells - 1) {
-                             const Real AvgLayerThick =
-                                 (LayerThick(ICell + 1) + LayerThick(ICell)) /
-                                 2;
-                             Scratch.DU(ICell, IVec) = -Diffusivity(ICell + 1) *
-                                                       TimeStep / AvgLayerThick;
-                          } else {
-                             Scratch.DU(ICell, IVec) = 0;
-                          }
+                      if (ICell < NCells - 1) {
+                         const Real AvgLayerThick =
+                             (LayerThick(ICell + 1) + LayerThick(ICell)) / 2;
+                         Scratch.DU(ICell, IVec) =
+                             -Diffusivity(ICell + 1) * TimeStep / AvgLayerThick;
+                      } else {
+                         Scratch.DU(ICell, IVec) = 0;
+                      }
 
-                          if (ICell > 0) {
-                             const Real AvgLayerThick =
-                                 (LayerThick(ICell) + LayerThick(ICell - 1)) /
-                                 2;
-                             Scratch.DL(ICell, IVec) =
-                                 -Diffusivity(ICell) * TimeStep / AvgLayerThick;
-                          } else {
-                             Scratch.DL(ICell, IVec) = 0;
-                          }
+                      if (ICell > 0) {
+                         const Real AvgLayerThick =
+                             (LayerThick(ICell) + LayerThick(ICell - 1)) / 2;
+                         Scratch.DL(ICell, IVec) =
+                             -Diffusivity(ICell) * TimeStep / AvgLayerThick;
+                      } else {
+                         Scratch.DL(ICell, IVec) = 0;
+                      }
 
-                          Scratch.D(ICell, IVec) = LayerThick(ICell) -
-                                                   Scratch.DU(ICell, IVec) -
-                                                   Scratch.DL(ICell, IVec);
+                      Scratch.D(ICell, IVec) = LayerThick(ICell) -
+                                               Scratch.DU(ICell, IVec) -
+                                               Scratch.DL(ICell, IVec);
 
-                          Scratch.X(ICell, IVec) = LayerThick(ICell) * U(ICell);
-                       }
-                    });
+                      Scratch.X(ICell, IVec) = LayerThick(ICell) * U(ICell);
+                   }
+                });
 
                 // Solve the system
                 Member.team_barrier();
@@ -364,38 +359,36 @@ Real runDiffusionStability(bool UseGeneralSolver, Real DiffValue) {
                 Member.team_barrier();
 
                 // Save the solution
-                Kokkos::parallel_for(
-                    TeamThreadRange(Member, NCells),
-                    [=](int ICell) { U(ICell) = Scratch.X(ICell, 0); });
+                parallelForInner(Member, NCells, [=](int ICell) {
+                   U(ICell) = Scratch.X(ICell, 0);
+                });
              });
       } else {
-         TeamPolicy Policy = TriDiagDiffSolver::makeTeamPolicy(1, NCells);
+         auto LConfig = TriDiagDiffSolver::makeLaunchConfig(1, NCells);
 
-         Kokkos::parallel_for(
-             Policy, KOKKOS_LAMBDA(const TeamMember &Member) {
+         parallelForOuter(
+             LConfig, KOKKOS_LAMBDA(int, const TeamMember &Member) {
                 TriDiagDiffScratch Scratch(Member, NCells);
 
                 // Setup the system to be solved in the form expected by the
                 // specialized diffusion tridiagonal solver
-                Kokkos::parallel_for(
-                    TeamThreadRange(Member, NCells), [=](int ICell) {
-                       for (int IVec = 0; IVec < VecLength; ++IVec) {
+                parallelForInner(Member, NCells, [=](int ICell) {
+                   for (int IVec = 0; IVec < VecLength; ++IVec) {
 
-                          Scratch.H(ICell, IVec) = LayerThick(ICell);
+                      Scratch.H(ICell, IVec) = LayerThick(ICell);
 
-                          if (ICell < NCells - 1) {
-                             const Real AvgLayerThick =
-                                 (LayerThick(ICell + 1) + LayerThick(ICell)) /
-                                 2;
-                             Scratch.G(ICell, IVec) = Diffusivity(ICell + 1) *
-                                                      TimeStep / AvgLayerThick;
-                          } else {
-                             Scratch.G(ICell, IVec) = 0;
-                          }
+                      if (ICell < NCells - 1) {
+                         const Real AvgLayerThick =
+                             (LayerThick(ICell + 1) + LayerThick(ICell)) / 2;
+                         Scratch.G(ICell, IVec) =
+                             Diffusivity(ICell + 1) * TimeStep / AvgLayerThick;
+                      } else {
+                         Scratch.G(ICell, IVec) = 0;
+                      }
 
-                          Scratch.X(ICell, IVec) = LayerThick(ICell) * U(ICell);
-                       }
-                    });
+                      Scratch.X(ICell, IVec) = LayerThick(ICell) * U(ICell);
+                   }
+                });
 
                 // Solve the system
                 Member.team_barrier();
@@ -403,9 +396,9 @@ Real runDiffusionStability(bool UseGeneralSolver, Real DiffValue) {
                 Member.team_barrier();
 
                 // Store the solution
-                Kokkos::parallel_for(
-                    TeamThreadRange(Member, NCells),
-                    [=](int ICell) { U(ICell) = Scratch.X(ICell, 0); });
+                parallelForInner(Member, NCells, [=](int ICell) {
+                   U(ICell) = Scratch.X(ICell, 0);
+                });
              });
       }
    }

--- a/components/omega/test/base/TriDiagSolversTest.cpp
+++ b/components/omega/test/base/TriDiagSolversTest.cpp
@@ -173,11 +173,11 @@ Real runDiffManufactured(int NCells) {
       const Real TimeNext = (Step + 1) * TimeStep;
 
       parallelForOuter(
-          LConfig, KOKKOS_LAMBDA(int, const TeamMember &Member) {
-             TriDiagDiffScratch Scratch(Member, NCells);
+          LConfig, KOKKOS_LAMBDA(int, const TeamMember &Team) {
+             TriDiagDiffScratch Scratch(Team, NCells);
 
              // Setup the system to be solved
-             parallelForInner(Member, NCells, [=](int ICell) {
+             parallelForInner(Team, NCells, [=](int ICell) {
                 for (int IVec = 0; IVec < VecLength; ++IVec) {
 
                    // Forcing term from the manufactured solution
@@ -205,12 +205,12 @@ Real runDiffManufactured(int NCells) {
              });
 
              // Solve the system
-             Member.team_barrier();
-             TriDiagDiffSolver::solve(Member, Scratch);
-             Member.team_barrier();
+             teamBarrier(Team);
+             TriDiagDiffSolver::solve(Team, Scratch);
+             teamBarrier(Team);
 
              // Store the solution
-             parallelForInner(Member, NCells, [=](int ICell) {
+             parallelForInner(Team, NCells, [=](int ICell) {
                 U(ICell) = Scratch.X(ICell, 0);
              });
           });
@@ -319,12 +319,12 @@ Real runDiffusionStability(bool UseGeneralSolver, Real DiffValue) {
          auto LConfig = TriDiagSolver::makeLaunchConfig(1, NCells);
 
          parallelForOuter(
-             LConfig, KOKKOS_LAMBDA(int, const TeamMember &Member) {
-                TriDiagScratch Scratch(Member, NCells);
+             LConfig, KOKKOS_LAMBDA(int, const TeamMember &Team) {
+                TriDiagScratch Scratch(Team, NCells);
 
                 // Setup the system to be solved in the form expected by the
                 // general tridiagonal solver
-                parallelForInner(Member, NCells, [=](int ICell) {
+                parallelForInner(Team, NCells, [=](int ICell) {
                    for (int IVec = 0; IVec < VecLength; ++IVec) {
 
                       if (ICell < NCells - 1) {
@@ -354,12 +354,12 @@ Real runDiffusionStability(bool UseGeneralSolver, Real DiffValue) {
                 });
 
                 // Solve the system
-                Member.team_barrier();
-                TriDiagSolver::solve(Member, Scratch);
-                Member.team_barrier();
+                teamBarrier(Team);
+                TriDiagSolver::solve(Team, Scratch);
+                teamBarrier(Team);
 
                 // Save the solution
-                parallelForInner(Member, NCells, [=](int ICell) {
+                parallelForInner(Team, NCells, [=](int ICell) {
                    U(ICell) = Scratch.X(ICell, 0);
                 });
              });
@@ -367,12 +367,12 @@ Real runDiffusionStability(bool UseGeneralSolver, Real DiffValue) {
          auto LConfig = TriDiagDiffSolver::makeLaunchConfig(1, NCells);
 
          parallelForOuter(
-             LConfig, KOKKOS_LAMBDA(int, const TeamMember &Member) {
-                TriDiagDiffScratch Scratch(Member, NCells);
+             LConfig, KOKKOS_LAMBDA(int, const TeamMember &Team) {
+                TriDiagDiffScratch Scratch(Team, NCells);
 
                 // Setup the system to be solved in the form expected by the
                 // specialized diffusion tridiagonal solver
-                parallelForInner(Member, NCells, [=](int ICell) {
+                parallelForInner(Team, NCells, [=](int ICell) {
                    for (int IVec = 0; IVec < VecLength; ++IVec) {
 
                       Scratch.H(ICell, IVec) = LayerThick(ICell);
@@ -391,12 +391,12 @@ Real runDiffusionStability(bool UseGeneralSolver, Real DiffValue) {
                 });
 
                 // Solve the system
-                Member.team_barrier();
-                TriDiagDiffSolver::solve(Member, Scratch);
-                Member.team_barrier();
+                teamBarrier(Team);
+                TriDiagDiffSolver::solve(Team, Scratch);
+                teamBarrier(Team);
 
                 // Store the solution
-                parallelForInner(Member, NCells, [=](int ICell) {
+                parallelForInner(Team, NCells, [=](int ICell) {
                    U(ICell) = Scratch.X(ICell, 0);
                 });
              });

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -355,7 +355,7 @@ Error testHiparFor2DFor1D(int N1, int N2) {
    HostArray3DI4 RefAH("RefA3H", N1, N2, N3);
    for (int J1 = 0; J1 < N1; ++J1) {
       for (int J2 = 0; J2 < N2; ++J2) {
-         for (int J3 = 0; J3 < J1 + J2; ++J3) {
+         for (int J3 = J1; J3 <= J1 + J2; ++J3) {
             RefAH(J1, J2, J3) = f3(J1, J2, J3, N1, N2, N3);
          }
       }
@@ -365,7 +365,7 @@ Error testHiparFor2DFor1D(int N1, int N2) {
    parallelForOuter(
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
           parallelForInner(
-              Team, J1 + J2, INNER_LAMBDA(int J3) {
+              Team, J1, J1 + J2, INNER_LAMBDA(int J3) {
                  A(J1, J2, J3) = f3(J1, J2, J3, N1, N2, N3);
               });
        });
@@ -389,7 +389,7 @@ Error testHiparFor2DReduce1D(int N1, int N2) {
       for (int J2 = 0; J2 < N2; ++J2) {
          I4 Sum = 0;
          I4 Max = std::numeric_limits<I4>::min();
-         for (int J3 = 0; J3 < J1 + J2; ++J3) {
+         for (int J3 = J1; J3 <= J1 + J2; ++J3) {
             Sum += f3(J1, J2, J3, N1, N2, N3);
             Max = std::max(Max, f3(J1, J2, J3, N1, N2, N3));
          }
@@ -404,7 +404,7 @@ Error testHiparFor2DReduce1D(int N1, int N2) {
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
           I4 Sum;
           parallelReduceInner(
-              Team, J1 + J2,
+              Team, J1, J1 + J2,
               INNER_LAMBDA(int J3, I4 &Accum) {
                  Accum += f3(J1, J2, J3, N1, N2, N3);
               },
@@ -413,7 +413,7 @@ Error testHiparFor2DReduce1D(int N1, int N2) {
 
           I4 Max;
           parallelReduceInner(
-              Team, J1 + J2,
+              Team, J1, J1 + J2,
               INNER_LAMBDA(int J3, I4 &Accum) {
                  Accum = Kokkos::max(Accum, f3(J1, J2, J3, N1, N2, N3));
               },
@@ -437,7 +437,7 @@ Error testHiparFor2DReduce1D(int N1, int N2) {
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
           I4 Sum, Max;
           parallelReduceInner(
-              Team, J1 + J2,
+              Team, J1, J1 + J2,
               INNER_LAMBDA(int J3, I4 &AccumSum, I4 &AccumMax) {
                  AccumSum += f3(J1, J2, J3, N1, N2, N3);
                  AccumMax = Kokkos::max(AccumMax, f3(J1, J2, J3, N1, N2, N3));
@@ -464,7 +464,7 @@ Error testHiparFor2DScan1D(int N1, int N2) {
    for (int J1 = 0; J1 < N1; ++J1) {
       for (int J2 = 0; J2 < N2; ++J2) {
          I4 RSum = 0;
-         for (int J3 = 0; J3 < J1 + J2; ++J3) {
+         for (int J3 = J1; J3 <= J1 + J2; ++J3) {
             RefRSumH(J1, J2, J3) = RSum;
             RSum += f3(J1, J2, J3, N1, N2, N3);
          }
@@ -475,7 +475,7 @@ Error testHiparFor2DScan1D(int N1, int N2) {
    parallelForOuter(
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
           parallelScanInner(
-              Team, J1 + J2, INNER_LAMBDA(int J3, I4 &Accum, bool IsFinal) {
+              Team, J1, J1 + J2, INNER_LAMBDA(int J3, I4 &Accum, bool IsFinal) {
                  if (IsFinal) {
                     RSum(J1, J2, J3) = Accum;
                  }
@@ -500,7 +500,7 @@ Error testHiparReduce2DReduce1D(int N1, int N2) {
    I4 RefMax = std::numeric_limits<I4>::min();
    for (int J1 = 0; J1 < N1; ++J1) {
       for (int J2 = 0; J2 < N2; ++J2) {
-         for (int J3 = 0; J3 < J1 + J2; ++J3) {
+         for (int J3 = J1; J3 <= J1 + J2; ++J3) {
             RefSum += f3(J1, J2, J3, N1, N2, N3);
             RefMax = std::max(RefMax, f3(J1, J2, J3, N1, N2, N3));
          }
@@ -513,7 +513,7 @@ Error testHiparReduce2DReduce1D(int N1, int N2) {
        KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team, I4 &AccumOuter) {
           I4 SumInner;
           parallelReduceInner(
-              Team, J1 + J2,
+              Team, J1, J1 + J2,
               INNER_LAMBDA(int J3, I4 &AccumInner) {
                  AccumInner += f3(J1, J2, J3, N1, N2, N3);
               },
@@ -534,7 +534,7 @@ Error testHiparReduce2DReduce1D(int N1, int N2) {
        KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team, I4 &AccumOuter) {
           I4 MaxInner;
           parallelReduceInner(
-              Team, J1 + J2,
+              Team, J1, J1 + J2,
               INNER_LAMBDA(int J3, I4 &AccumInner) {
                  AccumInner =
                      Kokkos::max(AccumInner, f3(J1, J2, J3, N1, N2, N3));
@@ -556,7 +556,7 @@ Error testHiparReduce2DReduce1D(int N1, int N2) {
                      I4 &AccumMaxOuter) {
           I4 SumInner, MaxInner;
           parallelReduceInner(
-              Team, J1 + J2,
+              Team, J1, J1 + J2,
               INNER_LAMBDA(int J3, I4 &AccumSumInner, I4 &AccumMaxInner) {
                  AccumSumInner += f3(J1, J2, J3, N1, N2, N3);
                  AccumMaxInner =

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -402,7 +402,7 @@ Error testHiparLaunchConfig1D(int N1, int N2) {
        LaunchConfig({N1}, TeamSize, TeamScratch<Real, I4>(N2, N2 - 2));
    parallelForOuter(
        LConfig, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
-          ArrayScratch1DI4 ScratchA(Team.team_scratch(0), N2);
+          ArrayScratch1DI4 ScratchA(teamScratch(Team), N2);
 
           parallelForInner(
               Team, N2, INNER_LAMBDA(int J2) {
@@ -411,7 +411,7 @@ Error testHiparLaunchConfig1D(int N1, int N2) {
 
           teamBarrier(Team);
 
-          ArrayScratch1DReal ScratchB(Team.team_scratch(0), N2 - 2);
+          ArrayScratch1DReal ScratchB(teamScratch(Team), N2 - 2);
 
           parallelForInner(
               Team, Range{1, N2 - 2}, INNER_LAMBDA(int J2) {

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -366,6 +366,75 @@ Error testHiparFor1DSearch1D(int N2) {
    return Err;
 }
 
+Error testHiparLaunchConfig1D(int N1, int N2) {
+   Error Err;
+
+   HostArray2DReal RefOutH("RefOutH", N1, N2 - 3);
+
+   for (int J1 = 0; J1 < N1; ++J1) {
+      HostArray1DI4 ScratchAH("ScratchAH", N2);
+
+      for (int J2 = 0; J2 < N2; ++J2) {
+         ScratchAH(J2) = f2(J1, J2, N1, N2) * f2(J1, J2, N1, N2);
+      }
+
+      HostArray1DReal ScratchBH("ScratchBH", N2 - 2);
+
+      for (int J2 = 1; J2 < N2 - 1; ++J2) {
+         ScratchBH(J2 - 1) =
+             1._Real / (1._Real + ScratchAH(J2 + 1) - ScratchAH(J2 - 1));
+      }
+
+      for (int J2 = 0; J2 < N2 - 3; ++J2) {
+         RefOutH(J1, J2) = ScratchBH(J2) / ScratchBH(J2 + 1);
+      }
+   }
+
+   Array2DReal OutD("OutD", N1, N2 - 3);
+
+#ifdef OMEGA_DEVICE
+   const int TeamSize = 32;
+#else
+   const int TeamSize = 1;
+#endif
+
+   auto LConfig =
+       LaunchConfig({N1}, TeamSize, TeamScratch<Real, I4>({N2, N2 - 2}));
+   parallelForOuter(
+       LConfig, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+          ArrayScratch1DI4 ScratchA(Team.team_scratch(0), N2);
+
+          parallelForInner(
+              Team, N2, INNER_LAMBDA(int J2) {
+                 ScratchA(J2) = f2(J1, J2, N1, N2) * f2(J1, J2, N1, N2);
+              });
+
+          teamBarrier(Team);
+
+          ArrayScratch1DReal ScratchB(Team.team_scratch(0), N2 - 2);
+
+          parallelForInner(
+              Team, Range{1, N2 - 2}, INNER_LAMBDA(int J2) {
+                 ScratchB(J2 - 1) =
+                     1._Real / (1._Real + ScratchA(J2 + 1) - ScratchA(J2 - 1));
+              });
+
+          teamBarrier(Team);
+
+          parallelForInner(
+              Team, N2 - 3, INNER_LAMBDA(int J2) {
+                 OutD(J1, J2) = ScratchB(J2) / ScratchB(J2 + 1);
+              });
+       });
+
+   if (!arraysEqual(OutD, RefOutH)) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelForLaunchConfig1D FAIL", N1, N2));
+   }
+
+   return Err;
+}
+
 Error testHiparFor1DMultiple1D(int N1, int N2) {
    Error Err;
 
@@ -793,6 +862,8 @@ int main(int argc, char **argv) {
             Err += testHiparReduce1DReduce1D(N1);
 #endif
             Err += testHiparFor1DSearch1D(N1);
+
+            Err += testHiparLaunchConfig1D(2 * N1, N1 + 3);
 
             Err += testHiparFor1DMultiple1D(1, N1);
             Err += testHiparFor1DMultiple1D((N1 + 1) / 2, N1);

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -399,7 +399,7 @@ Error testHiparLaunchConfig1D(int N1, int N2) {
 #endif
 
    auto LConfig =
-       LaunchConfig({N1}, TeamSize, TeamScratch<Real, I4>(N2, N2 - 2));
+       LaunchConfig({N1}, TeamSize, TeamScratch<Real, I4>(N2 - 2, N2));
    parallelForOuter(
        LConfig, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
           ArrayScratch1DI4 ScratchA(teamScratch(Team), N2);

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -400,7 +400,7 @@ Error testHiparLaunchConfig1D(int N1, int N2) {
        LaunchConfig({N1}, TeamSize, TeamScratch<Real, I4>(N2 - 2, N2));
    parallelForOuter(
        LConfig, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
-          ArrayScratch1DI4 ScratchA(teamScratch(Team), N2);
+          ScratchArray1DI4 ScratchA(teamScratch(Team), N2);
 
           parallelForInner(
               Team, N2, INNER_LAMBDA(int J2) {
@@ -409,7 +409,7 @@ Error testHiparLaunchConfig1D(int N1, int N2) {
 
           teamBarrier(Team);
 
-          ArrayScratch1DReal ScratchB(teamScratch(Team), N2 - 2);
+          ScratchArray1DReal ScratchB(teamScratch(Team), N2 - 2);
 
           parallelForInner(
               Team, Range{1, N2 - 2}, INNER_LAMBDA(int J2) {

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -349,12 +349,10 @@ Error testHiparFor1DSearch1D(int N2) {
              const int End   = 3 * N2 / 4 + J1 % (N2 / 4);
              int SearchIdx;
              parallelSearchInner(
-                 Team, End - Start,
-                 INNER_LAMBDA(int J2) {
-                    return DataD(J1, J2 + Start) >= Threshold;
-                 },
+                 Team, Range{Start, End - 1},
+                 INNER_LAMBDA(int J2) { return DataD(J1, J2) >= Threshold; },
                  SearchIdx);
-             IdxD(J1) = SearchIdx == -1 ? SearchIdx : SearchIdx + Start;
+             IdxD(J1) = SearchIdx;
           });
 
       if (!arraysEqual(IdxD, RefIdxH)) {

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -365,7 +365,7 @@ Error testHiparFor2DFor1D(int N1, int N2) {
    parallelForOuter(
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
           parallelForInner(
-              Team, J1, J1 + J2, INNER_LAMBDA(int J3) {
+              Team, Range{J1, J1 + J2}, INNER_LAMBDA(int J3) {
                  A(J1, J2, J3) = f3(J1, J2, J3, N1, N2, N3);
               });
        });
@@ -404,7 +404,7 @@ Error testHiparFor2DReduce1D(int N1, int N2) {
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
           I4 Sum;
           parallelReduceInner(
-              Team, J1, J1 + J2,
+              Team, Range{J1, J1 + J2},
               INNER_LAMBDA(int J3, I4 &Accum) {
                  Accum += f3(J1, J2, J3, N1, N2, N3);
               },
@@ -413,7 +413,7 @@ Error testHiparFor2DReduce1D(int N1, int N2) {
 
           I4 Max;
           parallelReduceInner(
-              Team, J1, J1 + J2,
+              Team, Range{J1, J1 + J2},
               INNER_LAMBDA(int J3, I4 &Accum) {
                  Accum = Kokkos::max(Accum, f3(J1, J2, J3, N1, N2, N3));
               },
@@ -437,7 +437,7 @@ Error testHiparFor2DReduce1D(int N1, int N2) {
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
           I4 Sum, Max;
           parallelReduceInner(
-              Team, J1, J1 + J2,
+              Team, Range{J1, J1 + J2},
               INNER_LAMBDA(int J3, I4 &AccumSum, I4 &AccumMax) {
                  AccumSum += f3(J1, J2, J3, N1, N2, N3);
                  AccumMax = Kokkos::max(AccumMax, f3(J1, J2, J3, N1, N2, N3));
@@ -475,7 +475,8 @@ Error testHiparFor2DScan1D(int N1, int N2) {
    parallelForOuter(
        {N1, N2}, KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team) {
           parallelScanInner(
-              Team, J1, J1 + J2, INNER_LAMBDA(int J3, I4 &Accum, bool IsFinal) {
+              Team, Range{J1, J1 + J2},
+              INNER_LAMBDA(int J3, I4 &Accum, bool IsFinal) {
                  if (IsFinal) {
                     RSum(J1, J2, J3) = Accum;
                  }
@@ -513,7 +514,7 @@ Error testHiparReduce2DReduce1D(int N1, int N2) {
        KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team, I4 &AccumOuter) {
           I4 SumInner;
           parallelReduceInner(
-              Team, J1, J1 + J2,
+              Team, Range{J1, J1 + J2},
               INNER_LAMBDA(int J3, I4 &AccumInner) {
                  AccumInner += f3(J1, J2, J3, N1, N2, N3);
               },
@@ -534,7 +535,7 @@ Error testHiparReduce2DReduce1D(int N1, int N2) {
        KOKKOS_LAMBDA(int J1, int J2, const TeamMember &Team, I4 &AccumOuter) {
           I4 MaxInner;
           parallelReduceInner(
-              Team, J1, J1 + J2,
+              Team, Range{J1, J1 + J2},
               INNER_LAMBDA(int J3, I4 &AccumInner) {
                  AccumInner =
                      Kokkos::max(AccumInner, f3(J1, J2, J3, N1, N2, N3));
@@ -556,7 +557,7 @@ Error testHiparReduce2DReduce1D(int N1, int N2) {
                      I4 &AccumMaxOuter) {
           I4 SumInner, MaxInner;
           parallelReduceInner(
-              Team, J1, J1 + J2,
+              Team, Range{J1, J1 + J2},
               INNER_LAMBDA(int J3, I4 &AccumSumInner, I4 &AccumMaxInner) {
                  AccumSumInner += f3(J1, J2, J3, N1, N2, N3);
                  AccumMaxInner =

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -262,6 +262,110 @@ Error testHiparReduce1DReduce1D(int N1) {
    return Err;
 }
 
+Error testHiparFor1DSearch1D(int N2) {
+   Error Err;
+
+   const int Threshold = N2 / 2;
+   const int N1        = 3 * N2 + 3;
+
+   HostArray2DI4 DataH("DataH", N1, N2);
+
+   for (int J1 = 0; J1 < 3 * N2; ++J1) {
+      if (J1 < N2 + 10) {
+         for (int J2 = 0; J2 < N2; ++J2) {
+            DataH(J1, J2) = Threshold - (J1 - J2);
+         }
+      } else {
+         for (int J2 = 0; J2 < N2; ++J2) {
+            DataH(J1, J2) = Threshold - (J1 / 4 - J2);
+         }
+      }
+   }
+
+   // Ensure these patterns are in the input data
+   for (int J2 = 0; J2 < N2; ++J2) {
+      // Everything above threshold
+      DataH(3 * N2, J2) = Threshold + 1;
+      // Everything below threshold
+      DataH(3 * N2 + 1, J2) = Threshold - 1;
+      // Multiple non-consecutive values above threshold
+      DataH(3 * N2 + 2, J2) = Threshold - 3 + J2 % 4;
+   }
+
+   auto DataD = createDeviceMirrorCopy(DataH);
+
+   HostArray1DI4 RefIdxH("RefIdxH", N1);
+   Array1DI4 IdxD("IdxD", N1);
+
+   // test searching full range
+
+   for (int J1 = 0; J1 < N1; ++J1) {
+      int Idx = -1;
+      for (int J2 = 0; J2 < N2; ++J2) {
+         if (DataH(J1, J2) >= Threshold) {
+            Idx = J2;
+            break;
+         }
+      }
+      RefIdxH(J1) = Idx;
+   }
+
+   parallelForOuter(
+       {N1}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+          parallelSearchInner(
+              Team, N2,
+              INNER_LAMBDA(int J2) { return DataD(J1, J2) >= Threshold; },
+              IdxD(J1));
+       });
+
+   if (!arraysEqual(IdxD, RefIdxH)) {
+      Err += Error(ErrorCode::Fail,
+                   errorMsg("parallelFor1DSearch1D Full FAIL", N1));
+   }
+
+   deepCopy(RefIdxH, 0);
+   deepCopy(IdxD, 0);
+
+   // test searching limited range
+
+   if (N2 / 4 > 0) {
+
+      for (int J1 = 0; J1 < N1; ++J1) {
+         int Idx         = -1;
+         const int Start = N2 / 4 - J1 % (N2 / 4);
+         const int End   = 3 * N2 / 4 + J1 % (N2 / 4);
+         for (int J2 = Start; J2 < End; ++J2) {
+            if (DataH(J1, J2) >= Threshold) {
+               Idx = J2;
+               break;
+            }
+         }
+         RefIdxH(J1) = Idx;
+      }
+
+      parallelForOuter(
+          {N1}, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
+             const int Start = N2 / 4 - J1 % (N2 / 4);
+             const int End   = 3 * N2 / 4 + J1 % (N2 / 4);
+             int SearchIdx;
+             parallelSearchInner(
+                 Team, End - Start,
+                 INNER_LAMBDA(int J2) {
+                    return DataD(J1, J2 + Start) >= Threshold;
+                 },
+                 SearchIdx);
+             IdxD(J1) = SearchIdx == -1 ? SearchIdx : SearchIdx + Start;
+          });
+
+      if (!arraysEqual(IdxD, RefIdxH)) {
+         Err += Error(ErrorCode::Fail,
+                      errorMsg("parallelFor1DSearch1D Limited FAIL", N1));
+      }
+   }
+
+   return Err;
+}
+
 Error testHiparFor1DMultiple1D(int N1, int N2) {
    Error Err;
 
@@ -688,6 +792,7 @@ int main(int argc, char **argv) {
 #if !defined(KOKKOS_ENABLE_SYCL) || KOKKOS_VERSION_GREATER_EQUAL(4, 7, 1)
             Err += testHiparReduce1DReduce1D(N1);
 #endif
+            Err += testHiparFor1DSearch1D(N1);
 
             Err += testHiparFor1DMultiple1D(1, N1);
             Err += testHiparFor1DMultiple1D((N1 + 1) / 2, N1);

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -399,7 +399,7 @@ Error testHiparLaunchConfig1D(int N1, int N2) {
 #endif
 
    auto LConfig =
-       LaunchConfig({N1}, TeamSize, TeamScratch<Real, I4>({N2, N2 - 2}));
+       LaunchConfig({N1}, TeamSize, TeamScratch<Real, I4>(N2, N2 - 2));
    parallelForOuter(
        LConfig, KOKKOS_LAMBDA(int J1, const TeamMember &Team) {
           ArrayScratch1DI4 ScratchA(Team.team_scratch(0), N2);

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -390,7 +390,7 @@ Error testHiparLaunchConfig1D(int N1, int N2) {
 
    Array2DReal OutD("OutD", N1, N2 - 3);
 
-#ifdef OMEGA_DEVICE
+#ifdef OMEGA_TARGET_DEVICE
    const int TeamSize = 32;
 #else
    const int TeamSize = 1;


### PR DESCRIPTION

This PR refactors Omega wrappers of Kokkos hierarchical parallelism. Specifically, it:
- Adds a new way of specifying ranges of inner loops through a helper struct `Range`:
   ```
    parallelForInner(Team, Range{Start, End}, INNER_LAMBDA ...
  ```
  This allows us to remove most uses of `vertRange(KMin, KMax)` with manual offsetting of loop indices.
- Changes how team scratch memory is requested. This is now done through helper structs `LaunchConfig` and `TeamScratch`. For example
  ```
   parallelForOuter(LaunchConfig({N}, TeamScratch<Real>(NScratch)), KOKKOS_LAMBDA ...
  ```
   This has the following benefits:
    - Use of scratch memory is more visible, compared to a trailing `int` parameter.
    - You can request scratch memory of different types: `TeamScratch<Real, int>(NScratchReal, NScratchInt)`.
    - You can use scratch memory in `parallelReduceOuter`.
    - `LaunchConfig` serves as a general customization point for outer loops. For example, you can also request a different team size.
- For better code organization, moves the wrappers out of `OmegaKokkos.h` into their own header files: `OmegaKokkosFlatPar.h` for flat parallelism and `OmegaKokkosHiPar.h` for hierarchical parallelism. `OmegaKokkos.h` now mostly contains general purpose Kokkos utilities. 
- Adds `parallelSearchInner` for searching an index range in parallel at the inner level of hierarchical parallelism.
- Adds documentation and tests for the new features.
- With help from copilot, changes existing code to make use of the new features.  
  
<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [x] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests
  * [x] New tests:
    * [x] CTest unit tests for new features have been added per the approved design.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


