### PR TITLE
Add Fortitude, a Fortran linter, to the pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,11 @@ repos:
     hooks:
       - id: fortitude
         args: ["--config-file=components/omega/.fortitude.toml", "--fix", "--preview"]
+
+  # Can run individually with `pre-commit run fprettify --all-files`
+  - repo: https://github.com/fortran-lang/fprettify
+    rev: v0.3.7
+    hooks:
+      - id: fprettify
+        files: \.[fF](90|95|03|08)$
+        args: ["--indent", "4"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,4 +63,4 @@ repos:
     hooks:
       - id: fprettify
         files: \.[fF](90|95|03|08)$
-        args: ["--indent", "4"]
+        args: ["--indent", "3"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,9 @@ repos:
         verbose: true
         additional_dependencies: ['types-requests']
 
+  # Can run individually with `pre-commit run fortitude --all-files`
+  - repo: https://github.com/PlasmaFAIR/fortitude-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: fortitude
+        args: ["--config-file=components/omega/.fortitude.toml", "--fix", "--preview"]

--- a/components/omega/.fortitude.toml
+++ b/components/omega/.fortitude.toml
@@ -1,0 +1,4 @@
+[check]
+# Ignored Rules and justification:
+#   C003: 'implicit none' missing 'external' - Fortran 2013 feature and we support older standards
+ignore = ["C003"]

--- a/components/omega/.fortitude.toml
+++ b/components/omega/.fortitude.toml
@@ -1,4 +1,15 @@
 [check]
+# consitent with C++ line length
+line-length = 80
+
 # Ignored Rules and justification:
 #   C003: 'implicit none' missing 'external' - Fortran 2013 feature and we support older standards
 ignore = ["C003"]
+
+# config option below is available in the latest version of fortitude, but has
+# not yet released. The snippet below should be uncommented after the next
+# release of fortitude (probably v0.9.0)
+#
+# [check.line-too-long]
+# # LLVM clang sytle enforces line length for comments, follow suit for fortran
+# ignore-comments = false

--- a/components/omega/.fortitude.toml
+++ b/components/omega/.fortitude.toml
@@ -6,6 +6,9 @@ line-length = 80
 #   C003: 'implicit none' missing 'external' - Fortran 2013 feature and we support older standards
 ignore = ["C003"]
 
+[check.invalid-tab]
+indent-width = 3
+
 # config option below is available in the latest version of fortitude, but has
 # not yet released. The snippet below should be uncommented after the next
 # release of fortitude (probably v0.9.0)

--- a/components/omega/dev-conda.txt
+++ b/components/omega/dev-conda.txt
@@ -15,6 +15,9 @@ cpplint
 lizard
 include-what-you-use
 
+# fortran linting
+fprettify
+
 # python linting
 isort
 flynt

--- a/components/omega/doc/devGuide/Linting.md
+++ b/components/omega/doc/devGuide/Linting.md
@@ -70,6 +70,17 @@ pre-commit run mypy --all-files
 ```
 You can specify one more more files instead of `--all-files`.
 
+## Linting Fortran Code
+
+The tool used to lint Fortran code is
+[fortitude](https://fortitude.readthedocs.io/en/stable/).
+
+You can run  this tool individually if you need to:
+```
+pre-commit run fortitude --all-files
+```
+You can specify one more more files instead of `--all-files`.
+
 ## Updating the linting pacakge
 
 To update the linting packages, you just need to recreate the development


### PR DESCRIPTION
This PR adds support for installing and running `Fortitude`, [a Fortran linter](https://fortitude.readthedocs.io/en/stable/), as a pre-commit hook. The linter will only be applied to Fortran code in the `components/omega` directory. 

While there is currently no Fortran code in the `components/omega` directory, there will be soon with the build out of coupling infrastructure. Seems like a good idea to get the linter in place before any Fortran code is added. 
<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
---
Checklist
* [ ] Documentation:
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [ ] Indicate "All tests passed" or document failing tests
    * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.
    * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


