### PR TITLE
Change Brunt-Vaisala frequency vertical dimension and fill boundary values

### DIFF
--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -46,8 +46,8 @@ Eos::Eos(const std::string &Name, ///< [in] Name for eos object
    SpecVol = Array2DReal("SpecVol", Mesh->NCellsSize, VCoord->NVertLayers);
    SpecVolDisplaced =
        Array2DReal("SpecVolDisplaced", Mesh->NCellsSize, VCoord->NVertLayers);
-   BruntVaisalaFreqSq =
-       Array2DReal("BruntVaisalaFreqSq", Mesh->NCellsSize, VCoord->NVertLayers);
+   BruntVaisalaFreqSq = Array2DReal("BruntVaisalaFreqSq", Mesh->NCellsSize,
+                                    VCoord->NVertLayersP1);
 
    deepCopy(SpecVol, 1.0_Real / RhoSw);
    deepCopy(SpecVolDisplaced, 1.0_Real / RhoSw);
@@ -282,13 +282,27 @@ void Eos::computeBruntVaisalaFreqSq(const Array2DReal &ConservTemp,
       parallelForOuter(
           "bvf-linear", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
-             const int KMin   = MinLayerCell(ICell);
+             // Compute Brunt-Vaisala frequency at interior vertical interfaces
+             const int KMin   = MinLayerCell(ICell) + 1;
              const int KMax   = MaxLayerCell(ICell);
              const int KRange = vertRangeChunked(KMin, KMax);
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
                     LocComputeBruntVaisalaFreqSqLinear(LocBruntVaisalaFreqSq,
                                                        ICell, KChunk, SpecVol);
+                 });
+
+             teamBarrier(Team);
+
+             // Fill Brunt-Vaisala frequency at vertical boundaries using the
+             // closest valid value. This is equivalent to doing one-sided
+             // differencing at the boundary.
+             Kokkos::single(
+                 PerTeam(Team), INNER_LAMBDA() {
+                    LocBruntVaisalaFreqSq(ICell, MinLayerCell(ICell)) =
+                        LocBruntVaisalaFreqSq(ICell, KMin);
+                    LocBruntVaisalaFreqSq(ICell, MaxLayerCell(ICell) + 1) =
+                        LocBruntVaisalaFreqSq(ICell, KMax);
                  });
           });
    } else if (EosChoice == EosType::Teos10Eos) {
@@ -297,7 +311,8 @@ void Eos::computeBruntVaisalaFreqSq(const Array2DReal &ConservTemp,
       parallelForOuter(
           "bvf-teos10", {Mesh->NCellsAll},
           KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
-             const int KMin   = MinLayerCell(ICell);
+             // Compute Brunt-Vaisala frequency at interior vertical interfaces
+             const int KMin   = MinLayerCell(ICell) + 1;
              const int KMax   = MaxLayerCell(ICell);
              const int KRange = vertRangeChunked(KMin, KMax);
              parallelForInner(
@@ -305,6 +320,19 @@ void Eos::computeBruntVaisalaFreqSq(const Array2DReal &ConservTemp,
                     LocComputeBruntVaisalaFreqSqTeos10(
                         LocBruntVaisalaFreqSq, ICell, KChunk, ConservTemp,
                         AbsSalinity, Pressure, SpecVol);
+                 });
+
+             teamBarrier(Team);
+
+             // Fill Brunt-Vaisala frequency at vertical boundaries using the
+             // closest valid value. This is equivalent to doing one-sided
+             // differencing at the boundary.
+             Kokkos::single(
+                 PerTeam(Team), INNER_LAMBDA() {
+                    LocBruntVaisalaFreqSq(ICell, MinLayerCell(ICell)) =
+                        LocBruntVaisalaFreqSq(ICell, KMin);
+                    LocBruntVaisalaFreqSq(ICell, MaxLayerCell(ICell) + 1) =
+                        LocBruntVaisalaFreqSq(ICell, KMax);
                  });
           });
    }
@@ -355,6 +383,10 @@ void Eos::defineFields() {
                      NDims,     // Number of dimensions
                      DimNames   // Dimension names
        );
+
+   // Brunt-Vaisala frequency is located at interfaces
+   DimNames[1] = "NVertLayersP1";
+
    /// Create and register the BruntVaisalaFreqSq field
    auto BruntVaisalaFreqSqField =
        Field::create(BruntVaisalaFreqSqFldName,                   // Field name

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -324,33 +324,27 @@ class Teos10BruntVaisalaFreqSq {
                                    const Array2DReal &Pressure,
                                    const Array2DReal &SpecVol) const {
 
-      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell) + 1);
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
-         if (K == 0) {
-            // No Brunt-Vaisala frequency at surface
-            BruntVaisalaFreqSq(ICell, K) = 0.0_Real;
-         } else {
-            // Calculate squared Brunt-Vaisala frequency
-            Real CtInt =
-                0.5_Real * (ConservTemp(ICell, K) + ConservTemp(ICell, K - 1));
-            Real SaInt =
-                0.5_Real * (AbsSalinity(ICell, K) + AbsSalinity(ICell, K - 1));
-            Real PInt =
-                0.5_Real * (Pressure(ICell, K) + Pressure(ICell, K - 1));
-            Real SpInt = 0.5_Real * (SpecVol(ICell, K) + SpecVol(ICell, K - 1));
-            Real AlphaInt = calcAlpha(SaInt, CtInt, PInt * Pa2Db, SpInt);
-            Real BetaInt  = calcBeta(SaInt, CtInt, PInt * Pa2Db, SpInt);
-            Real DSa      = AbsSalinity(ICell, K) - AbsSalinity(ICell, K - 1);
-            Real DCt      = ConservTemp(ICell, K) - ConservTemp(ICell, K - 1);
-            Real DP       = Pressure(ICell, K) - Pressure(ICell, K - 1);
+         // Calculate squared Brunt-Vaisala frequency
+         Real CtInt =
+             0.5_Real * (ConservTemp(ICell, K) + ConservTemp(ICell, K - 1));
+         Real SaInt =
+             0.5_Real * (AbsSalinity(ICell, K) + AbsSalinity(ICell, K - 1));
+         Real PInt  = 0.5_Real * (Pressure(ICell, K) + Pressure(ICell, K - 1));
+         Real SpInt = 0.5_Real * (SpecVol(ICell, K) + SpecVol(ICell, K - 1));
+         Real AlphaInt = calcAlpha(SaInt, CtInt, PInt * Pa2Db, SpInt);
+         Real BetaInt  = calcBeta(SaInt, CtInt, PInt * Pa2Db, SpInt);
+         Real DSa      = AbsSalinity(ICell, K) - AbsSalinity(ICell, K - 1);
+         Real DCt      = ConservTemp(ICell, K) - ConservTemp(ICell, K - 1);
+         Real DP       = Pressure(ICell, K) - Pressure(ICell, K - 1);
 
-            BruntVaisalaFreqSq(ICell, K) = Gravity * Gravity *
-                                           (BetaInt * DSa - AlphaInt * DCt) /
-                                           (SpInt * DP);
-         }
+         BruntVaisalaFreqSq(ICell, K) = Gravity * Gravity *
+                                        (BetaInt * DSa - AlphaInt * DCt) /
+                                        (SpInt * DP);
       }
    }
 
@@ -533,24 +527,19 @@ class LinearBruntVaisalaFreqSq {
                                    I4 KChunk,
                                    const Array2DReal &SpecVol) const {
 
-      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell) + 1);
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
 
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
-         if (K == 0) {
-            /// No Brunt-Vaisala frequency at the top level
-            BruntVaisalaFreqSq(ICell, K) = 0.0_Real;
-         } else {
-            /// Calculate squared Brunt-Vaisala frequency at mid-point between
-            /// K-1 and K Do not need to use displaced specific volume here
-            /// since only the linear EOS is used with this BVF formulation.
-            BruntVaisalaFreqSq(ICell, K) =
-                -(Gravity / RhoT0S0) *
-                ((1.0_Real / SpecVol(ICell, K - 1)) -
-                 (1.0_Real / SpecVol(ICell, K))) /
-                (GeomZMid(ICell, K - 1) - GeomZMid(ICell, K));
-         }
+         /// Calculate squared Brunt-Vaisala frequency at mid-point between
+         /// K-1 and K Do not need to use displaced specific volume here
+         /// since only the linear EOS is used with this BVF formulation.
+         BruntVaisalaFreqSq(ICell, K) =
+             -(Gravity / RhoT0S0) *
+             ((1.0_Real / SpecVol(ICell, K - 1)) -
+              (1.0_Real / SpecVol(ICell, K))) /
+             (GeomZMid(ICell, K - 1) - GeomZMid(ICell, K));
       }
    }
 

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -383,16 +383,13 @@ void testBruntVaisalaFreqSqLinear() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) { // should be zero
-                    if (BruntVaisalaFreqSq(ICell, K) != 0.0)
-                       InnerCount++;
-                 } else if (K == 1) { // should be ref value
+                 if (K == 1 || K == 0) { // should be ref value
                     if (!isApprox(BruntVaisalaFreqSq(ICell, K),
                                   LinearBVFExpValue, RTol))
                        InnerCount++;
@@ -414,18 +411,18 @@ void testBruntVaisalaFreqSqLinear() {
    if (NumMismatches != 0) {
       auto BruntVaisalaFreqSqH = createHostMirrorCopy(BruntVaisalaFreqSq);
       for (int I = 0; I < Mesh->NCellsAll; ++I) {
-         // top layer should be zero
-         if (BruntVaisalaFreqSqH(I, 0) != 0.0)
+         // top layer should be ref value
+         if (!isApprox(BruntVaisalaFreqSqH(I, 0), LinearBVFExpValue, RTol))
             LOG_ERROR("EosTest: Brunt-Vaisala Linear Bad Value: "
                       "BruntVaisala({},{}) = {}; Expected {}",
-                      I, 0, BruntVaisalaFreqSqH(I, 0), 0.0);
+                      I, 0, BruntVaisalaFreqSqH(I, 0), LinearBVFExpValue);
          // K = 1 should be ref value
          if (!isApprox(BruntVaisalaFreqSqH(I, 1), LinearBVFExpValue, RTol))
             LOG_ERROR("EosTest: Brunt-Vaisala Linear Bad Value: "
                       "BruntVaisala({},{}) = {}; Expected {}",
                       I, 1, BruntVaisalaFreqSqH(I, 1), LinearBVFExpValue);
          // remaining values just check for other conditions
-         for (int K = 2; K < NVertLayers; ++K) {
+         for (int K = 2; K < NVertLayers + 1; ++K) {
             if (BruntVaisalaFreqSqH(I, K) == 0.0 or
                 Kokkos::isnan(BruntVaisalaFreqSqH(I, K)) or
                 Kokkos::isinf(BruntVaisalaFreqSqH(I, K)))
@@ -647,16 +644,13 @@ void testBruntVaisalaFreqSqTeos10() {
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
           int NumMismatchesCol;
           const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell) + 1;
           const int KRange = vertRange(KMin, KMax);
           parallelReduceInner(
               Team, KRange,
               INNER_LAMBDA(int KOff, int &InnerCount) {
                  const int K = KMin + KOff;
-                 if (K == 0) { // should be zero at top
-                    if (BruntVaisalaFreqSq(ICell, K) != 0.0)
-                       InnerCount++;
-                 } else if (K == 1) { // should be ref value
+                 if (K == 1 || K == 0) { // should be ref value
                     if (!isApprox(BruntVaisalaFreqSq(ICell, K), TeosBVFExpValue,
                                   RTol))
                        InnerCount++;
@@ -678,18 +672,18 @@ void testBruntVaisalaFreqSqTeos10() {
    if (NumMismatches != 0) {
       auto BruntVaisalaFreqSqH = createHostMirrorCopy(BruntVaisalaFreqSq);
       for (int ICell = 0; ICell < Mesh->NCellsAll; ++ICell) {
-         // top layer should be zero
-         if (BruntVaisalaFreqSqH(ICell, 0) != 0.0)
+         // top layer should be ref value
+         if (!isApprox(BruntVaisalaFreqSqH(ICell, 0), TeosBVFExpValue, RTol))
             LOG_ERROR("EosTest: Brunt-Vaisala TEOS Bad Value: "
                       "BruntVaisala({},{}) = {}; Expected {}",
-                      ICell, 0, BruntVaisalaFreqSqH(ICell, 0), 0.0);
+                      ICell, 0, BruntVaisalaFreqSqH(ICell, 0), TeosBVFExpValue);
          // K = 1 should be ref value
          if (!isApprox(BruntVaisalaFreqSqH(ICell, 1), TeosBVFExpValue, RTol))
             LOG_ERROR("EosTest: Brunt-Vaisala TEOS Bad Value: "
                       "BruntVaisala({},{}) = {}; Expected {}",
                       ICell, 1, BruntVaisalaFreqSqH(ICell, 1), TeosBVFExpValue);
          // remaining values just check for other conditions
-         for (int K = 2; K < NVertLayers; ++K) {
+         for (int K = 2; K < NVertLayers + 1; ++K) {
             if (BruntVaisalaFreqSqH(ICell, K) == 0.0 or
                 Kokkos::isnan(BruntVaisalaFreqSqH(ICell, K)) or
                 Kokkos::isinf(BruntVaisalaFreqSqH(ICell, K)))


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
Motivated by the discussion in https://github.com/E3SM-Project/Omega/discussions/394, this PR changes the Brunt-Vaisala frequency vertical extent to `NVertLayersP1`, since it is a field that is located on interfaces. However, instead of filling the top and bottom interfaces with zeros or fill value, this PR sets these boundary values to values from the closest interior interface. This can be seen as equivalent to using one-sided differencing to calculate the boundary value, and is what is used in MPAS-O when the surface value of Brunt-Vaisala frequency is needed by the submesoscale eddy parametrization.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


