### PR TITLE
Disable SSH gradient tendency by default

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -41,7 +41,8 @@ Omega:
     ThicknessFluxTendencyEnable: true
     PVTendencyEnable: true
     KETendencyEnable: true
-    SSHTendencyEnable: true
+    # Only appropriate for shallow water (Omega v0) simulations
+    SSHTendencyEnable: false
     VelDiffTendencyEnable: true
     ViscDel2: 1.0e3
     VelHyperDiffTendencyEnable: true

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -163,6 +163,7 @@ class KEGradOnEdge {
 
 /// Gradient of sea surface height defined on edges multipled by gravitational
 /// acceleration, for momentum equation
+/// NOTE: This term is only appropriate for shallow water (Omega v0) simulations
 class SSHGradOnEdge {
  public:
    bool Enabled = false;


### PR DESCRIPTION
This term is not correct for the non-Boussinesq equations and should not be used in Omega v1.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #423 