### PR TITLE
Fix a bug in high-order tracer horizontal advection

### DIFF
--- a/components/omega/src/ocn/HorzOperators.cpp
+++ b/components/omega/src/ocn/HorzOperators.cpp
@@ -1,6 +1,7 @@
 #include "HorzOperators.h"
 #include "DataTypes.h"
 #include "HorzMesh.h"
+#include "VertCoord.h"
 
 namespace OMEGA {
 
@@ -49,9 +50,9 @@ SecondDerivativeOnCell::SecondDerivativeOnCell(HorzMesh const *Mesh)
 }
 
 MasksAndCoefficients::MasksAndCoefficients(
-    HorzMesh const *Mesh, const Array3DReal DerivTwo,
+    HorzMesh const *Mesh, VertCoord const *VCoord, const Array3DReal DerivTwo,
     Array1DI4 NAdvCellsForEdge, Array2DI4 AdvCellsForEdge,
-    Array1DI4 AdvMaskHighOrder, Array2DReal AdvCoefs, Array2DReal AdvCoefs3rd)
+    Array2DI4 AdvMaskHighOrder, Array2DReal AdvCoefs, Array2DReal AdvCoefs3rd)
     : NCellsGlobal(Mesh->NCellsGlobal), NCellsAll(Mesh->NCellsAll),
       NAdvCellsMax(Mesh->MaxEdges2), // PatchCellLists("PatchCellLists",
                                      // Mesh->NEdgesOwned, Mesh->NEdgesAll+1),
@@ -63,5 +64,5 @@ MasksAndCoefficients::MasksAndCoefficients(
       EdgesOnEdge(Mesh->EdgesOnEdge), CellsOnCell(Mesh->CellsOnCell),
       CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge),
       DvEdge(Mesh->DvEdge), AdvCoefs(AdvCoefs), AdvCoefs3rd(AdvCoefs3rd),
-      DerivTwo(DerivTwo) {}
+      BoundaryCell(VCoord->BoundaryCell), DerivTwo(DerivTwo) {}
 } // namespace OMEGA

--- a/components/omega/src/ocn/HorzOperators.h
+++ b/components/omega/src/ocn/HorzOperators.h
@@ -5,6 +5,7 @@
 #include "GlobalConstants.h"
 #include "HorzMesh.h"
 #include "HorzUtil.h"
+#include "VertCoord.h"
 
 namespace OMEGA {
 
@@ -467,10 +468,10 @@ class MasksAndCoefficients {
    }
 
  public:
-   MasksAndCoefficients(HorzMesh const *Mesh, const Array3DReal DerivTwo,
-                        Array1DI4 NAdvCellsForEdge, Array2DI4 AdvCellsForEdge,
-                        Array1DI4 AdvMaskHighOrder, Array2DReal AdvCoefs,
-                        Array2DReal AdvCoefs3rd);
+   MasksAndCoefficients(HorzMesh const *Mesh, VertCoord const *VCoord,
+                        const Array3DReal DerivTwo, Array1DI4 NAdvCellsForEdge,
+                        Array2DI4 AdvCellsForEdge, Array2DI4 AdvMaskHighOrder,
+                        Array2DReal AdvCoefs, Array2DReal AdvCoefs3rd);
 
    KOKKOS_FUNCTION void operator()(const int IEdge) const {
 
@@ -484,17 +485,35 @@ class MasksAndCoefficients {
       for (unsigned I = 0; I < CellIndexSorted.extent(0); ++I)
          for (unsigned K = 0; K < CellIndexSorted.extent(1); ++K)
             CellIndexSorted(I, K) = MaxI4;
+
       const int Cell1 = CellsOnEdge(IEdge, 0);
       const int Cell2 = CellsOnEdge(IEdge, 1);
-      // at boundaries, must stay at low order
-      AdvMaskHighOrder(IEdge) = 1;
-      for (int K = 0; K < NEdgesOnCell(Cell1); ++K)
-         if (CellsOnCell(Cell1, K) == NCellsGlobal)
-            AdvMaskHighOrder(IEdge) = 0;
 
-      for (int K = 0; K < NEdgesOnCell(Cell2); ++K)
-         if (CellsOnCell(Cell2, K) == NCellsGlobal)
-            AdvMaskHighOrder(IEdge) = 0;
+      // at boundaries, must stay at low order
+      const int NLyr = AdvMaskHighOrder.extent(1);
+      for (int K = 0; K < NLyr; ++K) {
+         if (BoundaryCell(Cell1, K) == 1 or BoundaryCell(Cell2, K) == 1) {
+            AdvMaskHighOrder(IEdge, K) = 0;
+         } else {
+            AdvMaskHighOrder(IEdge, K) = 1;
+         }
+      }
+
+      for (int J = 0; J < NEdgesOnCell(Cell1); ++J) {
+         if (CellsOnCell(Cell1, J) == NCellsGlobal) {
+            for (int K = 0; K < NLyr; ++K) {
+               AdvMaskHighOrder(IEdge, K) = 0;
+            }
+         }
+      }
+      for (int J = 0; J < NEdgesOnCell(Cell2); ++J) {
+         if (CellsOnCell(Cell2, J) == NCellsGlobal) {
+            for (int K = 0; K < NLyr; ++K) {
+               AdvMaskHighOrder(IEdge, K) = 0;
+            }
+         }
+      }
+
       // do only if this edge flux is needed to update owned cells
       if (Cell1 < NCellsAll && Cell2 < NCellsAll) {
          // Insert cellsOnEdge to list of advection cells
@@ -622,7 +641,7 @@ class MasksAndCoefficients {
    Array2DI4 CellIndx;
    Array3DI4 CellIndxSorted;
    Array1DI4 CellID;
-   Array1DI4 AdvMaskHighOrder;
+   Array2DI4 AdvMaskHighOrder;
    Array2DI4 EdgesOnEdge;
    Array2DI4 CellsOnCell;
    Array2DI4 CellsOnEdge;
@@ -630,6 +649,7 @@ class MasksAndCoefficients {
    Array1DReal DvEdge;
    Array2DReal AdvCoefs;
    Array2DReal AdvCoefs3rd;
+   Array2DReal BoundaryCell;
    Array3DReal DerivTwo;
 };
 } // namespace OMEGA

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -73,12 +73,13 @@ BottomDragOnEdge::BottomDragOnEdge(const HorzMesh *Mesh,
 
 TracerHorzAdvOnCell::TracerHorzAdvOnCell(const HorzMesh *Mesh,
                                          const VertCoord *VCoord)
-    : HorzontalMesh(Mesh),
+    : HorzontalMesh(Mesh), VerticalCoord(VCoord),
       NAdvCellsForEdge("NumberOfCellsContribToAdvectionAtEdge",
                        Mesh->NEdgesAll),
       AdvCellsForEdge("IndexOfCellsContributingToAdvection", Mesh->NEdgesAll,
                       Mesh->MaxEdges2 + 2),
-      AdvMaskHighOrder("MaskForHighOrderAdvectionTerms", Mesh->NEdgesAll),
+      AdvMaskHighOrder("MaskForHighOrderAdvectionTerms", Mesh->NEdgesAll,
+                       VCoord->NVertLayers),
       AdvCoefs("CommonAdvectionCoefficients", Mesh->MaxEdges2 + 2,
                Mesh->NEdgesAll),
       AdvCoefs3rd("CommonAdvectionCoeffsForHighOrder", Mesh->MaxEdges2 + 2,
@@ -115,11 +116,19 @@ SurfaceTracerRestoringOnCell::SurfaceTracerRestoringOnCell(
     const HorzMesh *Mesh) {}
 
 void TracerHorzAdvOnCell::init() {
-   const HorzMesh *Mesh = this->HorzontalMesh;
-   const auto MaxEdges2 = Mesh->MaxEdges2;
-   const auto NEdgesAll = Mesh->NEdgesAll;
-   const auto NCellsAll = Mesh->NCellsAll;
+   const HorzMesh *Mesh    = this->HorzontalMesh;
+   const VertCoord *VCoord = this->VerticalCoord;
+   const auto MaxEdges2    = Mesh->MaxEdges2;
+   const auto NEdgesAll    = Mesh->NEdgesAll;
+   const auto NCellsAll    = Mesh->NCellsAll;
    // Allocate Kokkos arrays in member data
+
+   if (ForceLowOrder) {
+      // Return when the 2nd-order tracer horz adv
+      deepCopy(NAdvCellsForEdge, 0);
+      deepCopy(AdvMaskHighOrder, 0);
+      return;
+   }
 
    SecondDerivativeOnCell secondDerivativeOnCell(Mesh);
    Array3DReal DerivTwo("DerivTwo", MaxEdges2 + 2, 2, NEdgesAll);
@@ -128,9 +137,9 @@ void TracerHorzAdvOnCell::init() {
        KOKKOS_LAMBDA(int ICell) { secondDerivativeOnCell(DerivTwo, ICell); });
    // Compute masks and coefficients
    Kokkos::fence();
-   MasksAndCoefficients masksAndCoefficients(Mesh, DerivTwo, NAdvCellsForEdge,
-                                             AdvCellsForEdge, AdvMaskHighOrder,
-                                             AdvCoefs, AdvCoefs3rd);
+   MasksAndCoefficients masksAndCoefficients(
+       Mesh, VCoord, DerivTwo, NAdvCellsForEdge, AdvCellsForEdge,
+       AdvMaskHighOrder, AdvCoefs, AdvCoefs3rd);
    Kokkos::fence();
    parallelFor(
        {NEdgesAll}, KOKKOS_LAMBDA(int IEdge) { masksAndCoefficients(IEdge); });

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -380,33 +380,35 @@ class TracerHorzAdvOnCell {
       const I4 KEnd   = KStart + VecLength;
       for (int K = KStart; K < KEnd; ++K)
          HighOrderFlxHorz(L, IEdge, K) = 0;
-      if (!ForceLowOrder && AdvMaskHighOrder(IEdge)) {
-         for (int I = 0; I < NAdvCellsForEdge(IEdge); ++I) {
-            const I4 ICell = AdvCellsForEdge(IEdge, I);
-            for (int K = KStart; K < KEnd; ++K) {
-               const Real NormalPseudoThicknessFlux =
-                   FluxPseudoThickEdge(IEdge, K) * NormVelEdge(IEdge, K);
-               const Real TracerWgt =
-                   (AdvCoefs(I, IEdge) +
-                    Coef3rdOrder *
-                        std::copysign(1._Real, NormalPseudoThicknessFlux) *
-                        AdvCoefs3rd(I, IEdge)) *
-                   NormalPseudoThicknessFlux;
-               HighOrderFlxHorz(L, IEdge, K) +=
-                   TracerWgt * TracerCell(L, ICell, K);
-            }
-         }
-      } else {
+
+      // Stay at low order at boundaries
+      for (int K = KStart; K < KEnd; ++K) {
+         const I4 JCell0 = CellsOnEdge(IEdge, 0);
+         const I4 JCell1 = CellsOnEdge(IEdge, 1);
+         const Real NormalThicknessFlux =
+             FluxLayerThickEdge(IEdge, K) * NormVelEdge(IEdge, K);
+         const Real TracerWgt = DvEdge(IEdge) * 0.5_Real * NormalThicknessFlux;
+         HighOrderFlxHorz(L, IEdge, K) +=
+             TracerWgt * (1._Real - AdvMaskHighOrder(IEdge, K)) *
+             (TracerCell(L, JCell1, K) + TracerCell(L, JCell0, K));
+      }
+
+      // High order (3rd or 4th) fluxes elsewhere when requested
+      //    - If HorzTracerFluxOrder = 2, NAdvCellsForEdge = 0 and
+      //      this loop is skipped.
+      for (int I = 0; I < NAdvCellsForEdge(IEdge); ++I) {
+         const I4 ICell = AdvCellsForEdge(IEdge, I);
          for (int K = KStart; K < KEnd; ++K) {
-            const I4 JCell0 = CellsOnEdge(IEdge, 0);
-            const I4 JCell1 = CellsOnEdge(IEdge, 1);
-            const Real NormalPseudoThicknessFlux =
-                FluxPseudoThickEdge(IEdge, K) * NormVelEdge(IEdge, K);
+            const Real NormalThicknessFlux =
+                FluxLayerThickEdge(IEdge, K) * NormVelEdge(IEdge, K);
             const Real TracerWgt =
-                DvEdge(IEdge) * 0.5_Real * NormalPseudoThicknessFlux;
-            HighOrderFlxHorz(L, IEdge, K) +=
-                TracerWgt *
-                (TracerCell(L, JCell1, K) + TracerCell(L, JCell0, K));
+                (AdvCoefs(I, IEdge) +
+                 Coef3rdOrder * std::copysign(1._Real, NormalThicknessFlux) *
+                     AdvCoefs3rd(I, IEdge)) *
+                NormalThicknessFlux;
+            HighOrderFlxHorz(L, IEdge, K) += TracerWgt *
+                                             TracerCell(L, ICell, K) *
+                                             AdvMaskHighOrder(IEdge, K);
          }
       }
    }
@@ -430,9 +432,10 @@ class TracerHorzAdvOnCell {
 
  private:
    const HorzMesh *HorzontalMesh;
+   const VertCoord *VerticalCoord;
    Array1DI4 NAdvCellsForEdge;
    Array2DI4 AdvCellsForEdge;
-   Array1DI4 AdvMaskHighOrder;
+   Array2DI4 AdvMaskHighOrder;
    Array2DReal AdvCoefs;
    Array2DReal AdvCoefs3rd;
    Array3DReal HighOrderFlxHorz;

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -386,7 +386,7 @@ class TracerHorzAdvOnCell {
          const I4 JCell0 = CellsOnEdge(IEdge, 0);
          const I4 JCell1 = CellsOnEdge(IEdge, 1);
          const Real NormalThicknessFlux =
-             FluxLayerThickEdge(IEdge, K) * NormVelEdge(IEdge, K);
+             FluxPseudoThickEdge(IEdge, K) * NormVelEdge(IEdge, K);
          const Real TracerWgt = DvEdge(IEdge) * 0.5_Real * NormalThicknessFlux;
          HighOrderFlxHorz(L, IEdge, K) +=
              TracerWgt * (1._Real - AdvMaskHighOrder(IEdge, K)) *
@@ -400,7 +400,7 @@ class TracerHorzAdvOnCell {
          const I4 ICell = AdvCellsForEdge(IEdge, I);
          for (int K = KStart; K < KEnd; ++K) {
             const Real NormalThicknessFlux =
-                FluxLayerThickEdge(IEdge, K) * NormVelEdge(IEdge, K);
+                FluxPseudoThickEdge(IEdge, K) * NormVelEdge(IEdge, K);
             const Real TracerWgt =
                 (AdvCoefs(I, IEdge) +
                  Coef3rdOrder * std::copysign(1._Real, NormalThicknessFlux) *

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -874,9 +874,10 @@ void VertCoord::setMasks() {
           const I4 KMax = LocMaxLyrEdgeTop(IEdge);
 
           parallelForInner(
-              Team, Range{KMin, KMax},
-              INNER_LAMBDA(int K) { LocEdgeMask(IEdge, K) = 1._Real;
-                                    LocBoundaryEdge(IEdge, K) = 0._Real;});
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
+                 LocEdgeMask(IEdge, K)     = 1._Real;
+                 LocBoundaryEdge(IEdge, K) = 0._Real;
+              });
        });
 
    EdgeMaskH     = createHostMirrorCopy(EdgeMask);

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -135,8 +135,9 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    VertexDegree   = Decomp->VertexDegree;
 
    // Retrieve connectivity arrays from Decomp
-   CellsOnEdge   = Decomp->CellsOnEdge;
-   CellsOnVertex = Decomp->CellsOnVertex;
+   CellsOnEdge    = Decomp->CellsOnEdge;
+   CellsOnVertex  = Decomp->CellsOnVertex;
+   VerticesOnEdge = Decomp->VerticesOnEdge;
 
    // Allocate device arrays
    MaxLayerCell    = Array1DI4("MaxLayerCell", NCellsSize);
@@ -854,14 +855,19 @@ void VertCoord::minMaxLayerVertex(Halo *MeshHalo) {
 // set computational masks for mesh elements
 void VertCoord::setMasks() {
 
-   EdgeMask = Array2DReal("EdgeMask", NEdgesSize, NVertLayers);
+   // EdgeMask & BoundaryEdge
+   EdgeMask     = Array2DReal("EdgeMask", NEdgesSize, NVertLayers);
+   BoundaryEdge = Array2DReal("BoundaryEdge", NEdgesSize, NVertLayers);
 
    OMEGA_SCOPE(LocEdgeMask, EdgeMask);
+   OMEGA_SCOPE(LocBoundaryEdge, BoundaryEdge);
    OMEGA_SCOPE(LocMinLyrEdgeBot, MinLayerEdgeBot);
    OMEGA_SCOPE(LocMaxLyrEdgeTop, MaxLayerEdgeTop);
 
    // EdgeMask = 1 if active layers on both sides, 0 otherwise.
+   // BoundaryEdge = 0 if active layers on both sides, 1 otherwise.
    deepCopy(EdgeMask, 0.);
+   deepCopy(BoundaryEdge, 1.);
    parallelForOuter(
        {NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
           const I4 KMin = LocMinLyrEdgeBot(IEdge);
@@ -869,11 +875,49 @@ void VertCoord::setMasks() {
 
           parallelForInner(
               Team, Range{KMin, KMax},
-              INNER_LAMBDA(int K) { LocEdgeMask(IEdge, K) = 1._Real; });
+              INNER_LAMBDA(int K) { LocEdgeMask(IEdge, K) = 1._Real;
+                                    LocBoundaryEdge(IEdge, K) = 0._Real;});
        });
 
-   EdgeMaskH = createHostMirrorCopy(EdgeMask);
+   EdgeMaskH     = createHostMirrorCopy(EdgeMask);
+   BoundaryEdgeH = createHostMirrorCopy(BoundaryEdge);
 
+   // BoundaryCell & BoundaryVertex
+   //              = 1 in inactive layers, 0 otherwise.
+   BoundaryCell   = Array2DReal("BoundaryCell", NCellsSize, NVertLayers);
+   BoundaryVertex = Array2DReal("BoundaryVertex", NVerticesSize, NVertLayers);
+
+   OMEGA_SCOPE(LocBoundaryCell, BoundaryCell);
+   OMEGA_SCOPE(LocBoundaryVertex, BoundaryVertex);
+   OMEGA_SCOPE(LocCellsOnEdge, CellsOnEdge);
+   OMEGA_SCOPE(LocVerticesOnEdge, CellsOnEdge);
+   OMEGA_SCOPE(LocNVertLayers, NVertLayers);
+
+   deepCopy(BoundaryCell, 0.);
+   deepCopy(BoundaryVertex, 0.);
+
+   parallelForOuter(
+       {NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const I4 JCell0   = LocCellsOnEdge(IEdge, 0);
+          const I4 JCell1   = LocCellsOnEdge(IEdge, 1);
+          const I4 JVertex0 = LocVerticesOnEdge(IEdge, 0);
+          const I4 JVertex1 = LocVerticesOnEdge(IEdge, 1);
+
+          parallelForInner(
+              Team, LocNVertLayers, INNER_LAMBDA(int K) {
+                 if (LocBoundaryEdge(IEdge, K) == 1._Real) {
+                    LocBoundaryCell(JCell0, K)     = 1._Real;
+                    LocBoundaryCell(JCell1, K)     = 1._Real;
+                    LocBoundaryVertex(JVertex0, K) = 1._Real;
+                    LocBoundaryVertex(JVertex1, K) = 1._Real;
+                 }
+              });
+       });
+
+   BoundaryCellH   = createHostMirrorCopy(BoundaryCell);
+   BoundaryVertexH = createHostMirrorCopy(BoundaryVertex);
+
+   // CellMask
    CellMask = Array2DReal("CellMask", NCellsSize, NVertLayers);
 
    OMEGA_SCOPE(LocCellMask, CellMask);
@@ -894,6 +938,7 @@ void VertCoord::setMasks() {
 
    CellMaskH = createHostMirrorCopy(CellMask);
 
+   // VertexMask
    VertexMask = Array2DReal("VertexMask", NVerticesSize, NVertLayers);
 
    OMEGA_SCOPE(LocVrtxMask, VertexMask);

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -64,6 +64,7 @@ class VertCoord {
    I4 VertexDegree;
    Array2DI4 CellsOnEdge;
    Array2DI4 CellsOnVertex;
+   Array2DI4 VerticesOnEdge;
 
    static VertCoord *DefaultVertCoord;
    static std::map<std::string, std::unique_ptr<VertCoord>> AllVertCoords;
@@ -151,6 +152,18 @@ class VertCoord {
                                 ///  done on vertex
    HostArray2DReal VertexMaskH; ///< Mask to determine if computations should be
                                 ///  done on vertex
+
+   Array2DReal BoundaryEdge; ///< Mask to determine boundary edges
+
+   HostArray2DReal BoundaryEdgeH; ///< Mask to determine boundary edges
+
+   Array2DReal BoundaryCell; ///< Mask to determine boundary cells
+
+   HostArray2DReal BoundaryCellH; ///< Mask to determine boundary cells
+
+   Array2DReal BoundaryVertex; ///< Mask to determine boundary vertex
+
+   HostArray2DReal BoundaryVertexH; ///< Mask to determine boundary vertex
 
    // BottomGeomDepth read from mesh file
    Array1DReal BottomGeomDepth;

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -882,8 +882,8 @@ int testTracerHorzAdvOnCell(int NVertLayers, int NTracers, Real RTol) {
    Array3DReal NumTrFluxDiv("NumTrFluxDiv", NTracers, Mesh->NCellsOwned,
                             NVertLayers);
    TracerHorzAdvOnCell TrHorzAdvOnC(Mesh, VCoord);
-   TrHorzAdvOnC.init();
    TrHorzAdvOnC.ForceLowOrder = true;
+   TrHorzAdvOnC.init();
 
    parallelFor(
        {NTracers, Mesh->NEdgesAll, NVertLayers},


### PR DESCRIPTION
This PR fixes a bug in high-order tracer advection that incorrectly handled boundary regions. With non-flat bottom topography, this caused results to differ from both second-order tracer advection in Omega and high-order advection in MPAS-Ocean (see https://github.com/E3SM-Project/Omega/issues/396#issue-4343844390).

`AdvMaskHighOrder` has been changed to a two-dimensional array and is constructed in the vertical direction using `BoundaryCell`, following MPAS-Ocean.

This PR also adds `BoundaryCell`, `BoundaryEdge`, and `BoundaryVertex` to `VertCoord` for determining boundary cells, edges, and vertices, respectively.

This PR fixes the issue #396 (see https://github.com/E3SM-Project/Omega/issues/396#issuecomment-4371991406).

Checklist
* [ ] Linting
  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [ ] Indicate "All tests passed" or document failing tests

