### PR TITLE
modification to Halo error handling and cleanup

### DIFF
--- a/components/omega/src/base/Halo.cpp
+++ b/components/omega/src/base/Halo.cpp
@@ -130,16 +130,14 @@ Halo::Neighbor::Neighbor(
 // Initialize and construct the default Halo. MachEnv and Decomp must already
 // be initialized
 
-int Halo::init() {
-
-   I4 IErr{0}; // error code
+void Halo::init() {
 
    MachEnv *DefEnv   = MachEnv::getDefault();
    Decomp *DefDecomp = Decomp::getDefault();
 
    Halo::DefaultHalo = create("Default", DefEnv, DefDecomp);
 
-   return IErr;
+   return;
 
 } // End Halo init
 
@@ -147,10 +145,10 @@ int Halo::init() {
 //------------------------------------------------------------------------------
 // Construct a Halo for the input Name, MachEnv, and Decomp.
 
-Halo::Halo(const std::string &Name, const MachEnv *InEnv,
-           const Decomp *InDecomp) {
-
-   I4 IErr{0}; // error code
+Halo::Halo(const std::string &Name, // [in] name for halo
+           const MachEnv *InEnv,    // [in] machine environment
+           const Decomp *InDecomp   // [in] domain decomposition
+) {
 
    // Set pointer for the Decomp
    MyDecomp = InDecomp;
@@ -175,20 +173,12 @@ Halo::Halo(const std::string &Name, const MachEnv *InEnv,
    std::vector<std::vector<std::vector<I4>>> SendVrtxLists;
 
    // Determine which tasks are neighbors to the local task
-   IErr = determineNeighbors(NumTasks);
-   if (IErr != 0)
-      LOG_ERROR("Halo: Error determining neighbors");
+   determineNeighbors(NumTasks);
 
    // Generate the exchange lists for each neighboring task in each index space
-   IErr = generateExchangeLists(SendCellLists, RecvCellLists, OnCell);
-   if (IErr != 0)
-      LOG_ERROR("Halo: Error generating exchange lists for Cells");
-   IErr = generateExchangeLists(SendEdgeLists, RecvEdgeLists, OnEdge);
-   if (IErr != 0)
-      LOG_ERROR("Halo: Error generating exchange lists for Edges");
-   IErr = generateExchangeLists(SendVrtxLists, RecvVrtxLists, OnVertex);
-   if (IErr != 0)
-      LOG_ERROR("Halo: Error generating exchange lists for Vertices");
+   generateExchangeLists(SendCellLists, RecvCellLists, OnCell);
+   generateExchangeLists(SendEdgeLists, RecvEdgeLists, OnEdge);
+   generateExchangeLists(SendVrtxLists, RecvVrtxLists, OnVertex);
 
    // Construct the Neighbor objects and save them in class member Neighbors
    for (int INghbr = 0; INghbr < NNghbr; ++INghbr) {
@@ -200,18 +190,19 @@ Halo::Halo(const std::string &Name, const MachEnv *InEnv,
 
 } // end Halo constructor
 
-/// Creates a new halo by calling the constructor and puts it in the AllHalos
-/// map
-Halo *Halo::create(const std::string &Name, const MachEnv *Env,
-                   const Decomp *Decomp) {
+//------------------------------------------------------------------------------
+// Creates a new halo by calling the constructor and puts it in the AllHalos
+// map
+Halo *Halo::create(const std::string &Name, // [in] name for halo
+                   const MachEnv *Env,      // [in] machine environment
+                   const Decomp *Decomp     // [in] domain decomposition
+) {
    // Check to see if a halo of the same name already exists and
    // if so, exit with an error
-   if (AllHalos.find(Name) != AllHalos.end()) {
-      LOG_ERROR("Attempted to create a Halo with name {} but a Halo of "
-                "that name already exists",
-                Name);
-      return nullptr;
-   }
+   if (AllHalos.find(Name) != AllHalos.end())
+      ABORT_ERROR("Attempted to create a Halo with name {} but a Halo of "
+                  "that name already exists",
+                  Name);
 
    // create a new halo on the heap and put it in a map of
    // unique_ptrs, which will manage its lifetime
@@ -234,7 +225,7 @@ Halo::~Halo() {
 //------------------------------------------------------------------------------
 // Removes a Halo from AllHalos map and destroys it
 
-void Halo::erase(std::string InName // name of Halo to remove
+void Halo::erase(std::string InName // [in] name of Halo to remove
 ) {
 
    AllHalos.erase(InName); // removes the Halo from the map and in
@@ -262,21 +253,21 @@ Halo *Halo::getDefault() { return Halo::DefaultHalo; }
 //------------------------------------------------------------------------------
 // Get Halo by name
 
-Halo *Halo::get(const std::string Name // name of Halo to retrieve
+Halo *Halo::get(const std::string Name // [in] name of Halo to retrieve
 ) {
 
    // look for an instance of this name
    auto it = AllHalos.find(Name);
 
-   // if found, return the Halo pointer
-   if (it != AllHalos.end()) {
-      return it->second.get();
-   } else {
-      // otherwise print an error and retrun a null pointer
-      LOG_ERROR("Halo::get: Attempt to retrieve non-existent Halo:");
-      LOG_ERROR(" {} has not been defined or has been removed", Name);
-      return nullptr;
-   }
+   // if not found, abort with error
+   if (it == AllHalos.end())
+      ABORT_ERROR("Halo::get: Attempt to retrieve non-existent Halo:"
+                  " {} has not been defined or has been removed",
+                  Name);
+
+   // return found halo
+   return it->second.get();
+
 } // end Halo get
 
 //------------------------------------------------------------------------------
@@ -287,10 +278,7 @@ MPI_Comm Halo::getComm() const { return MyComm; }
 // Sets Halo class members NeighborList, NNghbr, SendFlags, and RecvFlags during
 // Halo construction
 
-int Halo::determineNeighbors(const I4 NumTasks) {
-
-   I4 IErr{0}; // internal error code
-   I4 Err{0};  // error code to return
+void Halo::determineNeighbors(const I4 NumTasks) {
 
    NeighborList.clear();
 
@@ -329,12 +317,10 @@ int Halo::determineNeighbors(const I4 NumTasks) {
    // perform all to all with all tasks in MyComm in order to determine if there
    // are any tasks that need elements from the local task that the local task
    // does not already consider a neighbor
-   IErr =
+   I4 IErr =
        MPI_Alltoall(&HaloAll[0], 1, MPI_INT, &OwnedAll[0], 1, MPI_INT, MyComm);
-   if (IErr != 0) {
-      LOG_ERROR("Halo: MPI_Alltoall error");
-      Err = -1;
-   }
+   if (IErr != MPI_SUCCESS)
+      ABORT_ERROR("Halo:determine neighbors MPI_Alltoall error");
 
    // set vector of IDs for all tasks that need locally owned elements for
    // their halos
@@ -357,18 +343,19 @@ int Halo::determineNeighbors(const I4 NumTasks) {
    setNeighborFlags(EdgeTasks, OnEdge);
    setNeighborFlags(VertexTasks, OnVertex);
 
-   return Err;
+   return;
 }
 
 //------------------------------------------------------------------------------
 // Using input decomposition info for a particular index space, generate a
 // sorted list of the tasks that own elements in the Halo of the local task
 
-int Halo::generateListOfTasksInHalo(const I4 NOwned, const I4 NAll,
-                                    HostArray2DI4 Loc,
-                                    std::vector<I4> &ListOfTasks) {
-
-   I4 Err{0}; // error code to return
+void Halo::generateListOfTasksInHalo(
+    const I4 NOwned,             // [in] number of owned elements
+    const I4 NAll,               // [in] total num of elements (incl halo)
+    HostArray2DI4 Loc,           // [in] location of each element
+    std::vector<I4> &ListOfTasks // [out] list of tasks needed for halo
+) {
 
    // search through halo elements in input Loc array to find each unique
    // task ID and save in ListOfTasks
@@ -381,7 +368,7 @@ int Halo::generateListOfTasksInHalo(const I4 NOwned, const I4 NAll,
 
    std::sort(ListOfTasks.begin(), ListOfTasks.end());
 
-   return Err;
+   return;
 }
 
 //------------------------------------------------------------------------------
@@ -389,10 +376,9 @@ int Halo::generateListOfTasksInHalo(const I4 NOwned, const I4 NAll,
 // which Neighbors in NeighborList the local task needs to send elements to or
 // receive elements from during a halo exchange
 
-int Halo::setNeighborFlags(std::vector<I4> ListOfTasks,
-                           const MeshElement IdxSpace) {
-
-   I4 Err{0}; // error code to return
+void Halo::setNeighborFlags(std::vector<I4> ListOfTasks, // task list for halo
+                            const MeshElement IdxSpace   // [in] index space
+) {
 
    // allocate size of SendFlags and RecvFlags
    SendFlags[IdxSpace].resize(NNghbr);
@@ -417,32 +403,37 @@ int Halo::setNeighborFlags(std::vector<I4> ListOfTasks,
    std::vector<MPI_Request> RecvReqs(NNghbr);
    std::vector<MPI_Request> SendReqs(NNghbr);
 
+   Error SendRecvErr;
    for (int INghbr = 0; INghbr < NNghbr; ++INghbr) {
       RecvErr[INghbr] = MPI_Irecv(&SendFlags[IdxSpace][INghbr], 1, MPI_INT,
                                   NeighborList[INghbr], MPI_ANY_TAG, MyComm,
                                   &RecvReqs[INghbr]);
-      if (RecvErr[INghbr] != 0) {
-         LOG_ERROR("MPI error {} on task {} receive from task {}",
-                   RecvErr[INghbr], MyTask, NeighborList[INghbr]);
-         Err = -1;
-      }
+      if (RecvErr[INghbr] != 0)
+         SendRecvErr += Error(ErrorCode::Fail,
+                              "Halo::setNeighborFlags: "
+                              "MPI error {} on task {} receive from task {}",
+                              RecvErr[INghbr], MyTask, NeighborList[INghbr]);
    }
 
    for (int INghbr = 0; INghbr < NNghbr; ++INghbr) {
       SendErr[INghbr] =
           MPI_Isend(&RecvFlags[IdxSpace][INghbr], 1, MPI_INT,
                     NeighborList[INghbr], 0, MyComm, &SendReqs[INghbr]);
-      if (SendErr[INghbr] != 0) {
-         LOG_ERROR("MPI error {} on task {} send to task {}", SendErr[INghbr],
-                   MyTask, NeighborList[INghbr]);
-         Err = -1;
-      }
+      if (SendErr[INghbr] != 0)
+         SendRecvErr += Error(ErrorCode::Fail,
+                              "Halo::setNeighborFlags: "
+                              "MPI error {} on task {} send to task {}",
+                              SendErr[INghbr], MyTask, NeighborList[INghbr]);
    }
+
+   // Abort on any errors encountered
+   CHECK_ERROR_ABORT(SendRecvErr,
+                     "Halo::setNeighborFlags encountered MPI errors");
 
    MPI_Waitall(NNghbr, SendReqs.data(), MPI_STATUS_IGNORE);
    MPI_Waitall(NNghbr, RecvReqs.data(), MPI_STATUS_IGNORE);
 
-   return Err;
+   return;
 }
 
 //------------------------------------------------------------------------------
@@ -453,12 +444,10 @@ int Halo::setNeighborFlags(std::vector<I4> ListOfTasks,
 // remaining 2D vector is passed to the Neighbor constructor for that
 // neighboring task.
 
-int Halo::generateExchangeLists(
+void Halo::generateExchangeLists(
     std::vector<std::vector<std::vector<I4>>> &SendLists,
     std::vector<std::vector<std::vector<I4>>> &RecvLists,
     const MeshElement IndexSpace) {
-
-   I4 IErr{0}; // error code
 
    // Pointers to the needed info from the Decomp for the input index space
    const I4 *NOwnedPtr{nullptr};
@@ -562,7 +551,7 @@ int Halo::generateExchangeLists(
                                              std::vector<I4>(NumLayers, 0));
 
    // Exchange halo sizes with neighboring tasks.
-   IErr = exchangeVectorInt(NumNghbrHalo, NumLocalHalo);
+   exchangeVectorInt(NumNghbrHalo, NumLocalHalo);
 
    // Now that the number of locally owned elements that belong to the halos
    // of neighboring tasks is known, allocate space to receive this info.
@@ -578,7 +567,7 @@ int Halo::generateExchangeLists(
    // Send indices of elements needed by the local halo and receive
    // the indices of elements locally owned that are needed by the
    // halos of neighboring tasks.
-   IErr = exchangeVectorInt(HaloIdx, OwnedIdx);
+   exchangeVectorInt(HaloIdx, OwnedIdx);
 
    // Sort out the received lists of indices by halo layer and save
    // in SendLists, these are now ready to construct the ExchList
@@ -597,7 +586,7 @@ int Halo::generateExchangeLists(
       }
    }
 
-   return IErr;
+   return;
 } // end generateExchangeLists
 
 //------------------------------------------------------------------------------
@@ -608,7 +597,7 @@ int Halo::generateExchangeLists(
 // This communication is done using nonblocking MPI routines MPI_Isend
 // and MPI_Irecv
 
-int Halo::exchangeVectorInt(
+void Halo::exchangeVectorInt(
     const std::vector<std::vector<I4>> &SendVec, // vector of vectors to send
     std::vector<std::vector<I4>> &RecvVec // space to receive sent vectors
 ) {
@@ -617,7 +606,7 @@ int Halo::exchangeVectorInt(
    std::vector<I4> SendErr(NNghbr, 0);
    std::vector<I4> RecvErr(NNghbr, 0);
 
-   I4 Err{0}; // error code to return
+   Error SendRecvErr; // error code for accumulating MPI errors
 
    // initialize vectors of MPI_Request variables to control non-blocking
    // MPI communications
@@ -629,11 +618,11 @@ int Halo::exchangeVectorInt(
       RecvErr[INghbr] = MPI_Irecv(RecvVec[INghbr].data(), DimLen, MPI_INT,
                                   NeighborList[INghbr], MPI_ANY_TAG, MyComm,
                                   &RecvReqs[INghbr]);
-      if (RecvErr[INghbr] != 0) {
-         LOG_ERROR("MPI error {} on task {} receive from task {}",
-                   RecvErr[INghbr], MyTask, NeighborList[INghbr]);
-         Err = -1;
-      }
+      if (RecvErr[INghbr] != 0)
+         SendRecvErr += Error(ErrorCode::Fail,
+                              "Halo::exchangeVectorInt "
+                              "MPI error {} on task {} receive from task {}",
+                              RecvErr[INghbr], MyTask, NeighborList[INghbr]);
    }
 
    for (int INghbr = 0; INghbr < NNghbr; ++INghbr) {
@@ -641,29 +630,33 @@ int Halo::exchangeVectorInt(
       SendErr[INghbr] =
           MPI_Isend(SendVec[INghbr].data(), DimLen, MPI_INT,
                     NeighborList[INghbr], 0, MyComm, &SendReqs[INghbr]);
-      if (SendErr[INghbr] != 0) {
-         LOG_ERROR("MPI error {} on task {} send to task {}", SendErr[INghbr],
-                   MyTask, NeighborList[INghbr]);
-         Err = -1;
-      }
+      if (SendErr[INghbr] != 0)
+         SendRecvErr += Error(ErrorCode::Fail,
+                              "Halo::exchangeVectorInt "
+                              "MPI error {} on task {} send to task {}",
+                              SendErr[INghbr], MyTask, NeighborList[INghbr]);
    }
+
+   // Abort on any send/recv errors
+   CHECK_ERROR_ABORT(SendRecvErr,
+                     "Halo::exchangeVectorInt: MPI errors during send/recv");
 
    MPI_Waitall(NNghbr, SendReqs.data(), MPI_STATUS_IGNORE);
    MPI_Waitall(NNghbr, RecvReqs.data(), MPI_STATUS_IGNORE);
 
-   return Err;
+   return;
 } // end exchangeVectorInt
 
 //------------------------------------------------------------------------------
 // Allocate the required receive buffer and prepare for MPI communication by
 // calling MPI_Irecv for each Neighbor
 
-int Halo::startReceives(const bool UseDevBuffer) {
+void Halo::startReceives(const bool UseDevBuffer) {
 
    // Initialize vector to track MPI errors for each MPI_Irecv
    std::vector<I4> IErr(NNghbr, 0);
 
-   I4 Err{0}; // Error code to return
+   Error RecvErr; // Accumulated error codes for receives
 
    for (int INghbr = 0; INghbr < NNghbr; ++INghbr) {
       if (RecvFlags[CurElem][INghbr]) {
@@ -686,27 +679,29 @@ int Halo::startReceives(const bool UseDevBuffer) {
          IErr[INghbr] =
              MPI_Irecv(DataPtr, BufferSize, MPI_DOUBLE, LocNeighbor.TaskID,
                        MPI_ANY_TAG, MyComm, &LocNeighbor.RReq);
-         if (IErr[INghbr] != 0) {
-            LOG_ERROR("MPI error {} on task {} receive from task {}",
-                      IErr[INghbr], MyTask, LocNeighbor.TaskID);
-            Err = -1;
-         }
+         if (IErr[INghbr] != 0)
+            RecvErr += Error(ErrorCode::Fail,
+                             "Halo::startReceives: "
+                             "MPI error {} on task {} receive from task {}",
+                             IErr[INghbr], MyTask, LocNeighbor.TaskID);
       }
    }
 
-   return Err;
+   CHECK_ERROR_ABORT(RecvErr, "Halo::startReceives: MPI errors during Irecv");
+
+   return;
 } // end startReceives
 
 //------------------------------------------------------------------------------
 // Initiate MPI communication by calling MPI_Isend for each Neighbor to send
 // the packed buffers to each task
 
-int Halo::startSends(const bool UseDevBuffer) {
+void Halo::startSends(const bool UseDevBuffer) {
 
    // Initialize vector to track MPI errors for each MPI_Isend
    std::vector<I4> IErr(NNghbr, 0);
 
-   I4 Err{0}; // Error code to return
+   Error SendErr; // accumulated error codes for sends
 
    if (UseDevBuffer)
       Kokkos::fence();
@@ -746,15 +741,17 @@ int Halo::startSends(const bool UseDevBuffer) {
          IErr[INghbr] =
              MPI_Isend(DataPtr, BufferSize, MPI_DOUBLE, LocNeighbor.TaskID, 0,
                        MyComm, &LocNeighbor.SReq);
-         if (IErr[INghbr] != 0) {
-            LOG_ERROR("MPI error {} on task {} send to task {}", IErr[INghbr],
-                      MyTask, LocNeighbor.TaskID);
-            Err = -1;
-         }
+         if (IErr[INghbr] != 0)
+            SendErr += Error(ErrorCode::Fail,
+                             "Halo::startSends: "
+                             "MPI error {} on task {} send to task {}",
+                             IErr[INghbr], MyTask, LocNeighbor.TaskID);
       }
    }
 
-   return Err;
+   CHECK_ERROR_ABORT(SendErr,
+                     "Halo::startSends: errors encountered in MPI_Isend");
+   return;
 } // end startSends
 
 } // end namespace OMEGA

--- a/components/omega/src/base/Halo.h
+++ b/components/omega/src/base/Halo.h
@@ -20,7 +20,7 @@
 
 #include "DataTypes.h"
 #include "Decomp.h"
-#include "Logging.h"
+#include "Error.h"
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
@@ -44,9 +44,11 @@ static const MPI_Datatype MPI_RealKind = MPI_DOUBLE;
 /// The MeshElement enum identifies the index space to use for a halo exchange.
 enum MeshElement { OnCell, OnEdge, OnVertex };
 
-// Conditionally resize MPI buffer if it is not large enough
+/// Conditionally resize MPI buffer if it is not large enough
 template <class BufferType>
-void expandBuffer(BufferType &Buffer, int BufferSize) {
+void expandBuffer(BufferType &Buffer, ///< [inout] buffer to resize
+                  int BufferSize      ///< [in] new size for buffer
+) {
    if (Buffer.extent_int(0) < BufferSize) {
       Buffer = BufferType(Buffer.label(), BufferSize);
    }
@@ -171,10 +173,10 @@ class Halo {
       /// objects, as well as the ID of the neighboring task.
       Neighbor(const std::vector<std::vector<I4>> &SendCell,
                const std::vector<std::vector<I4>> &SendEdge,
-               const std::vector<std::vector<I4>> &SendVert,
+               const std::vector<std::vector<I4>> &SendVrtx,
                const std::vector<std::vector<I4>> &RecvCell,
                const std::vector<std::vector<I4>> &RecvEdge,
-               const std::vector<std::vector<I4>> &RecvVert, const I4 NghbrID);
+               const std::vector<std::vector<I4>> &RecvVrtx, const I4 NghbrID);
 
     public:
       /// Destructor
@@ -191,26 +193,34 @@ class Halo {
    /// Uses info from Decomp to generate a sorted list of tasks that own
    /// elements in the the Halo of the local task for a particular index space.
    /// Utilized only during halo construction
-   int generateListOfTasksInHalo(const I4 NOwned, const I4 NAll,
-                                 HostArray2DI4 Locs,
-                                 std::vector<I4> &ListOfTasks);
+   void generateListOfTasksInHalo(
+       const I4 NOwned,             ///< [in] num of owned elements
+       const I4 NAll,               ///< [in] tot num of elements (incl halo)
+       HostArray2DI4 Locs,          ///< [in] location of elements
+       std::vector<I4> &ListOfTasks ///< [out] tasks needed
+   );
 
    /// Set SendFlags and RecvFlags for the input index space. Utilized only
    /// during halo construction
-   int setNeighborFlags(std::vector<I4> NeighborElem,
-                        const MeshElement IdxSpace);
+   void
+   setNeighborFlags(std::vector<I4> NeighborElem, ///< [out] list of nbr flags
+                    const MeshElement IdxSpace    ///< [in] index space for halo
+   );
 
    /// Uses info from Decomp to determine all tasks which own elements in the
    /// halo of the local task or need locally owned elements for their halo.
    /// Utilized only during halo construction
-   int determineNeighbors(const I4 NumTasks);
+   void determineNeighbors(const I4 NumTasks ///< [in] num of tasks in decomp
+   );
 
    /// Send a vector of integers to each neighboring task and receive a vector
    /// of integers from each neighboring task. The first dimension of each
    /// input 2D vector represents the task in the order they appear in
    /// NeighborList. Utilized only during halo construction
-   int exchangeVectorInt(const std::vector<std::vector<I4>> &SendVec,
-                         std::vector<std::vector<I4>> &RecvVec);
+   void exchangeVectorInt(
+       const std::vector<std::vector<I4>> &SendVec, ///< [in] vec to send
+       std::vector<std::vector<I4>> &RecvVec        ///< [out] vec to recv
+   );
 
    /// Generate the lists of indices to send to and receive from each
    /// neighboring task for the input IndexSpace and the Decomp pointed to
@@ -219,7 +229,7 @@ class Halo {
    /// represent the task in the order they appear in NeighborList, and the
    /// remaining 2D vector is used in constructing a Neighbor object for
    /// that task. Utilized only during halo construction
-   int
+   void
    generateExchangeLists(std::vector<std::vector<std::vector<I4>>> &SendLists,
                          std::vector<std::vector<std::vector<I4>>> &RecvLists,
                          const MeshElement IndexSpace);
@@ -227,12 +237,12 @@ class Halo {
    /// Allocate the recieve buffers and call MPI_Irecv for each Neighbor.
    /// The input bool UseDevBuffer specifies whether or not the device buffer
    /// will be used in the unpackBuffer functionfor unpacking into the array.
-   int startReceives(bool UseDevBuffer);
+   void startReceives(bool UseDevBuffer);
 
    /// Call MPI_Isend for each Neighbor to send the packed buffers to the
    /// neighboring tasks. The input bool UseDevBuffer specifies whether or not
    /// the device buffer was packed in the packBuffer function.
-   int startSends(bool UseDevBuffer);
+   void startSends(bool UseDevBuffer);
 
    /// Function template that returns a bool that is true if the Array is
    /// on the device, or if the device and host memory spaces are the same
@@ -244,8 +254,11 @@ class Halo {
       return OnDev;
    }
 
-   /// Construct a new halo labeled Name for the input MachEnv and Decomp
-   Halo(const std::string &Name, const MachEnv *InEnv, const Decomp *InDecomp);
+   /// Construct a new halo
+   Halo(const std::string &Name, ///< [in] name for new halo
+        const MachEnv *InEnv,    ///< [in] machine environment
+        const Decomp *InDecomp   ///< [in] domain decomposition
+   );
 
    // Forbid copy and move construction
    Halo(const Halo &) = delete;
@@ -255,12 +268,14 @@ class Halo {
    // Methods
 
    /// initialize default Halo
-   static int init();
+   static void init();
 
    /// Creates a new halo by calling the constructor and puts it in the AllHalos
    /// map
-   static Halo *create(const std::string &Name, const MachEnv *Env,
-                       const Decomp *Decomp);
+   static Halo *create(const std::string &Name, ///< [in] name for halo
+                       const MachEnv *Env,      ///< [in] machine environment
+                       const Decomp *Decomp     ///< [in] domain decomposition
+   );
 
    /// Destructor
    ~Halo();
@@ -276,19 +291,21 @@ class Halo {
    static Halo *getDefault();
 
    /// Retrieves a pointer to a Halo object by Name
-   static Halo *get(std::string Name);
+   static Halo *get(std::string Name ///< [in] name of halo to retrieve
+   );
 
    /// Retrieves MPI communicator from a Halo object
    MPI_Comm getComm() const;
 
+   //---------------------------------------------------------------------------
    /// Buffer pack specialized function templates for supported Kokkos array
    /// ranks. Select out the proper elements from the input Array to send to a
    /// neighboring task and pack them into the proper send buffer for
    /// that Neighbor.
    template <typename T>
    std::enable_if_t<ArrayRank<T>::Is1D>
-   packBuffer(const T &Array,      // 1D Kokkos array of any type
-              const I4 CurNeighbor // current neighbor
+   packBuffer(const T &Array,      ///< [in] 1D Kokkos array of any type
+              const I4 CurNeighbor ///< [in] current neighbor
    ) {
       using ValType = typename T::non_const_value_type;
 
@@ -323,8 +340,8 @@ class Halo {
 
    template <typename T>
    std::enable_if_t<ArrayRank<T>::Is2D>
-   packBuffer(const T &Array,      // 2D Kokkos array of any type
-              const I4 CurNeighbor // current neighbor
+   packBuffer(const T &Array,      ///< [in] 2D Kokkos array of any type
+              const I4 CurNeighbor ///< [in] current neighbor
    ) {
 
       using ValType = typename T::non_const_value_type;
@@ -367,8 +384,8 @@ class Halo {
 
    template <typename T>
    std::enable_if_t<ArrayRank<T>::Is3D>
-   packBuffer(const T &Array,      // 3D Kokkos array of any type
-              const I4 CurNeighbor // current neighbor
+   packBuffer(const T &Array,      ///< [in] 3D Kokkos array of any type
+              const I4 CurNeighbor ///< [in] current neighbor
    ) {
 
       using ValType = typename T::non_const_value_type;
@@ -415,8 +432,8 @@ class Halo {
 
    template <typename T>
    std::enable_if_t<ArrayRank<T>::Is4D>
-   packBuffer(const T &Array,      // 4D Kokkos array of any type
-              const I4 CurNeighbor // current neighbor
+   packBuffer(const T &Array,      ///< [in] 4D Kokkos array of any type
+              const I4 CurNeighbor ///< [in] current neighbor
    ) {
 
       using ValType = typename T::non_const_value_type;
@@ -468,8 +485,8 @@ class Halo {
 
    template <typename T>
    std::enable_if_t<ArrayRank<T>::Is5D>
-   packBuffer(const T &Array,      // 5D Kokkos array of any type
-              const I4 CurNeighbor // current neighbor
+   packBuffer(const T &Array,      ///< [in] 5D Kokkos array of any type
+              const I4 CurNeighbor ///< [in] current neighbor
    ) {
 
       using ValType = typename T::non_const_value_type;
@@ -524,14 +541,15 @@ class Halo {
       }
    }
 
+   //---------------------------------------------------------------------------
    /// Buffer unpack specialized function templates for supported Kokkos array
    /// ranks. After receiving a message from a neighboring task, save the
    /// elements of the proper receive buffer for that Neighbor into the
    /// corresponding halo elements of the input Array
    template <typename T>
    std::enable_if_t<ArrayRank<T>::Is1D>
-   unpackBuffer(const T &Array,      // 1D Kokkos array of any type
-                const I4 CurNeighbor // current neighbor
+   unpackBuffer(const T &Array,      ///< [inout] 1D Kokkos array of any type
+                const I4 CurNeighbor ///< [in] current neighbor
    ) {
 
       using ValType = typename T::non_const_value_type;
@@ -565,8 +583,8 @@ class Halo {
 
    template <typename T>
    std::enable_if_t<ArrayRank<T>::Is2D>
-   unpackBuffer(const T &Array,      // 2D Kokkos array of any type
-                const I4 CurNeighbor // current neighbor
+   unpackBuffer(const T &Array,      ///< [inout] 2D Kokkos array of any type
+                const I4 CurNeighbor ///< [in] current neighbor
    ) {
 
       using ValType = typename T::non_const_value_type;
@@ -607,8 +625,8 @@ class Halo {
 
    template <typename T>
    std::enable_if_t<ArrayRank<T>::Is3D>
-   unpackBuffer(const T &Array,      // 3D Kokkos array of any type
-                const I4 CurNeighbor // current neighbor
+   unpackBuffer(const T &Array,      ///< [inout] 3D Kokkos array of any type
+                const I4 CurNeighbor ///< [in] current neighbor
    ) {
 
       using ValType = typename T::non_const_value_type;
@@ -654,8 +672,8 @@ class Halo {
 
    template <typename T>
    std::enable_if_t<ArrayRank<T>::Is4D>
-   unpackBuffer(const T &Array,      // 4D Kokkos array of any type
-                const I4 CurNeighbor // current neighbor
+   unpackBuffer(const T &Array,      ///< [inout] 4D Kokkos array of any type
+                const I4 CurNeighbor ///< [in] current neighbor
    ) {
 
       using ValType = typename T::non_const_value_type;
@@ -706,8 +724,8 @@ class Halo {
 
    template <typename T>
    std::enable_if_t<ArrayRank<T>::Is5D>
-   unpackBuffer(const T &Array,      // 5D Kokkos array of any type
-                const I4 CurNeighbor // current neighbor
+   unpackBuffer(const T &Array,      ///< [inout] 5D Kokkos array of any type
+                const I4 CurNeighbor ///< [in] current neighbor
    ) {
 
       using ValType = typename T::non_const_value_type;
@@ -762,19 +780,15 @@ class Halo {
    }
 
    //---------------------------------------------------------------------------
-   // Function template to perform a full halo exchange on the input Kokkos
-   // array of any supported type defined on the input index space ThisElem
+   /// Function template to perform a full halo exchange on the input Kokkos
+   /// array of any supported type defined on the input index space ThisElem
    template <typename T>
-   int
-   exchangeFullArrayHalo(T &Array,            // Kokkos array of any type
-                         MeshElement ThisElem // index space Array is defined on
+   void exchangeFullArrayHalo(
+       T &Array,            ///< [in] Kokkos array for updating halo
+       MeshElement ThisElem ///< [in] index space Array is defined on
    ) {
       // Add more context for timers in this function
-      // BUG: fails when there is no parent timer
-      // Uncomment after fixing in Pacer
-      // Pacer::addParentPrefix();
-
-      I4 IErr{0}; // error code
+      Pacer::addParentPrefix();
 
       // Logical flag to track if all messages have been received
       bool AllReceived{false};
@@ -888,11 +902,9 @@ class Halo {
             AllReceived = true;
          }
          ++IPass;
-         if (IPass == MaxIter) {
-            LOG_ERROR("Halo: Maximum iterations reached during halo exchange");
-            IErr = -1;
-            break;
-         }
+         if (IPass == MaxIter)
+            ABORT_ERROR(
+                "Halo: Maximum iterations reached during halo exchange");
       }
       Pacer::stop("Halo:receiveUnpack", 4);
 
@@ -907,11 +919,10 @@ class Halo {
       MPI_Waitall(SendReqs.size(), SendReqs.data(), MPI_STATUS_IGNORE);
       Pacer::stop("Halo:waitSends", 4);
 
-      // BUG: fails when there is no parent timer
-      // Uncomment after fixing in Pacer
-      // Pacer::removeParentPrefix();
+      // Reset Pacer timer prefix
+      Pacer::removeParentPrefix();
 
-      return IErr;
+      return;
    } // end exchangeFullArrayHalo
 
 }; // end class Halo

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -437,13 +437,10 @@ void AuxiliaryState::readConfigOptions(Config *OmegaConfig) {
 //------------------------------------------------------------------------------
 // Perform auxiliary state halo exchange
 // Note that only non-computed auxiliary variables needs to be exchanged
-I4 AuxiliaryState::exchangeHalo() {
-   I4 Err = 0;
+void AuxiliaryState::exchangeHalo() {
 
-   Err +=
-       MeshHalo->exchangeFullArrayHalo(WindForcingAux.ZonalStressCell, OnCell);
-   Err +=
-       MeshHalo->exchangeFullArrayHalo(WindForcingAux.MeridStressCell, OnCell);
+   MeshHalo->exchangeFullArrayHalo(WindForcingAux.ZonalStressCell, OnCell);
+   MeshHalo->exchangeFullArrayHalo(WindForcingAux.MeridStressCell, OnCell);
 
    // Performing halo exchange on individual tracers because full halo exchange
    // on a 2D array assumes the first dimension is the vertical
@@ -452,10 +449,10 @@ I4 AuxiliaryState::exchangeHalo() {
    for (I4 LTracer = 0; LTracer < NTracers; ++LTracer) {
       auto TracerSurfClimoCell = Kokkos::subview(
           SurfTracerRestAux.TracersMonthlySurfClimoCell, LTracer, Kokkos::ALL);
-      Err += MeshHalo->exchangeFullArrayHalo(TracerSurfClimoCell, OnCell);
+      MeshHalo->exchangeFullArrayHalo(TracerSurfClimoCell, OnCell);
    }
 
-   return Err;
+   return;
 
 } // end exchangeHalo
 

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -74,7 +74,7 @@ class AuxiliaryState {
    void readConfigOptions(Config *OmegaConfig);
 
    /// Exchange halo
-   I4 exchangeHalo();
+   void exchangeHalo();
 
    // Compute auxiliary variables for vertical dynamics
    void computeMomVertAux(const OceanState *State,

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -154,10 +154,7 @@ int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
    DefAuxState->exchangeHalo();
 
    // Now update tracers - assume using same time level index
-   Err = Tracers::exchangeHalo(CurTimeLevel);
-   if (Err != 0) {
-      ABORT_ERROR("Error updating tracer halo after restart");
-   }
+   Tracers::exchangeHalo(CurTimeLevel);
    Tracers::copyToHost(CurTimeLevel);
 
    return Err;
@@ -182,12 +179,7 @@ static int initOmegaModulesImpl(MPI_Comm Comm) {
    IO::init(Comm);
    Field::init(ModelClock);
    Decomp::init();
-
-   Err = Halo::init();
-   if (Err != 0) {
-      ABORT_ERROR("ocnInit: Error initializing default halo");
-   }
-
+   Halo::init();
    HorzMesh::init(ModelClock);
    VertCoord::init();
    Tracers::init();

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -413,16 +413,13 @@ void Tracers::copyToHost(const I4 TimeLevel) {
 // halo exchange
 // TimeLevel == [1:new, 0:current, -1:previous, -2:two times ago, ...]
 //---------------------------------------------------------------------------
-I4 Tracers::exchangeHalo(const I4 TimeLevel) {
+void Tracers::exchangeHalo(const I4 TimeLevel) {
 
-   I4 Err             = 0;
    const I4 TimeIndex = getTimeIndex(TimeLevel);
 
-   Err = MeshHalo->exchangeFullArrayHalo(TracerArrays[TimeIndex], OnCell);
-   if (Err != 0)
-      return -1;
+   MeshHalo->exchangeFullArrayHalo(TracerArrays[TimeIndex], OnCell);
 
-   return 0;
+   return;
 }
 
 //---------------------------------------------------------------------------

--- a/components/omega/src/ocn/Tracers.h
+++ b/components/omega/src/ocn/Tracers.h
@@ -187,7 +187,7 @@ class Tracers {
    //---------------------------------------------------------------------------
 
    /// Exchange halo
-   static I4 exchangeHalo(const I4 TimeLevel ///< [in] tracer time level
+   static void exchangeHalo(const I4 TimeLevel ///< [in] tracer time level
    );
 
    /// increment time levels

--- a/components/omega/test/base/HaloTest.cpp
+++ b/components/omega/test/base/HaloTest.cpp
@@ -18,6 +18,7 @@
 #include "Config.h"
 #include "DataTypes.h"
 #include "Decomp.h"
+#include "Error.h"
 #include "IO.h"
 #include "Logging.h"
 #include "MachEnv.h"
@@ -39,7 +40,7 @@ using namespace OMEGA;
 // any elements differ the test is a failure and an error is returned.
 
 template <typename T>
-int haloExchangeTest(
+Error haloExchangeTest(
     Halo *MyHalo,
     T InitArray,  /// Array initialized based on global IDs of mesh elements
     T &TestArray, /// Array only initialized in owned elements
@@ -47,37 +48,20 @@ int haloExchangeTest(
     MeshElement ThisElem = OnCell /// index space, cell by default
 ) {
 
-   I4 IErr   = 0; // error code
-   I4 RetErr = 0; // return error code
+   Error RetErr; // return error code
 
    // Set total array size and ensure arrays are of same size
    I4 NTot = InitArray.size();
-   if (NTot != TestArray.size()) {
-      LOG_ERROR("HaloTest: {} arrays must be of same size", Label);
-      LOG_INFO("HaloTest: {} exchange test FAIL", Label);
-      RetErr += 1;
-      return RetErr;
-   }
+   OMEGA_REQUIRE(NTot == TestArray.size(),
+                 "HaloTest: FAIL {} arrays must be of same size", Label);
 
    // Perform halo exchange
-   IErr = MyHalo->exchangeFullArrayHalo(TestArray, ThisElem);
-   if (IErr != 0) {
-      LOG_ERROR("HaloTest: Error during {} halo exchange", Label);
-      LOG_INFO("HaloTest: {} exchange test FAIL", Label);
-      RetErr += 1;
-      return RetErr;
-   }
+   MyHalo->exchangeFullArrayHalo(TestArray, ThisElem);
 
    // Confirm all elements are identical, if not set error code
    if (!arraysEqual(TestArray, InitArray)) {
-      IErr = -1;
-   }
-
-   if (IErr == 0) {
-      LOG_INFO("HaloTest: {} exchange test PASS", Label);
-   } else {
-      LOG_INFO("HaloTest: {} exchange test FAIL", Label);
-      RetErr += 1;
+      RetErr +=
+          Error(ErrorCode::Fail, "HaloTest: {} exchange test FAIL", Label);
    }
 
    return RetErr;
@@ -88,9 +72,7 @@ int haloExchangeTest(
 // Initialization routine for Halo tests. Calls all the init routines needed
 // to create the default Halo.
 
-int initHaloTest() {
-
-   I4 IErr{0};
+void initHaloTest() {
 
    // Initialize the machine environment and fetch the default environment
    // pointer and the MPI communicator
@@ -100,6 +82,7 @@ int initHaloTest() {
 
    // Initialize the logging system
    initLogging(DefEnv);
+   LOG_INFO("------ Halo Unit Tests ------");
 
    // Open config file
    Config("Omega");
@@ -112,11 +95,9 @@ int initHaloTest() {
    Decomp::init();
 
    // Initialize the default halo
-   IErr = Halo::init();
-   if (IErr != 0)
-      LOG_ERROR("HaloTest: error initializing default halo");
+   Halo::init();
 
-   return IErr;
+   return;
 
 } // end initHaloTest
 
@@ -132,8 +113,7 @@ int initHaloTest() {
 int main(int argc, char *argv[]) {
 
    // Error tracking variables
-   I4 TotErr = 0;
-   I4 IErr   = 0;
+   Error TotErr;
 
    // Initialize global MPI environment and Kokkos
    MPI_Init(&argc, &argv);
@@ -143,9 +123,7 @@ int main(int argc, char *argv[]) {
    {
 
       // Call Halo test initialization routine
-      IErr = initHaloTest();
-      if (IErr != 0)
-         LOG_ERROR("HaloTest: initHaloTest error");
+      initHaloTest();
 
       // Retrieve pointer to default halo
       Halo *DefHalo = Halo::getDefault();
@@ -561,20 +539,15 @@ int main(int argc, char *argv[]) {
       Decomp::clear();
       MachEnv::removeAll();
 
-      if (TotErr == 0) {
-         LOG_INFO("HaloTest: Successful completion");
-      } else {
-         LOG_INFO("HaloTest: Failed");
-      }
+      CHECK_ERROR_ABORT(TotErr, "HaloTest: FAIL");
+      // if we made it here, unit tests successful
+      LOG_INFO("------ Halo Unit Tests Successful ------");
    }
    Pacer::finalize();
    Kokkos::finalize();
    MPI_Finalize();
 
-   if (TotErr >= 256)
-      TotErr = 255;
-
-   return TotErr;
+   return 0;
 
 } // end of main
 //===-----------------------------------------------------------------------===/

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -86,8 +86,7 @@ int initState() {
 
 //------------------------------------------------------------------------------
 // The initialization routine for aux vars testing
-int initAuxStateTest(const std::string &mesh) {
-   int Err = 0;
+void initAuxStateTest(const std::string &mesh) {
 
    MachEnv::init(MPI_COMM_WORLD);
    MachEnv *DefEnv  = MachEnv::getDefault();
@@ -111,12 +110,7 @@ int initAuxStateTest(const std::string &mesh) {
    // Initialize streams
    Field::init(ModelClock);
    IOStream::init(ModelClock);
-
-   int HaloErr = Halo::init();
-   if (HaloErr != 0) {
-      Err++;
-      LOG_ERROR("AuxStateTest: error initializing default halo");
-   }
+   Halo::init();
 
    HorzMesh::init(ModelClock);
 
@@ -125,15 +119,14 @@ int initAuxStateTest(const std::string &mesh) {
    Tracers::init();
    int StateErr = OceanState::init();
    if (StateErr != 0) {
-      Err++;
-      LOG_ERROR("AuxStateTest: error initializing default state");
+      ABORT_ERROR("AuxStateTest: error initializing default state");
    }
 
    VertAdv::init();
 
    Eos::init();
 
-   return Err;
+   return;
 }
 
 int testAuxState() {
@@ -335,10 +328,8 @@ void finalizeAuxStateTest() {
 }
 
 int auxStateTest(const std::string &MeshFile = "OmegaMesh.nc") {
-   int Err = initAuxStateTest(MeshFile);
-   if (Err != 0) {
-      LOG_CRITICAL("AuxStateTest: Error initializing");
-   }
+   int Err = 0;
+   initAuxStateTest(MeshFile);
 
    const auto &Mesh = HorzMesh::getDefault();
 

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -781,8 +781,7 @@ int testTracerAuxVars(const Array2DReal &PseudoThickCell,
 }
 //------------------------------------------------------------------------------
 // The initialization routine for aux vars testing
-int initAuxVarsTest(const std::string &mesh) {
-   int Err = 0;
+void initAuxVarsTest(const std::string &mesh) {
 
    MachEnv::init(MPI_COMM_WORLD);
    MachEnv *DefEnv  = MachEnv::getDefault();
@@ -797,12 +796,7 @@ int initAuxVarsTest(const std::string &mesh) {
 
    IO::init(DefComm);
    Decomp::init(mesh);
-
-   int HaloErr = Halo::init();
-   if (HaloErr != 0) {
-      Err++;
-      LOG_ERROR("AuxVarsTest: error initializing default halo");
-   }
+   Halo::init();
 
    // Create dummy clock for IO
    Calendar::init("No Leap");
@@ -820,7 +814,7 @@ int initAuxVarsTest(const std::string &mesh) {
    // NVertLayers value
    VertCoord::init(false, NVertLayers);
 
-   return Err;
+   return;
 }
 
 void finalizeAuxVarsTest() {
@@ -834,10 +828,8 @@ void finalizeAuxVarsTest() {
 }
 
 int auxVarsTest(const std::string &mesh = DefaultMeshFile) {
-   int Err = initAuxVarsTest(mesh);
-   if (Err != 0) {
-      LOG_CRITICAL("AuxVarsTest: Error initializing");
-   }
+   int Err = 0;
+   initAuxVarsTest(mesh);
 
    const auto &Mesh = HorzMesh::getDefault();
 

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -55,9 +55,7 @@ void initHorzMeshTest() {
    Decomp::init();
 
    // Initialize the default halo
-   int Err = Halo::init();
-   if (Err != 0)
-      ABORT_ERROR("HorzMeshTest: error initializing default halo");
+   Halo::init();
 
    // Create a dummy model clock
    Calendar::init("No Leap");

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -919,8 +919,7 @@ int testsecondderivativeoncellconstructor(Real RTol) {
 }
 //------------------------------------------------------------------------------
 // The initialization routine for Operators testing
-int initOperatorsTest(const std::string &MeshFile) {
-   int Err = 0;
+void initOperatorsTest(const std::string &MeshFile) {
 
    MachEnv::init(MPI_COMM_WORLD);
    MachEnv *DefEnv  = MachEnv::getDefault();
@@ -936,12 +935,7 @@ int initOperatorsTest(const std::string &MeshFile) {
 
    IO::init(DefComm);
    Decomp::init(MeshFile);
-
-   int HaloErr = Halo::init();
-   if (HaloErr != 0) {
-      Err++;
-      LOG_ERROR("OperatorsTest: error initializing default halo");
-   }
+   Halo::init();
 
    // Create dummy model clock
    Calendar::init("No Leap");
@@ -955,7 +949,7 @@ int initOperatorsTest(const std::string &MeshFile) {
    IOStream::init(ModelClock);
    HorzMesh::init(ModelClock);
 
-   return Err;
+   return;
 }
 
 void finalizeOperatorsTest() {
@@ -969,13 +963,12 @@ void finalizeOperatorsTest() {
 }
 
 int operatorsTest(const std::string &MeshFile = DefaultMeshFile) {
-   int Err = initOperatorsTest(MeshFile);
-   if (Err != 0) {
-      LOG_CRITICAL("OperatorsTest: Error initializing");
-   }
+
+   initOperatorsTest(MeshFile);
 
    const Real RTol = sizeof(Real) == 4 ? 1e-2 : 1e-10;
 
+   int Err = 0;
    Err += testDivergence(RTol);
    Err += testGradient(RTol);
    Err += testCurl(RTol);

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -202,9 +202,7 @@ int setScalar(const Functor &Fun, const Array &ScalarElement, Geometry Geom,
 
    if (ExchangeHalosOpt == ExchangeHalos::Yes) {
       auto MyHalo = Halo::getDefault();
-      Err         = MyHalo->exchangeFullArrayHalo(ScalarElement, Element);
-      if (Err != 0)
-         LOG_ERROR("setScalarElement: error in halo exchange");
+      MyHalo->exchangeFullArrayHalo(ScalarElement, Element);
    }
    return Err;
 }
@@ -362,9 +360,7 @@ int setVectorEdge(const Functor &Fun, const Array &VectorFieldEdge,
 
    if (ExchangeHalosOpt == ExchangeHalos::Yes) {
       auto MyHalo = Halo::getDefault();
-      Err         = MyHalo->exchangeFullArrayHalo(VectorFieldEdge, OnEdge);
-      if (Err != 0)
-         LOG_ERROR("setVectorEdge: error in halo exchange");
+      MyHalo->exchangeFullArrayHalo(VectorFieldEdge, OnEdge);
    }
    return Err;
 }

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -1,10 +1,9 @@
-//===-- Test driver for OMEGA Pressure Gradient (PGrad) --------------*-
-// C++-*-===/
+//===-- Test driver for OMEGA Pressure Gradient (PGrad) --------*- // C++-*-===/
 //
 /// \file
 /// \brief Test driver for PressureGrad module
 //
-//===----------------------------------------------------------------------===/
+//===-----------------------------------------------------------------------===/
 
 #include "PGrad.h"
 
@@ -33,9 +32,6 @@
 using namespace OMEGA;
 
 void initPGradTest() {
-
-   Error Err;
-   int Err1;
 
    MachEnv::init(MPI_COMM_WORLD);
    MachEnv *DefEnv  = MachEnv::getDefault();
@@ -67,11 +63,7 @@ void initPGradTest() {
    IOStream::init(ModelClock);
 
    // Initialize the default halo
-   Err1 = Halo::init();
-   if (Err1 != 0) {
-      LOG_ERROR("PGrad: error initializing default halo");
-      Err += Error(ErrorCode::Fail, "PGrad: error initializing default halo");
-   }
+   Halo::init();
 
    // Initialize the default mesh
    HorzMesh::init(ModelClock);
@@ -87,8 +79,6 @@ void initPGradTest() {
 
    // Initialize tracers
    Tracers::init();
-
-   CHECK_ERROR_ABORT(Err, "PGrad: error during initialization");
 }
 
 int main(int argc, char *argv[]) {

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -76,9 +76,7 @@ void initStateTest() {
    Decomp::init();
 
    // Initialize the default halo
-   Err = Halo::init();
-   if (Err != 0)
-      ABORT_ERROR("State: error initializing default halo");
+   Halo::init();
 
    // Initialize the default mesh
    HorzMesh::init(ModelClock);

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -126,11 +126,7 @@ int initTendenciesTest(const std::string &mesh) {
    Field::init(ModelClock);
    IOStream::init(ModelClock);
 
-   int HaloErr = Halo::init();
-   if (HaloErr != 0) {
-      Err++;
-      LOG_ERROR("TendenciesTest: error initializing default halo");
-   }
+   Halo::init();
 
    // Read mesh
    HorzMesh::init(ModelClock);

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -1135,8 +1135,6 @@ int testSurfaceTracerRestoringOnCell(int NVertLayers, int NTracers, Real RTol) {
 
 void initTendTest(const std::string &MeshFile, int NVertLayers) {
 
-   Error Err;
-
    MachEnv::init(MPI_COMM_WORLD);
    MachEnv *DefEnv  = MachEnv::getDefault();
    MPI_Comm DefComm = DefEnv->getComm();
@@ -1154,13 +1152,8 @@ void initTendTest(const std::string &MeshFile, int NVertLayers) {
    Clock *ModelClock       = DefStepper->getClock();
 
    IO::init(DefComm);
-
    Decomp::init(MeshFile);
-
-   int HaloErr = Halo::init();
-   if (HaloErr != 0) {
-      ABORT_ERROR("TendencyTermsTest: error initializing default halo");
-   }
+   Halo::init();
 
    Field::init(ModelClock);    // Fields are used in streams
    IOStream::init(ModelClock); // initialize streams for mesh reading

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -37,9 +37,7 @@ const Real RefReal = 3.0;
 // The initialization routine for Tracers testing. It calls various
 // init routines, including the creation of the default decomposition.
 
-I4 initTracersTest() {
-
-   I4 Err = 0;
+void initTracersTest() {
 
    // Initialize the Machine Environment class - this also creates
    // the default MachEnv. Then retrieve the default environment and
@@ -66,11 +64,7 @@ I4 initTracersTest() {
    Decomp::init();
 
    // Initialize the default halo
-   Err = Halo::init();
-   if (Err != 0) {
-      LOG_ERROR("Tracers: error initializing default halo");
-      return Err;
-   }
+   Halo::init();
 
    // Read in the default mesh
    Field::init(ModelClock);
@@ -80,7 +74,7 @@ I4 initTracersTest() {
    // Initialize the vertical coordinate
    VertCoord::init(false);
 
-   return 0;
+   return;
 }
 
 //------------------------------------------------------------------------------
@@ -100,9 +94,7 @@ int main(int argc, char *argv[]) {
    {
 
       // Call initialization routine
-      Err = initTracersTest();
-      if (Err != 0)
-         LOG_ERROR("Tracers: Error initializing");
+      initTracersTest();
 
       // Get MPI vars if needed
       MachEnv *DefEnv = MachEnv::getDefault();

--- a/components/omega/test/ocn/VertAdvTest.cpp
+++ b/components/omega/test/ocn/VertAdvTest.cpp
@@ -101,8 +101,6 @@ Real tendTest(const int NLayers, VertAdv *VAdv) {
 // Initialize needed modules
 void initVertAdvTest() {
 
-   I4 Err;
-
    MachEnv::init(MPI_COMM_WORLD);
    MachEnv *DefEnv  = MachEnv::getDefault();
    MPI_Comm DefComm = DefEnv->getComm();
@@ -130,9 +128,7 @@ void initVertAdvTest() {
    IOStream::init(ModelClock);
 
    // Initialize the default halo
-   Err = Halo::init();
-   if (Err != 0)
-      ABORT_ERROR("VertAdvTest: error initializing default halo");
+   Halo::init();
 
    // Read and initialize the default mesh
    HorzMesh::init(ModelClock);

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -31,9 +31,7 @@
 
 using namespace OMEGA;
 
-int initVertCoordTest() {
-
-   int Err = 0;
+void initVertCoordTest() {
 
    MachEnv::init(MPI_COMM_WORLD);
    MachEnv *DefEnv  = MachEnv::getDefault();
@@ -62,9 +60,7 @@ int initVertCoordTest() {
    IOStream::init(ModelClock);
 
    // Initialize the default halo
-   Err = Halo::init();
-   if (Err != 0)
-      LOG_ERROR("VertCoordTest: error initializing default halo");
+   Halo::init();
 
    // Initialize the default mesh
    HorzMesh::init(ModelClock);
@@ -72,7 +68,7 @@ int initVertCoordTest() {
    // Initialize the default vertical coordinate
    VertCoord::init();
 
-   return Err;
+   return;
 } // end initVertCoordTest
 
 //------------------------------------------------------------------------------
@@ -89,9 +85,8 @@ int main(int argc, char *argv[]) {
    Pacer::initialize(MPI_COMM_WORLD);
    Pacer::setPrefix("Omega:");
    {
-      int Err = initVertCoordTest();
-      if (Err != 0)
-         ABORT_ERROR("VertCoordTest: Error initializing");
+      int Err = 0;
+      initVertCoordTest();
 
       auto *DefVertCoord = VertCoord::getDefault();
       auto *DefMesh      = HorzMesh::getDefault();

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -159,12 +159,7 @@ int initTimeStepperTest(const std::string &mesh) {
 
    IO::init(DefComm);
    Decomp::init(mesh);
-
-   int HaloErr = Halo::init();
-   if (HaloErr != 0) {
-      Err++;
-      LOG_ERROR("TimeStepperTest: error initializing default halo");
-   }
+   Halo::init();
 
    // Initialize IO streams
    Field::init(ModelClock);


### PR DESCRIPTION
A general cleanup of the Omega Halo functions that
  - removes halo return codes in favor of aborting
  - reduces output from halo test driver
  - cleans up some comments and formatting

Checklist
* [x] Documentation:
  * [x] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
  * [x] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [x] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests

