### PR TITLE
Implement P-star Vertical Coordinate

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -33,8 +33,6 @@ Omega:
   SurfaceRestoring:
     TracersToRestore: [Temperature, Salinity]
     PistonVelocity: 1.585e-5
-  VertCoord:
-    MovementWeightType: Uniform
   PressureGrad:
     PressureGradType: Centered
   Tendencies:

--- a/components/omega/doc/devGuide/VertCoord.md
+++ b/components/omega/doc/devGuide/VertCoord.md
@@ -55,7 +55,7 @@ A list of member variables along with their types and dimension sizes is below:
 | ZInterface | Real | NCellsSize, NVertLayersP1|
 | ZMid | Real | NCellsSize, NVertLayers |
 | GeopotentialMid | Real | NCellsSize, NVertLayers |
-| LayerThicknessPStar | Real | NCellsSize, NVertLayers|
+| LayerThicknessTarget | Real | NCellsSize, NVertLayers|
 | MinLayerCell | Integer | NCellsSize |
 | MaxLayerCell | Integer | NCellsSize |
 | MinLayerEdgeTop | Integer| NEdgesSize |
@@ -67,7 +67,7 @@ A list of member variables along with their types and dimension sizes is below:
 | MinLayerVertexBot | Integer | NVerticesSize |
 | MaxLayerVertexBot | Integer | NVerticesSize |
 | VertCoordMovementWeights | Real | NCellsSize, NVertLayers |
-| RefLayerThickness | Real | NCellsSize, NVertLayers |
+| RefPseudoThickness | Real | NCellsSize, NVertLayers |
 | BottomDepth | Real | NCellsSize |
 
 ### Removal

--- a/components/omega/doc/userGuide/VertCoord.md
+++ b/components/omega/doc/userGuide/VertCoord.md
@@ -32,7 +32,7 @@ Multiple instances of the vertical coordinate class can be created and accessed 
 | ZInterface | z height of layer interfaces | m |
 | ZMid | z height of layer midpoint | m |
 | GeopotentialMid | geopotential at layer mid points | m$^2$/s$^2$|
-| LayerThicknessPStar | desired layer thickness based on total perturbation from the reference thickness | - |
+| LayerThicknessTarget | desired layer thickness based on total perturbation from the reference thickness | m |
 | MinLayerCell | first active layer for cell | - |
 | MaxLayerCell | last active layer for cell | - |
 | MinLayerEdgeTop | min of the first active layers for cells on edge | - |
@@ -44,18 +44,5 @@ Multiple instances of the vertical coordinate class can be created and accessed 
 | MinLayerVertexBot | max of the first active layer for cells on vertex | - |
 | MaxLayerVertexBot | max of the last active layer for cells on vertex | - |
 | VertCoordMovementWeights | weights to specify how total column thickness changes are distributed across layers | - |
-| RefLayerThickness | reference layer thickness used to distribute total column thickness changes | m |
+| RefPseudoThickness | reference layer thickness used to distribute total column thickness changes | m |
 | BottomDepth | positive down distance from the reference geoid to the bottom | m |
-
-### Configuration options
-
-The vertical coordinate movement can be specified by the `MovementWeightType` option in the configuration file.
-```yaml
-omega:
-   VertCoord:
-      MovementWeightType: [Fixed,Uniform]
-```
-The option `Uniform` specifies that perturbations to the total pseudo-thickness of the water column is distributed evenly to all vertical layers.
-This is similar to the standard "z-star" coordinate in Boussinesq models.
-The option `Fixed` means that total pseudo-thickness perturbations are confined to the top layer, while all others remain constant.
-This is similar to the traditional "z" coordinate in Boussinesq models.

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -73,6 +73,11 @@ void IOStream::init(Clock *&ModelClock //< [inout] Omega model clock
 /// Initialize with no clock. Convenience overload for testing.
 void IOStream::init(void) {
 
+   // Create a calendar if one is not already defined
+   if (!Calendar::isDefined()) {
+      Calendar::init("No Leap");
+   }
+
    // Create an empty dummy clock on the stack (no heap alloc)
    Clock ModelClockObj;
    Clock *ModelClock = &ModelClockObj;

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1633,6 +1633,11 @@ Error IOStream::readFieldData(
    if (pos != std::string::npos) {
       OldFieldName.replace(pos, OmegaSubStr.length(), MPASSubStr);
    }
+   // Analog of RefPseudoThickness in MPAS is restingThickness
+   std::string OmegaStr = "RefPseudoThickness";
+   if (FieldName == OmegaStr) {
+      OldFieldName = "restingThickness";
+   }
    bool OnHost          = FieldPtr->isOnHost();
    bool IsDistributed   = FieldPtr->isDistributed();
    bool IsTimeDependent = FieldPtr->isTimeDependent();

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -136,6 +136,15 @@ IOStream::get(const std::string &StreamName ///< [in] name of stream to retrieve
 } // End get stream
 
 //------------------------------------------------------------------------------
+// Retrieves a string with the filename for the stream with the input name
+std::string
+IOStream::getFilename(const std::string &StreamName ///< [in] name of stream
+) {
+   auto StreamPtr = get(StreamName);
+   return StreamPtr->Filename;
+} // End getFilename
+
+//------------------------------------------------------------------------------
 // Adds a field to the contents of a stream. Because streams may be created
 // before all Fields have been defined, we only store the name. Validity
 // is either checked during read/write or can be checked using the validate

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -2276,8 +2276,10 @@ Error IOStream::readFieldData(
 
    } // end switch data type
 
-   // Clean up the decomp
-   IO::destroyDecomp(DecompID);
+   if (IsDistributed) {
+      // Clean up the decomp if necessary
+      IO::destroyDecomp(DecompID);
+   }
 
    return Err;
 

--- a/components/omega/src/infra/IOStream.h
+++ b/components/omega/src/infra/IOStream.h
@@ -295,6 +295,12 @@ class IOStream {
    );
 
    //---------------------------------------------------------------------------
+   // Retrieve the filename for a given stream
+   static std::string
+   getFilename(const std::string &StreamName ///< [in] name of stream
+   );
+
+   //---------------------------------------------------------------------------
    /// Adds a field to the contents of a stream. Because streams may be created
    /// before all Fields have been defined, we only store the name. Validity
    /// is either checked during read/write or can be checked using the validate

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -109,7 +109,7 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
 void AuxiliaryState::computeMomAux(const OceanState *State,
                                    const Array3DReal &TracerArray,
                                    int ThickTimeLevel, int VelTimeLevel,
-                                   const TimeInterval ProjCoeff) const {
+                                   const TimeInterval ProjDt) const {
    Array2DReal LayerThickCell = State->getLayerThickness(ThickTimeLevel);
    Array2DReal NormalVelEdge  = State->getNormalVelocity(VelTimeLevel);
 
@@ -132,8 +132,8 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
 
    R8 TimeStepSeconds;
    TimeStep.get(TimeStepSeconds, TimeUnits::Seconds);
-   R8 ProjDt;
-   ProjCoeff.get(ProjDt, TimeUnits::Seconds);
+   R8 ProjDtSeconds;
+   ProjDt.get(ProjDtSeconds, TimeUnits::Seconds);
 
    Pacer::start("AuxState:computeMomAux", 1);
 
@@ -262,7 +262,7 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
 
    const auto &FluxLayerThickEdge = LayerThicknessAux.FluxLayerThickEdge;
    VAdv->computeVerticalVelocity(NormalVelEdge, FluxLayerThickEdge,
-                                 LayerThickCell, ProjDt);
+                                 LayerThickCell, ProjDtSeconds);
 
    Pacer::stop("AuxState:computeVerticalVelocity", 2);
 
@@ -273,7 +273,7 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
 void AuxiliaryState::computeAll(const OceanState *State,
                                 const Array3DReal &TracerArray,
                                 int ThickTimeLevel, int VelTimeLevel,
-                                const TimeInterval ProjCoeff) const {
+                                const TimeInterval ProjDt) const {
    Array2DReal LayerThickCell = State->getLayerThickness(ThickTimeLevel);
    Array2DReal NormalVelEdge  = State->getNormalVelocity(VelTimeLevel);
 
@@ -291,7 +291,7 @@ void AuxiliaryState::computeAll(const OceanState *State,
 
    Pacer::start("AuxState:computeAll", 1);
 
-   computeMomAux(State, TracerArray, ThickTimeLevel, VelTimeLevel, ProjCoeff);
+   computeMomAux(State, TracerArray, ThickTimeLevel, VelTimeLevel, ProjDt);
 
    Pacer::start("AuxState:cellAuxState3", 2);
    parallelForOuter(
@@ -333,8 +333,8 @@ void AuxiliaryState::computeAll(const OceanState *State,
 
 void AuxiliaryState::computeAll(const OceanState *State,
                                 const Array3DReal &TracerArray, int TimeLevel,
-                                const TimeInterval ProjCoeff) const {
-   computeAll(State, TracerArray, TimeLevel, TimeLevel, ProjCoeff);
+                                const TimeInterval ProjDt) const {
+   computeAll(State, TracerArray, TimeLevel, TimeLevel, ProjDt);
 }
 
 // Create a non-default auxiliary state

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -99,6 +99,9 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
    // compute geometric height
    VCoord->computeZHeight(LayerThickCell, EosInstance->SpecVol);
 
+   // compute target thickness
+   VCoord->computeTargetThickness();
+
    Pacer::stop("AuxState:computeMomVertAux", 2);
 }
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -108,7 +108,8 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
 // Compute the auxiliary variables needed for momentum equation
 void AuxiliaryState::computeMomAux(const OceanState *State,
                                    const Array3DReal &TracerArray,
-                                   int ThickTimeLevel, int VelTimeLevel) const {
+                                   int ThickTimeLevel, int VelTimeLevel,
+                                   const TimeInterval ProjCoeff) const {
    Array2DReal LayerThickCell = State->getLayerThickness(ThickTimeLevel);
    Array2DReal NormalVelEdge  = State->getNormalVelocity(VelTimeLevel);
 
@@ -131,6 +132,8 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
 
    R8 TimeStepSeconds;
    TimeStep.get(TimeStepSeconds, TimeUnits::Seconds);
+   R8 ProjDt;
+   ProjCoeff.get(ProjDt, TimeUnits::Seconds);
 
    Pacer::start("AuxState:computeMomAux", 1);
 
@@ -258,7 +261,8 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
    Pacer::start("AuxState:computeVerticalVelocity", 2);
 
    const auto &FluxLayerThickEdge = LayerThicknessAux.FluxLayerThickEdge;
-   VAdv->computeVerticalVelocity(NormalVelEdge, FluxLayerThickEdge);
+   VAdv->computeVerticalVelocity(NormalVelEdge, FluxLayerThickEdge,
+                                 LayerThickCell, ProjDt);
 
    Pacer::stop("AuxState:computeVerticalVelocity", 2);
 
@@ -268,7 +272,8 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
 // Compute the auxiliary variables
 void AuxiliaryState::computeAll(const OceanState *State,
                                 const Array3DReal &TracerArray,
-                                int ThickTimeLevel, int VelTimeLevel) const {
+                                int ThickTimeLevel, int VelTimeLevel,
+                                const TimeInterval ProjCoeff) const {
    Array2DReal LayerThickCell = State->getLayerThickness(ThickTimeLevel);
    Array2DReal NormalVelEdge  = State->getNormalVelocity(VelTimeLevel);
 
@@ -286,7 +291,7 @@ void AuxiliaryState::computeAll(const OceanState *State,
 
    Pacer::start("AuxState:computeAll", 1);
 
-   computeMomAux(State, TracerArray, ThickTimeLevel, VelTimeLevel);
+   computeMomAux(State, TracerArray, ThickTimeLevel, VelTimeLevel, ProjCoeff);
 
    Pacer::start("AuxState:cellAuxState3", 2);
    parallelForOuter(
@@ -327,9 +332,9 @@ void AuxiliaryState::computeAll(const OceanState *State,
 }
 
 void AuxiliaryState::computeAll(const OceanState *State,
-                                const Array3DReal &TracerArray,
-                                int TimeLevel) const {
-   computeAll(State, TracerArray, TimeLevel, TimeLevel);
+                                const Array3DReal &TracerArray, int TimeLevel,
+                                const TimeInterval ProjCoeff) const {
+   computeAll(State, TracerArray, TimeLevel, TimeLevel, ProjCoeff);
 }
 
 // Create a non-default auxiliary state

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -84,15 +84,15 @@ class AuxiliaryState {
    // Compute all auxiliary variables needed for momentum equation
    void computeMomAux(const OceanState *State, const Array3DReal &TracerArray,
                       int ThickTimeLevel, int VelTimeLevel,
-                      const TimeInterval ProjCoeff) const;
+                      const TimeInterval ProjDt) const;
 
    /// Compute all auxiliary variables based on an ocean state at a given time
    /// level
    void computeAll(const OceanState *State, const Array3DReal &TracerArray,
                    int ThickTimeLevel, int VelTimeLevel,
-                   const TimeInterval ProjCoeff) const;
+                   const TimeInterval ProjDt) const;
    void computeAll(const OceanState *State, const Array3DReal &TracerArray,
-                   int TimeLevel, const TimeInterval ProjCoeff) const;
+                   int TimeLevel, const TimeInterval ProjDt) const;
 
  private:
    AuxiliaryState(const std::string &Name, const HorzMesh *Mesh, Halo *MeshHalo,

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -83,14 +83,16 @@ class AuxiliaryState {
 
    // Compute all auxiliary variables needed for momentum equation
    void computeMomAux(const OceanState *State, const Array3DReal &TracerArray,
-                      int ThickTimeLevel, int VelTimeLevel) const;
+                      int ThickTimeLevel, int VelTimeLevel,
+                      const TimeInterval ProjCoeff) const;
 
    /// Compute all auxiliary variables based on an ocean state at a given time
    /// level
    void computeAll(const OceanState *State, const Array3DReal &TracerArray,
-                   int ThickTimeLevel, int VelTimeLevel) const;
+                   int ThickTimeLevel, int VelTimeLevel,
+                   const TimeInterval ProjCoeff) const;
    void computeAll(const OceanState *State, const Array3DReal &TracerArray,
-                   int TimeLevel) const;
+                   int TimeLevel, const TimeInterval ProjCoeff) const;
 
  private:
    AuxiliaryState(const std::string &Name, const HorzMesh *Mesh, Halo *MeshHalo,

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -868,12 +868,13 @@ void Tendencies::computeVelocityTendencies(
     int VelTimeLevel,               ///< [in] Time level
     int TracerTimeLevel,            ///< [in] Time level
     TimeInstant Time,               ///< [in] Time
-    TimeInterval ProjCoeff          ///< [in] Time interval
+    TimeInterval ProjDt ///< [in] Time interval for projection over the current
+                        ///< time stepper stage
 ) {
    Pacer::start("Tend:computeVelocityTendencies", 1);
 
    AuxState->computeMomAux(State, TracerArray, ThickTimeLevel, VelTimeLevel,
-                           ProjCoeff);
+                           ProjDt);
    computeVelocityTendenciesOnly(State, AuxState, TracerArray, ThickTimeLevel,
                                  VelTimeLevel, TracerTimeLevel, Time);
 
@@ -932,10 +933,11 @@ void Tendencies::computeAllTendencies(
     int VelTimeLevel,               ///< [in] Time level
     int TracerTimeLevel,            ///< [in] Time level
     TimeInstant Time,               ///< [in] Time
-    TimeInterval ProjCoeff          ///< [in] Time interval
+    TimeInterval ProjDt ///< [in] Time interval for projection over the current
+                        ///< time stepper stage
 ) {
    AuxState->computeAll(State, TracerArray, ThickTimeLevel, VelTimeLevel,
-                        ProjCoeff);
+                        ProjDt);
 
    computeThicknessTendenciesOnly(State, AuxState, ThickTimeLevel, VelTimeLevel,
                                   Time);

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -867,11 +867,13 @@ void Tendencies::computeVelocityTendencies(
     int ThickTimeLevel,             ///< [in] Time level
     int VelTimeLevel,               ///< [in] Time level
     int TracerTimeLevel,            ///< [in] Time level
-    TimeInstant Time                ///< [in] Time
+    TimeInstant Time,               ///< [in] Time
+    TimeInterval ProjCoeff          ///< [in] Time interval
 ) {
    Pacer::start("Tend:computeVelocityTendencies", 1);
 
-   AuxState->computeMomAux(State, TracerArray, ThickTimeLevel, VelTimeLevel);
+   AuxState->computeMomAux(State, TracerArray, ThickTimeLevel, VelTimeLevel,
+                           ProjCoeff);
    computeVelocityTendenciesOnly(State, AuxState, TracerArray, ThickTimeLevel,
                                  VelTimeLevel, TracerTimeLevel, Time);
 
@@ -929,9 +931,11 @@ void Tendencies::computeAllTendencies(
     int ThickTimeLevel,             ///< [in] Time level
     int VelTimeLevel,               ///< [in] Time level
     int TracerTimeLevel,            ///< [in] Time level
-    TimeInstant Time                ///< [in] Time
+    TimeInstant Time,               ///< [in] Time
+    TimeInterval ProjCoeff          ///< [in] Time interval
 ) {
-   AuxState->computeAll(State, TracerArray, ThickTimeLevel, VelTimeLevel);
+   AuxState->computeAll(State, TracerArray, ThickTimeLevel, VelTimeLevel,
+                        ProjCoeff);
 
    computeThicknessTendenciesOnly(State, AuxState, ThickTimeLevel, VelTimeLevel,
                                   Time);

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -84,7 +84,8 @@ class Tendencies {
                                   const AuxiliaryState *AuxState,
                                   const Array3DReal &TracerArray,
                                   int ThickTimeLevel, int VelTimeLevel,
-                                  int TracerTimeLevel, TimeInstant Time);
+                                  int TracerTimeLevel, TimeInstant Time,
+                                  TimeInterval ProjCoeff);
    void computeTracerTendencies(const OceanState *State,
                                 const AuxiliaryState *AuxState,
                                 const Array3DReal &TracerArray,
@@ -94,7 +95,7 @@ class Tendencies {
                              const AuxiliaryState *AuxState,
                              const Array3DReal &TracerArray, int ThickTimeLevel,
                              int VelTimeLevel, int TracerTimeLevel,
-                             TimeInstant Time);
+                             TimeInstant Time, TimeInterval ProjCoeff);
    void computeThicknessTendenciesOnly(const OceanState *State,
                                        const AuxiliaryState *AuxState,
                                        int ThickTimeLevel, int VelTimeLevel,

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -85,7 +85,7 @@ class Tendencies {
                                   const Array3DReal &TracerArray,
                                   int ThickTimeLevel, int VelTimeLevel,
                                   int TracerTimeLevel, TimeInstant Time,
-                                  TimeInterval ProjCoeff);
+                                  TimeInterval ProjDt);
    void computeTracerTendencies(const OceanState *State,
                                 const AuxiliaryState *AuxState,
                                 const Array3DReal &TracerArray,
@@ -95,7 +95,7 @@ class Tendencies {
                              const AuxiliaryState *AuxState,
                              const Array3DReal &TracerArray, int ThickTimeLevel,
                              int VelTimeLevel, int TracerTimeLevel,
-                             TimeInstant Time, TimeInterval ProjCoeff);
+                             TimeInstant Time, TimeInterval ProjDt);
    void computeThicknessTendenciesOnly(const OceanState *State,
                                        const AuxiliaryState *AuxState,
                                        int ThickTimeLevel, int VelTimeLevel,

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -439,21 +439,19 @@ void VertAdv::computeVerticalVelocity(
                  }
               });
 
-          KRange = vertRangeChunked(KMin + 1, KMax);
           // Add contribution to transport velocity from movement of layer
           // interfaces, store in TotalVerticalVelocity.
-          parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 Real TotVertVelTmp[VecLength] = {0};
+          parallelScanInner(
+              Team, KRange, INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
+                 const I4 KRev      = KMax - K;
+                 const Real AleTerm = (LocThickTarget(ICell, KRev) -
+                                       LayerThickness(ICell, KRev)) /
+                                      Dt;
 
-                 const I4 KStart = chunkStart(KChunk, KMin + 1);
-                 const I4 KLen   = chunkLength(KChunk, KStart, KMax);
-                 for (int KVec = 0; KVec < KLen; ++KVec) {
-                    const I4 K = KStart + KVec;
-                    LocTotVertVel(ICell, K) =
-                        LocVertVel(ICell, K) -
-                        (LocThickTarget(ICell, K) - LayerThickness(ICell, K)) /
-                            Dt;
+                 Accum -= DivHU(KRev) + AleTerm;
+
+                 if (IsFinal) {
+                    LocTotVertVel(ICell, KRev) = Accum;
                  }
               });
        },

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -358,10 +358,10 @@ void VertAdv::readConfigOptions(Config *OmegaConfig) {
 // velocity (NormalVelocity), the layer thickness used for fluxes through
 // edges (FluxLayerThickEdge), and the cell-based LayerThickness.
 void VertAdv::computeVerticalVelocity(
-    const Array2DReal &NormalVelocity,     ///< [in] horizontal velocity
-    const Array2DReal &FluxLayerThickEdge, ///< [in] layer thickness at edges
-    const Array2DReal &LayerThickness,     ///< [in] pseudo thickness of layer
-    const Real Dt                          ///< [in] time interval
+    const Array2DReal &NormalVelocity,     //< [in] horizontal velocity
+    const Array2DReal &FluxLayerThickEdge, //< [in] layer thickness at edges
+    const Array2DReal &LayerThickness,     //< [in] pseudo thickness of layer
+    const Real Dt                          //< [in] time interval
 ) {
 
    // Return if mesh only has a single vertical layer

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -355,11 +355,13 @@ void VertAdv::readConfigOptions(Config *OmegaConfig) {
 
 //------------------------------------------------------------------------------
 // Compute VerticalVelocity and TotalVerticalVelocity from the horizontal
-// velocity (NormalVelocity) and the layer thickness used for fluxes through
-// edges (FluxLayerThickEdge)
+// velocity (NormalVelocity), the layer thickness used for fluxes through
+// edges (FluxLayerThickEdge), and the cell-based LayerThickness.
 void VertAdv::computeVerticalVelocity(
-    const Array2DReal &NormalVelocity,    //< [in] horizontal velocity
-    const Array2DReal &FluxLayerThickEdge //< [in] layer thickness at edges
+    const Array2DReal &NormalVelocity,     ///< [in] horizontal velocity
+    const Array2DReal &FluxLayerThickEdge, ///< [in] layer thickness at edges
+    const Array2DReal &LayerThickness,     ///< [in] pseudo thickness of layer
+    const Real Dt                          ///< [in] time interval
 ) {
 
    // Return if mesh only has a single vertical layer
@@ -367,6 +369,8 @@ void VertAdv::computeVerticalVelocity(
       return;
 
    OMEGA_SCOPE(LocVertVel, VerticalVelocity);
+   OMEGA_SCOPE(LocTotVertVel, TotalVerticalVelocity);
+   OMEGA_SCOPE(LocThickTarget, VCoord->LayerThicknessTarget);
    OMEGA_SCOPE(LocNVertLayers, NVertLayers);
    OMEGA_SCOPE(LocAreaCell, Mesh->AreaCell);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
@@ -416,8 +420,10 @@ void VertAdv::computeVerticalVelocity(
           // Set velocity through top and bottom interfaces to zero
           Kokkos::single(
               PerTeam(Team), INNER_LAMBDA() {
-                 LocVertVel(ICell, KMin)     = 0.;
-                 LocVertVel(ICell, KMax + 1) = 0.;
+                 LocVertVel(ICell, KMin)        = 0.;
+                 LocVertVel(ICell, KMax + 1)    = 0.;
+                 LocTotVertVel(ICell, KMin)     = 0.;
+                 LocTotVertVel(ICell, KMax + 1) = 0.;
               });
           KRange = vertRange(KMin + 1, KMax);
 
@@ -432,15 +438,26 @@ void VertAdv::computeVerticalVelocity(
                     LocVertVel(ICell, KRev) = Accum;
                  }
               });
+
+          KRange = vertRangeChunked(KMin + 1, KMax);
+          // Add contribution to transport velocity from movement of layer
+          // interfaces, store in TotalVerticalVelocity.
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 Real TotVertVelTmp[VecLength] = {0};
+
+                 const I4 KStart = chunkStart(KChunk, KMin + 1);
+                 const I4 KLen   = chunkLength(KChunk, KStart, KMax);
+                 for (int KVec = 0; KVec < KLen; ++KVec) {
+                    const I4 K = KStart + KVec;
+                    LocTotVertVel(ICell, K) =
+                        LocVertVel(ICell, K) -
+                        (LocThickTarget(ICell, K) - LayerThickness(ICell, K)) /
+                            Dt;
+                 }
+              });
        },
        NVertLayers);
-
-   // TODO: currently assuming TotalVerticalVelocity = VerticalVelocity, i.e.
-   //  purely from divergence of horizontal velocity. Need to add optional
-   //  corrections to transport velocity from other contributions, e.g.
-   //  movement of vertical interfaces, contribution of horizontal velocity
-   //  through tilted interface.
-   deepCopy(TotalVerticalVelocity, VerticalVelocity);
 
 } // end computeVerticalVelocity
 

--- a/components/omega/src/ocn/VertAdv.h
+++ b/components/omega/src/ocn/VertAdv.h
@@ -123,10 +123,12 @@ class VertAdv {
    void readConfigOptions(Config *Options);
 
    /// Determine transport due to vertical advection from divergence of
-   /// horizontal advection.
+   /// horizontal advection and movement of vertical interfaces.
    void computeVerticalVelocity(
-       const Array2DReal &NormalVelocity,    ///< [in] horizontal velocity
-       const Array2DReal &FluxLayerThickEdge ///< [in] layer thickness at edges
+       const Array2DReal &NormalVelocity,     ///< [in] horizontal velocity
+       const Array2DReal &FluxLayerThickEdge, ///< [in] layer thickness at edges
+       const Array2DReal &LayerThickness, ///< [in] pseudo thickness of layer
+       const Real Dt                      ///< [in] time interval
    );
 
    /// Compute pseudo thickness tendency due to vertical advection

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -86,27 +86,29 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    // Store name suffix
    Name = Name_;
 
-   // Retrieve mesh filename from Decomp
-   MeshFileName = Decomp->MeshFileName;
-
    // If InNVertlayers is 0 (default), attempt to read the dimension from the
    // mesh file. If the mesh file does not define a vertical dimension, use
    // NVertLayers = 1. If a value for InNVertLayers is explicitly provided,
    // use that value is instead.
    if (InNVertLayers == 0) {
 
+      // Retrieve filename from stream
+      std::string Filename = IOStream::getFilename("InitialVertCoord");
+      int FileID;
+
       std::string OmegaDimName = "NVertLayers";
       std::string MPASDimName  = "nVertLevels";
 
-      // Open the mesh file for reading (assume IO has already been initialized)
-      IO::openFileRead(MeshFileID, MeshFileName);
+      // Open the file for reading (assume IO has already been initialized)
+      IO::openFileRead(FileID, Filename);
 
       // Set NVertLayers
       I4 NVertLayersID;
-      Err = IO::getDimFromFile(MeshFileID, OmegaDimName, NVertLayersID,
-                               NVertLayers);
+      Err =
+          IO::getDimFromFile(FileID, OmegaDimName, NVertLayersID, NVertLayers);
+
       if (Err.isFail()) { // dim not found, try again with older MPAS name
-         Err = IO::getDimFromFile(MeshFileID, MPASDimName, NVertLayersID,
+         Err = IO::getDimFromFile(FileID, MPASDimName, NVertLayersID,
                                   NVertLayers);
          if (Err.isFail()) {
             LOG_INFO("VertCoord: vertical dimension not found in mesh file, "
@@ -114,6 +116,9 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
             NVertLayers = 1;
          }
       }
+
+      IO::closeFile(FileID);
+
    } else {
       NVertLayers = InNVertLayers;
    }

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -168,8 +168,8 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    GeopotentialMid = Array2DReal("GeopotentialMid", NCellsSize, NVertLayers);
    LayerThicknessTarget =
        Array2DReal("LayerThicknessTarget", NCellsSize, NVertLayers);
-   RefLayerThickness =
-       Array2DReal("RefLayerThickness", NCellsSize, NVertLayers);
+   RefPseudoThickness =
+       Array2DReal("RefPseudoThickness", NCellsSize, NVertLayers);
 
    // TODO: Temporary handling of SurfacePressure
    SurfacePressure = Array1DReal("SurfacePressure", NCellsSize);
@@ -182,7 +182,7 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    ZMidH                 = createHostMirrorCopy(ZMid);
    GeopotentialMidH      = createHostMirrorCopy(GeopotentialMid);
    LayerThicknessTargetH = createHostMirrorCopy(LayerThicknessTarget);
-   RefLayerThicknessH    = createHostMirrorCopy(RefLayerThickness);
+   RefPseudoThicknessH    = createHostMirrorCopy(RefPseudoThickness);
 
    // Define field metadata
    defineFields();
@@ -976,7 +976,7 @@ void VertCoord::computeGeopotential(
 
 //------------------------------------------------------------------------------
 // Compute the desired target thickness, given PressureInterface,
-// RefLayerThickness, and VertCoordMovementWeights. Hierarchical parallelsim is
+// RefPseudoThickness, and VertCoordMovementWeights. Hierarchical parallelsim is
 // used with an outer parallel_for loop over cells, and 2 paralel_reduce
 // reductions and a parallel_for over the active layers within a column.
 void VertCoord::computeTargetThickness() {
@@ -985,7 +985,7 @@ void VertCoord::computeTargetThickness() {
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocLayerThickTarget, LayerThicknessTarget);
    OMEGA_SCOPE(LocPressInterf, PressureInterface);
-   OMEGA_SCOPE(LocRefLayerThick, RefLayerThickness);
+   OMEGA_SCOPE(LocRefPseudoThick, RefPseudoThickness);
    OMEGA_SCOPE(LocVertCoordMvmtWgts, VertCoordMovementWeights);
 
    parallelForOuter(
@@ -1005,9 +1005,9 @@ void VertCoord::computeTargetThickness() {
               Team, KRange,
               INNER_LAMBDA(const int K, Real &LocalWh, Real &LocalSum) {
                  const I4 KLyr            = K + KMin;
-                 const Real RefLayerThick = LocRefLayerThick(ICell, KLyr);
-                 LocalWh += LocVertCoordMvmtWgts(KLyr) * RefLayerThick;
-                 LocalSum += RefLayerThick;
+                 const Real RefPseudoThick = LocRefPseudoThick(ICell, KLyr);
+                 LocalWh += LocVertCoordMvmtWgts(KLyr) * RefPseudoThick;
+                 LocalSum += RefPseudoThick;
               },
               SumWh, SumRefH);
           Coeff -= SumRefH;
@@ -1021,7 +1021,7 @@ void VertCoord::computeTargetThickness() {
                  for (int KVec = 0; KVec < KLen; ++KVec) {
                     const I4 K = KStart + KVec;
                     LocLayerThickTarget(ICell, K) =
-                        LocRefLayerThick(ICell, K) *
+                        LocRefPseudoThick(ICell, K) *
                         (1._Real + Coeff * LocVertCoordMvmtWgts(K) / SumWh);
                  }
               });
@@ -1038,7 +1038,7 @@ void VertCoord::copyToHost() {
    deepCopy(ZMidH, ZMid);
    deepCopy(GeopotentialMidH, GeopotentialMid);
    deepCopy(LayerThicknessTargetH, LayerThicknessTarget);
-   deepCopy(RefLayerThicknessH, RefLayerThickness);
+   deepCopy(RefPseudoThicknessH, RefPseudoThickness);
 }
 
 //------------------------------------------------------------------------------
@@ -1051,7 +1051,7 @@ void VertCoord::copyToDevice() {
    deepCopy(ZMid, ZMidH);
    deepCopy(GeopotentialMid, GeopotentialMidH);
    deepCopy(LayerThicknessTarget, LayerThicknessTargetH);
-   deepCopy(RefLayerThickness, RefLayerThicknessH);
+   deepCopy(RefPseudoThickness, RefPseudoThicknessH);
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -596,6 +596,7 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
    MeshHalo->exchangeFullArrayHalo(MinLayerCell, OnCell);
    MeshHalo->exchangeFullArrayHalo(MaxLayerCell, OnCell);
    MeshHalo->exchangeFullArrayHalo(BottomDepth, OnCell);
+   MeshHalo->exchangeFullArrayHalo(RefPseudoThickness, OnCell);
 
    // The index ICell = NCellsAll represents an inactive cell
    OMEGA_SCOPE(LocNCellsAll, NCellsAll);

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -583,17 +583,26 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
                            "from {}",
                            StreamName);
             }
-            Real Sum5 = 0.;
+            Real Sum5     = 0.;
+            I4 NumNonZero = 0;
             parallelReduce(
                 {VertCoordMovementWeights.extent_int(0)},
-                KOKKOS_LAMBDA(int I, Real &Accum) {
-                   Accum += LocVCoordMvmtWgts(I);
+                KOKKOS_LAMBDA(int I, Real &Accum, I4 &NonZeroCount) {
+                   Real W = LocVCoordMvmtWgts(I);
+                   Accum += W;
+                   if (W != 0) {
+                      NonZeroCount += 1;
+                   }
                 },
-                Sum5);
+                Sum5, NumNonZero);
             if (Sum5 < 0.) {
                ABORT_ERROR("VertCoord: Error reading VertCoordMovementWeights "
                            "from {}",
                            StreamName);
+            }
+            if (NumNonZero == 0) {
+               // TODO: ABORT_ERROR when all weights equal 0
+               deepCopy(VertCoordMovementWeights, 1._Real);
             }
          }
       } else {
@@ -602,6 +611,7 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
    } else {
       deepCopy(MinLayerCell, 1);
       deepCopy(MaxLayerCell, NVertLayers);
+      deepCopy(VertCoordMovementWeights, 1._Real);
    }
 
    // Subtract 1 to convert to zero-based indexing

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -182,7 +182,7 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    ZMidH                 = createHostMirrorCopy(ZMid);
    GeopotentialMidH      = createHostMirrorCopy(GeopotentialMid);
    LayerThicknessTargetH = createHostMirrorCopy(LayerThicknessTarget);
-   RefPseudoThicknessH    = createHostMirrorCopy(RefPseudoThickness);
+   RefPseudoThicknessH   = createHostMirrorCopy(RefPseudoThickness);
 
    // Define field metadata
    defineFields();
@@ -238,6 +238,7 @@ void VertCoord::defineFields() {
    MinLayerCellFldName   = "MinLayerCell";
    MaxLayerCellFldName   = "MaxLayerCell";
    BottomDepthFldName    = "BottomDepth";
+   RefPseudoThickFldName = "RefPseudoThickness";
    PressInterfFldName    = "PressureInterface";
    PressMidFldName       = "PressureMid";
    ZInterfFldName        = "ZInterface";
@@ -249,6 +250,7 @@ void VertCoord::defineFields() {
       MinLayerCellFldName.append(Name);
       MaxLayerCellFldName.append(Name);
       BottomDepthFldName.append(Name);
+      RefPseudoThickFldName.append(Name);
       PressInterfFldName.append(Name);
       PressMidFldName.append(Name);
       ZInterfFldName.append(Name);
@@ -303,6 +305,21 @@ void VertCoord::defineFields() {
 
    NDims = 2;
    DimNames.resize(NDims);
+   DimNames[1] = "NVertLayers";
+
+   auto RefPseudoThickField = Field::create(
+       RefPseudoThickFldName, // field name
+       "Reference pseudo thickness of ocean layers without SSH or internal "
+       "perturbation",                   // long name or description
+       "m",                              // units
+       "",                               // CF standard Name
+       0.0,                              // min valid value
+       std::numeric_limits<Real>::max(), // max valid value
+       FillValueReal,                    // scalar for undefined entries
+       NDims,                            // number of dimensions
+       DimNames                          // dimension names
+   );
+
    DimNames[1] = "NVertLayersP1";
 
    auto PressureInterfaceField = Field::create(
@@ -390,10 +407,12 @@ void VertCoord::defineFields() {
    InitVCoordGroup->addField(MinLayerCellFldName);
    InitVCoordGroup->addField(MaxLayerCellFldName);
    InitVCoordGroup->addField(BottomDepthFldName);
+   InitVCoordGroup->addField(RefPseudoThickFldName);
 
    MinLayerCellField->attachData<Array1DI4>(MinLayerCell);
    MaxLayerCellField->attachData<Array1DI4>(MaxLayerCell);
    BottomDepthField->attachData<Array1DReal>(BottomDepth);
+   RefPseudoThickField->attachData<Array2DReal>(RefPseudoThickness);
 
    // Create a field group for VertCoord fields
    GroupName = "VertCoord";
@@ -427,6 +446,7 @@ VertCoord::~VertCoord() {
       Field::destroy(MinLayerCellFldName);
       Field::destroy(MaxLayerCellFldName);
       Field::destroy(BottomDepthFldName);
+      Field::destroy(RefPseudoThickFldName);
       FieldGroup::destroy(InitGroupName);
    }
 
@@ -469,6 +489,7 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
    OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocBottomDepth, BottomDepth);
+   OMEGA_SCOPE(LocPseudoThick, RefPseudoThickness);
 
    // If ReadStream is true (default) attempt to read values for MinLayerCell,
    // MaxLayerCell, and BottomDepth from the InitialVertCoord stream. Otherwise,
@@ -483,6 +504,7 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
       deepCopy(MinLayerCell, FillValueI4);
       deepCopy(MaxLayerCell, FillValueI4);
       deepCopy(BottomDepth, FillValueReal);
+      deepCopy(RefPseudoThickness, FillValueReal);
 
       // Fetch input stream and validate
       std::string StreamName = "InitialVertCoord";
@@ -539,6 +561,19 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
                 Sum3);
             if (Sum3 < 0.) {
                ABORT_ERROR("VertCoord: Error reading bottomDepth from {}",
+                           StreamName);
+            }
+            Real Sum4 = 0.;
+            parallelReduce(
+                {RefPseudoThickness.extent_int(0),
+                 RefPseudoThickness.extent_int(1)},
+                KOKKOS_LAMBDA(int I, int J, Real &Accum) {
+                   Accum += LocPseudoThick(I, J);
+                },
+                Sum4);
+            if (Sum4 < 0.) {
+               ABORT_ERROR("VertCoord: Error reading RefPseudoThickness "
+                           "from {}",
                            StreamName);
             }
          }
@@ -1004,7 +1039,7 @@ void VertCoord::computeTargetThickness() {
           parallelReduceInner(
               Team, KRange,
               INNER_LAMBDA(const int K, Real &LocalWh, Real &LocalSum) {
-                 const I4 KLyr            = K + KMin;
+                 const I4 KLyr             = K + KMin;
                  const Real RefPseudoThick = LocRefPseudoThick(ICell, KLyr);
                  LocalWh += LocVertCoordMvmtWgts(KLyr) * RefPseudoThick;
                  LocalSum += RefPseudoThick;

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -65,24 +65,6 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
                   "is explicitly provided, which is not a valid combination");
    }
 
-   // Read Config for movement weight type, store in enum
-   Config VCoordConfig("VertCoord");
-   Err += Options->get(VCoordConfig);
-   CHECK_ERROR_ABORT(Err, "VertCoord: VertCoord group not found in Config");
-
-   std::string MovementWeightStr;
-   Err += VCoordConfig.get("MovementWeightType", MovementWeightStr);
-   CHECK_ERROR_ABORT(Err,
-                     "VertCoord: MovementWeightType not found in VertCoord");
-
-   if (MovementWeightStr == "Fixed") {
-      MvmtWgtChoice = MovementWeightType::Fixed;
-   } else if (MovementWeightStr == "Uniform") {
-      MvmtWgtChoice = MovementWeightType::Uniform;
-   } else {
-      ABORT_ERROR("VertCoord: Unknown MovementWeightType requested");
-   }
-
    // Store name suffix
    Name = Name_;
 
@@ -197,9 +179,6 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
 
    // Set computational masks
    setMasks();
-
-   // Initialize movement weights
-   initMovementWeights();
 
 } // end constructor
 
@@ -912,29 +891,6 @@ void VertCoord::setMasks() {
    VertexMaskH = createHostMirrorCopy(VertexMask);
 
 } // end setMasks()
-
-//------------------------------------------------------------------------------
-// Store VertCoordMovementWeights based on config choice
-void VertCoord::initMovementWeights() {
-
-   Error Err; // default successful error code
-
-   VertCoordMovementWeights =
-       Array1DReal("VertCoordMovementWeights", NVertLayers);
-
-   OMEGA_SCOPE(LocVertCoordMovementWeights, VertCoordMovementWeights);
-   if (MvmtWgtChoice == MovementWeightType::Fixed) {
-      deepCopy(VertCoordMovementWeights, 0._Real);
-      parallelFor(
-          {1}, KOKKOS_LAMBDA(const int &) {
-             LocVertCoordMovementWeights(0) = 1._Real;
-          });
-   } else if (MvmtWgtChoice == MovementWeightType::Uniform) {
-      deepCopy(VertCoordMovementWeights, 1._Real);
-   }
-
-   VertCoordMovementWeightsH = createHostMirrorCopy(VertCoordMovementWeights);
-}
 
 //------------------------------------------------------------------------------
 // Compute the pressure at each layer interface and midpoint given the

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -170,6 +170,8 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
        Array2DReal("LayerThicknessTarget", NCellsSize, NVertLayers);
    RefPseudoThickness =
        Array2DReal("RefPseudoThickness", NCellsSize, NVertLayers);
+   VertCoordMovementWeights =
+       Array1DReal("VertCoordMovementWeights", NVertLayers);
 
    // TODO: Temporary handling of SurfacePressure
    SurfacePressure = Array1DReal("SurfacePressure", NCellsSize);
@@ -182,7 +184,6 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    ZMidH                 = createHostMirrorCopy(ZMid);
    GeopotentialMidH      = createHostMirrorCopy(GeopotentialMid);
    LayerThicknessTargetH = createHostMirrorCopy(LayerThicknessTarget);
-   RefPseudoThicknessH   = createHostMirrorCopy(RefPseudoThickness);
 
    // Define field metadata
    defineFields();
@@ -239,6 +240,7 @@ void VertCoord::defineFields() {
    MaxLayerCellFldName   = "MaxLayerCell";
    BottomDepthFldName    = "BottomDepth";
    RefPseudoThickFldName = "RefPseudoThickness";
+   VCoordMvmtWgtsFldName = "VertCoordMovementWeights";
    PressInterfFldName    = "PressureInterface";
    PressMidFldName       = "PressureMid";
    ZInterfFldName        = "ZInterface";
@@ -251,6 +253,7 @@ void VertCoord::defineFields() {
       MaxLayerCellFldName.append(Name);
       BottomDepthFldName.append(Name);
       RefPseudoThickFldName.append(Name);
+      VCoordMvmtWgtsFldName.append(Name);
       PressInterfFldName.append(Name);
       PressMidFldName.append(Name);
       ZInterfFldName.append(Name);
@@ -320,6 +323,26 @@ void VertCoord::defineFields() {
        DimNames                          // dimension names
    );
 
+   NDims = 1;
+   DimNames.resize(NDims);
+   DimNames[0] = "NVertLayers";
+
+   auto VertCoordMvmtWgtsField = Field::create(
+       VCoordMvmtWgtsFldName, // field name
+       "Weights for distributing changes in total column thickness across "
+       "layers",                         // long name or description
+       "",                               // units
+       "",                               // CF standard Name
+       0.0,                              // min valid value
+       std::numeric_limits<Real>::max(), // max valid value
+       FillValueReal,                    // scalar for undefined entries
+       NDims,                            // number of dimensions
+       DimNames                          // dimension names
+   );
+
+   NDims = 2;
+   DimNames.resize(NDims);
+   DimNames[0] = "NCells";
    DimNames[1] = "NVertLayersP1";
 
    auto PressureInterfaceField = Field::create(
@@ -408,11 +431,13 @@ void VertCoord::defineFields() {
    InitVCoordGroup->addField(MaxLayerCellFldName);
    InitVCoordGroup->addField(BottomDepthFldName);
    InitVCoordGroup->addField(RefPseudoThickFldName);
+   InitVCoordGroup->addField(VCoordMvmtWgtsFldName);
 
    MinLayerCellField->attachData<Array1DI4>(MinLayerCell);
    MaxLayerCellField->attachData<Array1DI4>(MaxLayerCell);
    BottomDepthField->attachData<Array1DReal>(BottomDepth);
    RefPseudoThickField->attachData<Array2DReal>(RefPseudoThickness);
+   VertCoordMvmtWgtsField->attachData<Array1DReal>(VertCoordMovementWeights);
 
    // Create a field group for VertCoord fields
    GroupName = "VertCoord";
@@ -447,6 +472,7 @@ VertCoord::~VertCoord() {
       Field::destroy(MaxLayerCellFldName);
       Field::destroy(BottomDepthFldName);
       Field::destroy(RefPseudoThickFldName);
+      Field::destroy(VCoordMvmtWgtsFldName);
       FieldGroup::destroy(InitGroupName);
    }
 
@@ -490,6 +516,7 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocBottomDepth, BottomDepth);
    OMEGA_SCOPE(LocPseudoThick, RefPseudoThickness);
+   OMEGA_SCOPE(LocVCoordMvmtWgts, VertCoordMovementWeights);
 
    // If ReadStream is true (default) attempt to read values for MinLayerCell,
    // MaxLayerCell, and BottomDepth from the InitialVertCoord stream. Otherwise,
@@ -505,6 +532,7 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
       deepCopy(MaxLayerCell, FillValueI4);
       deepCopy(BottomDepth, FillValueReal);
       deepCopy(RefPseudoThickness, FillValueReal);
+      deepCopy(VertCoordMovementWeights, FillValueReal);
 
       // Fetch input stream and validate
       std::string StreamName = "InitialVertCoord";
@@ -576,6 +604,18 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
                            "from {}",
                            StreamName);
             }
+            Real Sum5 = 0.;
+            parallelReduce(
+                {VertCoordMovementWeights.extent_int(0)},
+                KOKKOS_LAMBDA(int I, Real &Accum) {
+                   Accum += LocVCoordMvmtWgts(I);
+                },
+                Sum5);
+            if (Sum5 < 0.) {
+               ABORT_ERROR("VertCoord: Error reading VertCoordMovementWeights "
+                           "from {}",
+                           StreamName);
+            }
          }
       } else {
          ABORT_ERROR("Error validating IO stream {}", StreamName);
@@ -608,9 +648,11 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
        });
 
    // Make host copies for device arrays read from mesh file
-   MaxLayerCellH = createHostMirrorCopy(MaxLayerCell);
-   MinLayerCellH = createHostMirrorCopy(MinLayerCell);
-   BottomDepthH  = createHostMirrorCopy(BottomDepth);
+   MaxLayerCellH             = createHostMirrorCopy(MaxLayerCell);
+   MinLayerCellH             = createHostMirrorCopy(MinLayerCell);
+   BottomDepthH              = createHostMirrorCopy(BottomDepth);
+   RefPseudoThicknessH       = createHostMirrorCopy(RefPseudoThickness);
+   VertCoordMovementWeightsH = createHostMirrorCopy(VertCoordMovementWeights);
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -26,11 +26,6 @@
 
 namespace OMEGA {
 
-enum class MovementWeightType {
-   Fixed,  /// Distribute perturbations in top level
-   Uniform /// Uniform stretching
-};
-
 KOKKOS_INLINE_FUNCTION int vertRange(int KMin, int KMax) {
    return KMax - KMin + 1;
 }
@@ -69,9 +64,6 @@ class VertCoord {
    I4 VertexDegree;
    Array2DI4 CellsOnEdge;
    Array2DI4 CellsOnVertex;
-
-   // Choice of VertCoorMovementWeight type
-   MovementWeightType MvmtWgtChoice;
 
    static VertCoord *DefaultVertCoord;
    static std::map<std::string, std::unique_ptr<VertCoord>> AllVertCoords;
@@ -228,7 +220,6 @@ class VertCoord {
    void setStreamArrays(const bool ReadStream, Halo *MeshHalo);
    void minMaxLayerEdge(Halo *MeshHalo);
    void minMaxLayerVertex(Halo *MeshHalo);
-   void initMovementWeights();
 
    /// Initialize computational masks
    void setMasks();

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -73,9 +73,6 @@ class VertCoord {
    // Choice of VertCoorMovementWeight type
    MovementWeightType MvmtWgtChoice;
 
-   std::string MeshFileName;
-   int MeshFileID;
-
    static VertCoord *DefaultVertCoord;
    static std::map<std::string, std::unique_ptr<VertCoord>> AllVertCoords;
 

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -139,10 +139,10 @@ class VertCoord {
 
    // p star coordinate variables
    Array1DReal VertCoordMovementWeights;
-   Array2DReal RefLayerThickness;
+   Array2DReal RefPseudoThickness;
 
    HostArray1DReal VertCoordMovementWeightsH;
-   HostArray2DReal RefLayerThicknessH;
+   HostArray2DReal RefPseudoThicknessH;
 
    // Masks
    Array2DReal EdgeMask;        ///< Mask to determine if computations should be

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -177,6 +177,7 @@ class VertCoord {
    std::string MinLayerCellFldName;   ///< Field name for MinLayerCell
    std::string MaxLayerCellFldName;   ///< Field name for MaxLayerCell
    std::string BottomDepthFldName;    ///< Field name for BottomDepth
+   std::string RefPseudoThickFldName; ///< Field name for RefPseudoThickness
    std::string PressInterfFldName;    ///< Field name for interface pressure
    std::string PressMidFldName;       ///< Field name for midpoint pressure
    std::string ZInterfFldName;        ///< Field name for interface Z height

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -178,11 +178,13 @@ class VertCoord {
    std::string MaxLayerCellFldName;   ///< Field name for MaxLayerCell
    std::string BottomDepthFldName;    ///< Field name for BottomDepth
    std::string RefPseudoThickFldName; ///< Field name for RefPseudoThickness
-   std::string PressInterfFldName;    ///< Field name for interface pressure
-   std::string PressMidFldName;       ///< Field name for midpoint pressure
-   std::string ZInterfFldName;        ///< Field name for interface Z height
-   std::string ZMidFldName;           ///< Field name for midpoint Z height
-   std::string GeopotFldName;         ///< Field name for geopotential
+   std::string
+       VCoordMvmtWgtsFldName;      ///< Field name for VertCoordMovementWeights
+   std::string PressInterfFldName; ///< Field name for interface pressure
+   std::string PressMidFldName;    ///< Field name for midpoint pressure
+   std::string ZInterfFldName;     ///< Field name for interface Z height
+   std::string ZMidFldName;        ///< Field name for midpoint Z height
+   std::string GeopotFldName;      ///< Field name for geopotential
    std::string LyrThickTargetFldName; ///< Field name for target thickness
 
    // methods

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -48,7 +48,7 @@ void ForwardBackwardStepper::doStep(
    // R_u^{n} = RHS_u(u^{n}, h^{n}, t^{n})
    Tend->computeVelocityTendencies(State, AuxState, CurTracerArray,
                                    ThickCurLevel, VelCurLevel, TracerCurLevel,
-                                   SimTime + TimeStep);
+                                   SimTime + TimeStep, TimeStep);
 
    // u^{n+1} = u^{n} + R_u^{n}
    updateVelocityByTend(State, VelNextLevel, State, VelCurLevel, TimeStep);

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -37,7 +37,7 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    // q = (h,u,phi)
    // R_q^{n} = RHS_q(u^{n}, h^{n}, phi^{n}, t^{n})
    Tend->computeAllTendencies(State, AuxState, CurTracerArray, CurLevel,
-                              CurLevel, CurLevel, SimTime);
+                              CurLevel, CurLevel, SimTime, 0.5 * TimeStep);
 
    // q^{n+0.5} = q^{n} + 0.5*dt*R_q^{n}
    updateStateByTend(State, NextLevel, State, CurLevel, 0.5 * TimeStep);
@@ -49,7 +49,8 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
 
    // R_q^{n+0.5} = RHS_q(u^{n+0.5}, h^{n+0.5}, phi^{n+0.5}, t^{n+0.5})
    Tend->computeAllTendencies(State, AuxState, NextTracerArray, NextLevel,
-                              NextLevel, NextLevel, SimTime + 0.5 * TimeStep);
+                              NextLevel, NextLevel, SimTime + 0.5 * TimeStep,
+                              0.5 * TimeStep);
 
    // q^{n+1} = q^{n} + dt*R_q^{n+0.5}
    updateStateByTend(State, NextLevel, State, CurLevel, TimeStep);

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -36,6 +36,11 @@ RungeKutta4Stepper::RungeKutta4Stepper(
    RKC[1] = 1. / 2;
    RKC[2] = 1. / 2;
    RKC[3] = 1;
+
+   RKProj[0] = 1. / 2;
+   RKProj[1] = 1. / 2;
+   RKProj[2] = 1.;
+   RKProj[3] = 1.;
 }
 
 //------------------------------------------------------------------------------
@@ -85,7 +90,8 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
       if (Stage == 0) {
          weightTracers(NextTracerArray, CurTracerArray, State, CurLevel);
          Tend->computeAllTendencies(State, AuxState, CurTracerArray, CurLevel,
-                                    CurLevel, CurLevel, StageTime);
+                                    CurLevel, CurLevel, StageTime,
+                                    RKProj[Stage] * TimeStep);
          updateStateByTend(State, NextLevel, State, CurLevel,
                            RKB[Stage] * TimeStep);
          accumulateTracersUpdate(NextTracerArray, RKB[Stage] * TimeStep);
@@ -106,7 +112,8 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
          Pacer::stop("RK4:haloExchProvis", 3);
 
          Tend->computeAllTendencies(ProvisState, AuxState, ProvisTracers,
-                                    CurLevel, CurLevel, CurLevel, StageTime);
+                                    CurLevel, CurLevel, CurLevel, StageTime,
+                                    RKProj[Stage] * TimeStep);
          updateStateByTend(State, NextLevel, State, NextLevel,
                            RKB[Stage] * TimeStep);
          accumulateTracersUpdate(NextTracerArray, RKB[Stage] * TimeStep);

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.h
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.h
@@ -46,7 +46,10 @@ class RungeKutta4Stepper : public TimeStepper {
    Real RKB[NStages];
    Real RKC[NStages];
 
-   // Projection factors
+   // Projection factors for each RK stage. These are the RKC coefficients
+   // shifted by one RK stage and represent the fraction of the timestep over
+   // which fields are projected from the old state to the state at the end of a
+   // RK stage.
    Real RKProj[NStages];
 };
 

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.h
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.h
@@ -45,6 +45,9 @@ class RungeKutta4Stepper : public TimeStepper {
    Real RKA[NStages];
    Real RKB[NStages];
    Real RKC[NStages];
+
+   // Projection factors
+   Real RKProj[NStages];
 };
 
 } // namespace OMEGA

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -198,7 +198,8 @@ int testAuxState() {
    // compute auxiliary variables
    const auto *State       = OceanState::getDefault();
    Array3DReal TracerArray = Tracers::getAll(0);
-   DefAuxState->computeAll(State, TracerArray, 0);
+   TimeInterval Interval(1., TimeUnits::Seconds);
+   DefAuxState->computeAll(State, TracerArray, 0, Interval);
 
    // check that everything got computed correctly
    int NCellsOwned    = Mesh->NCellsOwned;

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -15,6 +15,7 @@
 #include "Decomp.h"
 #include "Dimension.h"
 #include "IO.h"
+#include "IOStream.h"
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OceanTestCommon.h"
@@ -81,6 +82,9 @@ void initEosTest(const std::string &mesh) {
 
    /// Initialize parallel IO
    IO::init(DefComm);
+
+   /// Initialize streams
+   IOStream::init();
 
    /// Initialize decomposition
    Decomp::init(mesh);

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -215,9 +215,10 @@ int testTendencies() {
    int VelTimeLevel        = 0;
    int TracerTimeLevel     = 0;
    TimeInstant Time;
+   TimeInterval Interval(1., TimeUnits::Seconds);
    DefTendencies->computeAllTendencies(State, AuxState, TracerArray,
                                        ThickTimeLevel, VelTimeLevel,
-                                       TracerTimeLevel, Time);
+                                       TracerTimeLevel, Time, Interval);
 
    // check that everything got computed correctly
    int NCellsOwned = Mesh->NCellsOwned;

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -17,6 +17,7 @@
 #include "Halo.h"
 #include "HorzMesh.h"
 #include "IO.h"
+#include "IOStream.h"
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
@@ -61,6 +62,9 @@ I4 initTracersTest() {
 
    // Create the default decomposition (initializes the decomposition)
    Decomp::init();
+
+   // Initialize streams
+   IOStream::init();
 
    // Initialize the default halo
    Err = Halo::init();

--- a/components/omega/test/ocn/VertAdvTest.cpp
+++ b/components/omega/test/ocn/VertAdvTest.cpp
@@ -193,6 +193,8 @@ int main(int argc, char *argv[]) {
                                      DefDecomp->NEdgesSize, NVertLayers);
       Array2DReal NormalVelEdge("NormalVelEdge", DefDecomp->NEdgesSize,
                                 NVertLayers);
+      Array2DReal LayerThickCell("LayerThickCell", DefDecomp->NCellsSize,
+                                 NVertLayers);
 
       const I4 ICell0        = 0;
       const I4 NEdgesOnCell0 = DefDecomp->NEdgesOnCellH(ICell0);
@@ -202,6 +204,7 @@ int main(int argc, char *argv[]) {
 
       OMEGA_SCOPE(LocEOnC, DefDecomp->EdgesOnCell);
       OMEGA_SCOPE(LocESOnC, DefMesh->EdgeSignOnCell);
+      OMEGA_SCOPE(LocTargetThick, DefVCoord->LayerThicknessTarget);
 
       // Set uniform values for layer thickness and velocity on edges of column
       parallelFor(
@@ -210,11 +213,15 @@ int main(int argc, char *argv[]) {
                 const I4 JEdge               = LocEOnC(ICell0, J);
                 FluxLayerThickEdge(JEdge, K) = 1._Real;
                 NormalVelEdge(JEdge, K)      = 1._Real * LocESOnC(ICell0, J);
+                LayerThickCell(ICell0, K)    = 1._Real;
+                LocTargetThick(ICell0, K)    = 1._Real;
              }
           });
 
+      Real ProjDt = 1._Real;
       // Compute vertical velocity
-      DefVertAdv->computeVerticalVelocity(NormalVelEdge, FluxLayerThickEdge);
+      DefVertAdv->computeVerticalVelocity(NormalVelEdge, FluxLayerThickEdge,
+                                          LayerThickCell, ProjDt);
 
       HostArray2DReal VertVelH =
           createHostMirrorCopy(DefVertAdv->VerticalVelocity);

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -370,7 +370,7 @@ int main(int argc, char *argv[]) {
           {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
              SurfacePressure(ICell) = 0.0;
              for (int K = 0; K < NVertLayers; K++) {
-                RefPseudoThick(ICell, K)  = 1.0;
+                RefPseudoThick(ICell, K) = 1.0;
                 LayerThickness(ICell, K) = 2.0;
              }
           });
@@ -415,7 +415,7 @@ int main(int argc, char *argv[]) {
           {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
              SurfacePressure(ICell) = 0.0;
              for (int K = 0; K < NVertLayers; K++) {
-                RefPseudoThick(ICell, K)  = 1.0;
+                RefPseudoThick(ICell, K) = 1.0;
                 LayerThickness(ICell, K) = 2.0;
              }
           });

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -361,7 +361,7 @@ int main(int argc, char *argv[]) {
       }
 
       // Tests for computeTargetThickness
-      auto &RefLayerThick = DefVertCoord->RefLayerThickness;
+      auto &RefPseudoThick = DefVertCoord->RefPseudoThickness;
 
       /// Initialize surface pressure, vertical coord weights, ref layer
       /// thickness, and layer thickness so that the resulting target thickness
@@ -370,7 +370,7 @@ int main(int argc, char *argv[]) {
           {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
              SurfacePressure(ICell) = 0.0;
              for (int K = 0; K < NVertLayers; K++) {
-                RefLayerThick(ICell, K)  = 1.0;
+                RefPseudoThick(ICell, K)  = 1.0;
                 LayerThickness(ICell, K) = 2.0;
              }
           });
@@ -415,7 +415,7 @@ int main(int argc, char *argv[]) {
           {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
              SurfacePressure(ICell) = 0.0;
              for (int K = 0; K < NVertLayers; K++) {
-                RefLayerThick(ICell, K)  = 1.0;
+                RefPseudoThick(ICell, K)  = 1.0;
                 LayerThickness(ICell, K) = 2.0;
              }
           });

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -16,6 +16,7 @@
 #include "Field.h"
 #include "HorzMesh.h"
 #include "IO.h"
+#include "IOStream.h"
 #include "Logging.h"
 #include "MachEnv.h"
 #include "OceanTestCommon.h"
@@ -79,6 +80,9 @@ void initVertMixTest() {
 
    /// Initialize decomposition
    Decomp::init();
+
+   /// Initialize streams
+   IOStream::init();
 
    /// Initialize Halo
    Halo::init();


### PR DESCRIPTION
Changes include:

- Read `NVertLayers` from `InitVertCoord` stream
- Rename `RefLayerThickness` to `RefPseudoThickness` to avoid conflation with MPAS field `refLayerThickness`
- Add Field metadata for `RefPseudoThickness` to `InitVertCoord` stream
- Needed updates to `IOStream` class
- Add `computeTargetThickness` method to `computeMomVertAux`
- Add ALE contribution to `computeVerticalVelocity`


<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [x] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests

Fixes #391 
