### PR TITLE
Clean up `Default.yml`

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -85,6 +85,10 @@ Omega:
       NuZero: 0.005
       Alpha: 5.0
       Exponent: 2.0
+  ManufacturedSolution:
+    WavelengthX: 5.0e6
+    WavelengthY: 4.33013e6
+    Amplitude: 1.0
   IOStreams:
     HorzMeshIn:
       UsePointerFile: false
@@ -176,7 +180,3 @@ Omega:
       EndTime: 0001-07-31_00:00:00
       Contents:
         - Tracers
-  ManufacturedSolution:
-    WavelengthX: 5.0e6
-    WavelengthY: 4.33013e6
-    Amplitude: 1.0

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -65,7 +65,7 @@ Omega:
     PressureGradTendencyEnable: true
   Tracers:
     Base: [Temperature, Salinity]
-    Debug: [Debug1, Debug2, Debug3]
+    Debug: []
   Eos:
     EosType: teos10
     Linear:


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

Default to not debug tracers.

Move `ManufacturedSolution` configs above `IOStreams`

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [ ] Indicate "All tests passed" or document failing tests
    * [ ] Document testing used to verify the changes including any tests that are added/modified/impacted.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #406