### PR TITLE
Adds the spdlog library under Omega’s external folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "components/omega/external/cpptrace"]
 	path = components/omega/external/cpptrace
 	url = https://github.com/jeremy-rifkin/cpptrace.git
+[submodule "components/omega/external/spdlog"]
+	path = components/omega/external/spdlog
+	url = git@github.com:gabime/spdlog.git

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -24,8 +24,8 @@ set_target_properties(gswteos-10 PROPERTIES
 # Add the spdlog library
 if (NOT TARGET spdlog::spdlog)
 	add_subdirectory(
-	  ${E3SM_EXTERNALS_ROOT}/ekat/extern/spdlog
-	  ${CMAKE_CURRENT_BINARY_DIR}/ekat/extern/spdlog
+	  ${OMEGA_SOURCE_DIR}/external/spdlog
+	  ${CMAKE_CURRENT_BINARY_DIR}/external/spdlog
 	)
 endif()
 

--- a/components/omega/src/infra/LogFormatters.h
+++ b/components/omega/src/infra/LogFormatters.h
@@ -18,20 +18,20 @@
    struct fmt::formatter<OMEGA::ARR##DIM##TYPE>                                \
        : fmt::formatter<std::string> {                                         \
       auto format(OMEGA::ARR##DIM##TYPE my,                                    \
-                  format_context &ctx) -> decltype(ctx.out()) {                \
+                  format_context &ctx) const -> decltype(ctx.out()) {          \
          return fmt::format_to(ctx.out(), "{}({}D:{})", my.label(), my.rank(), \
                                my.size());                                     \
       }                                                                        \
    };
 #else
-#define GENERATE_FORMATTER(ARR, DIM, TYPE)                      \
-   template <>                                                  \
-   struct fmt::formatter<OMEGA::ARR##DIM##TYPE>                 \
-       : fmt::formatter<std::string> {                          \
-      auto format(OMEGA::ARR##DIM##TYPE my,                     \
-                  format_context &ctx) -> decltype(ctx.out()) { \
-         return fmt::format_to(ctx.out(), "{}", my.label());    \
-      }                                                         \
+#define GENERATE_FORMATTER(ARR, DIM, TYPE)                            \
+   template <>                                                        \
+   struct fmt::formatter<OMEGA::ARR##DIM##TYPE>                       \
+       : fmt::formatter<std::string> {                                \
+      auto format(OMEGA::ARR##DIM##TYPE my,                           \
+                  format_context &ctx) const -> decltype(ctx.out()) { \
+         return fmt::format_to(ctx.out(), "{}", my.label());          \
+      }                                                               \
    };
 #endif
 

--- a/components/omega/src/infra/Logging.cpp
+++ b/components/omega/src/infra/Logging.cpp
@@ -21,7 +21,7 @@ namespace OMEGA {
 
 //------------------------------------------------------------------------------
 // Utility function to create a log message with prefix
-std::string
+fmt::runtime_format_string<>
 _PackLogMsg(const char *file, //[in] file from where log called (cpp __FILE__)
             int line,         //[in] src code line where called (cpp __LINE__)
             const std::string &msg //[in] message text
@@ -31,11 +31,11 @@ _PackLogMsg(const char *file, //[in] file from where log called (cpp __FILE__)
    std::string path(file);
    size_t pos = path.find_last_of("\\/");
    if (pos != std::string::npos) {
-      return "[" + path.substr(pos + 1) + ":" + std::to_string(line) + "] " +
-             msg;
+      return fmt::runtime("[" + path.substr(pos + 1) + ":" +
+                          std::to_string(line) + "] " + msg);
    }
    // add prefix of form [file:line] to message string
-   return "[" + path + ":" + std::to_string(line) + "] " + msg;
+   return fmt::runtime("[" + path + ":" + std::to_string(line) + "] " + msg);
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/infra/Logging.cpp
+++ b/components/omega/src/infra/Logging.cpp
@@ -21,21 +21,21 @@ namespace OMEGA {
 
 //------------------------------------------------------------------------------
 // Utility function to create a log message with prefix
-fmt::runtime_format_string<>
-_PackLogMsg(const char *file, //[in] file from where log called (cpp __FILE__)
-            int line,         //[in] src code line where called (cpp __LINE__)
-            const std::string &msg //[in] message text
+std::string
+_PackLogMsg(const char *file, // [in] file from where log called (cpp __FILE__)
+            int line,         // [in] src code line where called (cpp __LINE__)
+            const std::string &msg // [in] message text
 ) {
-
    // find position after path where filename starts
    std::string path(file);
    size_t pos = path.find_last_of("\\/");
    if (pos != std::string::npos) {
-      return fmt::runtime("[" + path.substr(pos + 1) + ":" +
-                          std::to_string(line) + "] " + msg);
+      // add prefix of form [file:line] to message string
+      return "[" + path.substr(pos + 1) + ":" + std::to_string(line) + "] " +
+             msg;
    }
-   // add prefix of form [file:line] to message string
-   return fmt::runtime("[" + path + ":" + std::to_string(line) + "] " + msg);
+   // no path separator found, use the full file string
+   return "[" + path + ":" + std::to_string(line) + "] " + msg;
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/infra/Logging.h
+++ b/components/omega/src/infra/Logging.h
@@ -165,7 +165,7 @@ int initLogging(
 );
 
 /// Utility function to create a log message with prefix
-std::string
+fmt::runtime_format_string<>
 _PackLogMsg(const char *file, ///< [in] file where log called (cpp __FILE__)
             int line,         ///< [in] src code line where log (cpp __LINE__)
             const std::string &msg ///< [in] message text

--- a/components/omega/src/infra/Logging.h
+++ b/components/omega/src/infra/Logging.h
@@ -46,20 +46,18 @@
 /// Macro that writes a Log message when the TRACE or higher logging level is
 /// enabled. The trace label, together with the filename and line number from
 /// which the /// macro is called is pre-pended to the msg.
-#define LOG_TRACE(msg, ...)                                    \
-   spdlog::trace(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOG_TRACE(msg, ...)                                                 \
+   spdlog::trace(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                 ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOG_DEBUG(msg, ...)
 /// Macro that writes a Log message when the DEBUG or higher logging level is
 /// enabled. The debug label, together with the filename and line number from
 /// which the macro is called is pre-pended to the msg.
-#define LOG_DEBUG(msg, ...)                                    \
-   spdlog::debug(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOG_DEBUG(msg, ...)                                                 \
+   spdlog::debug(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                 ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOG_INFO(msg, ...)
@@ -67,20 +65,18 @@
 /// enabled. This is typically the default logging level. Unlike the other
 /// macros, the message is written as provided with no additional prefix.
 /// This should be used for general informational messages.
-#define LOG_INFO(msg, ...)                                    \
-   spdlog::info(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOG_INFO(msg, ...)                                                 \
+   spdlog::info(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOG_WARN(msg, ...)
 /// Macro that writes a Log message when the WARN or higher logging level is
 /// enabled. The warn label, together with the filename and line number from
 /// which the macro is called is pre-pended to the msg.
-#define LOG_WARN(msg, ...)                                    \
-   spdlog::warn(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOG_WARN(msg, ...)                                                 \
+   spdlog::warn(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 // original: define LOG_WARN(msg, ...)                                                   \
@@ -91,68 +87,60 @@
 /// Macro that writes a Log message when the ERROR or higher logging level is
 /// enabled. The error label, together with the filename and line number from
 /// which the macro is called is pre-pended to the msg.
-#define LOG_ERROR(msg, ...)                                    \
-   spdlog::error(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOG_ERROR(msg, ...)                                                 \
+   spdlog::error(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                 ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOG_CRITICAL(msg, ...)
 /// Macro that writes a Log message when the CRITICAL or higher logging level is
 /// enabled. The critical label, together with the filename and line number from
 /// which the macro is called is pre-pended to the msg.
-#define LOG_CRITICAL(msg, ...)                                    \
-   spdlog::critical(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOG_CRITICAL(msg, ...)                                                 \
+   spdlog::critical(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                    ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_TRACE(logger, msg, ...)
 /// Macro similar to LOG_TRACE but for a custom input logger.
-#define LOGGER_TRACE(logger, msg, ...)                                    \
-   logger->trace(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOGGER_TRACE(logger, msg, ...)                                      \
+   logger->trace(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                 ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_DEBUG(logger, msg, ...)
 /// Macro similar to LOG_DEBUG but for a custom input logger.
-#define LOGGER_DEBUG(logger, msg, ...)                                    \
-   logger->debug(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOGGER_DEBUG(logger, msg, ...)                                      \
+   logger->debug(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                 ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_INFO(logger, msg, ...)
 /// Macro similar to LOG_INFO but for a custom input logger.
-#define LOGGER_INFO(logger, msg, ...)                                    \
-   logger->info(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOGGER_INFO(logger, msg, ...)                                      \
+   logger->info(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_WARN(logger, msg, ...)
 /// Macro similar to LOG_WARN but for a custom input logger.
-#define LOGGER_WARN(logger, msg, ...)                                    \
-   logger->warn(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOGGER_WARN(logger, msg, ...)                                      \
+   logger->warn(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_ERROR(logger, msg, ...)
 /// Macro similar to LOG_ERROR but for a custom input logger.
-#define LOGGER_ERROR(logger, msg, ...)                                    \
-   logger->error(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOGGER_ERROR(logger, msg, ...)                                      \
+   logger->error(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                 ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_CRITICAL(logger, msg, ...)
 /// Macro similar to LOG_CRITICAL but for a custom input logger.
-#define LOGGER_CRITICAL(logger, msg, ...)                                    \
-   logger->critical(                                              \
-       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
-       ##__VA_ARGS__);                                            \
+#define LOGGER_CRITICAL(logger, msg, ...)                                      \
+   logger->critical(fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+                    ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def OMEGA_LOG_TASKS

--- a/components/omega/src/infra/Logging.h
+++ b/components/omega/src/infra/Logging.h
@@ -46,16 +46,20 @@
 /// Macro that writes a Log message when the TRACE or higher logging level is
 /// enabled. The trace label, together with the filename and line number from
 /// which the /// macro is called is pre-pended to the msg.
-#define LOG_TRACE(msg, ...)                                                   \
-   spdlog::trace(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+#define LOG_TRACE(msg, ...)                                    \
+   spdlog::trace(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOG_DEBUG(msg, ...)
 /// Macro that writes a Log message when the DEBUG or higher logging level is
 /// enabled. The debug label, together with the filename and line number from
 /// which the macro is called is pre-pended to the msg.
-#define LOG_DEBUG(msg, ...)                                                   \
-   spdlog::debug(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+#define LOG_DEBUG(msg, ...)                                    \
+   spdlog::debug(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOG_INFO(msg, ...)
@@ -63,16 +67,20 @@
 /// enabled. This is typically the default logging level. Unlike the other
 /// macros, the message is written as provided with no additional prefix.
 /// This should be used for general informational messages.
-#define LOG_INFO(msg, ...)           \
-   spdlog::info(msg, ##__VA_ARGS__); \
+#define LOG_INFO(msg, ...)                                    \
+   spdlog::info(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOG_WARN(msg, ...)
 /// Macro that writes a Log message when the WARN or higher logging level is
 /// enabled. The warn label, together with the filename and line number from
 /// which the macro is called is pre-pended to the msg.
-#define LOG_WARN(msg, ...)                                                   \
-   spdlog::warn(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+#define LOG_WARN(msg, ...)                                    \
+   spdlog::warn(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 // original: define LOG_WARN(msg, ...)                                                   \
@@ -83,54 +91,68 @@
 /// Macro that writes a Log message when the ERROR or higher logging level is
 /// enabled. The error label, together with the filename and line number from
 /// which the macro is called is pre-pended to the msg.
-#define LOG_ERROR(msg, ...)                                                   \
-   spdlog::error(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+#define LOG_ERROR(msg, ...)                                    \
+   spdlog::error(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOG_CRITICAL(msg, ...)
 /// Macro that writes a Log message when the CRITICAL or higher logging level is
 /// enabled. The critical label, together with the filename and line number from
 /// which the macro is called is pre-pended to the msg.
-#define LOG_CRITICAL(msg, ...)                                   \
-   spdlog::critical(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), \
-                    ##__VA_ARGS__);                              \
+#define LOG_CRITICAL(msg, ...)                                    \
+   spdlog::critical(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_TRACE(logger, msg, ...)
 /// Macro similar to LOG_TRACE but for a custom input logger.
-#define LOGGER_TRACE(logger, msg, ...)                                        \
-   logger->trace(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+#define LOGGER_TRACE(logger, msg, ...)                                    \
+   logger->trace(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_DEBUG(logger, msg, ...)
 /// Macro similar to LOG_DEBUG but for a custom input logger.
-#define LOGGER_DEBUG(logger, msg, ...)                                        \
-   logger->debug(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+#define LOGGER_DEBUG(logger, msg, ...)                                    \
+   logger->debug(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_INFO(logger, msg, ...)
 /// Macro similar to LOG_INFO but for a custom input logger.
-#define LOGGER_INFO(logger, msg, ...)                                        \
-   logger->info(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+#define LOGGER_INFO(logger, msg, ...)                                    \
+   logger->info(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_WARN(logger, msg, ...)
 /// Macro similar to LOG_WARN but for a custom input logger.
-#define LOGGER_WARN(logger, msg, ...)                                        \
-   logger->warn(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+#define LOGGER_WARN(logger, msg, ...)                                    \
+   logger->warn(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_ERROR(logger, msg, ...)
 /// Macro similar to LOG_ERROR but for a custom input logger.
-#define LOGGER_ERROR(logger, msg, ...)                                        \
-   logger->error(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), ##__VA_ARGS__); \
+#define LOGGER_ERROR(logger, msg, ...)                                    \
+   logger->error(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def LOGGER_CRITICAL(logger, msg, ...)
 /// Macro similar to LOG_CRITICAL but for a custom input logger.
-#define LOGGER_CRITICAL(logger, msg, ...)                        \
-   logger->critical(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg), \
-                    ##__VA_ARGS__);                              \
+#define LOGGER_CRITICAL(logger, msg, ...)                                    \
+   logger->critical(                                              \
+       fmt::runtime(OMEGA::_PackLogMsg(__FILE__, __LINE__, msg)), \
+       ##__VA_ARGS__);                                            \
    _LOG_FLUSH
 
 /// \def OMEGA_LOG_TASKS
@@ -165,7 +187,7 @@ int initLogging(
 );
 
 /// Utility function to create a log message with prefix
-fmt::runtime_format_string<>
+std::string
 _PackLogMsg(const char *file, ///< [in] file where log called (cpp __FILE__)
             int line,         ///< [in] src code line where log (cpp __LINE__)
             const std::string &msg ///< [in] message text

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -163,7 +163,7 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    // Make host copies for device arrays not being read from file
    PressureInterfaceH     = createHostMirrorCopy(PressureInterface);
    PressureMidH           = createHostMirrorCopy(PressureMid);
-   SshCellH               = createHostMirrorCopy(SshCellH);
+   SshCellH               = createHostMirrorCopy(SshCell);
    GeomZInterfaceH        = createHostMirrorCopy(GeomZInterface);
    GeomZMidH              = createHostMirrorCopy(GeomZMid);
    GeopotentialMidH       = createHostMirrorCopy(GeopotentialMid);
@@ -540,7 +540,12 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
 
       // Validate InitalVertCoord stream
       auto VCoordStream = IOStream::get(StreamName);
-      bool IsValidated  = VCoordStream->validate();
+      if (VCoordStream == nullptr)
+         ABORT_ERROR("VertCoord: IO stream '{}' is not defined", StreamName);
+      bool IsValidated = VCoordStream->validate();
+
+     // auto VCoordStream = IOStream::get(StreamName);
+      //bool IsValidated  = VCoordStream->validate();
 
       // Read InitialVertCoord stream
       if (IsValidated) {

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -544,8 +544,8 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
          ABORT_ERROR("VertCoord: IO stream '{}' is not defined", StreamName);
       bool IsValidated = VCoordStream->validate();
 
-     // auto VCoordStream = IOStream::get(StreamName);
-      //bool IsValidated  = VCoordStream->validate();
+      // auto VCoordStream = IOStream::get(StreamName);
+      // bool IsValidated  = VCoordStream->validate();
 
       // Read InitialVertCoord stream
       if (IsValidated) {


### PR DESCRIPTION
This PR adds the `spdlog` library under Omega’s external folder because the library is no longer provided through Ekat.

The changes include updates to the Omega logging module to support the latest formatting API in `spdlog`. It also fixes a simple typo.

7 out of 40 `CTest` items failed on PM-GPU. However, based on the Omega logs, the failures are likely unrelated to this PR and are being tracked separately at [https://github.com/E3SM-Project/Omega/issues/420](https://github.com/E3SM-Project/Omega/issues/420). Without this PR being merged, it may be difficult to debug other issues because the Omega build fails.

Fixes: https://github.com/E3SM-Project/Omega/issues/419, https://github.com/E3SM-Project/Omega/issues/417
