### PR TITLE
Extend halo for the vertical velocity computation

### DIFF
--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -375,11 +375,10 @@ void VertAdv::computeVerticalVelocity(
    OMEGA_SCOPE(LocEOnC, Mesh->EdgesOnCell);
    OMEGA_SCOPE(LocDvE, Mesh->DvEdge);
    OMEGA_SCOPE(LocESOnC, Mesh->EdgeSignOnCell);
-   OMEGA_SCOPE(LocNCellsHalo0, NCellsHalo0);
 
    // Loop over all cells owned by the task
    parallelForOuter(
-       "computeVerticalVelocity", {LocNCellsHalo0},
+       "computeVerticalVelocity", {NCellsHalo0},
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
           RealScratchArray DivHU(Team.team_scratch(0), LocNVertLayers);
 

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -55,6 +55,7 @@ VertAdv::VertAdv(const std::string &Name_,  //< [in] name for new VertAdv
    NVertLayers   = VCoord->NVertLayers;
    NVertLayersP1 = VCoord->NVertLayersP1;
    NCellsOwned   = Mesh->NCellsOwned;
+   NCellsHalo0   = Mesh->NCellsHaloH(0);
    NCellsAll     = Mesh->NCellsAll;
    NCellsSize    = Mesh->NCellsSize;
    NEdgesOwned   = Mesh->NEdgesOwned;
@@ -374,10 +375,11 @@ void VertAdv::computeVerticalVelocity(
    OMEGA_SCOPE(LocEOnC, Mesh->EdgesOnCell);
    OMEGA_SCOPE(LocDvE, Mesh->DvEdge);
    OMEGA_SCOPE(LocESOnC, Mesh->EdgeSignOnCell);
+   OMEGA_SCOPE(LocNCellsHalo0, NCellsHalo0);
 
    // Loop over all cells owned by the task
    parallelForOuter(
-       "computeVerticalVelocity", {NCellsOwned},
+       "computeVerticalVelocity", {LocNCellsHalo0},
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
           RealScratchArray DivHU(Team.team_scratch(0), LocNVertLayers);
 

--- a/components/omega/src/ocn/VertAdv.h
+++ b/components/omega/src/ocn/VertAdv.h
@@ -47,6 +47,7 @@ class VertAdv {
    I4 NVertLayers;
    I4 NVertLayersP1;
    I4 NCellsOwned;
+   I4 NCellsHalo0;
    I4 NCellsAll;
    I4 NCellsSize;
    I4 NEdgesOwned;


### PR DESCRIPTION
This PR extends the halo to `NCellsHaloH(0)` in the vertical velocity computation so that the first halo layer is valid when computing the velocity vertical advection tendency.

All CTests passed on `pm-cpu` (gnu compiler) and `pm-gpu` (gnugpu compiler).

Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests) have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html) has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests

