### PR TITLE
Update Omega to C++20

### DIFF
--- a/components/omega/CMakeLists.txt
+++ b/components/omega/CMakeLists.txt
@@ -38,7 +38,7 @@ if (NOT DEFINED PROJECT_NAME)
   # Collect machine and compiler info from CIME
   init_standalone_build()
 
-  set(CMAKE_CXX_STANDARD 17) # used in E3SM
+  set(CMAKE_CXX_STANDARD 20) # used in E3SM
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
   project(${OMEGA_PROJECT_NAME}

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -144,6 +144,7 @@ if (NOT TARGET cpptrace::cpptrace)
 	# PACKAGE_VERSION (e.g. 2.10.2) from leaking into libdwarf's configure_file
 	unset(PACKAGE_VERSION)
 	option(CPPTRACE_INHERIT_HOST_STANDARD "" ON)
+        option(CPPTRACE_DISABLE_CXX_20_MODULES "" ON)
 	add_subdirectory(
 	  ${OMEGA_SOURCE_DIR}/external/cpptrace
 	  ${CMAKE_CURRENT_BINARY_DIR}/external/cpptrace

--- a/components/omega/src/infra/OmegaKokkos.h
+++ b/components/omega/src/infra/OmegaKokkos.h
@@ -57,9 +57,10 @@ template <class T> constexpr ArrayDataType checkArrayType() {
 
 // determine ArrayMemLoc from Kokkos array type
 template <class T> constexpr ArrayMemLoc findArrayMemLoc() {
-   if (std::is_same_v<MemSpace, HostMemSpace>) {
+   if constexpr (std::is_same_v<MemSpace, HostMemSpace>) {
       return ArrayMemLoc::Both;
-   } else if (T::is_hostspace) {
+   } else if constexpr (std::is_same_v<typename T::memory_space,
+                                       HostMemSpace>) {
       return ArrayMemLoc::Host;
    } else {
       return ArrayMemLoc::Device;


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
This draft PR updates Omega C++ standard to C++20. E3SM is in the process to upgrading to Kokkos 5, which requires C++20. This PR has the necessary fixes on the Omega side.
<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [ ] Indicate "All tests passed" or document failing tests
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


