### PR TITLE
Support non-zero `SurfacePressure`

### DIFF
--- a/components/omega/doc/design/FillValues.md
+++ b/components/omega/doc/design/FillValues.md
@@ -221,6 +221,13 @@ Ordering invariants preserved by this design:
 - Compute routines run after initialization and overwrite active entries, leaving
   inactive entries (below `MaxLayerCell`) at the fill value.
 
+The fill value also serves as the "not read" sentinel for optional reads. A field
+marked with `Field::setOptionalRead(true)` that is absent from an input file is
+skipped by the IOStream read and keeps the fill value from `attachData()`; the
+owning module detects the fill value afterward and substitutes a default. For
+example, `VertCoord::SurfacePressure` defaults to zero when it is not present in
+the initial-condition or restart file.
+
 #### 4.2.2 No per-module manual initialization required
 
 Because `attachData()` handles initialization automatically, no module needs to

--- a/components/omega/doc/devGuide/Field.md
+++ b/components/omega/doc/devGuide/Field.md
@@ -192,6 +192,18 @@ The first determines whether the unlimited time dimension should be added
 during IO operations. The second determines whether any of the dimensions
 are distributed across MPI tasks so that parallel IO is required.
 
+A field can also be marked as an optional read, which controls what happens
+when the field's variable is missing from an input file:
+```c++
+   MyField->setOptionalRead(true);
+   bool IsOptionalRead = MyField->isOptionalRead();
+```
+Fields are required by default (`isOptionalRead()` returns `false`). When a
+field is marked optional and its variable is absent from a read stream's file,
+the [IOStream](#omega-dev-iostreams) read skips it, leaving the attached array
+at its [fill value](#omega-design-fill-values) instead of failing. The owning
+module is responsible for detecting that fill value and substituting a default.
+
 The data and metadata stored in a field can be retrieved using several
 functions.  To retrieve a pointer to the full Field, use:
 ```c++

--- a/components/omega/doc/devGuide/IOStreams.md
+++ b/components/omega/doc/devGuide/IOStreams.md
@@ -72,6 +72,20 @@ input stream is read using:
 The returned error code typically means that a field in the stream could
 not be found in the input file - most other errors abort immediately. The
 calling routine is then responsible for deciding what action to take.
+
+By default every field listed in a stream's contents must be present in the
+input file or the read returns an error. A field can instead be marked as an
+optional read using
+```c++
+   FieldPtr->setOptionalRead(true);
+```
+When such a field's variable is missing from the file, the read logs an
+informational message, leaves the field's attached array at the fill value set
+by `attachData` (see [Fill Values](#omega-design-fill-values)), and continues
+without contributing an error. The owning module is then responsible for
+detecting that fill value after the read and substituting a default value. This
+is how `VertCoord` allows `SurfacePressure` to be absent from the
+initial-condition or restart file and default to zero.
 The ReqMetadata argument is a variable of type Metadata (defined in Field but
 essentially a ``std::map<std::string, std::any>`` for the name/value pair).
 This variable should include the names of global metadata that are desired

--- a/components/omega/doc/devGuide/OceanState.md
+++ b/components/omega/doc/devGuide/OceanState.md
@@ -21,7 +21,10 @@ OceanState::create(const std::string &Name, ///< [in] Name for mesh
 );
 ```
 allocates the `NormalVelocity` and `PseudoThickness` arrays for a given number of time levels.
-The current time level is then registered with the IO infrastructure.
+The current time level of `NormalVelocity` and `PseudoThickness` are registered with the IO
+infrastructure and added to the `State` and `Restart` field groups.
+The `SurfacePressure` array is owned by [`VertCoord`](omega-dev-vert-coord) but is also added to
+these two groups so it is read from the initial-condition and restart files.
 
 After initialization, the default state object can be retrieved via:
 ```
@@ -70,6 +73,9 @@ HostArray2DReal NormVelH = State->getNormalVelocityH(TimeLevel);
 ```
 for the host arrays. These functions return the arrays directly and will abort
 via `OMEGA_REQUIRE` if an invalid `TimeLevel` is provided.
+
+The `SurfacePressure` array used as the top boundary condition for layer pressures is owned by
+[`VertCoord`](omega-dev-vert-coord); see that guide for how it is accessed and initialized.
 
 The time level convention is:
 | time level | `TimeLevel` |

--- a/components/omega/doc/devGuide/OceanState.md
+++ b/components/omega/doc/devGuide/OceanState.md
@@ -24,7 +24,9 @@ allocates the `NormalVelocity` and `PseudoThickness` arrays for a given number o
 The current time level of `NormalVelocity` and `PseudoThickness` are registered with the IO
 infrastructure and added to the `State` and `Restart` field groups.
 The `SurfacePressure` array is owned by [`VertCoord`](omega-dev-vert-coord) but is also added to
-these two groups so it is read from the initial-condition and restart files.
+these two groups so it is written to restart files and read from the initial-condition and restart
+files when present. Its read is optional, so it defaults to zero when absent (see the
+[`VertCoord`](omega-dev-vert-coord) guide).
 
 After initialization, the default state object can be retrieved via:
 ```

--- a/components/omega/doc/devGuide/VertCoord.md
+++ b/components/omega/doc/devGuide/VertCoord.md
@@ -82,8 +82,14 @@ during construction, `SurfacePressure` is a prognostic quantity read from the in
 or restart file. `defineFields()` therefore registers it and adds it to the `State` and `Restart`
 field groups (creating those groups if `VertCoord` initializes before `OceanState`). Because
 those streams are read later in `ocnInit`, the data are written directly into the attached device
-array; after the read, `initSurfacePressure()` must be called to exchange the halo and copy the
-device array to the host mirror:
+array.
+
+`SurfacePressure` is registered as an [optional read](omega-dev-iostreams)
+(`Field::setOptionalRead(true)`), so it is not required to be present in the initial-condition or
+restart file. When the variable is absent, the read is skipped and the array retains the fill
+value written by `attachData`. After the read, `initSurfacePressure()` must be called: it detects
+that leftover fill value on the owned cells and, if found, defaults the whole array to zero, then
+exchanges the halo and copies the device array to the host mirror:
 ```c++
 VertCoord::getDefault()->initSurfacePressure(Halo::getDefault());
 ```

--- a/components/omega/doc/devGuide/VertCoord.md
+++ b/components/omega/doc/devGuide/VertCoord.md
@@ -69,6 +69,27 @@ A list of member variables along with their types and dimension sizes is below:
 | VertCoordMovementWeights | Real | NCellsSize, NVertLayers |
 | RefPseudoThickness | Real | NCellsSize, NVertLayers |
 | BottomGeomDepth | Real | NCellsSize |
+| SurfacePressure | Real | NCellsSize |
+
+### Surface pressure
+
+`SurfacePressure` is the relative pressure (gauge pressure) at the top of the ocean column and
+is the top boundary condition used by `computePressure`. It is owned by `VertCoord` and its host
+mirror is `SurfacePressureH`.
+
+Unlike the other `VertCoord` fields, whose data come from the mesh file (`InitVertCoord` group)
+during construction, `SurfacePressure` is a prognostic quantity read from the initial-condition
+or restart file. `defineFields()` therefore registers it and adds it to the `State` and `Restart`
+field groups (creating those groups if `VertCoord` initializes before `OceanState`). Because
+those streams are read later in `ocnInit`, the data are written directly into the attached device
+array; after the read, `initSurfacePressure()` must be called to exchange the halo and copy the
+device array to the host mirror:
+```c++
+VertCoord::getDefault()->initSurfacePressure(Halo::getDefault());
+```
+Eventually `SurfacePressure` will be updated each timestep via the coupler as a weighted sum of
+atmosphere, sea-ice, and land-ice pressure; that forcing update will live in a separate forcing
+class that writes into this array.
 
 ### Removal
 

--- a/components/omega/doc/userGuide/OceanState.md
+++ b/components/omega/doc/userGuide/OceanState.md
@@ -13,4 +13,5 @@ This involves a halo update, time level index update, and updating the `IOFields
 The relative pressure at the top of the ocean column, `SurfacePressure`, is owned by the
 [vertical coordinate](omega-user-vert-coord) rather than the `OceanState`, since it is the top
 boundary condition of the pressure field. It is still registered in the `State` and `Restart`
-field groups, so it continues to be read from the initial-condition and restart files.
+field groups, so it continues to be written to restart files and read from the initial-condition
+and restart files when present; if it is absent, it defaults to zero.

--- a/components/omega/doc/userGuide/OceanState.md
+++ b/components/omega/doc/userGuide/OceanState.md
@@ -2,7 +2,15 @@
 
 ## Ocean State
 
-The `OceanState` class provides a container for the non-tracer prognostic variables in Omega, namely `NormalVelocity` and `PseudoThickness`.
-Upon creation of a `OceanState` instance, these variables are allocated and registered with the IO infrastructure.
+The `OceanState` class provides a container for the non-tracer prognostic variables in Omega:
+`NormalVelocity` and `PseudoThickness`.
+Upon creation of an `OceanState` instance, these variables are allocated and registered with the
+IO infrastructure as part of the `State` and `Restart` field groups, so they are read from the
+initial-condition file and written to restart files.
 The class contains a method to update the time levels for the state variables between timesteps.
 This involves a halo update, time level index update, and updating the `IOFields` data references.
+
+The relative pressure at the top of the ocean column, `SurfacePressure`, is owned by the
+[vertical coordinate](omega-user-vert-coord) rather than the `OceanState`, since it is the top
+boundary condition of the pressure field. It is still registered in the `State` and `Restart`
+field groups, so it continues to be read from the initial-condition and restart files.

--- a/components/omega/doc/userGuide/VertCoord.md
+++ b/components/omega/doc/userGuide/VertCoord.md
@@ -4,7 +4,9 @@
 
 ### Overview
 
-Omega uses pseudo height, $\tilde{z} = \frac{p}{\rho_0 g}$,  as the vertical coordinate ([V1 governing equation document](omega-design-governing-eqns-omega1)).
+Omega uses pseudo height, $\tilde{z} = \frac{p}{\rho_0 g}$,  as the vertical coordinate ([V1 governing equation document](omega-design-governing-eqns-omega1)),
+where $p$ is **relative pressure** (gauge pressure, i.e., absolute pressure minus the standard atmosphere of 101325 Pa).
+With this definition, $\tilde{z} = 0$ at the sea surface under standard atmospheric forcing.
 In practice, $\tilde{z}$ is not computed directly.
 Instead, the model tracks and evolves the pseudo-thickness, $\tilde{h} = \Delta \tilde{z}$, defined as the difference between adjacent layer interfaces.
 The pseudo height is essentially a normalized pressure coordinate, with the advantage that it has units of meters.
@@ -27,8 +29,8 @@ Multiple instances of the vertical coordinate class can be created and accessed 
 | ------------- | ----------- | ----- |
 | NVertLayers   | maximum number of vertical layers | - |
 | NVertLayersP1 | maximum number of vertical layers plus 1 | - |
-| PressureInterface | pressure at layer interfaces | force per unit area at layer interfaces | kg m$^{-1}$ s$^{-2}$ |
-| PressureMid | pressure at layer mid points | force per unit area at layer mid point | kg m$^{-1}$ s$^{-2}$ |
+| PressureInterface | relative pressure (gauge pressure) at layer interfaces | Pa |
+| PressureMid | relative pressure (gauge pressure) at layer midpoints | Pa |
 | GeomZInterface | geometric height of layer interfaces | m |
 | GeomZMid | geometric height of layer midpoint | m |
 | GeopotentialMid | geopotential at layer mid points | m$^2$/s$^2$|
@@ -46,6 +48,22 @@ Multiple instances of the vertical coordinate class can be created and accessed 
 | VertCoordMovementWeights | weights to specify how total column thickness changes are distributed across layers | - |
 | RefPseudoThickness | reference pseudo-thickness used to distribute total column thickness changes | m |
 | BottomGeomDepth | positive down distance from the reference geoid to the bottom | m |
+| SurfacePressure | relative pressure (gauge pressure) at the top of the ocean column | Pa |
+
+### Surface pressure
+
+`SurfacePressure` is the relative pressure (gauge pressure, i.e., absolute pressure minus the
+standard atmosphere of 101325 Pa) at the top of the ocean column. It is the top boundary
+condition used when integrating layer pressures downward in `computePressure`, and is
+effectively $\tilde{z}$ at the top of the water column (times a scaling factor).
+Unlike the other pressure variables, which are recomputed each timestep, `SurfacePressure` is
+registered in the `State` and `Restart` field groups, so it is read from the initial-condition
+file and written to restart files.
+For a free-surface ocean run with standard atmospheric forcing, the surface pressure is
+zero (0 Pa) in the initial-condition file.
+For a coupled ocean–atmosphere run, `SurfacePressure` holds the anomaly of the atmospheric
+surface pressure from the standard atmosphere; eventually it will be updated each timestep
+via the coupler as a weighted sum of atmosphere, sea-ice, and land-ice pressure.
 
 ### Inactive and boundary layers in output
 

--- a/components/omega/doc/userGuide/VertCoord.md
+++ b/components/omega/doc/userGuide/VertCoord.md
@@ -57,10 +57,11 @@ standard atmosphere of 101325 Pa) at the top of the ocean column. It is the top 
 condition used when integrating layer pressures downward in `computePressure`, and is
 effectively $\tilde{z}$ at the top of the water column (times a scaling factor).
 Unlike the other pressure variables, which are recomputed each timestep, `SurfacePressure` is
-registered in the `State` and `Restart` field groups, so it is read from the initial-condition
-file and written to restart files.
+registered in the `State` and `Restart` field groups, so it is written to restart files and read
+from the initial-condition and restart files when present. The read is optional: if
+`SurfacePressure` is not present in the file, it defaults to zero rather than causing an error.
 For a free-surface ocean run with standard atmospheric forcing, the surface pressure is
-zero (0 Pa) in the initial-condition file.
+zero (0 Pa), so it may simply be omitted from the initial-condition file.
 For a coupled ocean–atmosphere run, `SurfacePressure` holds the anomaly of the atmospheric
 surface pressure from the standard atmosphere; eventually it will be updated each timestep
 via the coupler as a weighted sum of atmosphere, sea-ice, and land-ice pressure.

--- a/components/omega/src/infra/Field.cpp
+++ b/components/omega/src/infra/Field.cpp
@@ -125,6 +125,11 @@ Field::create(const std::string &FieldName,   // [in] Name of variable/field
    // if reduced precision for the stream/file is requested
    ThisField->RetainPrecision = RetainPrecision;
 
+   // Fields are required in input files by default; owning modules may mark a
+   // field optional via setOptionalRead if it should default to its fill value
+   // when absent from a read stream.
+   ThisField->OptionalRead = false;
+
    // Number of dimensions for the field
    ThisField->NDims = NumDims;
 
@@ -332,6 +337,16 @@ bool Field::isDistributed() const { return Distributed; }
 // Determinse whether full precision should be retained in IO operations
 // when reduced precision for the stream/file is requested
 bool Field::retainPrecision() const { return RetainPrecision; }
+
+//------------------------------------------------------------------------------
+// Determines whether the field may be absent from an input file. When true, a
+// read stream that does not contain the field's variable skips it and leaves
+// the attached array at its fill value rather than failing.
+bool Field::isOptionalRead() const { return OptionalRead; }
+
+//------------------------------------------------------------------------------
+// Sets whether the field may be absent from an input file (see isOptionalRead)
+void Field::setOptionalRead(bool OptRead) { OptionalRead = OptRead; }
 
 //------------------------------------------------------------------------------
 // Returns a vector of dimension names associated with each dimension

--- a/components/omega/src/infra/Field.h
+++ b/components/omega/src/infra/Field.h
@@ -79,6 +79,11 @@ class Field {
    /// operations when reduced precision is requested
    bool RetainPrecision;
 
+   /// Flag for whether this field may be absent from an input file. When true,
+   /// a read stream that does not contain this field's variable skips it
+   /// (leaving the attached array at its fill value) instead of failing.
+   bool OptionalRead;
+
    /// Data attached to this field. This will be a pointer to the Kokkos
    /// array holding the data. We use a void pointer to manage all the
    /// various types and cast to the appropriate type when needed.
@@ -225,6 +230,16 @@ class Field {
    /// Determine whether full precision should be maintained in cases where
    /// a reduced precision stream is requested.
    bool retainPrecision() const;
+
+   /// Determine whether this field may be absent from an input file. When true,
+   /// a read stream that does not contain the field's variable skips it and
+   /// leaves the attached array at its fill value rather than failing.
+   bool isOptionalRead() const;
+
+   /// Set whether this field may be absent from an input file (see
+   /// isOptionalRead). Fields are required (not optional) by default.
+   void setOptionalRead(bool OptRead ///< [in] optional-read flag value
+   );
 
    //---------------------------------------------------------------------------
    // Metadata functions

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1725,11 +1725,22 @@ Error IOStream::readFieldData(
       } else {
          Err = IO::readNDVar(DataPtr, OldFieldName, FileID, FieldID);
       }
-      if (Err.isFail()) // still cannot find field, return with error
+      if (Err.isFail()) {
+         // If the field is optional, a missing variable is not an error. Leave
+         // the attached array at the fill value set by Field::attachData and
+         // return success so the remaining fields in the stream still read.
+         if (FieldPtr->isOptionalRead()) {
+            LOG_INFO("IOStream::readFieldData: optional field {} not found in "
+                     "stream {}; leaving fill value",
+                     FieldName, Name);
+            return Error{}; // success
+         }
+         // still cannot find field, return with error
          RETURN_ERROR(
              Err, ErrorCode::Fail,
              "IOStream::readFieldData: Field {} or {} not found in stream {}",
              FieldName, OldFieldName, Name);
+      }
    }
 
    // Unpack vector into array based on type, dims and location

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -36,8 +36,10 @@ class Teos10Eos {
 
    //   The functor takes the full arrays of specific volume (inout),
    //   the indices ICell and KChunk, and the ocean tracers (conservative)
-   //   temperature, and (absolute) salinity as inputs, and outputs the
-   //   specific volume according to the Roquet et al. 2015 75 term expansion.
+   //   temperature, (absolute) salinity, and relative pressure (gauge pressure,
+   //   i.e., absolute pressure minus the standard atmosphere) as inputs, and
+   //   outputs the specific volume according to the Roquet et al. 2015 75 term
+   //   expansion.
    KOKKOS_FUNCTION void operator()(Array2DReal SpecVol, I4 ICell, I4 KChunk,
                                    const Array2DReal &ConservTemp,
                                    const Array2DReal &AbsSalinity,
@@ -353,7 +355,9 @@ class Teos10Eos {
    }
 
    /// Calculates freezing Conservative Temperature using TEOS-10 polynomial
-   /// (polynomial error in [-5e-4, 6e-4] K, from GSW package)
+   /// (polynomial error in [-5e-4, 6e-4] K, from GSW package).
+   /// P is relative pressure (gauge pressure in Pa, i.e., absolute pressure
+   /// minus the standard atmosphere).
    KOKKOS_FUNCTION Real calcCtFreezing(const Real Sa, const Real P,
                                        const Real SaturationFract) const {
       constexpr Real Sso = 35.16504;
@@ -482,8 +486,9 @@ class Teos10BruntVaisalaFreqSq {
 
    //   The functor takes the full arrays of squared Brunt-Vaisala frequency
    //   (inout) the index ICell, and the ocean tracers (conservative)
-   //   temperature, (absolute) salinity, pressure, specific volume as inputs,
-   //   and outputs the squared Brunt-Vaisala frequency.
+   //   temperature, (absolute) salinity, relative pressure (gauge pressure,
+   //   i.e., absolute pressure minus the standard atmosphere), and specific
+   //   volume as inputs, and outputs the squared Brunt-Vaisala frequency.
    KOKKOS_FUNCTION void operator()(Array2DReal BruntVaisalaFreqSq, I4 ICell,
                                    I4 KChunk, const Array2DReal &ConservTemp,
                                    const Array2DReal &AbsSalinity,

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -157,6 +157,7 @@ int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
    DefState->applyLayerMasks(CurTimeLevel);
 
    DefState->copyToHost(CurTimeLevel);
+   VertCoord::getDefault()->initSurfacePressure(Halo::getDefault());
 
    Forcing *DefForcing = Forcing::getDefault();
    DefForcing->exchangeHalo();

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -18,6 +18,7 @@
 #include "OmegaKokkos.h"
 #include "TimeStepper.h"
 #include "Tracers.h"
+#include "VertCoord.h"
 
 namespace OMEGA {
 
@@ -227,12 +228,18 @@ void OceanState::defineFields() {
                      DimNames          // dimension names
        );
 
-   // Create a field group for state fields
+   // Create a field group for state fields. VertCoord initializes before
+   // OceanState and owns SurfacePressure, which it also adds to this "State"
+   // group, so the group may already exist; reuse it if so.
    StateGroupName = "State";
    if (Name != "Default") {
       StateGroupName.append(Name);
    }
-   auto StateGroup = FieldGroup::create(StateGroupName);
+   std::shared_ptr<FieldGroup> StateGroup;
+   if (FieldGroup::exists(StateGroupName))
+      StateGroup = FieldGroup::get(StateGroupName);
+   else
+      StateGroup = FieldGroup::create(StateGroupName);
 
    // Add restart group if needed
    if (!FieldGroup::exists("Restart"))

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -300,14 +300,16 @@ void VertCoord::defineFields() {
    );
 
    auto SurfacePressureField = Field::create(
-       SurfacePressureFldName,                             // field name
-       "Relative pressure at the top of the ocean column", // long name
-       "Pa",                                               // units
-       "",                                                 // CF standard Name
-       -9.99E+10,                                          // min valid value
-       9.99E+10,                                           // max valid value
-       NDims,                                              // number of dims
-       DimNames                                            // dimension names
+       SurfacePressureFldName, // field name
+       "Pressure at the top of the ocean column relative to reference "
+       "atmospheric pressure (i.e. absolute pressure - 101,325 Pa)", // long
+                                                                     // name
+       "Pa",                                                         // units
+       "",        // CF standard Name
+       -9.99E+10, // min valid value
+       9.99E+10,  // max valid value
+       NDims,     // number of dims
+       DimNames   // dimension names
    );
 
    // SurfacePressure is optional in the initial-state/restart file; when it is

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -310,6 +310,10 @@ void VertCoord::defineFields() {
        DimNames                                            // dimension names
    );
 
+   // SurfacePressure is optional in the initial-state/restart file; when it is
+   // absent the read is skipped and it defaults to zero in initSurfacePressure.
+   SurfacePressureField->setOptionalRead(true);
+
    NDims = 2;
    DimNames.resize(NDims);
    DimNames[1] = "NVertLayers";
@@ -459,10 +463,12 @@ void VertCoord::defineFields() {
    PseudoThicknessTargetField->attachData<Array2DReal>(PseudoThicknessTarget);
    SshField->attachData<Array1DReal>(SshCell);
 
-   // Add SurfacePressure to the State and Restart groups so it is read from the
-   // initial-state and restart files. VertCoord initializes before OceanState,
-   // which also contributes fields to these groups, so create each group only
-   // if it does not already exist.
+   // Add SurfacePressure to the State and Restart groups so it is written to
+   // the history/restart files and read from the initial-state and restart
+   // files when present. The read is optional (see setOptionalRead above): if
+   // the variable is absent, SurfacePressure defaults to zero. VertCoord
+   // initializes before OceanState, which also contributes fields to these
+   // groups, so create each group only if it does not already exist.
    std::string StateGrpName = "State";
    if (Name != "Default") {
       StateGrpName.append(Name);
@@ -702,9 +708,30 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
 }
 
 //------------------------------------------------------------------------------
-// Exchange halo and copy SurfacePressure to host after the initial-state or
+// Apply the zero default when SurfacePressure was absent from the input, then
+// exchange halo and copy SurfacePressure to host after the initial-state or
 // restart stream has been read.
 void VertCoord::initSurfacePressure(Halo *MeshHalo) {
+   // SurfacePressure is an optional read. If it was not present in the
+   // initial-state or restart file, its owned cells still hold the fill value
+   // set by attachData; in that case default the whole array to zero. Only the
+   // owned cells are checked because halo cells are not populated until the
+   // exchange below.
+   OMEGA_SCOPE(LocSurfacePressure, SurfacePressure);
+   I4 NFill = 0;
+   parallelReduce(
+       {NCellsOwned},
+       KOKKOS_LAMBDA(int ICell, I4 &Count) {
+          if (LocSurfacePressure(ICell) == FillValueReal)
+             ++Count;
+       },
+       NFill);
+   if (NFill > 0) {
+      LOG_INFO("VertCoord: SurfacePressure not found in input, "
+               "using SurfacePressure = 0");
+      deepCopy(SurfacePressure, 0._Real);
+   }
+
    MeshHalo->exchangeFullArrayHalo(SurfacePressure, OnCell);
    deepCopy(SurfacePressureH, SurfacePressure);
 }

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -143,6 +143,7 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    MaxLayerCell    = Array1DI4("MaxLayerCell", NCellsSize);
    MinLayerCell    = Array1DI4("MinLayerCell", NCellsSize);
    BottomGeomDepth = Array1DReal("BottomGeomDepth", NCellsSize);
+   SurfacePressure = Array1DReal("SurfacePressure", NCellsSize);
    PressureInterface =
        Array2DReal("PressureInterface", NCellsSize, NVertLayersP1);
    PressureMid     = Array2DReal("PressureMid", NCellsSize, NVertLayers);
@@ -157,10 +158,6 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    VertCoordMovementWeights =
        Array1DReal("VertCoordMovementWeights", NVertLayers);
 
-   // TODO: Temporary handling of SurfacePressure
-   SurfacePressure = Array1DReal("SurfacePressure", NCellsSize);
-   deepCopy(SurfacePressure, 0);
-
    // Make host copies for device arrays not being read from file
    PressureInterfaceH     = createHostMirrorCopy(PressureInterface);
    PressureMidH           = createHostMirrorCopy(PressureMid);
@@ -169,6 +166,10 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    GeomZMidH              = createHostMirrorCopy(GeomZMid);
    GeopotentialMidH       = createHostMirrorCopy(GeopotentialMid);
    PseudoThicknessTargetH = createHostMirrorCopy(PseudoThicknessTarget);
+
+   // SurfacePressure is read from the initial-state/restart stream later, in
+   // OceanInit; its host mirror is refreshed then by initSurfacePressure().
+   SurfacePressureH = createHostMirrorCopy(SurfacePressure);
 
    // Define field metadata
    defineFields();
@@ -230,6 +231,7 @@ void VertCoord::defineFields() {
    SshFldName                   = "SshCell";
    GeopotFldName                = "GeopotentialMid";
    PseudoThicknessTargetFldName = "PseudoThicknessTarget";
+   SurfacePressureFldName       = "SurfacePressure";
 
    if (Name != "Default") {
       MinLayerCellFldName.append(Name);
@@ -244,6 +246,7 @@ void VertCoord::defineFields() {
       GeopotFldName.append(Name);
       PseudoThicknessTargetFldName.append(Name);
       SshFldName.append(Name);
+      SurfacePressureFldName.append(Name);
    }
 
    // Create fields for VertCoord variables
@@ -296,6 +299,17 @@ void VertCoord::defineFields() {
        DimNames                             // dimension names
    );
 
+   auto SurfacePressureField = Field::create(
+       SurfacePressureFldName,                             // field name
+       "Relative pressure at the top of the ocean column", // long name
+       "Pa",                                               // units
+       "",                                                 // CF standard Name
+       -9.99E+10,                                          // min valid value
+       9.99E+10,                                           // max valid value
+       NDims,                                              // number of dims
+       DimNames                                            // dimension names
+   );
+
    NDims = 2;
    DimNames.resize(NDims);
    DimNames[1] = "NVertLayers";
@@ -334,14 +348,14 @@ void VertCoord::defineFields() {
    DimNames[1] = "NVertLayersP1";
 
    auto PressureInterfaceField = Field::create(
-       PressInterfFldName,                      // field name
-       "Pressure at vertical layer interfaces", // long name or description
-       "Pa",                                    // units
-       "sea_water_pressure",                    // CF standard Name
-       0.0,                                     // min valid value
-       std::numeric_limits<Real>::max(),        // max valid value
-       NDims,                                   // number of dimensions
-       DimNames                                 // dimension names
+       PressInterfFldName,                                       // field name
+       "Relative pressure (gauge pressure) at layer interfaces", // long name
+       "Pa",                                                     // units
+       "",                               // CF standard Name
+       -AtmRefP,                         // min valid value
+       std::numeric_limits<Real>::max(), // max valid value
+       NDims,                            // number of dimensions
+       DimNames                          // dimension names
    );
 
    auto GeomZInterfaceField = Field::create(
@@ -358,14 +372,14 @@ void VertCoord::defineFields() {
    DimNames[1] = "NVertLayers";
 
    auto PressureMidField = Field::create(
-       PressMidFldName,                        // field name
-       "Pressure at vertical layer midpoints", // long name or description
-       "Pa",                                   // units
-       "sea_water_pressure",                   // CF standard Name
-       0.0,                                    // min valid value
-       std::numeric_limits<Real>::max(),       // max valid value
-       NDims,                                  // number of dimensions
-       DimNames                                // dimension names
+       PressMidFldName,                                         // field name
+       "Relative pressure (gauge pressure) at layer midpoints", // long name
+       "Pa",                                                    // units
+       "",                               // CF standard Name
+       -AtmRefP,                         // min valid value
+       std::numeric_limits<Real>::max(), // max valid value
+       NDims,                            // number of dimensions
+       DimNames                          // dimension names
    );
 
    auto GeomZMidField = Field::create(
@@ -445,6 +459,24 @@ void VertCoord::defineFields() {
    PseudoThicknessTargetField->attachData<Array2DReal>(PseudoThicknessTarget);
    SshField->attachData<Array1DReal>(SshCell);
 
+   // Add SurfacePressure to the State and Restart groups so it is read from the
+   // initial-state and restart files. VertCoord initializes before OceanState,
+   // which also contributes fields to these groups, so create each group only
+   // if it does not already exist.
+   std::string StateGrpName = "State";
+   if (Name != "Default") {
+      StateGrpName.append(Name);
+   }
+   if (!FieldGroup::exists(StateGrpName))
+      FieldGroup::create(StateGrpName);
+   FieldGroup::addFieldToGroup(SurfacePressureFldName, StateGrpName);
+
+   if (!FieldGroup::exists("Restart"))
+      FieldGroup::create("Restart");
+   FieldGroup::addFieldToGroup(SurfacePressureFldName, "Restart");
+
+   SurfacePressureField->attachData<Array1DReal>(SurfacePressure);
+
 } // end defineFields
 
 //------------------------------------------------------------------------------
@@ -469,6 +501,12 @@ VertCoord::~VertCoord() {
       Field::destroy(PseudoThicknessTargetFldName);
       Field::destroy(SshFldName);
       FieldGroup::destroy(GroupName);
+   }
+
+   // SurfacePressure belongs to the shared "State"/"Restart" groups (owned by
+   // OceanState), so destroy only the field here, not those groups.
+   if (Field::exists(SurfacePressureFldName)) {
+      Field::destroy(SurfacePressureFldName);
    }
 
 } // end destructor
@@ -661,6 +699,14 @@ void VertCoord::setStreamArrays(const bool ReadStream, Halo *MeshHalo) {
    BottomGeomDepthH          = createHostMirrorCopy(BottomGeomDepth);
    RefPseudoThicknessH       = createHostMirrorCopy(RefPseudoThickness);
    VertCoordMovementWeightsH = createHostMirrorCopy(VertCoordMovementWeights);
+}
+
+//------------------------------------------------------------------------------
+// Exchange halo and copy SurfacePressure to host after the initial-state or
+// restart stream has been read.
+void VertCoord::initSurfacePressure(Halo *MeshHalo) {
+   MeshHalo->exchangeFullArrayHalo(SurfacePressure, OnCell);
+   deepCopy(SurfacePressureH, SurfacePressure);
 }
 
 //------------------------------------------------------------------------------
@@ -958,11 +1004,12 @@ void VertCoord::setMasks() {
 } // end setMasks()
 
 //------------------------------------------------------------------------------
-// Compute the pressure at each layer interface and midpoint given the
-// PseudoThickness and SurfacePressure. Hierarchical parallelism is used with a
-// parallel_for loop over all cells and a parallel_scan performing a prefix sum
-// in each column to compute pressure from the top-most active layer to the
-// bottom-most active layer.
+// Compute the relative pressure (gauge pressure, i.e., absolute pressure minus
+// the standard atmosphere of 101325 Pa) at each layer interface and midpoint
+// given PseudoThickness and SurfacePressure (also relative). Hierarchical
+// parallelism is used with a parallel_for loop over all cells and a
+// parallel_scan performing a prefix sum in each column from the top-most active
+// layer to the bottom-most active layer.
 void VertCoord::computePressure(
     const Array2DReal &PseudoThickness, // [in] pseudo-thickness
     const Array1DReal &SurfacePressure  // [in] surface pressure

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -170,7 +170,10 @@ class VertCoord {
 
    HostArray1DReal BottomGeomDepthH;
 
-   // TODO: Temporary handling of SurfacePressure
+   // Relative pressure (gauge pressure) at the top of the ocean column. Read
+   // from the initial-state/restart file via the "State"/"Restart" groups and
+   // used as the top boundary condition of the pressure field in
+   // computePressure().
    Array1DReal SurfacePressure;
 
    HostArray1DReal SurfacePressureH;
@@ -194,8 +197,9 @@ class VertCoord {
    std::string GeomZMidFldName; ///< Field name for midpoint geometric height
    std::string GeopotFldName;   ///< Field name for geopotential
    std::string
-       PseudoThicknessTargetFldName; ///< Field name for target thickness
-   std::string SshFldName;           ///< Field name for sea surface height
+       PseudoThicknessTargetFldName;   ///< Field name for target thickness
+   std::string SshFldName;             ///< Field name for sea surface height
+   std::string SurfacePressureFldName; ///< Field name for SurfacePressure
 
    // methods
 
@@ -215,6 +219,10 @@ class VertCoord {
 
    /// Copy member arrays from device to host
    void copyToHost();
+
+   /// Exchange halo and copy SurfacePressure to host after the initial-state
+   /// or restart stream has been read
+   void initSurfacePressure(Halo *MeshHalo);
 
    /// Copy member arrays from host to device
    void copyToDevice();
@@ -270,9 +278,12 @@ class VertCoord {
 
    /// Sums the mass thickness times g from the top layer down, starting with
    /// the surface pressure
+   /// Computes the relative pressure (gauge pressure, i.e., absolute pressure
+   /// minus the standard atmosphere) at layer interfaces and midpoints by
+   /// summing mass thickness times g from the top layer down.
    void computePressure(
        const Array2DReal &PseudoThickness, ///< [in] pseudo-thickness
-       const Array1DReal &SurfacePressure  ///< [in] surface pressure
+       const Array1DReal &SurfacePressure  ///< [in] relative surface pressure
    );
 
    /// Sum the mass thickness times specific volume from the bottom layer up,

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -165,7 +165,7 @@ class VertCoord {
 
    HostArray2DReal BoundaryVertexH; ///< Mask to determine boundary vertex
 
-   // BottomGeomDepth read from mesh file
+   // BottomGeomDepth read from initial vertical coordinate file
    Array1DReal BottomGeomDepth;
 
    HostArray1DReal BottomGeomDepthH;

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -18,6 +18,7 @@
 #include "Eos.h"
 #include "Error.h"
 #include "Field.h"
+#include "FillValues.h"
 #include "Forcing.h"
 #include "Halo.h"
 #include "HorzMesh.h"
@@ -183,10 +184,41 @@ int main(int argc, char **argv) {
       I4 NCellsOwned    = DefDecomp->NCellsOwned;
       Array1DI4 CellID  = DefDecomp->CellID;
 
+      // Register a field that is absent from the input file and mark it as an
+      // optional read, then add it to the InitialState stream. Reading the
+      // stream should succeed and leave the array at its fill value rather than
+      // failing because the variable is missing from the file.
+      Array1DReal OptTestData("OptionalTestField", NCellsSize);
+      auto OptTestField = Field::create("OptionalTestField", // field name
+                                        "optional read test field", // long name
+                                        "none",                     // units
+                                        "",         // CF standard name
+                                        -9.99E+10,  // min valid value
+                                        9.99E+10,   // max valid value
+                                        1,          // number of dimensions
+                                        {"NCells"}, // dimension names
+                                        false);     // not time dependent
+      OptTestField->setOptionalRead(true);
+      OptTestField->attachData<Array1DReal>(OptTestData);
+      IOStream::get("InitialState")->addField("OptionalTestField");
+
       // Read restart file for initial temperature and salinity data
       Metadata ReqMetadata; // leave empty for now - no required metadata
       Err = IOStream::read("InitialState", ModelClock, ReqMetadata);
       CHECK_ERROR_ABORT(Err, "IOStreamTest: Error reading initial state");
+
+      // The optional field was not in the file, so it should have been skipped
+      // and retain the fill value set by attachData on all owned cells.
+      I4 NOptFill     = 0;
+      auto OptReducer = Kokkos::Sum<I4>(NOptFill);
+      parallelReduce(
+          {NCellsOwned},
+          KOKKOS_LAMBDA(int Cell, I4 &Acc) {
+             if (OptTestData(Cell) == FillValueReal)
+                ++Acc;
+          },
+          OptReducer);
+      TestEval("Optional read fill retained", NOptFill, NCellsOwned, Err);
 
       // Overwrite salinity array with values associated with global cell
       // ID to test proper indexing of IO

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -279,8 +279,9 @@ int main(int argc, char *argv[]) {
          LOG_INFO("State: Out-of-range {} Non-zero: {}", Count2, Count1);
       }
 
-      // SurfacePressure is now owned by VertCoord but read from the same
-      // InitialState stream; verify its host mirror is sized and read
+      // SurfacePressure is owned by VertCoord and an optional read from the
+      // InitialState stream. It is absent from the test input file, so it
+      // defaults to zero; verify its host mirror is sized and defaulted
       // correctly.
       VertCoord *DefVCoord = VertCoord::getDefault();
       if (DefVCoord->SurfacePressureH.extent_int(0) == DefState->NCellsSize) {

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -136,6 +136,10 @@ void initStateTest() {
    DefState->exchangeHalo(0);
    DefState->copyToHost(0);
 
+   // SurfacePressure is owned by VertCoord but read from the same InitialState
+   // stream; finish its initialization (halo exchange + copy to host).
+   VertCoord::getDefault()->initSurfacePressure(Halo::getDefault());
+
    return;
 }
 
@@ -273,6 +277,28 @@ int main(int argc, char *argv[]) {
          RetVal += 1;
          LOG_INFO("State: State read FAIL");
          LOG_INFO("State: Out-of-range {} Non-zero: {}", Count2, Count1);
+      }
+
+      // SurfacePressure is now owned by VertCoord but read from the same
+      // InitialState stream; verify its host mirror is sized and read
+      // correctly.
+      VertCoord *DefVCoord = VertCoord::getDefault();
+      if (DefVCoord->SurfacePressureH.extent_int(0) == DefState->NCellsSize) {
+         LOG_INFO("State: SurfacePressureH size PASS");
+      } else {
+         RetVal += 1;
+         LOG_INFO("State: SurfacePressureH size FAIL");
+      }
+      int Count3 = 0;
+      for (int Cell = 0; Cell < NCellsAll; Cell++) {
+         if (DefVCoord->SurfacePressureH(Cell) != 0.0)
+            Count3++;
+      }
+      if (Count3 == 0) {
+         LOG_INFO("State: SurfacePressure read PASS");
+      } else {
+         RetVal += 1;
+         LOG_INFO("State: SurfacePressure read FAIL");
       }
 
       // Test time swapping with 2 and higher numbers of time levels

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -128,6 +128,16 @@ int main(int argc, char *argv[]) {
              Error(ErrorCode::Fail, "VertCoordTest: Bathy min/max test FAIL");
       }
 
+      // SurfacePressure is owned by VertCoord and its host mirror is sized on
+      // cells. Its value is read from the InitialState stream (exercised in
+      // StateTest); here we just verify the host mirror allocation.
+      if (DefVertCoord->SurfacePressureH.extent_int(0) == NCellsSize) {
+         LOG_INFO("VertCoordTest: SurfacePressureH size PASS");
+      } else {
+         ErrAll += Error(ErrorCode::Fail,
+                         "VertCoordTest: SurfacePressureH size FAIL");
+      }
+
       // Tests for computePressure
 
       Array2DReal PseudoThickness("PseudoThickness", NCellsSize, NVertLayers);


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

Register SurfacePressure as an input/output field owned by the vertical coordinate so it is read from the initial-condition and restart files, and define all Omega pressure fields as relative (gauge) pressure. SurfacePressure was previously a zeroed placeholder in VertCoord; it is now allocated, registered as a field, and added to the State and Restart field groups next to the other prognostic variables, with a post-read step to exchange halos and update its host mirror. Because VertCoord is the sole consumer of SurfacePressure when computing 3D pressure, it owns the array directly. SurfacePressure is registered as an optional read, so it is read from the initial condition or restart file when present but defaults to zero when absent rather than causing the read to fail. Supporting this adds a general per-field optional-read capability to the IO layer.

## Changes

### Register `SurfacePressure` as a `VertCoord` IO field

- Allocate `SurfacePressure`/`SurfacePressureH` in `VertCoord` and remove the placeholder `TODO` zero-fill
- Register `SurfacePressure` as a 1D (`NCells`) field and add it to the `State` and `Restart` field groups so it is included in the initial-condition and restart streams
- Keep ownership in `VertCoord`, its only consumer, so no array needs to be shared between classes to compute 3D pressure
- Because `VertCoord` initializes before `OceanState` and both contribute to the `State` group, create the `State`/`Restart` groups from whichever initializes first; `OceanState` guards its `State`-group creation accordingly
- Add `VertCoord::initSurfacePressure(Halo*)` to exchange halos and sync device→host after the initial-state/restart stream read, and call it from `OceanInit` after the read so the host mirror and halo are ready before the model advances

`SurfacePressure` is marked as an optional read, so it is not required in the Omega initial condition or restart file. When it is absent, the stream read leaves it at its fill value and `initSurfacePressure` defaults it to zero (0 Pa), which is the correct value for standard atmospheric forcing.

### Add an optional-read capability to IO fields

Fields registered in a read stream are normally required to be present in the input file, which is why an owner like `VertCoord` could not simply default `SurfacePressure` when it lives in the shared `State`/`Restart` read. This adds a general way to make a field optional.

- Add a per-field `OptionalRead` flag to `Field` (`setOptionalRead`/`isOptionalRead`, required by default) so a field may be absent from an input file
- Update `IOStream::readFieldData` to skip a missing optional field — log, return success, and leave the array at the fill value set by `attachData` — instead of failing the whole stream read; required fields are unaffected
- Mark `VertCoord::SurfacePressure` as an optional read and default it to zero in `initSurfacePressure` when its owned cells still hold the fill value after the read, so a missing `SurfacePressure` no longer aborts initialization
- Add an `IOStreamTest` case that reads a stream containing an optional field absent from the file and verifies the read succeeds with the array left at its fill value
- Document the optional-read behavior in the `Field` and IOStreams developer guides and the fill-values design doc

### Define all pressure fields as relative (gauge) pressure

Omega's pressure fields (`SurfacePressure`, `PressureInterface`, `PressureMid`) are defined as **relative pressure** — absolute pressure minus the standard atmosphere (101325 Pa). Motivations:

- **TEOS-10** expects relative (gauge) pressure; `Eos.h` already passes `Pressure * Pa2Db` with no offset, consistent with this definition.
- **z-tilde pseudo-height** `ẑ = p / (ρ₀ g)` equals zero at the sea surface under standard atmospheric forcing only when `p` is relative pressure. Under absolute pressure the surface pseudo-height would already be ≈ −10 m, which is conceptually strange.
- The CF standard name `sea_water_pressure` is defined for absolute pressure, so it is not used for these fields; no CF standard name exists for relative pressure.

Specific changes:

- `VertCoord.cpp`: create `SurfacePressure` with units Pa, long name "relative pressure at the top of the ocean column", and no CF standard name; remove the `sea_water_pressure` CF standard name from `PressureInterface` and `PressureMid`, update their long names to "relative pressure (gauge pressure)", and set their minimum valid value to `−AtmRefP` (≈ −101325 Pa, since absolute pressure ≥ 0 implies relative pressure ≥ −standard atmosphere)
- `Eos.h`: document that `Pressure` inputs to the TEOS-10 specific-volume, freezing-temperature, and Brunt-Väisälä functors are relative pressure
- `VertCoord.h`/`VertCoord.cpp`: clarify that `computePressure` computes relative pressure given relative `SurfacePressure`
- User guide (`VertCoord.md`, `OceanState.md`): describe the pressure fields as relative, document that `SurfacePressure` is owned by `VertCoord` and is an optional read that defaults to zero, and note that it is 0 Pa for standard atmospheric forcing and represents the atmospheric anomaly in coupled runs
- Developer guide (`VertCoord.md`, `OceanState.md`): document that `SurfacePressure` is a `VertCoord` field, is relative pressure, and is an optional read that defaults to zero

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests
    * [x] Document testing used to verify the changes including any tests that are added/modified/impacted.
  * [x] New tests:
    * [x] CTest unit tests for new features have been added per the approved design.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


