### PR TITLE
Add state validation checks for NaNs and OOBounds

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -24,6 +24,9 @@ Omega:
     NTimeLevels: 2
     PrescribeThicknessType: None
     PrescribeVelocityType: None
+    Validation:
+      AbortOnOOB: false
+      AbortOnNan: true
   Advection:
     Coef3rdOrder: 0.25
     FluxThicknessType: Center

--- a/components/omega/doc/design/StateValidation.md
+++ b/components/omega/doc/design/StateValidation.md
@@ -12,9 +12,19 @@ variables at runtime. After each timestep (or at user-defined intervals) the
 model can call `validateOceanState` to scan every owned cell and vertical layer
 for NaN (Not-a-Number) values and values that lie outside a pre-defined
 physically meaningful range. Any detected anomaly is reported through the
-OMEGA logging infrastructure as a critical error together with a full stack
-backtrace; the run is then terminated via `MPI_Abort` so that corrupted output
-is not silently written to disk.
+OMEGA logging infrastructure as a critical error message.
+
+Whether the run is aborted on detection is controlled by two runtime
+configuration options under `Omega::State::Validation`:
+
+- **`AbortOnNan`** (default: `true`) — when `true`, the presence of any NaN
+  values in a checked field causes the run to be terminated via `MPI_Abort`
+  (with a full stack backtrace printed first).
+- **`AbortOnOOB`** (default: `false`) — when `true`, out-of-bounds values
+  trigger the same hard abort.
+
+When both flags are `false` and errors are detected, a critical-level log
+message is emitted and the run continues rather than being terminated.
 
 ## 2 Requirements
 
@@ -71,9 +81,7 @@ parallel reductions.
 
 On detection of any failure the module must log a critical-level message that
 identifies the field name, the nature of the problem (NaN or out-of-bounds),
-and the number of offending elements.  After all fields are checked the
-module must additionally print a stack backtrace to assist with debugging,
-then abort the run via `MPI_Abort`.
+and the number of offending elements.
 
 ### 2.9 Requirement: Graceful handling of absent tracers
 
@@ -81,13 +89,29 @@ If the Temperature or Salinity tracer is not present in the tracer registry
 (e.g. in configurations that do not activate active tracers) the
 corresponding check must be skipped silently rather than causing an error.
 
-### 2.10 Desired: Configurable valid ranges
+### 2.10 Requirement: Configurable abort-on-error behavior
+
+The user must be able to independently control whether NaN errors and
+out-of-bounds errors cause the run to abort.  Two boolean YAML options
+(`AbortOnNan` and `AbortOnOOB`, both nested under
+`Omega::State::Validation`) govern this:
+
+- When `AbortOnNan: true`, any detected NaN value triggers a hard abort via
+  `MPI_Abort` (with a stack backtrace printed beforehand).
+- When `AbortOnOOB: true`, any detected out-of-bounds value triggers the same
+  hard abort.
+- When both are `false`, errors are logged at critical severity and the run
+  continues.
+
+The defaults are `AbortOnNan: true` and `AbortOnOOB: false`.
+
+### 2.11 Desired: Configurable valid ranges
 
 In the future it may be desirable to allow the user to override the default
 valid ranges through the OMEGA configuration system (e.g. for idealised
 process studies that intentionally use non-oceanic parameter values).
 
-### 2.11 Desired: Configurable validation frequency
+### 2.12 Desired: Configurable validation frequency
 
 In the future it may be desirable to allow the user to control whether
 validation is performed every timestep, every N timesteps, or only at
@@ -147,9 +171,30 @@ implementation:
 | `Temperature`        | −10       | 50     |
 | `Salinity`           | −2        | 60     |
 
+The abort-on-error behavior is governed by two runtime YAML options nested
+under `Omega::State::Validation`:
+
+| YAML key      | Type | Default | Meaning                                      |
+|---------------|------|---------|----------------------------------------------|
+| `AbortOnNan`  | bool | `true`  | Abort via `MPI_Abort` when NaNs are detected |
+| `AbortOnOOB`  | bool | `false` | Abort via `MPI_Abort` when OOBs are detected |
+
+When both flags are `false` and errors are found, a CRITICAL log message is
+emitted and the run continues.
+
 #### 4.1.2 Class/structs/data types
 
-No new classes or data types are introduced. The module uses the existing
+The module introduces one file-local plain struct:
+
+```c++
+struct ValidationAbortConfig {
+   bool AbortOnOOB = false;
+   bool AbortOnNan = true;
+};
+```
+
+This struct is populated by `getValidationAbortConfig` (see §4.2.5) and
+consumed by `validateOceanState`. All other types are the existing
 `OceanState`, `AuxiliaryState`, `VertCoord`, and `Tracers` types from the
 OMEGA ocean component.
 
@@ -157,23 +202,23 @@ OMEGA ocean component.
 
 #### 4.2.1 `checkOceanState` (public)
 
-Performs all field checks and returns the total count of errors found:
+Performs all field checks and returns separate NaN and out-of-bounds counts:
 
 ```c++
-I4 checkOceanState(const OceanState *State,
-                   const AuxiliaryState *AuxState,
-                   const VertCoord *VCoord,
-                   I4 TimeLevel);
+std::pair<I4, I4> checkOceanState(const OceanState *State,
+                                  const AuxiliaryState *AuxState,
+                                  const VertCoord *VCoord,
+                                  I4 TimeLevel);
 ```
 
 Checks all fields described in Section 2, skipping inactive cells
 (`CellMask == 0`). Logs critical messages for each type of error. Returns
-the total number of errors as an `I4`; returns 0 if all checks pass. Does
+`{TotalNaNs, TotalOOBs}` where both values are 0 if all checks pass. Does
 **not** abort. Suitable for calling from tests.
 
 #### 4.2.2 `validateOceanState` (public)
 
-Production entry-point that aborts on failure:
+Production entry-point that applies the configured abort policy on failure:
 
 ```c++
 void validateOceanState(const OceanState *State,
@@ -182,8 +227,15 @@ void validateOceanState(const OceanState *State,
                         I4 TimeLevel);
 ```
 
-Calls `checkOceanState` and aborts via `MPI_Abort` if the return value is
-greater than zero.
+Calls `checkOceanState` to obtain `{NaNs, OOBs}`, then reads
+`ValidationAbortConfig` via `getValidationAbortConfig`. Aborts via
+`abortWithMessage` (which logs at CRITICAL severity, prints a stack
+backtrace, and calls `MPI_Abort`) if:
+- `NaNs > 0` **and** `AbortOnNan` is `true`, **or**
+- `OOBs > 0` **and** `AbortOnOOB` is `true`.
+
+If neither abort condition is met but errors were detected, a CRITICAL log
+message is emitted and the function returns normally.
 
 #### 4.2.3 `checkArray2D` (file-local helper)
 
@@ -215,7 +267,19 @@ Performs the NaN and bounds counts for a single tracer slice (identified by
 `TracerIdx`) of the 3-D tracer array, restricted to active cells
 (`CellMask(Cell, K) > 0`). Returns `{NaNCount, OutOfRangeCount}`.
 
-#### 4.2.5 `abortWithMessage` (file-local helper)
+#### 4.2.5 `getValidationAbortConfig` (file-local helper)
+
+```c++
+static ValidationAbortConfig getValidationAbortConfig();
+```
+
+Reads the two boolean options `AbortOnNan` and `AbortOnOOB` from the OMEGA
+config under `Omega::State::Validation` and returns a populated
+`ValidationAbortConfig`. If the config node is absent the struct's
+default-initialised values (`AbortOnNan = true`, `AbortOnOOB = false`) are
+returned unchanged.
+
+#### 4.2.6 `abortWithMessage` (file-local helper)
 
 ```c++
 static void abortWithMessage(const std::string &Msg);
@@ -254,7 +318,8 @@ errors can be detected without triggering `MPI_Abort`. Each sub-test:
 1. Resets the state to valid values via `restoreValidState`.
 2. Injects a single type of invalid value (NaN or OOB) into one field using
    a `parallelFor` kernel that overwrites all owned cell-layer entries.
-3. Calls `checkOceanState` and verifies a non-zero error count is returned.
+3. Calls `checkOceanState`, which returns `{NaNs, OOBs}`, and verifies that
+   the sum `NaNs + OOBs` is greater than zero.
 
 The following sub-tests are implemented:
 
@@ -270,4 +335,4 @@ The following sub-tests are implemented:
 | `testNaNSalinity`             | NaN                    | Salinity           |
 | `testOOBSalinity`             | 9999 g kg⁻¹ (> max 60) | Salinity           |
 
-Tests requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8.
+Tests requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.10.

--- a/components/omega/doc/design/StateValidation.md
+++ b/components/omega/doc/design/StateValidation.md
@@ -155,9 +155,25 @@ OMEGA ocean component.
 
 ### 4.2 Methods
 
-#### 4.2.1 `validateOceanState` (public)
+#### 4.2.1 `checkOceanState` (public)
 
-The sole public interface of the module:
+Performs all field checks and returns the total count of errors found:
+
+```c++
+I4 checkOceanState(const OceanState *State,
+                   const AuxiliaryState *AuxState,
+                   const VertCoord *VCoord,
+                   I4 TimeLevel);
+```
+
+Checks all fields described in Section 2, skipping inactive cells
+(`CellMask == 0`). Logs critical messages for each type of error. Returns
+the total number of errors as an `I4`; returns 0 if all checks pass. Does
+**not** abort. Suitable for calling from tests.
+
+#### 4.2.2 `validateOceanState` (public)
+
+Production entry-point that aborts on failure:
 
 ```c++
 void validateOceanState(const OceanState *State,
@@ -166,13 +182,10 @@ void validateOceanState(const OceanState *State,
                         I4 TimeLevel);
 ```
 
-Validates all fields described in Section 2, skipping inactive cells
-(`CellMask == 0`). Logs critical errors for each failed check and aborts the
-run if any check fails. `VCoord` supplies the `CellMask` array. `TimeLevel`
-specifies the time-level index within the state arrays to validate (0 =
-current timestep).
+Calls `checkOceanState` and aborts via `MPI_Abort` if the return value is
+greater than zero.
 
-#### 4.2.2 `checkArray2D` (file-local helper)
+#### 4.2.3 `checkArray2D` (file-local helper)
 
 ```c++
 static std::pair<I4, I4> checkArray2D(const Array2DReal &Arr,
@@ -188,7 +201,7 @@ Performs the NaN and bounds counts for a 2-D device array over the first
 bound is enforced (not needed for any current field but useful for future
 extension). Returns `{NaNCount, OutOfRangeCount}`.
 
-#### 4.2.3 `checkTracerArray` (file-local helper)
+#### 4.2.4 `checkTracerArray` (file-local helper)
 
 ```c++
 static std::pair<I4, I4> checkTracerArray(const Array3DReal &Tracers3D,
@@ -202,7 +215,7 @@ Performs the NaN and bounds counts for a single tracer slice (identified by
 `TracerIdx`) of the 3-D tracer array, restricted to active cells
 (`CellMask(Cell, K) > 0`). Returns `{NaNCount, OutOfRangeCount}`.
 
-#### 4.2.4 `abortWithMessage` (file-local helper)
+#### 4.2.5 `abortWithMessage` (file-local helper)
 
 ```c++
 static void abortWithMessage(const std::string &Msg);
@@ -234,27 +247,27 @@ The test passes if `validateOceanState` returns without calling `MPI_Abort`.
 
 Tests requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.9.
 
-### 5.2 Test: NaN in LayerThickness triggers abort
+### 5.2 Negative tests: invalid values are detected
 
-A future test should set a subset of `LayerThickness` entries to `NaN` and
-verify that `validateOceanState` detects and logs the error and calls
-`MPI_Abort`. Because `MPI_Abort` terminates the process this test would
-need to be run in a separate executable or with a death-test framework.
+The public `checkOceanState` function is used for negative tests so that
+errors can be detected without triggering `MPI_Abort`. Each sub-test:
+1. Resets the state to valid values via `restoreValidState`.
+2. Injects a single type of invalid value (NaN or OOB) into one field using
+   a `parallelFor` kernel that overwrites all owned cell-layer entries.
+3. Calls `checkOceanState` and verifies a non-zero error count is returned.
 
-Tests requirement: 2.1, 2.3, 2.8.
+The following sub-tests are implemented:
 
-### 5.3 Test: Out-of-bounds value in Temperature triggers abort
+| Sub-test                      | Injected value         | Field              |
+|-------------------------------|------------------------|--------------------|
+| `testNaNLayerThickness`       | NaN                    | LayerThickness     |
+| `testOOBHighLayerThickness`   | 2000 m (> max 1000 m)  | LayerThickness     |
+| `testOOBLowLayerThickness`    | −1 m (< min 1×10⁻¹⁰)  | LayerThickness     |
+| `testNaNKineticEnergy`        | NaN                    | KineticEnergyCell  |
+| `testOOBKineticEnergy`        | 9999 J kg⁻¹ (> max 10) | KineticEnergyCell  |
+| `testNaNTemperature`          | NaN                    | Temperature        |
+| `testOOBTemperature`          | 9999 °C (> max 50)     | Temperature        |
+| `testNaNSalinity`             | NaN                    | Salinity           |
+| `testOOBSalinity`             | 9999 g kg⁻¹ (> max 60) | Salinity           |
 
-A future test should set a subset of `Temperature` entries to a value
-outside [−10, 50] (e.g. 999 °C) and verify that `validateOceanState`
-detects and logs the error.
-
-Tests requirement: 2.2, 2.5, 2.8.
-
-### 5.4 Test: Missing tracer is skipped gracefully
-
-A future test should invoke `validateOceanState` in a configuration where
-neither Temperature nor Salinity tracers are registered and verify that the
-function completes without error.
-
-Tests requirement: 2.9.
+Tests requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8.

--- a/components/omega/doc/design/StateValidation.md
+++ b/components/omega/doc/design/StateValidation.md
@@ -96,7 +96,9 @@ specific points in the run (e.g. after restart reads).
 ## 3 Algorithmic Formulation
 
 No complex numerical algorithms are required. Each field is checked with two
-independent `parallelReduce` passes over the domain:
+independent `parallelReduce` passes over the domain, restricted to active
+cells where `CellMask(i, k) > 0` (inactive cells, such as land cells, are
+skipped):
 
 1. **NaN pass** – counts elements for which `Kokkos::isnan(val)` is `true`.
 2. **Bounds pass** – counts elements that are finite yet lie outside
@@ -109,13 +111,16 @@ For a 2-D field $f_{i,k}$ with $i \in [0,\, N_\text{cells})$ and
 $k \in [0,\, N_\text{vert})$ the two counts are:
 
 $$
-N_\text{NaN}    = \sum_{i,k} \mathbf{1}[\,\text{isnan}(f_{i,k})\,]
+N_\text{NaN}    = \sum_{i,k} M_{i,k}\,\mathbf{1}[\,\text{isnan}(f_{i,k})\,]
 $$
 
 $$
-N_\text{OOB}    = \sum_{i,k} \mathbf{1}[\,\lnot\,\text{isnan}(f_{i,k})
+N_\text{OOB}    = \sum_{i,k} M_{i,k}\,\mathbf{1}[\,\lnot\,\text{isnan}(f_{i,k})
                    \land (f_{i,k} < f_\text{min} \lor f_{i,k} > f_\text{max})\,]
 $$
+
+where $M_{i,k}$ is `CellMask(i, k)` (1 for active cell-layer, 0 for
+inactive).
 
 For a 3-D tracer array $T_{n,i,k}$ the same expressions are applied at a
 fixed tracer index $n$.
@@ -145,8 +150,8 @@ implementation:
 #### 4.1.2 Class/structs/data types
 
 No new classes or data types are introduced. The module uses the existing
-`OceanState`, `AuxiliaryState`, and `Tracers` types from the OMEGA ocean
-component.
+`OceanState`, `AuxiliaryState`, `VertCoord`, and `Tracers` types from the
+OMEGA ocean component.
 
 ### 4.2 Methods
 
@@ -157,13 +162,15 @@ The sole public interface of the module:
 ```c++
 void validateOceanState(const OceanState *State,
                         const AuxiliaryState *AuxState,
+                        const VertCoord *VCoord,
                         I4 TimeLevel);
 ```
 
-Validates all fields described in Section 2. Logs critical errors for each
-failed check and aborts the run if any check fails. `TimeLevel` specifies
-the time-level index within the state arrays to validate (0 = current
-timestep).
+Validates all fields described in Section 2, skipping inactive cells
+(`CellMask == 0`). Logs critical errors for each failed check and aborts the
+run if any check fails. `VCoord` supplies the `CellMask` array. `TimeLevel`
+specifies the time-level index within the state arrays to validate (0 =
+current timestep).
 
 #### 4.2.2 `checkArray2D` (file-local helper)
 
@@ -171,11 +178,13 @@ timestep).
 static std::pair<I4, I4> checkArray2D(const Array2DReal &Arr,
                                       I4 NRows, I4 NCols,
                                       Real MinVal, Real MaxVal,
-                                      bool CheckMin);
+                                      bool CheckMin,
+                                      const Array2DReal &CellMask);
 ```
 
 Performs the NaN and bounds counts for a 2-D device array over the first
-`NRows` rows and `NCols` columns. When `CheckMin` is `false` only the upper
+`NRows` rows and `NCols` columns, restricted to active cells
+(`CellMask(Row, Col) > 0`). When `CheckMin` is `false` only the upper
 bound is enforced (not needed for any current field but useful for future
 extension). Returns `{NaNCount, OutOfRangeCount}`.
 
@@ -185,11 +194,13 @@ extension). Returns `{NaNCount, OutOfRangeCount}`.
 static std::pair<I4, I4> checkTracerArray(const Array3DReal &Tracers3D,
                                           I4 TracerIdx,
                                           I4 NCells, I4 NVert,
-                                          Real MinVal, Real MaxVal);
+                                          Real MinVal, Real MaxVal,
+                                          const Array2DReal &CellMask);
 ```
 
 Performs the NaN and bounds counts for a single tracer slice (identified by
-`TracerIdx`) of the 3-D tracer array. Returns `{NaNCount, OutOfRangeCount}`.
+`TracerIdx`) of the 3-D tracer array, restricted to active cells
+(`CellMask(Cell, K) > 0`). Returns `{NaNCount, OutOfRangeCount}`.
 
 #### 4.2.4 `abortWithMessage` (file-local helper)
 

--- a/components/omega/doc/design/StateValidation.md
+++ b/components/omega/doc/design/StateValidation.md
@@ -1,0 +1,249 @@
+<!--- OMEGA Ocean State Validation requirements and design ------------------->
+
+(omega-design-state-validation)=
+
+# Ocean State Validation
+
+## 1 Overview
+
+The Ocean State Validation module provides a mechanism for checking the
+physical plausibility of the ocean prognostic state and selected auxiliary
+variables at runtime. After each timestep (or at user-defined intervals) the
+model can call `validateOceanState` to scan every owned cell and vertical layer
+for NaN (Not-a-Number) values and values that lie outside a pre-defined
+physically meaningful range. Any detected anomaly is reported through the
+OMEGA logging infrastructure as a critical error together with a full stack
+backtrace; the run is then terminated via `MPI_Abort` so that corrupted output
+is not silently written to disk.
+
+## 2 Requirements
+
+### 2.1 Requirement: Check for NaN values
+
+The validation function must detect NaN values in the ocean state fields.
+NaNs indicate a numerical instability or a programming error, and their
+presence in the prognostic state makes continued time-stepping meaningless.
+Every element of each validated array must be tested.
+
+### 2.2 Requirement: Check for out-of-bounds values
+
+In addition to NaN detection, the validation function must check that every
+element of each validated field lies within a physically plausible range.
+Values outside these ranges indicate catastrophic model failure and should
+halt the simulation before corrupted output is written to disk.
+
+### 2.3 Requirement: Validate LayerThickness
+
+`LayerThickness` must be validated for each owned cell over all vertical
+layers. The valid range is $[10^{-10},\, 1000]$ m.
+Negative or near-zero layer thicknesses indicate numerical collapse of the
+column and must be caught immediately.
+
+### 2.4 Requirement: Validate KineticEnergyCell
+
+`KineticEnergyCell` from the kinematic auxiliary state must be validated for
+each owned cell over all vertical layers. The valid range is $[0,\, 10]$
+m$^2$ s$^{-2}$.  Negative kinetic energies are unphysical, and values
+exceeding 10 m$^2$ s$^{-2}$ correspond to current speeds above
+$\sim 4.5$ m s$^{-1}$, which are unrealistic for the open ocean.
+
+### 2.5 Requirement: Validate Temperature tracer
+
+Ocean Conservative Temperature must be validated for each owned cell over
+all vertical layers. The valid range is $[-10,\, 50]$ °C.
+This broad range accommodates all realistic oceanographic regimes including
+polar and hydrothermal vent environments.
+
+### 2.6 Requirement: Validate Salinity tracer
+
+Ocean Absolute Salinity must be validated for each owned cell over all
+vertical layers. The valid range is $[-2,\, 60]$ g kg$^{-1}$.
+Values below $-2$ g kg$^{-1}$ are unphysical and values above 60 g kg$^{-1}$
+are outside the valid domain of the TEOS-10 equation of state.
+
+### 2.7 Requirement: GPU/CPU portability
+
+All validation kernels must execute on both CPU and GPU hardware using the
+Kokkos parallel programming model and therefore must be expressed as Kokkos
+parallel reductions.
+
+### 2.8 Requirement: Informative error reporting
+
+On detection of any failure the module must log a critical-level message that
+identifies the field name, the nature of the problem (NaN or out-of-bounds),
+and the number of offending elements.  After all fields are checked the
+module must additionally print a stack backtrace to assist with debugging,
+then abort the run via `MPI_Abort`.
+
+### 2.9 Requirement: Graceful handling of absent tracers
+
+If the Temperature or Salinity tracer is not present in the tracer registry
+(e.g. in configurations that do not activate active tracers) the
+corresponding check must be skipped silently rather than causing an error.
+
+### 2.10 Desired: Configurable valid ranges
+
+In the future it may be desirable to allow the user to override the default
+valid ranges through the OMEGA configuration system (e.g. for idealised
+process studies that intentionally use non-oceanic parameter values).
+
+### 2.11 Desired: Configurable validation frequency
+
+In the future it may be desirable to allow the user to control whether
+validation is performed every timestep, every N timesteps, or only at
+specific points in the run (e.g. after restart reads).
+
+## 3 Algorithmic Formulation
+
+No complex numerical algorithms are required. Each field is checked with two
+independent `parallelReduce` passes over the domain:
+
+1. **NaN pass** – counts elements for which `Kokkos::isnan(val)` is `true`.
+2. **Bounds pass** – counts elements that are finite yet lie outside
+   $[\text{MinVal},\, \text{MaxVal}]$.
+
+Separating the two passes avoids potentially undefined behaviour when
+comparing NaN values with `<` or `>`.
+
+For a 2-D field $f_{i,k}$ with $i \in [0,\, N_\text{cells})$ and
+$k \in [0,\, N_\text{vert})$ the two counts are:
+
+$$
+N_\text{NaN}    = \sum_{i,k} \mathbf{1}[\,\text{isnan}(f_{i,k})\,]
+$$
+
+$$
+N_\text{OOB}    = \sum_{i,k} \mathbf{1}[\,\lnot\,\text{isnan}(f_{i,k})
+                   \land (f_{i,k} < f_\text{min} \lor f_{i,k} > f_\text{max})\,]
+$$
+
+For a 3-D tracer array $T_{n,i,k}$ the same expressions are applied at a
+fixed tracer index $n$.
+
+The validation traverses only the `NCellsOwned` cells (excluding halo cells)
+to avoid double-counting in the parallel decomposition.
+
+## 4 Design
+
+The module is implemented as a free function (`validateOceanState`) plus two
+file-local helper functions. It does not introduce a class or persistent state.
+
+### 4.1 Data types and parameters
+
+#### 4.1.1 Parameters
+
+The valid ranges for each field are compile-time constants embedded in the
+implementation:
+
+| Field                | MinVal    | MaxVal |
+|----------------------|-----------|--------|
+| `LayerThickness`     | 1×10⁻¹⁰  | 1000   |
+| `KineticEnergyCell`  | 0         | 10     |
+| `Temperature`        | −10       | 50     |
+| `Salinity`           | −2        | 60     |
+
+#### 4.1.2 Class/structs/data types
+
+No new classes or data types are introduced. The module uses the existing
+`OceanState`, `AuxiliaryState`, and `Tracers` types from the OMEGA ocean
+component.
+
+### 4.2 Methods
+
+#### 4.2.1 `validateOceanState` (public)
+
+The sole public interface of the module:
+
+```c++
+void validateOceanState(const OceanState *State,
+                        const AuxiliaryState *AuxState,
+                        I4 TimeLevel);
+```
+
+Validates all fields described in Section 2. Logs critical errors for each
+failed check and aborts the run if any check fails. `TimeLevel` specifies
+the time-level index within the state arrays to validate (0 = current
+timestep).
+
+#### 4.2.2 `checkArray2D` (file-local helper)
+
+```c++
+static std::pair<I4, I4> checkArray2D(const Array2DReal &Arr,
+                                      I4 NRows, I4 NCols,
+                                      Real MinVal, Real MaxVal,
+                                      bool CheckMin);
+```
+
+Performs the NaN and bounds counts for a 2-D device array over the first
+`NRows` rows and `NCols` columns. When `CheckMin` is `false` only the upper
+bound is enforced (not needed for any current field but useful for future
+extension). Returns `{NaNCount, OutOfRangeCount}`.
+
+#### 4.2.3 `checkTracerArray` (file-local helper)
+
+```c++
+static std::pair<I4, I4> checkTracerArray(const Array3DReal &Tracers3D,
+                                          I4 TracerIdx,
+                                          I4 NCells, I4 NVert,
+                                          Real MinVal, Real MaxVal);
+```
+
+Performs the NaN and bounds counts for a single tracer slice (identified by
+`TracerIdx`) of the 3-D tracer array. Returns `{NaNCount, OutOfRangeCount}`.
+
+#### 4.2.4 `abortWithMessage` (file-local helper)
+
+```c++
+static void abortWithMessage(const std::string &Msg);
+```
+
+Logs `Msg` at critical severity, prints a stack backtrace using `cpptrace`,
+then calls `MPI_Abort` on the default OMEGA communicator with error code
+`ErrorCode::Critical`.
+
+## 5 Verification and Testing
+
+### 5.1 Test: Valid state passes without abort
+
+A unit test constructs a minimal OMEGA environment (MachEnv, Decomp,
+HorzMesh, VertCoord, Tracers, OceanState, AuxiliaryState) using the standard
+test mesh `OmegaMesh.nc`.  All state arrays are filled with physically
+plausible values:
+
+- `LayerThickness` = 100 m (valid range [1×10⁻¹⁰, 1000])
+- `NormalVelocity` = 0 m s⁻¹ (not directly validated but required for
+  `KineticEnergyCell` to be zero)
+- `Temperature` = 10 °C (valid range [−10, 50])
+- `Salinity` = 35 g kg⁻¹ (valid range [−2, 60])
+
+`AuxiliaryState::computeAll` is called to populate `KineticEnergyCell`
+before `validateOceanState` is invoked.
+
+The test passes if `validateOceanState` returns without calling `MPI_Abort`.
+
+Tests requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.9.
+
+### 5.2 Test: NaN in LayerThickness triggers abort
+
+A future test should set a subset of `LayerThickness` entries to `NaN` and
+verify that `validateOceanState` detects and logs the error and calls
+`MPI_Abort`. Because `MPI_Abort` terminates the process this test would
+need to be run in a separate executable or with a death-test framework.
+
+Tests requirement: 2.1, 2.3, 2.8.
+
+### 5.3 Test: Out-of-bounds value in Temperature triggers abort
+
+A future test should set a subset of `Temperature` entries to a value
+outside [−10, 50] (e.g. 999 °C) and verify that `validateOceanState`
+detects and logs the error.
+
+Tests requirement: 2.2, 2.5, 2.8.
+
+### 5.4 Test: Missing tracer is skipped gracefully
+
+A future test should invoke `validateOceanState` in a configuration where
+neither Temperature nor Salinity tracers are registered and verify that the
+function completes without error.
+
+Tests requirement: 2.9.

--- a/components/omega/doc/design/StateValidation.md
+++ b/components/omega/doc/design/StateValidation.md
@@ -32,9 +32,9 @@ element of each validated field lies within a physically plausible range.
 Values outside these ranges indicate catastrophic model failure and should
 halt the simulation before corrupted output is written to disk.
 
-### 2.3 Requirement: Validate LayerThickness
+### 2.3 Requirement: Validate PseudoThickness
 
-`LayerThickness` must be validated for each owned cell over all vertical
+`PseudoThickness` must be validated for each owned cell over all vertical
 layers. The valid range is $[10^{-10},\, 1000]$ m.
 Negative or near-zero layer thicknesses indicate numerical collapse of the
 column and must be caught immediately.
@@ -142,7 +142,7 @@ implementation:
 
 | Field                | MinVal    | MaxVal |
 |----------------------|-----------|--------|
-| `LayerThickness`     | 1×10⁻¹⁰  | 1000   |
+| `PseudoThickness`    | 1×10⁻¹⁰   | 1000   |
 | `KineticEnergyCell`  | 0         | 10     |
 | `Temperature`        | −10       | 50     |
 | `Salinity`           | −2        | 60     |
@@ -234,7 +234,7 @@ HorzMesh, VertCoord, Tracers, OceanState, AuxiliaryState) using the standard
 test mesh `OmegaMesh.nc`.  All state arrays are filled with physically
 plausible values:
 
-- `LayerThickness` = 100 m (valid range [1×10⁻¹⁰, 1000])
+- `PseudoThickness` = 100 m (valid range [1×10⁻¹⁰, 1000])
 - `NormalVelocity` = 0 m s⁻¹ (not directly validated but required for
   `KineticEnergyCell` to be zero)
 - `Temperature` = 10 °C (valid range [−10, 50])
@@ -260,9 +260,9 @@ The following sub-tests are implemented:
 
 | Sub-test                      | Injected value         | Field              |
 |-------------------------------|------------------------|--------------------|
-| `testNaNLayerThickness`       | NaN                    | LayerThickness     |
-| `testOOBHighLayerThickness`   | 2000 m (> max 1000 m)  | LayerThickness     |
-| `testOOBLowLayerThickness`    | −1 m (< min 1×10⁻¹⁰)  | LayerThickness     |
+| `testNaNPseudoThickness`      | NaN                    | PseudoThickness    |
+| `testOOBHighPseudoThickness`  | 2000 m (> max 1000 m)  | PseudoThickness    |
+| `testOOBLowPseudoThickness`   | −1 m (< min 1×10⁻¹⁰)   | PseudoThickness    |
 | `testNaNKineticEnergy`        | NaN                    | KineticEnergyCell  |
 | `testOOBKineticEnergy`        | 9999 J kg⁻¹ (> max 10) | KineticEnergyCell  |
 | `testNaNTemperature`          | NaN                    | Temperature        |

--- a/components/omega/doc/index.md
+++ b/components/omega/doc/index.md
@@ -125,6 +125,7 @@ design/IO
 design/IOStreams
 design/Reductions
 design/State
+design/StateValidation
 design/SubmesoscaleEddies
 design/Tendency
 design/Tendencies

--- a/components/omega/src/ocn/StateValidation.cpp
+++ b/components/omega/src/ocn/StateValidation.cpp
@@ -134,24 +134,25 @@ I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
    const Array2DReal &CellMask = VCoord->CellMask;
 
    // -------------------------------------------------------------------------
-   // LayerThickness: valid range [1e-10, 1000]
+   // PseudoThickness: valid range [1e-10, 1000]
    // -------------------------------------------------------------------------
    {
-      Array2DReal LayerThick = State->getLayerThickness(TimeLevel);
+      Array2DReal PseudoThick = State->getPseudoThickness(TimeLevel);
       auto [NaNs, OOB] =
-          checkArray2D(LayerThick, State->NCellsOwned, State->NVertLayers,
+          checkArray2D(PseudoThick, State->NCellsOwned, State->NVertLayers,
                        static_cast<Real>(1e-10), static_cast<Real>(1000.0),
                        /*CheckMin=*/true, CellMask);
 
       if (NaNs > 0) {
          LOG_CRITICAL(
-             "StateValidation: LayerThickness contains {} NaN value(s)", NaNs);
+             "StateValidation: PseudoThickness contains {} NaN value(s)", NaNs);
          TotalErrors += NaNs;
       }
       if (OOB > 0) {
-         LOG_CRITICAL("StateValidation: LayerThickness has {} value(s) outside "
-                      "valid range [1e-10, 1000]",
-                      OOB);
+         LOG_CRITICAL(
+             "StateValidation: PseudoThickness has {} value(s) outside "
+             "valid range [1e-10, 1000]",
+             OOB);
          TotalErrors += OOB;
       }
    }

--- a/components/omega/src/ocn/StateValidation.cpp
+++ b/components/omega/src/ocn/StateValidation.cpp
@@ -123,13 +123,13 @@ static std::pair<I4, I4> checkTracerArray(const Array3DReal &Tracers3D,
 }
 
 //------------------------------------------------------------------------------
-/// Validate ocean state fields for NaN and out-of-bounds conditions.
+/// Check ocean state fields for NaN and out-of-bounds conditions.
 /// Only active cells (where CellMask > 0) are checked.
-/// Aborts via MPI_Abort on failure.
-void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
-                        const VertCoord *VCoord, I4 TimeLevel) {
+/// Returns the total count of errors found; does not abort.
+I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
+                   const VertCoord *VCoord, I4 TimeLevel) {
 
-   bool AnyFailure = false;
+   I4 TotalErrors = 0;
 
    const Array2DReal &CellMask = VCoord->CellMask;
 
@@ -146,13 +146,13 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
       if (NaNs > 0) {
          LOG_CRITICAL(
              "StateValidation: LayerThickness contains {} NaN value(s)", NaNs);
-         AnyFailure = true;
+         TotalErrors += NaNs;
       }
       if (OOB > 0) {
          LOG_CRITICAL("StateValidation: LayerThickness has {} value(s) outside "
                       "valid range [1e-10, 1000]",
                       OOB);
-         AnyFailure = true;
+         TotalErrors += OOB;
       }
    }
 
@@ -170,14 +170,14 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
          LOG_CRITICAL(
              "StateValidation: KineticEnergyCell contains {} NaN value(s)",
              NaNs);
-         AnyFailure = true;
+         TotalErrors += NaNs;
       }
       if (OOB > 0) {
          LOG_CRITICAL(
              "StateValidation: KineticEnergyCell has {} value(s) outside "
              "valid range [0, 10]",
              OOB);
-         AnyFailure = true;
+         TotalErrors += OOB;
       }
    }
 
@@ -193,13 +193,13 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
       if (NaNs > 0) {
          LOG_CRITICAL("StateValidation: Temperature contains {} NaN value(s)",
                       NaNs);
-         AnyFailure = true;
+         TotalErrors += NaNs;
       }
       if (OOB > 0) {
          LOG_CRITICAL("StateValidation: Temperature has {} value(s) outside "
                       "valid range [-10, 50]",
                       OOB);
-         AnyFailure = true;
+         TotalErrors += OOB;
       }
    }
 
@@ -215,20 +215,27 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
       if (NaNs > 0) {
          LOG_CRITICAL("StateValidation: Salinity contains {} NaN value(s)",
                       NaNs);
-         AnyFailure = true;
+         TotalErrors += NaNs;
       }
       if (OOB > 0) {
          LOG_CRITICAL("StateValidation: Salinity has {} value(s) outside "
                       "valid range [-2, 60]",
                       OOB);
-         AnyFailure = true;
+         TotalErrors += OOB;
       }
    }
 
-   // -------------------------------------------------------------------------
-   // Abort if any check failed
-   // -------------------------------------------------------------------------
-   if (AnyFailure) {
+   return TotalErrors;
+}
+
+//------------------------------------------------------------------------------
+/// Validate ocean state fields for NaN and out-of-bounds conditions.
+/// Only active cells (where CellMask > 0) are checked.
+/// Aborts via MPI_Abort on failure.
+void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
+                        const VertCoord *VCoord, I4 TimeLevel) {
+
+   if (checkOceanState(State, AuxState, VCoord, TimeLevel) > 0) {
       abortWithMessage("StateValidation: Ocean state validation failed. "
                        "See critical messages above for details.");
    }

--- a/components/omega/src/ocn/StateValidation.cpp
+++ b/components/omega/src/ocn/StateValidation.cpp
@@ -16,6 +16,7 @@
 #include "OceanState.h"
 #include "OmegaKokkos.h"
 #include "Tracers.h"
+#include "VertCoord.h"
 #include "mpi.h"
 
 #include <cmath>
@@ -36,17 +37,22 @@ static void abortWithMessage(const std::string &Msg) {
 
 //------------------------------------------------------------------------------
 // Helper: count NaN entries and out-of-range entries in a 2-D Real device
-// array over the first NCells/NEdges rows and NVert columns.
+// array over the first NCells/NEdges rows and NVert columns, restricted to
+// active cells (CellMask > 0).
 // Returns {NaNCount, OutOfRangeCount}.
 static std::pair<I4, I4> checkArray2D(const Array2DReal &Arr, I4 NRows,
                                       I4 NCols, Real MinVal, Real MaxVal,
-                                      bool CheckMin) {
+                                      bool CheckMin,
+                                      const Array2DReal &CellMask) {
    I4 NaNCount        = 0;
    I4 OutOfRangeCount = 0;
 
    parallelReduce(
        "CheckNaN", {NRows, NCols},
        KOKKOS_LAMBDA(int Row, int Col, int &Accum) {
+          if (CellMask(Row, Col) == 0) {
+             return;
+          }
           Real Val = Arr(Row, Col);
           if (Kokkos::isnan(Val)) {
              ++Accum;
@@ -57,6 +63,9 @@ static std::pair<I4, I4> checkArray2D(const Array2DReal &Arr, I4 NRows,
    parallelReduce(
        "CheckBounds", {NRows, NCols},
        KOKKOS_LAMBDA(int Row, int Col, int &Accum) {
+          if (CellMask(Row, Col) == 0) {
+             return;
+          }
           Real Val = Arr(Row, Col);
           if (!Kokkos::isnan(Val)) {
              if (Val > MaxVal) {
@@ -73,16 +82,21 @@ static std::pair<I4, I4> checkArray2D(const Array2DReal &Arr, I4 NRows,
 
 //------------------------------------------------------------------------------
 // Helper: count NaN and out-of-range entries for a single tracer (row = cell,
-// col = vert) extracted from the 3-D tracer array at the given tracer index.
+// col = vert) extracted from the 3-D tracer array at the given tracer index,
+// restricted to active cells (CellMask > 0).
 static std::pair<I4, I4> checkTracerArray(const Array3DReal &Tracers3D,
                                           I4 TracerIdx, I4 NCells, I4 NVert,
-                                          Real MinVal, Real MaxVal) {
+                                          Real MinVal, Real MaxVal,
+                                          const Array2DReal &CellMask) {
    I4 NaNCount        = 0;
    I4 OutOfRangeCount = 0;
 
    parallelReduce(
        "CheckTracerNaN", {NCells, NVert},
        KOKKOS_LAMBDA(int Cell, int K, int &Accum) {
+          if (CellMask(Cell, K) == 0) {
+             return;
+          }
           Real Val = Tracers3D(TracerIdx, Cell, K);
           if (Kokkos::isnan(Val)) {
              ++Accum;
@@ -93,6 +107,9 @@ static std::pair<I4, I4> checkTracerArray(const Array3DReal &Tracers3D,
    parallelReduce(
        "CheckTracerBounds", {NCells, NVert},
        KOKKOS_LAMBDA(int Cell, int K, int &Accum) {
+          if (CellMask(Cell, K) == 0) {
+             return;
+          }
           Real Val = Tracers3D(TracerIdx, Cell, K);
           if (!Kokkos::isnan(Val)) {
              if (Val < MinVal || Val > MaxVal) {
@@ -107,11 +124,14 @@ static std::pair<I4, I4> checkTracerArray(const Array3DReal &Tracers3D,
 
 //------------------------------------------------------------------------------
 /// Validate ocean state fields for NaN and out-of-bounds conditions.
+/// Only active cells (where CellMask > 0) are checked.
 /// Aborts via MPI_Abort on failure.
 void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
-                        I4 TimeLevel) {
+                        const VertCoord *VCoord, I4 TimeLevel) {
 
    bool AnyFailure = false;
+
+   const Array2DReal &CellMask = VCoord->CellMask;
 
    // -------------------------------------------------------------------------
    // LayerThickness: valid range [1e-10, 1000]
@@ -121,7 +141,7 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
       auto [NaNs, OOB] =
           checkArray2D(LayerThick, State->NCellsOwned, State->NVertLayers,
                        static_cast<Real>(1e-10), static_cast<Real>(1000.0),
-                       /*CheckMin=*/true);
+                       /*CheckMin=*/true, CellMask);
 
       if (NaNs > 0) {
          LOG_CRITICAL(
@@ -144,7 +164,7 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
       auto [NaNs, OOB] =
           checkArray2D(KE, State->NCellsOwned, State->NVertLayers,
                        static_cast<Real>(0.0), static_cast<Real>(10.0),
-                       /*CheckMin=*/true);
+                       /*CheckMin=*/true, CellMask);
 
       if (NaNs > 0) {
          LOG_CRITICAL(
@@ -168,7 +188,7 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
       Array3DReal AllTracers = Tracers::getAll(TimeLevel);
       auto [NaNs, OOB]       = checkTracerArray(
           AllTracers, Tracers::IndxTemp, State->NCellsOwned, State->NVertLayers,
-          static_cast<Real>(-10.0), static_cast<Real>(50.0));
+          static_cast<Real>(-10.0), static_cast<Real>(50.0), CellMask);
 
       if (NaNs > 0) {
          LOG_CRITICAL("StateValidation: Temperature contains {} NaN value(s)",
@@ -190,7 +210,7 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
       Array3DReal AllTracers = Tracers::getAll(TimeLevel);
       auto [NaNs, OOB]       = checkTracerArray(
           AllTracers, Tracers::IndxSalt, State->NCellsOwned, State->NVertLayers,
-          static_cast<Real>(-2.0), static_cast<Real>(60.0));
+          static_cast<Real>(-2.0), static_cast<Real>(60.0), CellMask);
 
       if (NaNs > 0) {
          LOG_CRITICAL("StateValidation: Salinity contains {} NaN value(s)",

--- a/components/omega/src/ocn/StateValidation.cpp
+++ b/components/omega/src/ocn/StateValidation.cpp
@@ -1,14 +1,18 @@
 //===-- ocn/StateValidation.cpp - ocean state validation --------*- C++ -*-===//
 //
 // Validates ocean state fields by checking for NaN values and
-// out-of-bounds conditions. Any failure triggers a critical error log with
-// backtrace and MPI_Abort on the local communicator.
+// out-of-bounds conditions. Abort behaviour is controlled at runtime via the
+// YAML options Omega::State::Validation::AbortOnNan (default true) and
+// Omega::State::Validation::AbortOnOOB (default false). When an abort flag is
+// set a critical error log with backtrace is emitted and MPI_Abort is called;
+// otherwise a CRITICAL log message is written and execution continues.
 //
 //===----------------------------------------------------------------------===//
 
 #include "StateValidation.h"
 
 #include "AuxiliaryState.h"
+#include "Config.h"
 #include "DataTypes.h"
 #include "Error.h"
 #include "Logging.h"
@@ -25,6 +29,35 @@
 #include <utility>
 
 namespace OMEGA {
+
+struct ValidationAbortConfig {
+   bool AbortOnOOB = false;
+   bool AbortOnNan = true;
+};
+
+static ValidationAbortConfig getValidationAbortConfig() {
+   ValidationAbortConfig AbortConfig;
+
+   Config *OmegaConfig = Config::getOmegaConfig();
+   if (!OmegaConfig) {
+      return AbortConfig;
+   }
+
+   Config StateConfig("State");
+   if (!OmegaConfig->get(StateConfig).isSuccess()) {
+      return AbortConfig;
+   }
+
+   Config ValidationConfig("Validation");
+   if (!StateConfig.get(ValidationConfig).isSuccess()) {
+      return AbortConfig;
+   }
+
+   ValidationConfig.get("AbortOnOOB", AbortConfig.AbortOnOOB);
+   ValidationConfig.get("AbortOnNan", AbortConfig.AbortOnNan);
+
+   return AbortConfig;
+}
 
 //------------------------------------------------------------------------------
 // Helper: abort on the local Omega communicator with a message and backtrace
@@ -126,10 +159,12 @@ static std::pair<I4, I4> checkTracerArray(const Array3DReal &Tracers3D,
 /// Check ocean state fields for NaN and out-of-bounds conditions.
 /// Only active cells (where CellMask > 0) are checked.
 /// Returns the total count of errors found; does not abort.
-I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
-                   const VertCoord *VCoord, I4 TimeLevel) {
+std::pair<I4, I4> checkOceanState(const OceanState *State,
+                                  const AuxiliaryState *AuxState,
+                                  const VertCoord *VCoord, I4 TimeLevel) {
 
-   I4 TotalErrors = 0;
+   I4 TotalNaNs = 0;
+   I4 TotalOOBs = 0;
 
    const Array2DReal &CellMask = VCoord->CellMask;
 
@@ -146,14 +181,14 @@ I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
       if (NaNs > 0) {
          LOG_CRITICAL(
              "StateValidation: PseudoThickness contains {} NaN value(s)", NaNs);
-         TotalErrors += NaNs;
+         TotalNaNs += NaNs;
       }
       if (OOB > 0) {
          LOG_CRITICAL(
              "StateValidation: PseudoThickness has {} value(s) outside "
              "valid range [1e-10, 1000]",
              OOB);
-         TotalErrors += OOB;
+         TotalOOBs += OOB;
       }
    }
 
@@ -171,14 +206,14 @@ I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
          LOG_CRITICAL(
              "StateValidation: KineticEnergyCell contains {} NaN value(s)",
              NaNs);
-         TotalErrors += NaNs;
+         TotalNaNs += NaNs;
       }
       if (OOB > 0) {
          LOG_CRITICAL(
              "StateValidation: KineticEnergyCell has {} value(s) outside "
              "valid range [0, 10]",
              OOB);
-         TotalErrors += OOB;
+         TotalOOBs += OOB;
       }
    }
 
@@ -194,13 +229,13 @@ I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
       if (NaNs > 0) {
          LOG_CRITICAL("StateValidation: Temperature contains {} NaN value(s)",
                       NaNs);
-         TotalErrors += NaNs;
+         TotalNaNs += NaNs;
       }
       if (OOB > 0) {
          LOG_CRITICAL("StateValidation: Temperature has {} value(s) outside "
                       "valid range [-10, 50]",
                       OOB);
-         TotalErrors += OOB;
+         TotalOOBs += OOB;
       }
    }
 
@@ -216,17 +251,17 @@ I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
       if (NaNs > 0) {
          LOG_CRITICAL("StateValidation: Salinity contains {} NaN value(s)",
                       NaNs);
-         TotalErrors += NaNs;
+         TotalNaNs += NaNs;
       }
       if (OOB > 0) {
          LOG_CRITICAL("StateValidation: Salinity has {} value(s) outside "
                       "valid range [-2, 60]",
                       OOB);
-         TotalErrors += OOB;
+         TotalOOBs += OOB;
       }
    }
 
-   return TotalErrors;
+   return {TotalNaNs, TotalOOBs};
 }
 
 //------------------------------------------------------------------------------
@@ -236,9 +271,27 @@ I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
 void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
                         const VertCoord *VCoord, I4 TimeLevel) {
 
-   if (checkOceanState(State, AuxState, VCoord, TimeLevel) > 0) {
-      abortWithMessage("StateValidation: Ocean state validation failed. "
-                       "See critical messages above for details.");
+   auto [NaNs, OOBs]      = checkOceanState(State, AuxState, VCoord, TimeLevel);
+   const auto AbortConfig = getValidationAbortConfig();
+   bool abort             = false;
+
+   if (NaNs > 0 && AbortConfig.AbortOnNan) {
+      abort = true;
+   }
+   if (OOBs > 0 && AbortConfig.AbortOnOOB) {
+      abort = true;
+   }
+   if (abort) {
+      abortWithMessage(
+          "StateValidation: Ocean state validation aborting with " +
+          std::to_string(NaNs) + " NaNs and " + std::to_string(OOBs) +
+          " OOBs." + "See critical messages above for details.");
+   } else if ((NaNs + OOBs) > 0) {
+      LOG_CRITICAL(
+          "StateValidation: Ocean state validation failed with {} "
+          "NaNs and {} OOBs. AbortOnOOB and AbortOnNan are both false; "
+          "continuing after logging.",
+          NaNs, OOBs);
    }
 }
 

--- a/components/omega/src/ocn/StateValidation.cpp
+++ b/components/omega/src/ocn/StateValidation.cpp
@@ -164,7 +164,7 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
    // -------------------------------------------------------------------------
    // Temperature tracer: valid range [-10, 50]
    // -------------------------------------------------------------------------
-   if (Tracers::IndxTemp != Tracers::IndxInvalid) {
+   if (Tracers::IndxTemp != -1) {
       Array3DReal AllTracers = Tracers::getAll(TimeLevel);
       auto [NaNs, OOB]       = checkTracerArray(
           AllTracers, Tracers::IndxTemp, State->NCellsOwned, State->NVertLayers,
@@ -186,7 +186,7 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
    // -------------------------------------------------------------------------
    // Salinity tracer: valid range [-2, 60]
    // -------------------------------------------------------------------------
-   if (Tracers::IndxSalt != Tracers::IndxInvalid) {
+   if (Tracers::IndxSalt != -1) {
       Array3DReal AllTracers = Tracers::getAll(TimeLevel);
       auto [NaNs, OOB]       = checkTracerArray(
           AllTracers, Tracers::IndxSalt, State->NCellsOwned, State->NVertLayers,

--- a/components/omega/src/ocn/StateValidation.cpp
+++ b/components/omega/src/ocn/StateValidation.cpp
@@ -1,0 +1,219 @@
+//===-- ocn/StateValidation.cpp - ocean state validation --------*- C++ -*-===//
+//
+// Validates ocean state fields by checking for NaN values and
+// out-of-bounds conditions. Any failure triggers a critical error log with
+// backtrace and MPI_Abort on the local communicator.
+//
+//===----------------------------------------------------------------------===//
+
+#include "StateValidation.h"
+
+#include "AuxiliaryState.h"
+#include "DataTypes.h"
+#include "Error.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "OceanState.h"
+#include "OmegaKokkos.h"
+#include "Tracers.h"
+#include "mpi.h"
+
+#include <cmath>
+#include <cpptrace/cpptrace.hpp>
+#include <string>
+#include <utility>
+
+namespace OMEGA {
+
+//------------------------------------------------------------------------------
+// Helper: abort on the local Omega communicator with a message and backtrace
+static void abortWithMessage(const std::string &Msg) {
+   LOG_CRITICAL("{}", Msg);
+   cpptrace::generate_trace().print();
+   MPI_Comm Comm = MachEnv::getDefault()->getComm();
+   MPI_Abort(Comm, static_cast<int>(ErrorCode::Critical));
+}
+
+//------------------------------------------------------------------------------
+// Helper: count NaN entries and out-of-range entries in a 2-D Real device
+// array over the first NCells/NEdges rows and NVert columns.
+// Returns {NaNCount, OutOfRangeCount}.
+static std::pair<I4, I4> checkArray2D(const Array2DReal &Arr, I4 NRows,
+                                      I4 NCols, Real MinVal, Real MaxVal,
+                                      bool CheckMin) {
+   I4 NaNCount        = 0;
+   I4 OutOfRangeCount = 0;
+
+   parallelReduce(
+       "CheckNaN", {NRows, NCols},
+       KOKKOS_LAMBDA(int Row, int Col, int &Accum) {
+          Real Val = Arr(Row, Col);
+          if (Kokkos::isnan(Val)) {
+             ++Accum;
+          }
+       },
+       NaNCount);
+
+   parallelReduce(
+       "CheckBounds", {NRows, NCols},
+       KOKKOS_LAMBDA(int Row, int Col, int &Accum) {
+          Real Val = Arr(Row, Col);
+          if (!Kokkos::isnan(Val)) {
+             if (Val > MaxVal) {
+                ++Accum;
+             } else if (CheckMin && Val < MinVal) {
+                ++Accum;
+             }
+          }
+       },
+       OutOfRangeCount);
+
+   return {NaNCount, OutOfRangeCount};
+}
+
+//------------------------------------------------------------------------------
+// Helper: count NaN and out-of-range entries for a single tracer (row = cell,
+// col = vert) extracted from the 3-D tracer array at the given tracer index.
+static std::pair<I4, I4> checkTracerArray(const Array3DReal &Tracers3D,
+                                          I4 TracerIdx, I4 NCells, I4 NVert,
+                                          Real MinVal, Real MaxVal) {
+   I4 NaNCount        = 0;
+   I4 OutOfRangeCount = 0;
+
+   parallelReduce(
+       "CheckTracerNaN", {NCells, NVert},
+       KOKKOS_LAMBDA(int Cell, int K, int &Accum) {
+          Real Val = Tracers3D(TracerIdx, Cell, K);
+          if (Kokkos::isnan(Val)) {
+             ++Accum;
+          }
+       },
+       NaNCount);
+
+   parallelReduce(
+       "CheckTracerBounds", {NCells, NVert},
+       KOKKOS_LAMBDA(int Cell, int K, int &Accum) {
+          Real Val = Tracers3D(TracerIdx, Cell, K);
+          if (!Kokkos::isnan(Val)) {
+             if (Val < MinVal || Val > MaxVal) {
+                ++Accum;
+             }
+          }
+       },
+       OutOfRangeCount);
+
+   return {NaNCount, OutOfRangeCount};
+}
+
+//------------------------------------------------------------------------------
+/// Validate ocean state fields for NaN and out-of-bounds conditions.
+/// Aborts via MPI_Abort on failure.
+void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
+                        I4 TimeLevel) {
+
+   bool AnyFailure = false;
+
+   // -------------------------------------------------------------------------
+   // LayerThickness: valid range [1e-10, 1000]
+   // -------------------------------------------------------------------------
+   {
+      Array2DReal LayerThick = State->getLayerThickness(TimeLevel);
+      auto [NaNs, OOB] =
+          checkArray2D(LayerThick, State->NCellsOwned, State->NVertLayers,
+                       static_cast<Real>(1e-10), static_cast<Real>(1000.0),
+                       /*CheckMin=*/true);
+
+      if (NaNs > 0) {
+         LOG_CRITICAL(
+             "StateValidation: LayerThickness contains {} NaN value(s)", NaNs);
+         AnyFailure = true;
+      }
+      if (OOB > 0) {
+         LOG_CRITICAL("StateValidation: LayerThickness has {} value(s) outside "
+                      "valid range [1e-10, 1000]",
+                      OOB);
+         AnyFailure = true;
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // KineticEnergyCell: valid range [0, 10]
+   // -------------------------------------------------------------------------
+   {
+      const Array2DReal &KE = AuxState->KineticAux.KineticEnergyCell;
+      auto [NaNs, OOB] =
+          checkArray2D(KE, State->NCellsOwned, State->NVertLayers,
+                       static_cast<Real>(0.0), static_cast<Real>(10.0),
+                       /*CheckMin=*/true);
+
+      if (NaNs > 0) {
+         LOG_CRITICAL(
+             "StateValidation: KineticEnergyCell contains {} NaN value(s)",
+             NaNs);
+         AnyFailure = true;
+      }
+      if (OOB > 0) {
+         LOG_CRITICAL(
+             "StateValidation: KineticEnergyCell has {} value(s) outside "
+             "valid range [0, 10]",
+             OOB);
+         AnyFailure = true;
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // Temperature tracer: valid range [-10, 50]
+   // -------------------------------------------------------------------------
+   if (Tracers::IndxTemp != Tracers::IndxInvalid) {
+      Array3DReal AllTracers = Tracers::getAll(TimeLevel);
+      auto [NaNs, OOB]       = checkTracerArray(
+          AllTracers, Tracers::IndxTemp, State->NCellsOwned, State->NVertLayers,
+          static_cast<Real>(-10.0), static_cast<Real>(50.0));
+
+      if (NaNs > 0) {
+         LOG_CRITICAL("StateValidation: Temperature contains {} NaN value(s)",
+                      NaNs);
+         AnyFailure = true;
+      }
+      if (OOB > 0) {
+         LOG_CRITICAL("StateValidation: Temperature has {} value(s) outside "
+                      "valid range [-10, 50]",
+                      OOB);
+         AnyFailure = true;
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // Salinity tracer: valid range [-2, 60]
+   // -------------------------------------------------------------------------
+   if (Tracers::IndxSalt != Tracers::IndxInvalid) {
+      Array3DReal AllTracers = Tracers::getAll(TimeLevel);
+      auto [NaNs, OOB]       = checkTracerArray(
+          AllTracers, Tracers::IndxSalt, State->NCellsOwned, State->NVertLayers,
+          static_cast<Real>(-2.0), static_cast<Real>(60.0));
+
+      if (NaNs > 0) {
+         LOG_CRITICAL("StateValidation: Salinity contains {} NaN value(s)",
+                      NaNs);
+         AnyFailure = true;
+      }
+      if (OOB > 0) {
+         LOG_CRITICAL("StateValidation: Salinity has {} value(s) outside "
+                      "valid range [-2, 60]",
+                      OOB);
+         AnyFailure = true;
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // Abort if any check failed
+   // -------------------------------------------------------------------------
+   if (AnyFailure) {
+      abortWithMessage("StateValidation: Ocean state validation failed. "
+                       "See critical messages above for details.");
+   }
+}
+
+} // namespace OMEGA
+
+//===----------------------------------------------------------------------===//

--- a/components/omega/src/ocn/StateValidation.h
+++ b/components/omega/src/ocn/StateValidation.h
@@ -15,10 +15,13 @@
 #include "AuxiliaryState.h"
 #include "OceanState.h"
 #include "Tracers.h"
+#include "VertCoord.h"
 
 namespace OMEGA {
 
 /// Check ocean state fields for NaN values and out-of-bounds conditions.
+///
+/// Only active ocean cells (where CellMask > 0) are checked.
 ///
 /// The following fields are validated:
 ///   - LayerThickness      : [1e-10, 1000]  (from OceanState)
@@ -33,9 +36,10 @@ namespace OMEGA {
 ///
 /// \param[in] State       Ocean state to validate
 /// \param[in] AuxState    Auxiliary state containing KineticEnergyCell
+/// \param[in] VCoord      Vertical coordinate containing the CellMask
 /// \param[in] TimeLevel   Time level index to validate (typically 0 = current)
 void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
-                        I4 TimeLevel);
+                        const VertCoord *VCoord, I4 TimeLevel);
 
 } // namespace OMEGA
 

--- a/components/omega/src/ocn/StateValidation.h
+++ b/components/omega/src/ocn/StateValidation.h
@@ -27,7 +27,7 @@ namespace OMEGA {
 /// messages are emitted for each type of error found.
 ///
 /// The following fields are validated:
-///   - LayerThickness      : [1e-10, 1000]  (from OceanState)
+///   - PseudoThickness     : [1e-10, 1000]  (from OceanState)
 ///   - KineticEnergyCell   : [0, 10]
 ///                           (from AuxiliaryState::KineticAux)
 ///   - Temperature tracer  : [-10, 50]      (from Tracers)
@@ -47,7 +47,7 @@ I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
 /// Only active ocean cells (where CellMask > 0) are checked.
 ///
 /// The following fields are validated:
-///   - LayerThickness      : [1e-10, 1000]  (from OceanState)
+///   - PseudoThickness     : [1e-10, 1000]  (from OceanState)
 ///   - KineticEnergyCell   : [0, 10]
 ///                           (from AuxiliaryState::KineticAux)
 ///   - Temperature tracer  : [-10, 50]      (from Tracers)

--- a/components/omega/src/ocn/StateValidation.h
+++ b/components/omega/src/ocn/StateValidation.h
@@ -7,9 +7,12 @@
 ///
 /// Provides two functions:
 ///   - checkOceanState: checks for NaN and out-of-bounds conditions and
-///     returns the total error count without aborting. Suitable for testing.
-///   - validateOceanState: calls checkOceanState and aborts via MPI_Abort if
-///     any errors are found.
+///     returns the NaN count and out-of-bounds count as a pair without
+///     aborting. Suitable for testing.
+///   - validateOceanState: calls checkOceanState and conditionally aborts
+///     via MPI_Abort based on runtime YAML options AbortOnNan and AbortOnOOB
+///     (under Omega::State::Validation). When both flags are false a
+///     CRITICAL log message is emitted and the run continues.
 //
 //===----------------------------------------------------------------------===//
 
@@ -21,7 +24,7 @@
 namespace OMEGA {
 
 /// Check ocean state fields for NaN values and out-of-bounds conditions
-/// without aborting, returning the total count of errors found.
+/// without aborting, returning counts of each error type found.
 ///
 /// Only active ocean cells (where CellMask > 0) are checked. Critical log
 /// messages are emitted for each type of error found.
@@ -37,14 +40,17 @@ namespace OMEGA {
 /// \param[in] AuxState    Auxiliary state containing KineticEnergyCell
 /// \param[in] VCoord      Vertical coordinate containing the CellMask
 /// \param[in] TimeLevel   Time level index to validate (typically 0 = current)
-/// \return I4 total count of errors found across all checked fields (0 = valid)
-I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
-                   const VertCoord *VCoord, I4 TimeLevel);
+/// \return std::pair<I4,I4> {NaN count, out-of-bounds count}; both 0 if valid
+std::pair<I4, I4> checkOceanState(const OceanState *State,
+                                  const AuxiliaryState *AuxState,
+                                  const VertCoord *VCoord, I4 TimeLevel);
 
 /// Check ocean state fields for NaN values and out-of-bounds conditions.
 ///
-/// Calls checkOceanState and aborts via MPI_Abort if any errors are found.
-/// Only active ocean cells (where CellMask > 0) are checked.
+/// Calls checkOceanState and conditionally aborts via MPI_Abort based on the
+/// runtime YAML options AbortOnNan and AbortOnOOB (under
+/// Omega::State::Validation). Only active ocean cells (where CellMask > 0)
+/// are checked.
 ///
 /// The following fields are validated:
 ///   - PseudoThickness     : [1e-10, 1000]  (from OceanState)
@@ -53,9 +59,11 @@ I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
 ///   - Temperature tracer  : [-10, 50]      (from Tracers)
 ///   - Salinity tracer     : [-2, 60]       (from Tracers)
 ///
-/// If any check fails a critical error is logged with an informative message
-/// and a stack backtrace, and the run is aborted via MPI_Abort on the
-/// communicator obtained from the default MachEnv.
+/// If AbortOnNan is true and NaN values are detected, or AbortOnOOB is true
+/// and out-of-bounds values are detected, a critical error is logged with a
+/// stack backtrace and the run is aborted via MPI_Abort. When both flags are
+/// false but errors are found, a CRITICAL log message is emitted and execution
+/// continues.
 ///
 /// \param[in] State       Ocean state to validate
 /// \param[in] AuxState    Auxiliary state containing KineticEnergyCell

--- a/components/omega/src/ocn/StateValidation.h
+++ b/components/omega/src/ocn/StateValidation.h
@@ -3,12 +3,13 @@
 //===-- ocn/StateValidation.h - ocean state validation ----------*- C++ -*-===//
 //
 /// \file
-/// \brief Declares the validateOceanState function for ocean state validation
+/// \brief Declares state validation functions for ocean state validation
 ///
-/// Provides a function that validates the ocean prognostic state and selected
-/// auxiliary/tracer fields by checking for NaN values and out-of-bounds
-/// conditions. If any check fails the function logs a critical error with a
-/// backtrace and aborts via MPI_Abort on the local MPI communicator.
+/// Provides two functions:
+///   - checkOceanState: checks for NaN and out-of-bounds conditions and
+///     returns the total error count without aborting. Suitable for testing.
+///   - validateOceanState: calls checkOceanState and aborts via MPI_Abort if
+///     any errors are found.
 //
 //===----------------------------------------------------------------------===//
 
@@ -19,8 +20,30 @@
 
 namespace OMEGA {
 
+/// Check ocean state fields for NaN values and out-of-bounds conditions
+/// without aborting, returning the total count of errors found.
+///
+/// Only active ocean cells (where CellMask > 0) are checked. Critical log
+/// messages are emitted for each type of error found.
+///
+/// The following fields are validated:
+///   - LayerThickness      : [1e-10, 1000]  (from OceanState)
+///   - KineticEnergyCell   : [0, 10]
+///                           (from AuxiliaryState::KineticAux)
+///   - Temperature tracer  : [-10, 50]      (from Tracers)
+///   - Salinity tracer     : [-2, 60]       (from Tracers)
+///
+/// \param[in] State       Ocean state to validate
+/// \param[in] AuxState    Auxiliary state containing KineticEnergyCell
+/// \param[in] VCoord      Vertical coordinate containing the CellMask
+/// \param[in] TimeLevel   Time level index to validate (typically 0 = current)
+/// \return I4 total count of errors found across all checked fields (0 = valid)
+I4 checkOceanState(const OceanState *State, const AuxiliaryState *AuxState,
+                   const VertCoord *VCoord, I4 TimeLevel);
+
 /// Check ocean state fields for NaN values and out-of-bounds conditions.
 ///
+/// Calls checkOceanState and aborts via MPI_Abort if any errors are found.
 /// Only active ocean cells (where CellMask > 0) are checked.
 ///
 /// The following fields are validated:

--- a/components/omega/src/ocn/StateValidation.h
+++ b/components/omega/src/ocn/StateValidation.h
@@ -1,0 +1,43 @@
+#ifndef OMEGA_STATEVALIDATION_H
+#define OMEGA_STATEVALIDATION_H
+//===-- ocn/StateValidation.h - ocean state validation ----------*- C++ -*-===//
+//
+/// \file
+/// \brief Declares the validateOceanState function for ocean state validation
+///
+/// Provides a function that validates the ocean prognostic state and selected
+/// auxiliary/tracer fields by checking for NaN values and out-of-bounds
+/// conditions. If any check fails the function logs a critical error with a
+/// backtrace and aborts via MPI_Abort on the local MPI communicator.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AuxiliaryState.h"
+#include "OceanState.h"
+#include "Tracers.h"
+
+namespace OMEGA {
+
+/// Check ocean state fields for NaN values and out-of-bounds conditions.
+///
+/// The following fields are validated:
+///   - LayerThickness      : [1e-10, 1000]  (from OceanState)
+///   - KineticEnergyCell   : [0, 10]
+///                           (from AuxiliaryState::KineticAux)
+///   - Temperature tracer  : [-10, 50]      (from Tracers)
+///   - Salinity tracer     : [-2, 60]       (from Tracers)
+///
+/// If any check fails a critical error is logged with an informative message
+/// and a stack backtrace, and the run is aborted via MPI_Abort on the
+/// communicator obtained from the default MachEnv.
+///
+/// \param[in] State       Ocean state to validate
+/// \param[in] AuxState    Auxiliary state containing KineticEnergyCell
+/// \param[in] TimeLevel   Time level index to validate (typically 0 = current)
+void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
+                        I4 TimeLevel);
+
+} // namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif // defined OMEGA_STATEVALIDATION_H

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -86,6 +86,8 @@ void ForwardBackwardStepper::doStep(
    Tracers::updateTimeLevels();
    Pacer::stop("ForwardBackward:haloExch", 3);
 
+   validateOceanState(State, AuxState, VertCoord::getDefault(), 0);
+
    // Advance the clock and update the simulation time
    StepClock->advance();
    SimTime = StepClock->getCurrentTime();

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -70,6 +70,8 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    Tracers::updateTimeLevels();
    Pacer::stop("RK2:haloExch", 3);
 
+   validateOceanState(State, AuxState, VertCoord::getDefault(), CurLevel);
+
    // Advance the clock and update the simulation time
    StepClock->advance();
    SimTime = StepClock->getCurrentTime();

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -135,6 +135,8 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
    Tracers::updateTimeLevels();
    Pacer::stop("RK4:haloExch", 3);
 
+   validateOceanState(State, AuxState, VertCoord::getDefault(), CurLevel);
+
    // Advance the clock and update the simulation time
    StepClock->advance();
    SimTime = StepClock->getCurrentTime();

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -42,6 +42,7 @@
 #include "Halo.h"
 #include "HorzMesh.h"
 #include "OceanState.h"
+#include "StateValidation.h"
 #include "Tendencies.h"
 #include "TimeMgr.h"
 #include "Tracers.h"

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -544,3 +544,14 @@ add_omega_test(
     ocn/VertAdvTest.cpp
     "-n;1"
 )
+
+##########################
+# State Validation test
+##########################
+
+add_omega_test(
+    STATE_VALIDATION_TEST
+    testStateValidation.exe
+    ocn/StateValidationTest.cpp
+    "-n;8"
+)

--- a/components/omega/test/ocn/StateValidationTest.cpp
+++ b/components/omega/test/ocn/StateValidationTest.cpp
@@ -7,7 +7,7 @@
 /// Tests both the positive path (valid state passes) and the negative paths
 /// (NaN and out-of-bounds values in each checked field are detected) of
 /// validateOceanState / checkOceanState. Checked fields are:
-///   - LayerThickness, KineticEnergyCell, Temperature, Salinity.
+///   - PseudoThickness, KineticEnergyCell, Temperature, Salinity.
 //
 //===-----------------------------------------------------------------------===/
 
@@ -17,6 +17,7 @@
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "Dimension.h"
+#include "Eos.h"
 #include "Error.h"
 #include "Field.h"
 #include "Halo.h"
@@ -71,6 +72,7 @@ int initStateValidationTest(const std::string &MeshFile) {
    HorzMesh::init();
    VertCoord::init();
    Tracers::init();
+   Eos::init();
 
    int StateErr = OceanState::init();
    if (StateErr != 0) {
@@ -94,11 +96,11 @@ static int fillValidState() {
    const int NVert  = State->NVertLayers;
    const int NEdges = State->NEdgesAll;
 
-   // LayerThickness: fill with 100 m (valid range [1e-10, 1000])
-   Array2DReal LayerThick = State->getLayerThickness(0);
+   // PseudoThickness: fill with 100 m (valid range [1e-10, 1000])
+   Array2DReal PseudoThick = State->getPseudoThickness(0);
    parallelFor(
-       "FillLayerThick", {NCells, NVert},
-       KOKKOS_LAMBDA(int ICell, int K) { LayerThick(ICell, K) = 100.0; });
+       "FillPseudoThick", {NCells, NVert},
+       KOKKOS_LAMBDA(int ICell, int K) { PseudoThick(ICell, K) = 100.0; });
 
    // NormalVelocity: fill with 0 (not checked, but needed for AuxState)
    Array2DReal NormalVel = State->getNormalVelocity(0);
@@ -134,7 +136,8 @@ static int fillValidState() {
 static void restoreValidState(OceanState *State, AuxiliaryState *AuxState) {
    fillValidState();
    Array3DReal AllTracers = Tracers::getAll(0);
-   AuxState->computeAll(State, AllTracers, 0);
+   TimeInterval Interval(1., TimeUnits::Seconds);
+   AuxState->computeAll(State, AllTracers, 0, Interval);
 }
 
 //------------------------------------------------------------------------------
@@ -167,46 +170,47 @@ static int expectErrors(const char *TestName, OceanState *State,
    return 0;
 }
 
-// --- LayerThickness ---
+// --- PseudoThickness ---
 
-static int testNaNLayerThickness(OceanState *State, AuxiliaryState *AuxState,
-                                 VertCoord *VCoord) {
+static int testNaNPseudoThickness(OceanState *State, AuxiliaryState *AuxState,
+                                  VertCoord *VCoord) {
    restoreValidState(State, AuxState);
    const Real NaN   = std::numeric_limits<Real>::quiet_NaN();
-   Array2DReal LT   = State->getLayerThickness(0);
+   Array2DReal PT   = State->getPseudoThickness(0);
    const int NCells = State->NCellsAll;
    const int NVert  = State->NVertLayers;
    parallelFor(
-       "InjectNaNLayerThick", {NCells, NVert},
-       KOKKOS_LAMBDA(int I, int K) { LT(I, K) = NaN; });
-   return expectErrors("NaN in LayerThickness", State, AuxState, VCoord);
+       "InjectNaNPseudoThick", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { PT(I, K) = NaN; });
+   return expectErrors("NaN in PseudoThickness", State, AuxState, VCoord);
 }
 
-static int testOOBHighLayerThickness(OceanState *State,
-                                     AuxiliaryState *AuxState,
-                                     VertCoord *VCoord) {
+static int testOOBHighPseudoThickness(OceanState *State,
+                                      AuxiliaryState *AuxState,
+                                      VertCoord *VCoord) {
    restoreValidState(State, AuxState);
-   Array2DReal LT   = State->getLayerThickness(0);
+   Array2DReal PT   = State->getPseudoThickness(0);
    const int NCells = State->NCellsAll;
    const int NVert  = State->NVertLayers;
    // 2000 m is above the valid max of 1000 m
    parallelFor(
-       "InjectOOBHighLayerThick", {NCells, NVert},
-       KOKKOS_LAMBDA(int I, int K) { LT(I, K) = 2000.0; });
-   return expectErrors("OOB-high in LayerThickness", State, AuxState, VCoord);
+       "InjectOOBHighPseudoThick", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { PT(I, K) = 2000.0; });
+   return expectErrors("OOB-high in PseudoThickness", State, AuxState, VCoord);
 }
 
-static int testOOBLowLayerThickness(OceanState *State, AuxiliaryState *AuxState,
-                                    VertCoord *VCoord) {
+static int testOOBLowPseudoThickness(OceanState *State,
+                                     AuxiliaryState *AuxState,
+                                     VertCoord *VCoord) {
    restoreValidState(State, AuxState);
-   Array2DReal LT   = State->getLayerThickness(0);
+   Array2DReal PT   = State->getPseudoThickness(0);
    const int NCells = State->NCellsAll;
    const int NVert  = State->NVertLayers;
    // -1.0 m is below the valid min of 1e-10 m
    parallelFor(
-       "InjectOOBLowLayerThick", {NCells, NVert},
-       KOKKOS_LAMBDA(int I, int K) { LT(I, K) = -1.0; });
-   return expectErrors("OOB-low in LayerThickness", State, AuxState, VCoord);
+       "InjectOOBLowPseudoThick", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { PT(I, K) = -1.0; });
+   return expectErrors("OOB-low in PseudoThickness", State, AuxState, VCoord);
 }
 
 // --- KineticEnergyCell ---
@@ -330,7 +334,8 @@ int testStateValidation() {
    fillValidState();
    {
       Array3DReal AllTracers = Tracers::getAll(0);
-      DefAuxState->computeAll(DefState, AllTracers, 0);
+      TimeInterval Interval(1., TimeUnits::Seconds);
+      DefAuxState->computeAll(DefState, AllTracers, 0, Interval);
    }
 
    // ---- Positive test ----
@@ -338,10 +343,10 @@ int testStateValidation() {
 
    // ---- Negative tests: each injects a bad value and verifies detection ----
 
-   // LayerThickness
-   Err += testNaNLayerThickness(DefState, DefAuxState, VCoord);
-   Err += testOOBHighLayerThickness(DefState, DefAuxState, VCoord);
-   Err += testOOBLowLayerThickness(DefState, DefAuxState, VCoord);
+   // PseudoThickness
+   Err += testNaNPseudoThickness(DefState, DefAuxState, VCoord);
+   Err += testOOBHighPseudoThickness(DefState, DefAuxState, VCoord);
+   Err += testOOBLowPseudoThickness(DefState, DefAuxState, VCoord);
 
    // KineticEnergyCell
    Err += testNaNKineticEnergy(DefState, DefAuxState, VCoord);
@@ -364,6 +369,7 @@ int testStateValidation() {
 
 void finalizeStateValidationTest() {
    Tracers::clear();
+   Eos::destroyInstance();
    OceanState::clear();
    VertAdv::clear();
    VertCoord::clear();

--- a/components/omega/test/ocn/StateValidationTest.cpp
+++ b/components/omega/test/ocn/StateValidationTest.cpp
@@ -111,13 +111,13 @@ static int fillValidState() {
    // Use deepCopy with individual tracer subviews
    if (Tracers::getNumTracers() > 0) {
       // Temperature = 10.0 (valid: -10 to 50)
-      if (Tracers::IndxTemp != Tracers::IndxInvalid) {
+      if (Tracers::IndxTemp != -1) {
          Array2DReal TempArr = Tracers::getByIndex(0, Tracers::IndxTemp);
          deepCopy(TempArr, static_cast<Real>(10.0));
       }
 
       // Salinity = 35.0 (valid: -2 to 60)
-      if (Tracers::IndxSalt != Tracers::IndxInvalid) {
+      if (Tracers::IndxSalt != -1) {
          Array2DReal SaltArr = Tracers::getByIndex(0, Tracers::IndxSalt);
          deepCopy(SaltArr, static_cast<Real>(35.0));
       }

--- a/components/omega/test/ocn/StateValidationTest.cpp
+++ b/components/omega/test/ocn/StateValidationTest.cpp
@@ -160,7 +160,7 @@ int testStateValidation() {
 
    // Test: validation should pass on valid state (no abort expected)
    LOG_INFO("StateValidationTest: Testing validation on valid state");
-   validateOceanState(DefState, DefAuxState, 0);
+   validateOceanState(DefState, DefAuxState, VertCoord::getDefault(), 0);
    LOG_INFO("StateValidationTest: Valid state validation PASS");
 
    AuxiliaryState::clear();

--- a/components/omega/test/ocn/StateValidationTest.cpp
+++ b/components/omega/test/ocn/StateValidationTest.cpp
@@ -57,11 +57,13 @@ int initStateValidationTest(const std::string &MeshFile) {
    Config::readAll("omega.yml");
 
    TimeStepper::init1();
+   TimeStepper *DefStepper = TimeStepper::getDefault();
+   Clock *ModelClock       = DefStepper->getClock();
 
    IO::init(DefComm);
    Decomp::init(MeshFile);
 
-   IOStream::init();
+   IOStream::init(ModelClock);
 
    int HaloErr = Halo::init();
    if (HaloErr != 0) {
@@ -69,7 +71,7 @@ int initStateValidationTest(const std::string &MeshFile) {
       LOG_ERROR("StateValidationTest: error initializing default halo");
    }
 
-   HorzMesh::init();
+   HorzMesh::init(ModelClock);
    VertCoord::init();
    Tracers::init();
    Eos::init();

--- a/components/omega/test/ocn/StateValidationTest.cpp
+++ b/components/omega/test/ocn/StateValidationTest.cpp
@@ -1,0 +1,221 @@
+//===-- Test driver for OMEGA StateValidation -----------------------*- C++
+//-*-===/
+//
+/// \file
+/// \brief Test driver for ocean state validation
+///
+/// Tests the validateOceanState function by verifying that it passes on valid
+/// state data. Checks cover LayerThickness, KineticEnergyCell, Temperature,
+/// and Salinity fields.
+//
+//===-----------------------------------------------------------------------===/
+
+#include "StateValidation.h"
+#include "AuxiliaryState.h"
+#include "Config.h"
+#include "DataTypes.h"
+#include "Decomp.h"
+#include "Dimension.h"
+#include "Error.h"
+#include "Field.h"
+#include "Halo.h"
+#include "HorzMesh.h"
+#include "IO.h"
+#include "IOStream.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "OceanState.h"
+#include "OmegaKokkos.h"
+#include "Pacer.h"
+#include "TimeStepper.h"
+#include "Tracers.h"
+#include "VertAdv.h"
+#include "VertCoord.h"
+#include "mpi.h"
+
+#include <cmath>
+
+using namespace OMEGA;
+
+//------------------------------------------------------------------------------
+// Initialize the Omega subsystems required for state validation testing
+
+int initStateValidationTest(const std::string &MeshFile) {
+   int Err = 0;
+
+   MachEnv::init(MPI_COMM_WORLD);
+   MachEnv *DefEnv  = MachEnv::getDefault();
+   MPI_Comm DefComm = DefEnv->getComm();
+
+   initLogging(DefEnv);
+   LOG_INFO("------ StateValidation unit tests ------");
+
+   Config("Omega");
+   Config::readAll("omega.yml");
+
+   TimeStepper::init1();
+
+   IO::init(DefComm);
+   Decomp::init(MeshFile);
+
+   IOStream::init();
+
+   int HaloErr = Halo::init();
+   if (HaloErr != 0) {
+      Err++;
+      LOG_ERROR("StateValidationTest: error initializing default halo");
+   }
+
+   HorzMesh::init();
+   VertCoord::init();
+   Tracers::init();
+
+   int StateErr = OceanState::init();
+   if (StateErr != 0) {
+      Err++;
+      LOG_ERROR("StateValidationTest: error initializing default state");
+   }
+
+   VertAdv::init();
+
+   return Err;
+}
+
+//------------------------------------------------------------------------------
+// Fill state and auxiliary/tracer arrays with known-valid values
+
+static int fillValidState() {
+   int Err = 0;
+
+   auto *State      = OceanState::getDefault();
+   const int NCells = State->NCellsAll;
+   const int NVert  = State->NVertLayers;
+   const int NEdges = State->NEdgesAll;
+
+   // LayerThickness: fill with 100 m (valid range [1e-10, 1000])
+   Array2DReal LayerThick = State->getLayerThickness(0);
+   parallelFor(
+       "FillLayerThick", {NCells, NVert},
+       KOKKOS_LAMBDA(int ICell, int K) { LayerThick(ICell, K) = 100.0; });
+
+   // NormalVelocity: fill with 0 (not checked, but needed for AuxState)
+   Array2DReal NormalVel = State->getNormalVelocity(0);
+   parallelFor(
+       "FillNormalVel", {NEdges, NVert},
+       KOKKOS_LAMBDA(int IEdge, int K) { NormalVel(IEdge, K) = 0.0; });
+
+   // Exchange halos so auxiliary state computations are consistent
+   State->exchangeHalo(0);
+
+   // Tracers: fill Temperature with 10 C and Salinity with 35 g/kg
+   // Use deepCopy with individual tracer subviews
+   if (Tracers::getNumTracers() > 0) {
+      // Temperature = 10.0 (valid: -10 to 50)
+      if (Tracers::IndxTemp != Tracers::IndxInvalid) {
+         Array2DReal TempArr = Tracers::getByIndex(0, Tracers::IndxTemp);
+         deepCopy(TempArr, static_cast<Real>(10.0));
+      }
+
+      // Salinity = 35.0 (valid: -2 to 60)
+      if (Tracers::IndxSalt != Tracers::IndxInvalid) {
+         Array2DReal SaltArr = Tracers::getByIndex(0, Tracers::IndxSalt);
+         deepCopy(SaltArr, static_cast<Real>(35.0));
+      }
+   }
+
+   return Err;
+}
+
+//------------------------------------------------------------------------------
+// Run state validation tests
+
+int testStateValidation() {
+   int Err = 0;
+
+   // Initialize the auxiliary state (needed for KineticEnergyCell)
+   AuxiliaryState::init();
+   auto *DefAuxState = AuxiliaryState::getDefault();
+
+   if (!DefAuxState) {
+      Err++;
+      LOG_ERROR("StateValidationTest: Default AuxiliaryState not found");
+      return Err;
+   }
+
+   auto *DefState = OceanState::getDefault();
+   if (!DefState) {
+      Err++;
+      LOG_ERROR("StateValidationTest: Default OceanState not found");
+      return Err;
+   }
+
+   // Fill state arrays with valid values
+   Err += fillValidState();
+
+   // Compute auxiliary variables so KineticEnergyCell is populated
+   {
+      Array3DReal AllTracers = Tracers::getAll(0);
+      DefAuxState->computeAll(DefState, AllTracers, 0);
+   }
+
+   // Test: validation should pass on valid state (no abort expected)
+   LOG_INFO("StateValidationTest: Testing validation on valid state");
+   validateOceanState(DefState, DefAuxState, 0);
+   LOG_INFO("StateValidationTest: Valid state validation PASS");
+
+   AuxiliaryState::clear();
+   return Err;
+}
+
+//------------------------------------------------------------------------------
+// Finalize Omega objects
+
+void finalizeStateValidationTest() {
+   Tracers::clear();
+   OceanState::clear();
+   VertAdv::clear();
+   VertCoord::clear();
+   HorzMesh::clear();
+   Field::clear();
+   Dimension::clear();
+   TimeStepper::clear();
+   Halo::clear();
+   Decomp::clear();
+   MachEnv::removeAll();
+}
+
+//------------------------------------------------------------------------------
+// Main entry point
+
+int main(int argc, char *argv[]) {
+   int RetVal = 0;
+
+   MPI_Init(&argc, &argv);
+   Kokkos::initialize(argc, argv);
+   Pacer::initialize(MPI_COMM_WORLD);
+   Pacer::setPrefix("Omega:");
+
+   {
+      int Err = initStateValidationTest("OmegaMesh.nc");
+      if (Err != 0) {
+         LOG_CRITICAL("StateValidationTest: Error during initialization");
+      } else {
+         RetVal += testStateValidation();
+      }
+      finalizeStateValidationTest();
+   }
+
+   if (RetVal == 0)
+      LOG_INFO("------ StateValidation unit tests successful ------");
+
+   Pacer::finalize();
+   Kokkos::finalize();
+   MPI_Finalize();
+
+   if (RetVal >= 256)
+      RetVal = 255;
+
+   return RetVal;
+
+} // end of main
+//===-----------------------------------------------------------------------===/

--- a/components/omega/test/ocn/StateValidationTest.cpp
+++ b/components/omega/test/ocn/StateValidationTest.cpp
@@ -4,9 +4,10 @@
 /// \file
 /// \brief Test driver for ocean state validation
 ///
-/// Tests the validateOceanState function by verifying that it passes on valid
-/// state data. Checks cover LayerThickness, KineticEnergyCell, Temperature,
-/// and Salinity fields.
+/// Tests both the positive path (valid state passes) and the negative paths
+/// (NaN and out-of-bounds values in each checked field are detected) of
+/// validateOceanState / checkOceanState. Checked fields are:
+///   - LayerThickness, KineticEnergyCell, Temperature, Salinity.
 //
 //===-----------------------------------------------------------------------===/
 
@@ -34,6 +35,7 @@
 #include "mpi.h"
 
 #include <cmath>
+#include <limits>
 
 using namespace OMEGA;
 
@@ -127,7 +129,180 @@ static int fillValidState() {
 }
 
 //------------------------------------------------------------------------------
-// Run state validation tests
+// Restore the default state to valid values and recompute the auxiliary state
+
+static void restoreValidState(OceanState *State, AuxiliaryState *AuxState) {
+   fillValidState();
+   Array3DReal AllTracers = Tracers::getAll(0);
+   AuxState->computeAll(State, AllTracers, 0);
+}
+
+//------------------------------------------------------------------------------
+// Positive test: validate a clean, valid state — expects 0 errors
+
+static int testValidState(OceanState *State, AuxiliaryState *AuxState,
+                          VertCoord *VCoord) {
+   LOG_INFO("StateValidationTest: Testing validation on valid state");
+   validateOceanState(State, AuxState, VCoord, 0);
+   LOG_INFO("StateValidationTest: Valid state validation PASS");
+   return 0;
+}
+
+//------------------------------------------------------------------------------
+// Negative tests: inject an invalid value, verify checkOceanState returns > 0,
+// then restore valid state.
+//
+// Returns 0 on success (i.e. the error was caught), 1 otherwise.
+
+static int expectErrors(const char *TestName, OceanState *State,
+                        AuxiliaryState *AuxState, VertCoord *VCoord) {
+   I4 Errs = checkOceanState(State, AuxState, VCoord, 0);
+   if (Errs == 0) {
+      LOG_ERROR("StateValidationTest: {} - expected errors but got none",
+                TestName);
+      return 1;
+   }
+   LOG_INFO("StateValidationTest: {} PASS (caught {} error(s))", TestName,
+            Errs);
+   return 0;
+}
+
+// --- LayerThickness ---
+
+static int testNaNLayerThickness(OceanState *State, AuxiliaryState *AuxState,
+                                 VertCoord *VCoord) {
+   restoreValidState(State, AuxState);
+   const Real NaN   = std::numeric_limits<Real>::quiet_NaN();
+   Array2DReal LT   = State->getLayerThickness(0);
+   const int NCells = State->NCellsAll;
+   const int NVert  = State->NVertLayers;
+   parallelFor(
+       "InjectNaNLayerThick", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { LT(I, K) = NaN; });
+   return expectErrors("NaN in LayerThickness", State, AuxState, VCoord);
+}
+
+static int testOOBHighLayerThickness(OceanState *State,
+                                     AuxiliaryState *AuxState,
+                                     VertCoord *VCoord) {
+   restoreValidState(State, AuxState);
+   Array2DReal LT   = State->getLayerThickness(0);
+   const int NCells = State->NCellsAll;
+   const int NVert  = State->NVertLayers;
+   // 2000 m is above the valid max of 1000 m
+   parallelFor(
+       "InjectOOBHighLayerThick", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { LT(I, K) = 2000.0; });
+   return expectErrors("OOB-high in LayerThickness", State, AuxState, VCoord);
+}
+
+static int testOOBLowLayerThickness(OceanState *State, AuxiliaryState *AuxState,
+                                    VertCoord *VCoord) {
+   restoreValidState(State, AuxState);
+   Array2DReal LT   = State->getLayerThickness(0);
+   const int NCells = State->NCellsAll;
+   const int NVert  = State->NVertLayers;
+   // -1.0 m is below the valid min of 1e-10 m
+   parallelFor(
+       "InjectOOBLowLayerThick", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { LT(I, K) = -1.0; });
+   return expectErrors("OOB-low in LayerThickness", State, AuxState, VCoord);
+}
+
+// --- KineticEnergyCell ---
+
+static int testNaNKineticEnergy(OceanState *State, AuxiliaryState *AuxState,
+                                VertCoord *VCoord) {
+   restoreValidState(State, AuxState);
+   const Real NaN   = std::numeric_limits<Real>::quiet_NaN();
+   Array2DReal KE   = AuxState->KineticAux.KineticEnergyCell;
+   const int NCells = State->NCellsAll;
+   const int NVert  = State->NVertLayers;
+   parallelFor(
+       "InjectNaNKE", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { KE(I, K) = NaN; });
+   return expectErrors("NaN in KineticEnergyCell", State, AuxState, VCoord);
+}
+
+static int testOOBKineticEnergy(OceanState *State, AuxiliaryState *AuxState,
+                                VertCoord *VCoord) {
+   restoreValidState(State, AuxState);
+   Array2DReal KE   = AuxState->KineticAux.KineticEnergyCell;
+   const int NCells = State->NCellsAll;
+   const int NVert  = State->NVertLayers;
+   // 9999 J/kg is above the valid max of 10 J/kg
+   parallelFor(
+       "InjectOOBKE", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { KE(I, K) = 9999.0; });
+   return expectErrors("OOB in KineticEnergyCell", State, AuxState, VCoord);
+}
+
+// --- Temperature tracer ---
+
+static int testNaNTemperature(OceanState *State, AuxiliaryState *AuxState,
+                              VertCoord *VCoord) {
+   if (Tracers::IndxTemp == -1)
+      return 0; // tracer not active; skip
+   restoreValidState(State, AuxState);
+   const Real NaN      = std::numeric_limits<Real>::quiet_NaN();
+   Array2DReal TempArr = Tracers::getByIndex(0, Tracers::IndxTemp);
+   const int NCells    = State->NCellsAll;
+   const int NVert     = State->NVertLayers;
+   parallelFor(
+       "InjectNaNTemp", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { TempArr(I, K) = NaN; });
+   return expectErrors("NaN in Temperature", State, AuxState, VCoord);
+}
+
+static int testOOBTemperature(OceanState *State, AuxiliaryState *AuxState,
+                              VertCoord *VCoord) {
+   if (Tracers::IndxTemp == -1)
+      return 0; // tracer not active; skip
+   restoreValidState(State, AuxState);
+   Array2DReal TempArr = Tracers::getByIndex(0, Tracers::IndxTemp);
+   const int NCells    = State->NCellsAll;
+   const int NVert     = State->NVertLayers;
+   // 9999 C is above the valid max of 50 C
+   parallelFor(
+       "InjectOOBTemp", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { TempArr(I, K) = 9999.0; });
+   return expectErrors("OOB in Temperature", State, AuxState, VCoord);
+}
+
+// --- Salinity tracer ---
+
+static int testNaNSalinity(OceanState *State, AuxiliaryState *AuxState,
+                           VertCoord *VCoord) {
+   if (Tracers::IndxSalt == -1)
+      return 0; // tracer not active; skip
+   restoreValidState(State, AuxState);
+   const Real NaN      = std::numeric_limits<Real>::quiet_NaN();
+   Array2DReal SaltArr = Tracers::getByIndex(0, Tracers::IndxSalt);
+   const int NCells    = State->NCellsAll;
+   const int NVert     = State->NVertLayers;
+   parallelFor(
+       "InjectNaNSalt", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { SaltArr(I, K) = NaN; });
+   return expectErrors("NaN in Salinity", State, AuxState, VCoord);
+}
+
+static int testOOBSalinity(OceanState *State, AuxiliaryState *AuxState,
+                           VertCoord *VCoord) {
+   if (Tracers::IndxSalt == -1)
+      return 0; // tracer not active; skip
+   restoreValidState(State, AuxState);
+   Array2DReal SaltArr = Tracers::getByIndex(0, Tracers::IndxSalt);
+   const int NCells    = State->NCellsAll;
+   const int NVert     = State->NVertLayers;
+   // 9999 g/kg is above the valid max of 60 g/kg
+   parallelFor(
+       "InjectOOBSalt", {NCells, NVert},
+       KOKKOS_LAMBDA(int I, int K) { SaltArr(I, K) = 9999.0; });
+   return expectErrors("OOB in Salinity", State, AuxState, VCoord);
+}
+
+//------------------------------------------------------------------------------
+// Run all state validation tests
 
 int testStateValidation() {
    int Err = 0;
@@ -149,19 +324,36 @@ int testStateValidation() {
       return Err;
    }
 
-   // Fill state arrays with valid values
-   Err += fillValidState();
+   VertCoord *VCoord = VertCoord::getDefault();
 
-   // Compute auxiliary variables so KineticEnergyCell is populated
+   // Fill state arrays with valid values and compute auxiliary state
+   fillValidState();
    {
       Array3DReal AllTracers = Tracers::getAll(0);
       DefAuxState->computeAll(DefState, AllTracers, 0);
    }
 
-   // Test: validation should pass on valid state (no abort expected)
-   LOG_INFO("StateValidationTest: Testing validation on valid state");
-   validateOceanState(DefState, DefAuxState, VertCoord::getDefault(), 0);
-   LOG_INFO("StateValidationTest: Valid state validation PASS");
+   // ---- Positive test ----
+   Err += testValidState(DefState, DefAuxState, VCoord);
+
+   // ---- Negative tests: each injects a bad value and verifies detection ----
+
+   // LayerThickness
+   Err += testNaNLayerThickness(DefState, DefAuxState, VCoord);
+   Err += testOOBHighLayerThickness(DefState, DefAuxState, VCoord);
+   Err += testOOBLowLayerThickness(DefState, DefAuxState, VCoord);
+
+   // KineticEnergyCell
+   Err += testNaNKineticEnergy(DefState, DefAuxState, VCoord);
+   Err += testOOBKineticEnergy(DefState, DefAuxState, VCoord);
+
+   // Temperature tracer
+   Err += testNaNTemperature(DefState, DefAuxState, VCoord);
+   Err += testOOBTemperature(DefState, DefAuxState, VCoord);
+
+   // Salinity tracer
+   Err += testNaNSalinity(DefState, DefAuxState, VCoord);
+   Err += testOOBSalinity(DefState, DefAuxState, VCoord);
 
    AuxiliaryState::clear();
    return Err;

--- a/components/omega/test/ocn/StateValidationTest.cpp
+++ b/components/omega/test/ocn/StateValidationTest.cpp
@@ -161,7 +161,8 @@ static int testValidState(OceanState *State, AuxiliaryState *AuxState,
 
 static int expectErrors(const char *TestName, OceanState *State,
                         AuxiliaryState *AuxState, VertCoord *VCoord) {
-   I4 Errs = checkOceanState(State, AuxState, VCoord, 0);
+   auto [NaNs, OOBs] = checkOceanState(State, AuxState, VCoord, 0);
+   auto Errs         = NaNs + OOBs;
    if (Errs == 0) {
       LOG_ERROR("StateValidationTest: {} - expected errors but got none",
                 TestName);


### PR DESCRIPTION
Initial validateOceanState function to check for NaNs and bounds
- PseudoThickness: 1e-10 to 1000
- KineticEnergyCell: up to 10 (don't need a lower bound)
- Temperature: -10 to 50
- Salinity: -2 to 60

Testing:
- aurora
```
oneapi-ifx:
      Start 41: STATE_VALIDATION_TEST
41/41 Test #41: STATE_VALIDATION_TEST ......................   Passed    2.15 sec

85% tests passed, 6 tests failed out of 41

Label Time Summary:
Omega-0    =  83.16 sec*proc (40 tests)
SERIAL     =  83.16 sec*proc (40 tests)

Total Test time (real) =  83.63 sec

The following tests FAILED:
         11 - HORZOPERATORS_PLANE_TEST (Failed)                 Omega-0 SERIAL
         12 - HORZOPERATORS_SPHERE_TEST (Failed)                Omega-0 SERIAL
         20 - TEND_PLANE_TEST (Failed)                          Omega-0 SERIAL
         21 - TEND_PLANE_SINGLE_PRECISION_TEST (Failed)         Omega-0 SERIAL
         22 - TEND_SPHERE_TEST (Failed)                         Omega-0 SERIAL
         23 - TENDENCIES_TEST (Failed)                          Omega-0 SERIAL

oneapi-ifxgpu:
      Start 41: STATE_VALIDATION_TEST
41/41 Test #41: STATE_VALIDATION_TEST ......................   Passed    2.84 sec

76% tests passed, 10 tests failed out of 41

Label Time Summary:
Omega-0    =  97.10 sec*proc (40 tests)
SYCL       =  97.10 sec*proc (40 tests)

Total Test time (real) =  99.11 sec

The following tests FAILED:
         11 - HORZOPERATORS_PLANE_TEST (Failed)                 Omega-0 SYCL
         12 - HORZOPERATORS_SPHERE_TEST (Failed)                Omega-0 SYCL
         13 - AUXVARS_PLANE_TEST (Failed)                       Omega-0 SYCL
         14 - AUXVARS_SPHERE_TEST (Failed)                      Omega-0 SYCL
         20 - TEND_PLANE_TEST (Failed)                          Omega-0 SYCL
         21 - TEND_PLANE_SINGLE_PRECISION_TEST (Failed)         Omega-0 SYCL
         22 - TEND_SPHERE_TEST (Failed)                         Omega-0 SYCL
         30 - TIMESTEPPER_TEST (Failed)                         Omega-0 SYCL
         37 - EOS_TEST (Failed)                                 Omega-0 SYCL
         39 - VERTMIX_TEST (Failed)                             Omega-0 SYCL
```
- pm-cpu+gnu:
```
      Start 41: STATE_VALIDATION_TEST
41/41 Test #41: STATE_VALIDATION_TEST ......................   Passed    1.69 sec
 
100% tests passed, 0 tests failed out of 41
 
Label Time Summary:
Omega-0    =  60.83 sec*proc (40 tests)
SERIAL     =  60.83 sec*proc (40 tests)
 
Total Test time (real) =  61.13 sec
```
- pm-gpu+gnugpu:
```
      Start 41: STATE_VALIDATION_TEST
41/41 Test #41: STATE_VALIDATION_TEST ......................   Passed    6.98 sec
 
100% tests passed, 0 tests failed out of 41
 
Label Time Summary:
CUDA       = 207.18 sec*proc (40 tests)
Omega-0    = 207.18 sec*proc (40 tests)
 
Total Test time (real) = 207.57 sec
```

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
  * [ ] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [ ] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [x] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [ ] Indicate "All tests passed" or document failing tests
    * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.
    * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
  * [x] New tests:
    * [x] CTest unit tests for new features have been added per the approved design.
    * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
* [ ] Stealth Features
  * [ ] If any stealth features are included in the PR, please confirm that they have been documented.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


