### PR TITLE
Add an SSH check to VertCoordTest

### DIFF
--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -245,7 +245,7 @@ int main(int argc, char *argv[]) {
       DefVertCoord->computeGeomZHeight(PseudoThickness, SpecVol);
       auto GeomZInterfH = createHostMirrorCopy(DefVertCoord->GeomZInterface);
       auto GeomZMidH    = createHostMirrorCopy(DefVertCoord->GeomZMid);
-      auto SshCellH = createHostMirrorCopy(DefVertCoord->SshCell);
+      auto SshCellH     = createHostMirrorCopy(DefVertCoord->SshCell);
 
       /// Check results
       Err = 0;

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -245,6 +245,7 @@ int main(int argc, char *argv[]) {
       DefVertCoord->computeGeomZHeight(PseudoThickness, SpecVol);
       auto GeomZInterfH = createHostMirrorCopy(DefVertCoord->GeomZInterface);
       auto GeomZMidH    = createHostMirrorCopy(DefVertCoord->GeomZMid);
+      auto SshCellH = createHostMirrorCopy(DefVertCoord->SshCell);
 
       /// Check results
       Err = 0;
@@ -263,6 +264,12 @@ int main(int argc, char *argv[]) {
             if (Diff > 1e-10) {
                Err += 1;
             }
+         }
+         /// SshCell should equal ZInterface at the top of the active column
+         Real Expected = -DefVertCoord->MinLayerCellH(ICell);
+         Real Diff     = std::abs(SshCellH(ICell) - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
          }
       }
 
@@ -291,6 +298,7 @@ int main(int argc, char *argv[]) {
       /// Call functions and get host copy of output
       DefVertCoord->computeGeomZHeight(PseudoThickness, SpecVol);
       auto ZInterfH2 = createHostMirrorCopy(DefVertCoord->GeomZInterface);
+      auto SshCellH2 = createHostMirrorCopy(DefVertCoord->SshCell);
 
       /// Check results
       Err = 0;
@@ -303,6 +311,14 @@ int main(int argc, char *argv[]) {
             if (Diff > 1e-10) {
                Err += 1;
             }
+         }
+         /// SshCell should equal ZInterface at the top of the active column,
+         /// which is -((MinLayer+1)*MinLayer)/2
+         I4 MinK       = DefVertCoord->MinLayerCellH(ICell);
+         Real Expected = -((MinK + 1.0_Real) * MinK) / 2.0_Real;
+         Real Diff     = std::abs(SshCellH2(ICell) - Expected);
+         if (Diff > 1e-10) {
+            Err += 1;
          }
       }
 


### PR DESCRIPTION
Add an SSH check to VertCoordTest

Checklist
* [N/A] Documentation:
  * [N/A] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
  * [N/A] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [N/A] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [N/A] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [X] Linting
  * [X] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [X] Building
  * [X] CMake build does not produce any new warnings from changes in this PR
* [X] Testing
  * [X] Add a comment to the PR titled `Testing` with the following:
    * [X] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [N/A] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [N/A] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [X] Indicate "All tests passed" or document failing tests
    * [X] Document testing used to verify the changes including any tests that are added/modified/impacted.
    * [N/A] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
  * [N/A] New tests:
    * [N/A] CTest unit tests for new features have been added per the approved design.
    * [N/A] Polaris tests for new features have been added per the approved design (and included in a test suite)
* [N/A] Stealth Features
  * [N/A] If any stealth features are included in the PR, please confirm that they have been documented.
