### PR TITLE
Cleanup of omega broadcast and time mgr to remove warnings

### DIFF
--- a/components/omega/src/base/Broadcast.cpp
+++ b/components/omega/src/base/Broadcast.cpp
@@ -129,8 +129,7 @@ void Broadcast(std::string &Value, const MachEnv *InEnv, const int RankBcast) {
          Value.resize(StrSize);
 
       // Now broadcast the string
-      RetVal =
-          MPI_Bcast((void *)Value.c_str(), Value.size(), MPI_CHAR, Root, Comm);
+      RetVal = MPI_Bcast(&Value[0], Value.size(), MPI_CHAR, Root, Comm);
       if (RetVal != MPI_SUCCESS)
          ABORT_ERROR("Broadcast string: Error in MPI Broadcast");
    }
@@ -230,7 +229,6 @@ void Broadcast(std::vector<R8> &Value, const int RankBcast) {
 // Broadcast bool array
 void Broadcast(std::vector<bool> &Value, const MachEnv *InEnv,
                const int RankBcast) {
-   int RetVal;
 
    // Due to special packing of std::vector<bool> we convert to an integer
    I4 VecSize = Value.size();

--- a/components/omega/src/infra/TimeMgr.cpp
+++ b/components/omega/src/infra/TimeMgr.cpp
@@ -1271,10 +1271,6 @@ Calendar::~Calendar(void) {}
 // This should only be used during testing as it will invalidate most
 // time instants and other time manager functions
 void Calendar::reset() {
-
-   LOG_WARN("Removing Omega calendar");
-   LOG_WARN("This invalidates all prior time manager values"
-            "and should only be used in testing");
    Calendar::OmegaCal.reset(); // Resets the calendar pointer
 }
 
@@ -3020,11 +3016,6 @@ TimeInterval::operator/(const I4 Divisor) const { //! [in] integer divisor
    // for calendar-dependent intervals, divide the
    // year, month or day intervals
    if (Quotient.IsCalendar) {
-      // generate warning if divisor does not divide evenly
-      if (Quotient.CalInterval != 0 && Quotient.CalInterval % Divisor != 0) {
-         LOG_WARN("TimeMgr: TimeInterval::operator/ (int) interval does not "
-                  "divide evenly");
-      }
       // return the result of the integer division
       Quotient.CalInterval /= Divisor;
 

--- a/components/omega/test/infra/TimeIntervalParseExtendedFormatsTest.cpp
+++ b/components/omega/test/infra/TimeIntervalParseExtendedFormatsTest.cpp
@@ -1,16 +1,12 @@
-//===-- Test driver for OMEGA TimeInterval extended string formats -*- C++
-//-*-===/
+//===-- Test driver for OMEGA TimeInterval extended string formats -*- C++ -*-=/
 //
 // This test encodes the *desired* behavior for parsing time interval strings
 // from config (e.g., TimeIntegration::TimeStep and RunDuration).
 //
 // It intentionally checks "short" forms like HH:MM:SS(.sss), MM:SS(.sss), and
-// SS(.sss). Today, the implementation assumes the string always begins with
-// days (DDDD_HH:MM:SS(.sss)), so these cases reproduce the bug.
+// SS(.sss).
 //
-// This test is expected to fail until parsing is improved.
-//
-//===----------------------------------------------------------------------===/
+//===-----------------------------------------------------------------------===/
 
 #include "DataTypes.h"
 #include "Error.h"
@@ -27,37 +23,35 @@ using namespace OMEGA;
 namespace {
 
 struct ExpectedParts {
-   I8 days{0};
-   I8 hours{0};
-   I8 minutes{0};
-   I8 secondsWhole{0};
-   R8 secondsFrac{0.0};
+   I8 Days{0};
+   I8 Hours{0};
+   I8 Minutes{0};
+   I8 SecondsWhole{0};
+   R8 SecondsFrac{0.0};
 };
 
-bool nearlyEqual(R8 a, R8 b, R8 tol) { return std::fabs(a - b) <= tol; }
+bool nearlyEqual(R8 A, R8 B, R8 Tol) { return std::fabs(A - B) <= Tol; }
 
-int checkSeconds(const std::string &label, const std::string &input,
-                 const ExpectedParts &exp, R8 tol = 1e-12) {
+void checkSeconds(const std::string &Label, const std::string &Input,
+                  const ExpectedParts &Exp, R8 Tol = 1e-12) {
 
-   const R8 expectedSeconds =
-       static_cast<R8>(exp.days) * static_cast<R8>(SECONDS_PER_DAY) +
-       static_cast<R8>(exp.hours) * static_cast<R8>(SECONDS_PER_HOUR) +
-       static_cast<R8>(exp.minutes) * static_cast<R8>(SECONDS_PER_MINUTE) +
-       static_cast<R8>(exp.secondsWhole) + exp.secondsFrac;
+   const R8 ExpectedSeconds =
+       static_cast<R8>(Exp.Days) * static_cast<R8>(SECONDS_PER_DAY) +
+       static_cast<R8>(Exp.Hours) * static_cast<R8>(SECONDS_PER_HOUR) +
+       static_cast<R8>(Exp.Minutes) * static_cast<R8>(SECONDS_PER_MINUTE) +
+       static_cast<R8>(Exp.SecondsWhole) + Exp.SecondsFrac;
 
-   std::string s = input; // ctor takes non-const ref
-   TimeInterval interval(s);
+   std::string S = Input; // ctor takes non-const ref
+   TimeInterval Interval(S);
 
-   R8 seconds{0.0};
-   interval.get(seconds, TimeUnits::Seconds);
+   R8 Seconds{0.0};
+   Interval.get(Seconds, TimeUnits::Seconds);
 
-   if (!nearlyEqual(seconds, expectedSeconds, tol)) {
-      LOG_ERROR("{}: '{}' parsed seconds mismatch: got {}, expected {}", label,
-                input, seconds, expectedSeconds);
-      return 1;
-   }
+   if (!nearlyEqual(Seconds, ExpectedSeconds, Tol))
+      ABORT_ERROR("{}: '{}' parsed seconds mismatch: got {}, expected {}",
+                  Label, Input, Seconds, ExpectedSeconds);
 
-   return 0;
+   return;
 }
 
 } // namespace
@@ -70,34 +64,28 @@ int main(int argc, char **argv) {
    MachEnv *defEnv = MachEnv::getDefault();
    initLogging(defEnv);
 
-   int errCount = 0;
+   LOG_INFO("----- TimeIntervalParseExtendedFormatsTest -----");
 
    // Desired: HH:MM:SS(.sss)
-   errCount += checkSeconds("Extended TimeInterval parse", "01:23:45",
-                            ExpectedParts{0, 1, 23, 45, 0.0});
-   errCount += checkSeconds("Extended TimeInterval parse", "01:23:45.678",
-                            ExpectedParts{0, 1, 23, 45, 0.678});
+   checkSeconds("Extended TimeInterval parse", "01:23:45",
+                ExpectedParts{0, 1, 23, 45, 0.0});
+   checkSeconds("Extended TimeInterval parse", "01:23:45.678",
+                ExpectedParts{0, 1, 23, 45, 0.678});
 
    // Desired: MM:SS(.sss)
-   errCount += checkSeconds("Extended TimeInterval parse", "23:45.678",
-                            ExpectedParts{0, 0, 23, 45, 0.678});
+   checkSeconds("Extended TimeInterval parse", "23:45.678",
+                ExpectedParts{0, 0, 23, 45, 0.678});
 
    // Desired: SS(.sss)
-   errCount += checkSeconds("Extended TimeInterval parse", "45.678",
-                            ExpectedParts{0, 0, 0, 45, 0.678});
-   errCount += checkSeconds("Extended TimeInterval parse", "45.6",
-                            ExpectedParts{0, 0, 0, 45, 0.6});
-   errCount += checkSeconds("Extended TimeInterval parse", "45.000001",
-                            ExpectedParts{0, 0, 0, 45, 0.000001});
+   checkSeconds("Extended TimeInterval parse", "45.678",
+                ExpectedParts{0, 0, 0, 45, 0.678});
+   checkSeconds("Extended TimeInterval parse", "45.6",
+                ExpectedParts{0, 0, 0, 45, 0.6});
+   checkSeconds("Extended TimeInterval parse", "45.000001",
+                ExpectedParts{0, 0, 0, 45, 0.000001});
 
-   if (errCount != 0) {
-      LOG_ERROR("TimeIntervalParseExtendedFormatsTest: FAIL ({} errors)",
-                errCount);
-      MPI_Finalize();
-      return 1;
-   }
-
-   LOG_INFO("TimeIntervalParseExtendedFormatsTest: PASS");
+   // If we made it here, the tests were successful
+   LOG_INFO("----- TimeIntervalParseExtendedFormatsTest Successful -----");
 
    MPI_Finalize();
    return 0;

--- a/components/omega/test/infra/TimeIntervalParseTest.cpp
+++ b/components/omega/test/infra/TimeIntervalParseTest.cpp
@@ -1,10 +1,9 @@
-//===-- Test driver for OMEGA TimeInterval string parsing ---------*- C++
-//-*-===/
+//===-- Test driver for OMEGA TimeInterval string parsing   ------*- C++ -*-===/
 //
 // This test exercises the TimeInterval(std::string&) constructor used by
 // TimeIntegration options like TimeStep and RunDuration.
 //
-//===----------------------------------------------------------------------===/
+//===-----------------------------------------------------------------------===/
 
 #include "DataTypes.h"
 #include "Error.h"
@@ -21,76 +20,71 @@ using namespace OMEGA;
 namespace {
 
 struct ExpectedParts {
-   I8 days{0};
-   I8 hours{0};
-   I8 minutes{0};
-   I8 secondsWhole{0};
-   R8 secondsFrac{0.0};
+   I8 Days{0};
+   I8 Hours{0};
+   I8 Minutes{0};
+   I8 SecondsWhole{0};
+   R8 SecondsFrac{0.0};
 };
 
-ExpectedParts splitInterval(const TimeInterval &interval) {
-   I8 whole{0}, numer{0}, denom{1};
-   interval.get(whole, numer, denom);
+ExpectedParts splitInterval(const TimeInterval &Interval) {
+   I8 Whole{0}, Numer{0}, Denom{1};
+   Interval.get(Whole, Numer, Denom);
 
    // Decompose whole seconds into D/H/M/S (non-negative assumed for this test)
-   ExpectedParts parts;
-   parts.days         = whole / SECONDS_PER_DAY;
-   I8 rem             = whole % SECONDS_PER_DAY;
-   parts.hours        = rem / SECONDS_PER_HOUR;
-   rem                = rem % SECONDS_PER_HOUR;
-   parts.minutes      = rem / SECONDS_PER_MINUTE;
-   parts.secondsWhole = rem % SECONDS_PER_MINUTE;
+   ExpectedParts Parts;
+   Parts.Days         = Whole / SECONDS_PER_DAY;
+   I8 Rem             = Whole % SECONDS_PER_DAY;
+   Parts.Hours        = Rem / SECONDS_PER_HOUR;
+   Rem                = Rem % SECONDS_PER_HOUR;
+   Parts.Minutes      = Rem / SECONDS_PER_MINUTE;
+   Parts.SecondsWhole = Rem % SECONDS_PER_MINUTE;
 
-   parts.secondsFrac = static_cast<R8>(numer) / static_cast<R8>(denom);
-   return parts;
+   Parts.SecondsFrac = static_cast<R8>(Numer) / static_cast<R8>(Denom);
+   return Parts;
 }
 
-bool nearlyEqual(R8 a, R8 b, R8 tol) { return std::fabs(a - b) <= tol; }
+bool nearlyEqual(R8 A, R8 B, R8 Tol) { return std::fabs(A - B) <= Tol; }
 
-int checkCase(const std::string &label, const std::string &input,
-              const ExpectedParts &exp, R8 tol = 1e-12) {
+void checkCase(const std::string &Label, const std::string &Input,
+               const ExpectedParts &Exp, R8 Tol = 1e-12) {
 
-   std::string s = input; // ctor takes non-const ref
-   TimeInterval interval(s);
+   std::string S = Input; // ctor takes non-const ref
+   TimeInterval Interval(S);
 
-   R8 seconds{0.0};
-   interval.get(seconds, TimeUnits::Seconds);
+   R8 Seconds{0.0};
+   Interval.get(Seconds, TimeUnits::Seconds);
 
-   const R8 expectedSeconds =
-       static_cast<R8>(exp.days) * static_cast<R8>(SECONDS_PER_DAY) +
-       static_cast<R8>(exp.hours) * static_cast<R8>(SECONDS_PER_HOUR) +
-       static_cast<R8>(exp.minutes) * static_cast<R8>(SECONDS_PER_MINUTE) +
-       static_cast<R8>(exp.secondsWhole) + exp.secondsFrac;
+   const R8 ExpectedSeconds =
+       static_cast<R8>(Exp.Days) * static_cast<R8>(SECONDS_PER_DAY) +
+       static_cast<R8>(Exp.Hours) * static_cast<R8>(SECONDS_PER_HOUR) +
+       static_cast<R8>(Exp.Minutes) * static_cast<R8>(SECONDS_PER_MINUTE) +
+       static_cast<R8>(Exp.SecondsWhole) + Exp.SecondsFrac;
 
-   auto parts = splitInterval(interval);
+   auto Parts = splitInterval(Interval);
 
-   int err = 0;
-
-   if (!nearlyEqual(seconds, expectedSeconds, tol)) {
-      ++err;
-      LOG_ERROR("{}: '{}' seconds mismatch: got {}, expected {}", label, input,
-                seconds, expectedSeconds);
+   if (!nearlyEqual(Seconds, ExpectedSeconds, Tol)) {
+      ABORT_ERROR("{}: '{}' seconds mismatch: got {}, expected {}", Label,
+                  Input, Seconds, ExpectedSeconds);
    }
 
-   if (parts.days != exp.days || parts.hours != exp.hours ||
-       parts.minutes != exp.minutes || parts.secondsWhole != exp.secondsWhole) {
-      ++err;
-      LOG_ERROR(
+   if (Parts.Days != Exp.Days || Parts.Hours != Exp.Hours ||
+       Parts.Minutes != Exp.Minutes || Parts.SecondsWhole != Exp.SecondsWhole) {
+      ABORT_ERROR(
           "{}: '{}' parts mismatch: got {}d {:02d}h {:02d}m {:02d}s, expected "
           "{}d {:02d}h {:02d}m {:02d}s",
-          label, input, parts.days, static_cast<int>(parts.hours),
-          static_cast<int>(parts.minutes), static_cast<int>(parts.secondsWhole),
-          exp.days, static_cast<int>(exp.hours), static_cast<int>(exp.minutes),
-          static_cast<int>(exp.secondsWhole));
+          Label, Input, Parts.Days, static_cast<int>(Parts.Hours),
+          static_cast<int>(Parts.Minutes), static_cast<int>(Parts.SecondsWhole),
+          Exp.Days, static_cast<int>(Exp.Hours), static_cast<int>(Exp.Minutes),
+          static_cast<int>(Exp.SecondsWhole));
    }
 
-   if (!nearlyEqual(parts.secondsFrac, exp.secondsFrac, tol)) {
-      ++err;
-      LOG_ERROR("{}: '{}' fractional seconds mismatch: got {}, expected {}",
-                label, input, parts.secondsFrac, exp.secondsFrac);
+   if (!nearlyEqual(Parts.SecondsFrac, Exp.SecondsFrac, Tol)) {
+      ABORT_ERROR("{}: '{}' fractional seconds mismatch: got {}, expected {}",
+                  Label, Input, Parts.SecondsFrac, Exp.SecondsFrac);
    }
 
-   return err;
+   return;
 }
 
 } // namespace
@@ -103,32 +97,27 @@ int main(int argc, char **argv) {
    MachEnv *defEnv = MachEnv::getDefault();
    initLogging(defEnv);
 
-   int errCount = 0;
+   LOG_INFO("----- TimeIntervalParseTest -----");
 
    // Currently documented/implemented format is:
    //   DDDD_HH:MM:SS(.sss...) with arbitrary day/second widths and any
    //   single-character separators.
 
-   errCount += checkCase("TimeInterval parse", "0000_01:23:45",
-                         ExpectedParts{0, 1, 23, 45, 0.0});
+   checkCase("TimeInterval parse", "0000_01:23:45",
+             ExpectedParts{0, 1, 23, 45, 0.0});
 
-   errCount += checkCase("TimeInterval parse", "0000_01:23:45.678",
-                         ExpectedParts{0, 1, 23, 45, 0.678});
+   checkCase("TimeInterval parse", "0000_01:23:45.678",
+             ExpectedParts{0, 1, 23, 45, 0.678});
 
-   errCount += checkCase("TimeInterval parse", "0000_01:23:45.6789",
-                         ExpectedParts{0, 1, 23, 45, 0.6789});
+   checkCase("TimeInterval parse", "0000_01:23:45.6789",
+             ExpectedParts{0, 1, 23, 45, 0.6789});
 
    // Mixed separators are allowed by the implementation.
-   errCount += checkCase("TimeInterval parse", "0012-01.23/45.5",
-                         ExpectedParts{12, 1, 23, 45, 0.5});
+   checkCase("TimeInterval parse", "0012-01.23/45.5",
+             ExpectedParts{12, 1, 23, 45, 0.5});
 
-   if (errCount != 0) {
-      LOG_ERROR("TimeIntervalParseTest: FAIL ({} errors)", errCount);
-      MPI_Finalize();
-      return 1;
-   }
-
-   LOG_INFO("TimeIntervalParseTest: PASS");
+   // If we made it here, we are successful
+   LOG_INFO("----- TimeIntervalParseTest Successful -----");
 
    MPI_Finalize();
    return 0;

--- a/components/omega/test/infra/TimeMgrTest.cpp
+++ b/components/omega/test/infra/TimeMgrTest.cpp
@@ -25,7 +25,8 @@ using namespace OMEGA;
 
 void testTimeFrac(void) {
 
-   LOG_INFO("TimeMgrTest: TimeFrac tests ------------------------------------");
+   LOG_INFO("----- TimeMgr Unit Tests -----");
+   LOG_INFO("----- TimeMgrTest: TimeFrac tests -----");
 
    // Initialize error codes
    Error ErrAll;
@@ -404,7 +405,7 @@ void testTimeFrac(void) {
 
 void testCalendar(void) {
 
-   LOG_INFO("TimeMgrTest: Calendar tests ------------------------------------");
+   LOG_INFO("----- TimeMgrTest: Calendar tests -----");
 
    // Initialize error codes
    Error ErrAll;
@@ -1330,7 +1331,7 @@ void testCalendar(void) {
 
 void testTimeInterval(void) {
 
-   LOG_INFO("TimeMgrTest: TimeInterval tests --------------------------------");
+   LOG_INFO("----- TimeMgrTest: TimeInterval tests -----");
 
    // Initialize error codes
    Error ErrAll;
@@ -2330,7 +2331,7 @@ void testTimeInterval(void) {
 
 void testTimeInstant(void) {
 
-   LOG_INFO("TimeMgrTest: TimeInstant tests ---------------------------------");
+   LOG_INFO("----- TimeMgrTest: TimeInstant tests -----");
 
    // Initialize error codes
    Error ErrAll;
@@ -2841,7 +2842,7 @@ void testTimeInstant(void) {
 
 void testAlarm(void) {
 
-   LOG_INFO("TimeMgrTest: Alarm tests ---------------------------------------");
+   LOG_INFO("----- TimeMgrTest: Alarm tests -----");
 
    // Initialize error codes
    Error ErrAll;
@@ -3183,7 +3184,7 @@ void testAlarm(void) {
 
 void testClock(void) {
 
-   LOG_INFO("TimeMgrTest: Clock tests ---------------------------------------");
+   LOG_INFO("----- TimeMgrTest: Clock tests -----");
 
    // Initialize error codes
    Error ErrAll;
@@ -3479,6 +3480,7 @@ int main(int argc, char *argv[]) {
    testClock();
 
    // if it made it here, all tests successful
+   LOG_INFO("----- TimeMgr Unit Tests Successful -----");
 
    MPI_Finalize();
    return 0;


### PR DESCRIPTION
   - changes method for retrieving char ptr for string bcast
   - removes some unnecessary warnings from time mgr
   - updates some related test drivers for consistency and to conform to coding conventions

Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests
after.

Fixes #336 
Fixes #292 

