### PR TITLE
Add missing named dimensions for `SurfTracerRestAuxVars`

### DIFF
--- a/components/omega/src/infra/Field.cpp
+++ b/components/omega/src/infra/Field.cpp
@@ -137,8 +137,18 @@ Field::create(const std::string &FieldName,   // [in] Name of variable/field
    // the dimensions are distributed.
    ThisField->Distributed = false;
    if (NumDims > 0) {
+      if (static_cast<int>(Dimensions.size()) != NumDims)
+         ABORT_ERROR("Attempt to create field {} failed. Expected {} "
+                     "dimension names but received {}.",
+                     FieldName, NumDims, Dimensions.size());
+
       ThisField->DimNames.resize(NumDims);
       for (int I = 0; I < NumDims; ++I) {
+         if (Dimensions[I].empty())
+            ABORT_ERROR("Attempt to create field {} failed. Dimension {} "
+                        "has an empty name.",
+                        FieldName, I);
+
          ThisField->DimNames[I] = Dimensions[I];
          if (Dimension::isDistributedDim(Dimensions[I]))
             ThisField->Distributed = true;

--- a/components/omega/src/ocn/auxiliaryVars/SurfTracerRestAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/SurfTracerRestAuxVars.cpp
@@ -29,6 +29,9 @@ void SurfTracerRestAuxVars::registerFields(
       DimSuffix = MeshName;
    }
 
+   DimNames[0] = "NTracers";
+   DimNames[1] = "NCells" + DimSuffix;
+
    auto TracersMonthlySurfClimoCellField =
        Field::create(TracersMonthlySurfClimoCell.label(),
                      "monthly surface tracer climatology", // long name/describe


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

Fixes #389 
