### PR TITLE
Add workaround for ICE with Intel classic compiler

### DIFF
--- a/components/omega/src/infra/OmegaKokkosHiPar.h
+++ b/components/omega/src/infra/OmegaKokkosHiPar.h
@@ -34,6 +34,43 @@ constexpr int OMEGA_TEAMSIZE = 1;
 #define INNER_LAMBDA [=]
 // #define INNER_LAMBDA [&]
 
+// Workaround for ICE with the Intel classic compiler
+// To be removed as soon as Omega stops supporting it
+#define OMEGA_ISSUE_413_WORKAROUND 1
+#ifdef OMEGA_ISSUE_413_WORKAROUND
+
+template <class T> size_t TeamScratch(int N1) {
+   return ScratchArray1D<T>::shmem_size(N1);
+}
+
+template <class T1, class T2> size_t TeamScratch(int N1, int N2) {
+   return ScratchArray1D<T1>::shmem_size(N1) +
+          ScratchArray1D<T2>::shmem_size(N2);
+}
+
+template <int N> struct LaunchConfig {
+   std::array<int, N> UpperBounds;
+   int TeamSize;
+   size_t ScratchBytesPerTeam;
+
+   LaunchConfig(const int (&UpperBoundsIn)[N], int TeamSize,
+                size_t ScratchBytes)
+       : TeamSize(TeamSize), ScratchBytesPerTeam(ScratchBytes) {
+      std::copy(std::begin(UpperBoundsIn), std::end(UpperBoundsIn),
+                std::begin(UpperBounds));
+   }
+
+   LaunchConfig(const int (&UpperBounds)[N], size_t ScratchBytes)
+       : LaunchConfig(UpperBounds, OMEGA_TEAMSIZE, ScratchBytes) {}
+
+   LaunchConfig(const int (&UpperBounds)[N], int TeamSize)
+       : LaunchConfig(UpperBounds, TeamSize, 0) {}
+
+   LaunchConfig(const int (&UpperBounds)[N])
+       : LaunchConfig(UpperBounds, OMEGA_TEAMSIZE, 0) {}
+};
+#else
+
 // Helper struct for providing information about scratch memory requirements
 // TeamScratch<Real, I4>(4, 8) stores the number of bytes needed for
 // 4 values of type Real and 8 vals of type I4
@@ -71,6 +108,7 @@ template <int N> struct LaunchConfig {
    LaunchConfig(const int (&UpperBounds)[N])
        : LaunchConfig(UpperBounds, OMEGA_TEAMSIZE, TeamScratch<>{}) {}
 };
+#endif
 
 KOKKOS_INLINE_FUNCTION void teamBarrier(const TeamMember &Team) {
    Team.team_barrier();


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

Trying to fix #413.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Documentation:
  * [ ] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
  * [ ] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [ ] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [ ] Linting
  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [ ] Indicate "All tests passed" or document failing tests
    * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.
    * [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
  * [ ] New tests:
    * [ ] CTest unit tests for new features have been added per the approved design.
    * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
* [ ] Stealth Features
  * [ ] If any stealth features are included in the PR, please confirm that they have been documented.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


