### PR TITLE
Allow `TimeStepper`'s `StopTime` to be optional 

### DIFF
--- a/components/omega/doc/devGuide/TimeStepping.md
+++ b/components/omega/doc/devGuide/TimeStepping.md
@@ -66,7 +66,7 @@ TimeStepper* DefTimeStepper = TimeStepper::getDefault();
 
 In standalone simulations, `TimeStepper::init1();` will read the StartTime from
 the configuration file. For coupled simulations the StartTime is provided by
-coupler, overriding the value defined in the configuration file.
+the coupler, overriding the value defined in the configuration file.
 In this case, the first phase of time stepper initialization would look like:
 ```c++
 // coupled simulations have a start time but no stop time

--- a/components/omega/doc/devGuide/TimeStepping.md
+++ b/components/omega/doc/devGuide/TimeStepping.md
@@ -20,12 +20,14 @@ enum class TimeStepperType { ForwardBackward, RungeKutta4, RungeKutta2 };
 The `TimeStepper` class is a base class for all Omega time steppers. It stores
 as members common data needed by every time stepper. These include a name and
 time stepping method as well as some time tracking variables, including
-StartTime, StopTime, TimeStep, a Clock and an EndAlarm. Its `doStep` method
-defines the interface that every time stepper needs to implement. In addition to this
-method, it provides a number of other methods that can divided into two groups.
-The first group is for general time stepper management. The second group is
-utility functions that provide common functionality that can be re-used in
-implementation of different time steppers.
+a Clock, TimeStep, StartTime, StopTime (optional) and an EndAlarm (optional).
+The StopTime and EndAlarm are optional, because in coupled E3SM simulations the
+components do not know the StopTime and therefore no EndAlarm can be created.
+Its `doStep` method defines the interface that every time stepper needs to
+implement. In addition to this method, it provides a number of other methods
+that can divided into two groups. The first group is for general time stepper
+management. The second group is utility functions that provide common
+functionality that can be re-used in implementation of different time steppers.
 
 ### Do step method
 The `doStep` method is the main method of every time stepper class. It exists
@@ -62,14 +64,26 @@ retrieved at any time using:
 TimeStepper* DefTimeStepper = TimeStepper::getDefault();
 ```
 
+In standalone simulations, `TimeStepper::init1();` will read the StartTime from
+the configuration file. For coupled simulations the StartTime is provided by
+coupler, overriding the value defined in the configuration file.
+In this case, the first phase of time stepper initialization would look like:
+```c++
+// coupled simulations have a start time but no stop time
+TimeInitParams TimeParams{StartTime, std::nullopt};
+
+// initialize TimeStepper with coupler provided start time
+TimeStepper::init1(TimeParams);
+```
+
 #### Creation of non-default time steppers
 
 A non-default time stepper can be created from a string `Name`, time stepper
 type `Type`, `TimeStep`, `StartTime`, `EndTime`, tendencies `Tend`,
 auxiliary state `AuxState`, horizontal mesh `Mesh`, and halo layer `MyHalo`
 ```c++
-TimeStepper*  NewTimeStepper = TimeStepper::create(Name, Type, StartTime,
-         EndTime, TimeStep, Tend, AuxState, Mesh, MyHalo);
+TimeStepper*  NewTimeStepper = TimeStepper::create(Name, Type, TimeStep,
+          StartTime, EndTime, Tend, AuxState, Mesh, MyHalo);
 ```
 For convenience, this returns a pointer to the newly created time stepper.
 Given its name, a pointer to a named time stepper can be obtained at any time

--- a/components/omega/src/ocn/OceanDriver.h
+++ b/components/omega/src/ocn/OceanDriver.h
@@ -13,6 +13,7 @@
 
 #include "Config.h"
 #include "TimeMgr.h"
+#include "TimeStepper.h"
 
 #include "mpi.h"
 
@@ -33,6 +34,9 @@ int ocnFinalize(const TimeInstant &CurrTime);
 
 /// Initialize Omega modules needed to run ocean model
 int initOmegaModules(MPI_Comm Comm);
+
+/// Initialize Omega modules with coupler-provided time parameters
+int initOmegaModules(MPI_Comm Comm, const TimeInitParams &TParams);
 
 } // end namespace OMEGA
 

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -102,58 +102,8 @@ int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
    if (Err != 0)
       ABORT_ERROR("ocnInit: Error initializing Omega modules");
 
-   return Err;
-
-} // end ocnInit
-
-// Call init routines for remaining Omega modules
-int initOmegaModules(MPI_Comm Comm) {
-
-   // error and return codes
-   int Err = 0;
-
-   // Initialize the default time stepper (phase 1) that includes the
-   // calendar, model clock and start/stop times and alarms
-   TimeStepper::init1();
    TimeStepper *DefStepper = TimeStepper::getDefault();
    Clock *ModelClock       = DefStepper->getClock();
-
-   // Initialize IOStreams - this does not yet validate the contents
-   // of each file, only creates streams from Config
-   IOStream::init(ModelClock);
-
-   IO::init(Comm);
-   Field::init(ModelClock);
-   Decomp::init();
-
-   Err = Halo::init();
-   if (Err != 0) {
-      ABORT_ERROR("ocnInit: Error initializing default halo");
-   }
-
-   HorzMesh::init();
-   VertCoord::init();
-   Tracers::init();
-   VertAdv::init();
-   AuxiliaryState::init();
-   Eos::init();
-   PressureGrad::init();
-   Tendencies::init();
-
-   // Validate SurfaceTracerRestoring configuration
-   Tendencies *DefTend = Tendencies::getDefault();
-   if (DefTend->SurfaceTracerRestoring.Enabled &&
-       DefTend->SurfaceTracerRestoring.NTracersToRestore == 0) {
-      ABORT_ERROR("OceanInit: SurfaceTracerRestoring is enabled but "
-                  "TracersToRestore is empty");
-   }
-
-   TimeStepper::init2();
-
-   Err = OceanState::init();
-   if (Err != 0) {
-      ABORT_ERROR("ocnInit: Error initializing default state");
-   }
 
    // Now that all fields have been defined, validate all the streams
    // contents
@@ -212,7 +162,74 @@ int initOmegaModules(MPI_Comm Comm) {
 
    return Err;
 
-} // end initOmegaModules
+} // end ocnInit
+
+// Call init routines for remaining Omega modules
+// Internal helper — all module init after TimeStepper::init1 is called.
+// Called by both initOmegaModules overloads.
+static int initOmegaModulesImpl(MPI_Comm Comm) {
+
+   // error and return codes
+   int Err = 0;
+
+   TimeStepper *DefStepper = TimeStepper::getDefault();
+   Clock *ModelClock       = DefStepper->getClock();
+
+   // Initialize IOStreams - this does not yet validate the contents
+   // of each file, only creates streams from Config
+   IOStream::init(ModelClock);
+
+   IO::init(Comm);
+   Field::init(ModelClock);
+   Decomp::init();
+
+   Err = Halo::init();
+   if (Err != 0) {
+      ABORT_ERROR("ocnInit: Error initializing default halo");
+   }
+
+   HorzMesh::init();
+   VertCoord::init();
+   Tracers::init();
+   VertAdv::init();
+   AuxiliaryState::init();
+   Eos::init();
+   PressureGrad::init();
+   Tendencies::init();
+
+   // Validate SurfaceTracerRestoring configuration
+   Tendencies *DefTend = Tendencies::getDefault();
+   if (DefTend->SurfaceTracerRestoring.Enabled &&
+       DefTend->SurfaceTracerRestoring.NTracersToRestore == 0) {
+      ABORT_ERROR("OceanInit: SurfaceTracerRestoring is enabled but "
+                  "TracersToRestore is empty");
+   }
+
+   TimeStepper::init2();
+
+   Err = OceanState::init();
+   if (Err != 0) {
+      ABORT_ERROR("ocnInit: Error initializing default state");
+   }
+
+   return Err;
+
+} // end initOmegaModulesImpl
+
+int initOmegaModules(MPI_Comm Comm) {
+   // Initialize the default time stepper (phase 1) that includes the
+   // calendar, model clock and start/stop times and alarms with all options
+   // read from the config file
+   TimeStepper::init1();
+   return initOmegaModulesImpl(Comm);
+}
+
+int initOmegaModules(MPI_Comm Comm, const TimeInitParams &TParams) {
+   // Initialize time stepper (phase 1) using coupler provided time parameters
+   // Calendar should have already been initalized
+   TimeStepper::init1(TParams);
+   return initOmegaModulesImpl(Comm);
+}
 
 } // end namespace OMEGA
 //===----------------------------------------------------------------------===//

--- a/components/omega/src/ocn/OceanRun.cpp
+++ b/components/omega/src/ocn/OceanRun.cpp
@@ -23,6 +23,9 @@ int ocnRun(TimeInstant &CurrTime ///< [inout] current sim time
    OceanState *DefOceanState   = OceanState::getDefault();
    TimeStepper *DefTimeStepper = TimeStepper::getDefault();
 
+   // EndAlarm must be set before calling ocnRun
+   OMEGA_REQUIRE(DefTimeStepper->hasEndAlarm(), "ocnRun: no EndAlarm");
+
    // get simulation time and other time info
    Clock *OmegaClock     = DefTimeStepper->getClock();
    Alarm *EndAlarm       = DefTimeStepper->getEndAlarm();

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -15,12 +15,12 @@ namespace OMEGA {
 // Mostly passes relevant info to the base constructor.
 ForwardBackwardStepper::ForwardBackwardStepper(
     const std::string &InName,      ///< [in] name of time stepper
+    const TimeInterval &InTimeStep, ///< [in] time step
     const TimeInstant &InStartTime, ///< [in] start time for time stepping
-    const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
-    const TimeInterval &InTimeStep  ///< [in] time step
-    )
-    : TimeStepper(InName, TimeStepperType::ForwardBackward, 2, InStartTime,
-                  InStopTime, InTimeStep) {}
+    ///< [in] stop time for time stepping, missing in coupled mode
+    std::optional<TimeInstant> InStopTime)
+    : TimeStepper(InName, TimeStepperType::ForwardBackward, 2, InTimeStep,
+                  InStartTime, InStopTime) {}
 
 //------------------------------------------------------------------------------
 // Advance the state by one step of the forward-backward scheme

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.h
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.h
@@ -16,10 +16,10 @@ class ForwardBackwardStepper : public TimeStepper {
    /// fills with some time information. Data pointers are added later.
    ForwardBackwardStepper(
        const std::string &InName,      ///< [in] name of time stepper
+       const TimeInterval &InTimeStep, ///< [in] time step
        const TimeInstant &InStartTime, ///< [in] start time for time stepping
-       const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
-       const TimeInterval &InTimeStep  ///< [in] time step
-   );
+       ///< [in] stop time for time stepping, missing in coupled mode
+       std::optional<TimeInstant> InStopTime = std::nullopt);
 
    /// Advance the state by one step of the forward-backward scheme
    void doStep(OceanState *State,   ///< [inout] model state

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -15,12 +15,12 @@ namespace OMEGA {
 // Mostly just passes info to the base constructor.
 RungeKutta2Stepper::RungeKutta2Stepper(
     const std::string &InName,      ///< [in] name of time stepper
+    const TimeInterval &InTimeStep, ///< [in] time step
     const TimeInstant &InStartTime, ///< [in] start time for time stepping
-    const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
-    const TimeInterval &InTimeStep  ///< [in] time step
-    )
-    : TimeStepper(InName, TimeStepperType::RungeKutta2, 2, InStartTime,
-                  InStopTime, InTimeStep) {}
+    ///< [in] stop time for time stepping, missing in coupled mode
+    std::optional<TimeInstant> InStopTime)
+    : TimeStepper(InName, TimeStepperType::RungeKutta2, 2, InTimeStep,
+                  InStartTime, InStopTime) {}
 
 //------------------------------------------------------------------------------
 // Advance the state by one step of the midpoint Runge Kutta scheme

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.h
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.h
@@ -18,10 +18,10 @@ class RungeKutta2Stepper : public TimeStepper {
    /// fills with some time information. Data pointers are added later.
    RungeKutta2Stepper(
        const std::string &InName,      ///< [in] name of time stepper
+       const TimeInterval &InTimeStep, ///< [in] time step
        const TimeInstant &InStartTime, ///< [in] start time for time stepping
-       const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
-       const TimeInterval &InTimeStep  ///< [in] time step
-   );
+       ///< [in] stop time for time stepping, missing in coupled mode
+       std::optional<TimeInstant> InStopTime = std::nullopt);
 
    /// Advance the state by one step of the midpoint Runge Kutta scheme
    void doStep(OceanState *State,   ///< [inout] model state

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -15,12 +15,12 @@ namespace OMEGA {
 // Uses the base constructor and adds some coefficients.
 RungeKutta4Stepper::RungeKutta4Stepper(
     const std::string &InName,      ///< [in] name of time stepper
+    const TimeInterval &InTimeStep, ///< [in] time step
     const TimeInstant &InStartTime, ///< [in] start time for time stepping
-    const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
-    const TimeInterval &InTimeStep  ///< [in] time step
-    )
-    : TimeStepper(InName, TimeStepperType::RungeKutta4, 2, InStartTime,
-                  InStopTime, InTimeStep) {
+    ///< [in] stop time for time stepping, missing in coupled mode
+    std::optional<TimeInstant> InStopTime)
+    : TimeStepper(InName, TimeStepperType::RungeKutta4, 2, InTimeStep,
+                  InStartTime, InStopTime) {
 
    RKA[0] = 0;
    RKA[1] = 1. / 2;

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.h
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.h
@@ -17,10 +17,10 @@ class RungeKutta4Stepper : public TimeStepper {
    /// fills with some time information. Data pointers are added later.
    RungeKutta4Stepper(
        const std::string &InName,      ///< [in] name of time stepper
+       const TimeInterval &InTimeStep, ///< [in] time step
        const TimeInstant &InStartTime, ///< [in] start time for time stepping
-       const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
-       const TimeInterval &InTimeStep  ///< [in] time step
-   );
+       ///< [in] stop time for time stepping, missing in coupled mode
+       std::optional<TimeInstant> InStopTime = std::nullopt);
 
    /// Advance the state by one step of the fourth-order Runge Kutta scheme
    void doStep(OceanState *State,   ///< [inout] model state

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -127,46 +127,15 @@ TimeStepper *TimeStepper::create(
     Halo *InMeshHalo                ///< [in] ptr to halos
 ) {
 
-   // Check for duplicates
-   if (AllTimeSteppers.find(InName) != AllTimeSteppers.end()) {
-      LOG_ERROR("Attempted to create a new TimeStepper with name {} but it "
-                "already exists",
-                InName);
-      return nullptr;
-   }
-
-   TimeStepper *NewTimeStepper;
-
-   // Call specific constructor with time info
-   // These constructors mostly just call the constructor above with some
-   // additional info (NTimeLevels)
-   switch (InType) {
-   case TimeStepperType::ForwardBackward:
-      NewTimeStepper = new ForwardBackwardStepper(InName, InTimeStep,
-                                                  InStartTime, InStopTime);
-      break;
-   case TimeStepperType::RungeKutta4:
-      NewTimeStepper =
-          new RungeKutta4Stepper(InName, InTimeStep, InStartTime, InStopTime);
-      break;
-   case TimeStepperType::RungeKutta2:
-      NewTimeStepper =
-          new RungeKutta2Stepper(InName, InTimeStep, InStartTime, InStopTime);
-      break;
-   case TimeStepperType::Invalid:
-      ABORT_ERROR("Invalid time stepping method");
-   default:
-      ABORT_ERROR("Unknown time stepping method");
-   }
+   // Start by calling the two-phase create function
+   TimeStepper *NewTimeStepper =
+       create(InName, InType, InTimeStep, InStartTime, InStopTime);
 
    NewTimeStepper->PrescribeThicknessMode = DefaultPrescribeThicknessMode;
    NewTimeStepper->PrescribeVelocityMode  = DefaultPrescribeVelocityMode;
 
    // Attach data pointers
    NewTimeStepper->attachData(InTend, InAuxState, InMesh, InVCoord, InMeshHalo);
-
-   // Store instance
-   AllTimeSteppers.emplace(InName, NewTimeStepper);
 
    return NewTimeStepper;
 }
@@ -176,10 +145,10 @@ TimeStepper *TimeStepper::create(
 // and tendencies are defined. It creates an instance and only fills
 // the time information. Data pointers are attached later.
 TimeStepper *TimeStepper::create(
-    const std::string &InName, // [in] name of time stepper
-    TimeStepperType InType,    // [in] type (time stepping method)
-    TimeInterval &InTimeStep,  // [in] time step
-    TimeInstant &InStartTime,  // [in] start time for time stepping
+    const std::string &InName,      // [in] name of time stepper
+    TimeStepperType InType,         // [in] type (time stepping method)
+    const TimeInterval &InTimeStep, // [in] time step
+    const TimeInstant &InStartTime, // [in] start time for time stepping
     ///< [in] stop time for time stepping, missing in coupled mode
     std::optional<TimeInstant> InStopTime) {
 
@@ -382,14 +351,12 @@ void TimeStepper::init1(const TimeInitParams &TimeParams) {
    CHECK_ERROR_ABORT(Err, "TimeStep not found in TimeIntegration Config");
    TimeInterval TimeStep(TimeStepStr);
 
-   // Local non-const copies required by the 2-phase create() signature
-   TimeInstant StartTime = TimeParams.StartTime;
-
    // Now that all the inputs are defined, create the default time stepper
    // Use the partial creation function for only the time info. Data
    // pointers will be attached in phase 2 initialization
-   TimeStepper::DefaultTimeStepper = create(
-       "Default", TimeStepperChoice, TimeStep, StartTime, TimeParams.StopTime);
+   TimeStepper::DefaultTimeStepper =
+       create("Default", TimeStepperChoice, TimeStep, TimeParams.StartTime,
+              TimeParams.StopTime);
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -272,7 +272,7 @@ void TimeStepper::clear() {
 // Initialize the default time stepper in two phases
 
 // Begin initialization of the default time stepper (phase 1)
-// This is primarily the time information.
+// This is primarily the time information read directly from the config file
 void TimeStepper::init1() {
 
    Error Err; // error code - default to success
@@ -283,23 +283,11 @@ void TimeStepper::init1() {
    Err = OmegaConfig->get(TimeIntConfig);
    CHECK_ERROR_ABORT(Err, "TimeIntegration group not found in Config");
 
-   // Must initialize the calendar first
+   // Must initialize the calendar first, before any TimeInstant objects
    std::string CalendarStr;
    Err += TimeIntConfig.get("CalendarType", CalendarStr);
    CHECK_ERROR_ABORT(Err, "CalendarType not found in TimeIntegration Config");
    Calendar::init(CalendarStr);
-
-   // Initialize choice of time stepper
-   std::string TimeStepperStr;
-   Err += TimeIntConfig.get("TimeStepper", TimeStepperStr);
-   CHECK_ERROR_ABORT(Err, "TimeStepper not found in TimeIntegration Config");
-   TimeStepperType TimeStepperChoice = getTimeStepperFromStr(TimeStepperStr);
-
-   // Initialize time step
-   std::string TimeStepStr;
-   Err += TimeIntConfig.get("TimeStep", TimeStepStr);
-   CHECK_ERROR_ABORT(Err, "TimeStep not found in TimeIntegration Config");
-   TimeInterval TimeStep(TimeStepStr);
 
    // Initialize start time
    std::string StartTimeStr;
@@ -360,12 +348,48 @@ void TimeStepper::init1() {
              getPrescribeVelocityTypeFromStr(VelocityMode);
       }
    }
+   
+   TimeInitParams TimeParams{StartTime, StopTime};
+
+   init1(TimeParams);
+}
+
+void TimeStepper::init1(const TimeInitParams &TimeParams) {
+
+   // Calendar must be initialized before this is called — the no-arg init1()
+   // does this internally. In coupled mode, the caller (ocnInit) is responsible
+   // for calling Calendar::init() before constructing TimeInitParams.
+   OMEGA_REQUIRE(Calendar::isDefined(),
+                 "Calendar must be initialized before TimeStepper::init1");
+
+   Error Err; // error code - default to success
+
+   // TimeStepper and TimeStep are always read from the Config
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config TimeIntConfig("TimeIntegration");
+   Err = OmegaConfig->get(TimeIntConfig);
+   CHECK_ERROR_ABORT(Err, "TimeIntegration group not found in Config");
+
+   // Initialize choice of time stepper
+   std::string TimeStepperStr;
+   Err += TimeIntConfig.get("TimeStepper", TimeStepperStr);
+   CHECK_ERROR_ABORT(Err, "TimeStepper not found in TimeIntegration Config");
+   TimeStepperType TimeStepperChoice = getTimeStepperFromStr(TimeStepperStr);
+
+   // Initialize time step
+   std::string TimeStepStr;
+   Err += TimeIntConfig.get("TimeStep", TimeStepStr);
+   CHECK_ERROR_ABORT(Err, "TimeStep not found in TimeIntegration Config");
+   TimeInterval TimeStep(TimeStepStr);
+
+   // Local non-const copies required by the 2-phase create() signature
+   TimeInstant StartTime = TimeParams.StartTime;
 
    // Now that all the inputs are defined, create the default time stepper
    // Use the partial creation function for only the time info. Data
    // pointers will be attached in phase 2 initialization
-   TimeStepper::DefaultTimeStepper =
-       create("Default", TimeStepperChoice, TimeStep, StartTime, StopTime);
+   TimeStepper::DefaultTimeStepper = create(
+       "Default", TimeStepperChoice, TimeStep, StartTime, TimeParams.StopTime);
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -85,29 +85,31 @@ getPrescribeVelocityTypeFromStr(const std::string &InString) {
 //------------------------------------------------------------------------------
 // Constructors and creation methods.
 
-// Constructor creates a new instance and fills in the time
-// related data. attachData function is used to add the data pointers
+/// Constructor creates a new instance and fills in the time
+/// related data. attachData function is used to add the data pointers
 TimeStepper::TimeStepper(
-    const std::string &InName,      // [in] name of time stepper
-    TimeStepperType InType,         // [in] type (time stepping method)
-    I4 InNTimeLevels,               // [in] num time levels needed by method
-    const TimeInstant &InStartTime, // [in] start time for time stepping
-    const TimeInstant &InStopTime,  // [in] stop  time for time stepping
-    const TimeInterval &InTimeStep  // [in] time step
-    )
+    const std::string &InName,      ///< [in] name of time stepper
+    TimeStepperType InType,         ///< [in] type (time stepping method)
+    I4 InNTimeLevels,               ///< [in] num time levels for method
+    const TimeInterval &InTimeStep, ///< [in] time step
+    const TimeInstant &InStartTime, ///< [in] start time for time stepping
+    ///< [in] stop time for time stepping, missing in coupled mode
+    std::optional<TimeInstant> InStopTime)
     : Name(InName), Type(InType), NTimeLevels(InNTimeLevels),
-      StartTime(InStartTime), StopTime(InStopTime), TimeStep(InTimeStep) {
+      TimeStep(InTimeStep), StartTime(InStartTime), StopTime(InStopTime) {
    // Most variables initialized via initializer list
 
    // Set up clock associated with this time stepper
    StepClock = std::make_unique<Clock>(Clock(InStartTime, InTimeStep));
 
-   // Create an EndAlarm associated with the StopTime
-   std::string AlarmName = "EndAlarm";
-   if (InName != "Default")
-      AlarmName += InName;
-   EndAlarm = std::make_unique<Alarm>(Alarm(AlarmName, InStopTime));
-   StepClock->attachAlarm(EndAlarm.get());
+   if (InStopTime.has_value()) {
+      // Create an EndAlarm associated with the StopTime
+      std::string AlarmName = "EndAlarm";
+      if (InName != "Default")
+         AlarmName += InName;
+      EndAlarm = std::make_unique<Alarm>(Alarm(AlarmName, *InStopTime));
+      StepClock->attachAlarm(EndAlarm.get());
+   }
 }
 
 //------------------------------------------------------------------------------
@@ -115,9 +117,9 @@ TimeStepper::TimeStepper(
 TimeStepper *TimeStepper::create(
     const std::string &InName,      ///< [in] name of time stepper
     TimeStepperType InType,         ///< [in] type (time stepping method)
+    const TimeInterval &InTimeStep, ///< [in] time step
     const TimeInstant &InStartTime, ///< [in] start time for time stepping
     const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
-    const TimeInterval &InTimeStep, ///< [in] time step
     Tendencies *InTend,             ///< [in] ptr to tendencies
     AuxiliaryState *InAuxState,     ///< [in] ptr to aux state variables
     HorzMesh *InMesh,               ///< [in] ptr to mesh information
@@ -140,16 +142,16 @@ TimeStepper *TimeStepper::create(
    // additional info (NTimeLevels)
    switch (InType) {
    case TimeStepperType::ForwardBackward:
-      NewTimeStepper = new ForwardBackwardStepper(InName, InStartTime,
-                                                  InStopTime, InTimeStep);
+      NewTimeStepper = new ForwardBackwardStepper(InName, InTimeStep,
+                                                  InStartTime, InStopTime);
       break;
    case TimeStepperType::RungeKutta4:
       NewTimeStepper =
-          new RungeKutta4Stepper(InName, InStartTime, InStopTime, InTimeStep);
+          new RungeKutta4Stepper(InName, InTimeStep, InStartTime, InStopTime);
       break;
    case TimeStepperType::RungeKutta2:
       NewTimeStepper =
-          new RungeKutta2Stepper(InName, InStartTime, InStopTime, InTimeStep);
+          new RungeKutta2Stepper(InName, InTimeStep, InStartTime, InStopTime);
       break;
    case TimeStepperType::Invalid:
       ABORT_ERROR("Invalid time stepping method");
@@ -176,10 +178,10 @@ TimeStepper *TimeStepper::create(
 TimeStepper *TimeStepper::create(
     const std::string &InName, // [in] name of time stepper
     TimeStepperType InType,    // [in] type (time stepping method)
+    TimeInterval &InTimeStep,  // [in] time step
     TimeInstant &InStartTime,  // [in] start time for time stepping
-    TimeInstant &InStopTime,   // [in] stop  time for time stepping
-    TimeInterval &InTimeStep   // [in] time step
-) {
+    ///< [in] stop time for time stepping, missing in coupled mode
+    std::optional<TimeInstant> InStopTime) {
 
    // Check for duplicates
    if (AllTimeSteppers.find(InName) != AllTimeSteppers.end()) {
@@ -194,16 +196,16 @@ TimeStepper *TimeStepper::create(
    // Call specific constructor with time info
    switch (InType) {
    case TimeStepperType::ForwardBackward:
-      NewTimeStepper = new ForwardBackwardStepper(InName, InStartTime,
-                                                  InStopTime, InTimeStep);
+      NewTimeStepper = new ForwardBackwardStepper(InName, InTimeStep,
+                                                  InStartTime, InStopTime);
       break;
    case TimeStepperType::RungeKutta4:
       NewTimeStepper =
-          new RungeKutta4Stepper(InName, InStartTime, InStopTime, InTimeStep);
+          new RungeKutta4Stepper(InName, InTimeStep, InStartTime, InStopTime);
       break;
    case TimeStepperType::RungeKutta2:
       NewTimeStepper =
-          new RungeKutta2Stepper(InName, InStartTime, InStopTime, InTimeStep);
+          new RungeKutta2Stepper(InName, InTimeStep, InStartTime, InStopTime);
       break;
    case TimeStepperType::Invalid:
       ABORT_ERROR("Invalid time stepping method");
@@ -363,7 +365,7 @@ void TimeStepper::init1() {
    // Use the partial creation function for only the time info. Data
    // pointers will be attached in phase 2 initialization
    TimeStepper::DefaultTimeStepper =
-       create("Default", TimeStepperChoice, StartTime, StopTime, TimeStep);
+       create("Default", TimeStepperChoice, TimeStep, StartTime, StopTime);
 }
 
 //------------------------------------------------------------------------------
@@ -431,10 +433,13 @@ TimeInterval TimeStepper::getTimeStep() const { return TimeStep; }
 TimeInstant TimeStepper::getStartTime() const { return StartTime; }
 
 // Get stop time from instance
-TimeInstant TimeStepper::getStopTime() const { return StopTime; }
+std::optional<TimeInstant> TimeStepper::getStopTime() const { return StopTime; }
 
 // Get clock (ptr) from instance
 Clock *TimeStepper::getClock() { return StepClock.get(); }
+
+// Check if time stepper has an end alarm (i.e. if stop time is defined)
+bool TimeStepper::hasEndAlarm() const { return EndAlarm != nullptr; }
 
 // Get end alarm (ptr) from instance
 Alarm *TimeStepper::getEndAlarm() { return EndAlarm.get(); }

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -317,7 +317,7 @@ void TimeStepper::init1() {
              getPrescribeVelocityTypeFromStr(VelocityMode);
       }
    }
-   
+
    TimeInitParams TimeParams{StartTime, StopTime};
 
    init1(TimeParams);

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -129,10 +129,10 @@ class TimeStepper {
    /// and tendencies are defined. It creates an instance and only fills
    /// the time information. Data pointers are attached later.
    static TimeStepper *
-   create(const std::string &InName, ///< [in] name of time stepper
-          TimeStepperType InType,    ///< [in] type (time stepping method)
-          TimeInterval &InTimeStep,  ///< [in] time step
-          TimeInstant &InStartTime,  ///< [in] start time for time stepping
+   create(const std::string &InName,      ///< [in] name of time stepper
+          TimeStepperType InType,         ///< [in] type (time stepping method)
+          const TimeInterval &InTimeStep, ///< [in] time step
+          const TimeInstant &InStartTime, ///< [in] start time for time stepping
           ///< [in] stop time for time stepping, missing in coupled mode
           std::optional<TimeInstant> InStopTime = std::nullopt);
 

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -49,6 +49,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace OMEGA {
@@ -103,9 +104,9 @@ class TimeStepper {
    static TimeStepper *
    create(const std::string &InName,      ///< [in] name of time stepper
           TimeStepperType InType,         ///< [in] type (time stepping method)
+          const TimeInterval &InTimeStep, ///< [in] time step
           const TimeInstant &InStartTime, ///< [in] start time for time stepping
           const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
-          const TimeInterval &InTimeStep, ///< [in] time step
           Tendencies *InTend,             ///< [in] ptr to tendencies
           AuxiliaryState *InAuxState,     ///< [in] ptr to aux state variables
           HorzMesh *InMesh,               ///< [in] ptr to mesh information
@@ -119,10 +120,10 @@ class TimeStepper {
    static TimeStepper *
    create(const std::string &InName, ///< [in] name of time stepper
           TimeStepperType InType,    ///< [in] type (time stepping method)
+          TimeInterval &InTimeStep,  ///< [in] time step
           TimeInstant &InStartTime,  ///< [in] start time for time stepping
-          TimeInstant &InStopTime,   ///< [in] stop  time for time stepping
-          TimeInterval &InTimeStep   ///< [in] time step
-   );
+          ///< [in] stop time for time stepping, missing in coupled mode
+          std::optional<TimeInstant> InStopTime = std::nullopt);
 
    /// For 2-step creation, this attaches all the data pointers to an instance
    /// once the data and tendencies have been created.
@@ -166,7 +167,10 @@ class TimeStepper {
    TimeInstant getStartTime() const;
 
    /// Get stop time
-   TimeInstant getStopTime() const;
+   std::optional<TimeInstant> getStopTime() const;
+
+   /// Check if time stepper has an end alarm (i.e. if stop time is defined)
+   bool hasEndAlarm() const;
 
    /// Get a pointer to the clock
    Clock *getClock();
@@ -296,7 +300,7 @@ class TimeStepper {
    TimeInstant StartTime;
 
    /// Stop time
-   TimeInstant StopTime;
+   std::optional<TimeInstant> StopTime; // std::nullopt in coupled mode
 
    /// Alarm that rings at StopTime
    std::unique_ptr<Alarm> EndAlarm;
@@ -321,10 +325,10 @@ class TimeStepper {
        const std::string &InName,      ///< [in] name of time stepper
        TimeStepperType InType,         ///< [in] type (time stepping method)
        I4 InNTimeLevels,               ///< [in] num time levels for method
+       const TimeInterval &InTimeStep, ///< [in] time step
        const TimeInstant &InStartTime, ///< [in] start time for time stepping
-       const TimeInstant &InStopTime,  ///< [in] stop  time for time stepping
-       const TimeInterval &InTimeStep  ///< [in] time step
-   );
+       ///< [in] stop time for time stepping, missing in coupled mode
+       std::optional<TimeInstant> InStopTime = std::nullopt);
 
    // Disable copy constructor
    TimeStepper(const TimeStepper &) = delete;

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -339,7 +339,7 @@ class TimeStepper {
        const TimeInterval &InTimeStep, ///< [in] time step
        const TimeInstant &InStartTime, ///< [in] start time for time stepping
        ///< [in] stop time for time stepping, missing in coupled mode
-       std::optional<TimeInstant> InStopTime = std::nullopt);
+       std::optional<TimeInstant> InStopTime);
 
    // Disable copy constructor
    TimeStepper(const TimeStepper &) = delete;

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -67,6 +67,16 @@ enum class TimeStepperType {
 /// reference time level
 enum class PrescribeStateType { None, Init, NonDivergent, Divergent, Invalid };
 
+/// Parameters required by TimeStepper::init1 for time setup.
+/// In standalone mode all fields are populated from config.
+/// In coupled mode, StartTime comes from the coupler and StopTime is absent
+/// (the coupler controls run length externally).
+/// Calendar::init() must be called before constructing this struct.
+struct TimeInitParams {
+   TimeInstant StartTime;               ///< Simulation start time
+   std::optional<TimeInstant> StopTime; ///< Absent in coupled mode
+};
+
 //------------------------------------------------------------------------------
 // Utility routine
 /// Translate string for time stepper type into enum
@@ -96,6 +106,7 @@ class TimeStepper {
 
    /// 1st phase of Initialization for the default time stepper
    static void init1();
+   static void init1(const TimeInitParams &TimeParams);
 
    /// 2nd phase of Initialization for the default time stepper
    static void init2();

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -319,7 +319,7 @@ int testTimeStepper(const std::string &Name, TimeStepperType Type,
    TimeInterval TimeStepTI(BaseTimeStepSeconds, TimeUnits::Seconds);
 
    auto *TestTimeStepper = TimeStepper::create(
-       "TestTimeStepper", Type, TimeStart, TimeEndTI, TimeStepTI,
+       "TestTimeStepper", Type, TimeStepTI, TimeStart, TimeEndTI,
        TestTendencies, TestAuxState, DefMesh, DefVCoord, DefHalo);
 
    if (!TestTimeStepper) {
@@ -370,6 +370,57 @@ int testTimeStepper(const std::string &Name, TimeStepperType Type,
    return Err;
 }
 
+int testOptionalStopTime(const std::string &Name, TimeStepperType Type) {
+   int Err = 0;
+
+   auto *DefMesh        = HorzMesh::getDefault();
+   auto *DefVCoord      = VertCoord::getDefault();
+   auto *DefHalo        = Halo::getDefault();
+   auto *TestAuxState   = AuxiliaryState::get("TestAuxState");
+   auto *TestTendencies = Tendencies::get("TestTendencies");
+
+   TimeInstant TimeStart(0, 0, 0, 0, 0, 0);
+   TimeInterval TimeStep(0.2, TimeUnits::Seconds);
+
+   // 2-phase create without StopTime — used by the coupled driver
+   auto *Stepper =
+       TimeStepper::create("CoupledTestStepper", Type, TimeStep, TimeStart);
+
+   if (!Stepper) {
+      Err++;
+      LOG_ERROR("TimeStepperTest: error creating test stepper StopTime {}",
+                Name);
+      return Err;
+   }
+
+   if (Stepper->hasEndAlarm()) {
+      Err++;
+      LOG_ERROR("TimeStepperTest: {}: hasEndAlarm() should be false without "
+                "StopTime",
+                Name);
+   }
+
+   if (Stepper->getStopTime().has_value()) {
+      Err++;
+      LOG_ERROR("TimeStepperTest: {}: getStopTime() should return nullopt "
+                "without StopTime",
+                Name);
+   }
+
+   // Verify doStep works without an EndAlarm (coupled run loop never uses it)
+   Stepper->attachData(TestTendencies, TestAuxState, DefMesh, DefVCoord,
+                       DefHalo);
+   auto *State = OceanState::get("TestState");
+   initState();
+   TimeInstant CurTime = TimeStart;
+   Stepper->doStep(State, CurTime);
+   Stepper->doStep(State, CurTime);
+
+   TimeStepper::erase("CoupledTestStepper");
+
+   return Err;
+}
+
 int timeStepperTest(const std::string &MeshFile = "OmegaMesh.nc") {
 
    int Err = initTimeStepperTest(MeshFile);
@@ -394,6 +445,11 @@ int timeStepperTest(const std::string &MeshFile = "OmegaMesh.nc") {
    ATol          = 0.1;
    Err += testTimeStepper("RungeKutta2", TimeStepperType::RungeKutta2,
                           ExpectedOrder, ATol);
+
+   // Verify stepper operates correctly without StopTime/EndAlarm
+
+   Err += testOptionalStopTime("ForwardBackward",
+                               TimeStepperType::ForwardBackward);
 
    if (Err == 0) {
       LOG_INFO("TimeStepperTest: Successful completion");


### PR DESCRIPTION
This PR enables `StopTime` to be optional for `TimeStepper`'s. In coupled E3SM simulations components do not know the stop time (coupler is responsible for calling finalize). 

The optional `StopTime` was enabled by reordering the arguments to `TimeStepper::create` so that `StopTime` was the last argument, which is a requirement of `std::optional`. 

An overload to `TimeStepper::init1` is added that accepts a structure (`TimeInitParams`), which will be how the coupler will provides the `StartTime` instead of it being read from the config file.  

I've also added an overload to `initOmegaModules` which accepts this `TimeInitParams` structure, which will be used in the coupled version of `ocnInit`. In refactoring `initOmegaModules` to be suitable for both standalone and coupled configuration, I moved a bunch of code not related to init'ing modules from `initOmegaModules` into `ocnInit`. This code was primarily related to reading the restart and initial condition IOStreams, which will need different handling in coupled mode. 

While this PR adds an overload to `initOmegaModules` that accepts `TimeInitParams`, I have intentionally not added an analogous overload to `ocnInit`. Exactly what we pass `ocnInit` in a coupled simulation is still being scoped out and how to pass that (e.g. all as separate arguments or as struct(s)) is yet to be determined. A follow on PR that adds coupled overloads for `ocnInit`, `ocnRun`, and `ocnFinalize` will come later. Given that the work enclosed in this PR is self contained, I figured it would make sense to get reviewed and merged while we figure out more details for the coupled driver. 

 ---

**Checklist**
* [x] Documentation:
  * [ ] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [x] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests
    * [x] Document testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] New tests:
    * [x] CTest unit tests for new features have been added per the approved design.


<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


