### PR TITLE
Add fix for missing debug tracers to tracer and tendency tests

### DIFF
--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -1,6 +1,7 @@
 #ifndef OMEGA_OCEAN_TEST_COMMON_H
 #define OMEGA_OCEAN_TEST_COMMON_H
 
+#include "Config.h"
 #include "DataTypes.h"
 #include "Halo.h"
 #include "HorzMesh.h"
@@ -8,7 +9,61 @@
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 
+#include <string>
+#include <vector>
+
 namespace OMEGA {
+
+// Ensure required debug tracers are available in Tracers.Debug config.
+inline void ensureDebugTracersConfigured(const std::string &TestName) {
+
+   Config *OmegaConfig = Config::getOmegaConfig();
+   if (OmegaConfig == nullptr) {
+      LOG_ERROR("{}: Omega configuration is not initialized", TestName);
+      return;
+   }
+
+   Config TracersConfig("Tracers");
+   Error Err = OmegaConfig->get(TracersConfig);
+   if (!Err.isSuccess()) {
+      LOG_ERROR("{}: Tracers section not found in configuration", TestName);
+      return;
+   }
+
+   std::vector<std::string> DebugTracers = {"Debug1", "Debug2", "Debug3"};
+   bool HasAllDebugTracers               = false;
+
+   if (TracersConfig.existsVar("Debug")) {
+      std::vector<std::string> ConfiguredDebugTracers;
+      Error DebugErr = TracersConfig.get("Debug", ConfiguredDebugTracers);
+      if (DebugErr.isSuccess()) {
+         auto hasTracer =
+             [&ConfiguredDebugTracers](const std::string &TracerName) {
+                for (const auto &Name : ConfiguredDebugTracers) {
+                   if (Name == TracerName)
+                      return true;
+                }
+                return false;
+             };
+
+         HasAllDebugTracers =
+             hasTracer("Debug1") && hasTracer("Debug2") && hasTracer("Debug3");
+      }
+   }
+
+   if (!HasAllDebugTracers) {
+      if (TracersConfig.existsVar("Debug")) {
+         TracersConfig.set("Debug", DebugTracers);
+      } else {
+         TracersConfig.add("Debug", DebugTracers);
+      }
+      LOG_INFO("{}: Configured debug tracers (Debug1, Debug2, Debug3)",
+               TestName);
+   } else {
+      LOG_INFO("{}: Debug tracers Debug1/Debug2/Debug3 are already configured",
+               TestName);
+   }
+}
 
 // check if two real numbers are equal with a given relative tolerance
 KOKKOS_INLINE_FUNCTION

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -1,7 +1,6 @@
 #ifndef OMEGA_OCEAN_TEST_COMMON_H
 #define OMEGA_OCEAN_TEST_COMMON_H
 
-#include "Config.h"
 #include "DataTypes.h"
 #include "Halo.h"
 #include "HorzMesh.h"
@@ -9,61 +8,7 @@
 #include "MachEnv.h"
 #include "OmegaKokkos.h"
 
-#include <string>
-#include <vector>
-
 namespace OMEGA {
-
-// Ensure required debug tracers are available in Tracers.Debug config.
-inline void ensureDebugTracersConfigured(const std::string &TestName) {
-
-   Config *OmegaConfig = Config::getOmegaConfig();
-   if (OmegaConfig == nullptr) {
-      LOG_ERROR("{}: Omega configuration is not initialized", TestName);
-      return;
-   }
-
-   Config TracersConfig("Tracers");
-   Error Err = OmegaConfig->get(TracersConfig);
-   if (!Err.isSuccess()) {
-      LOG_ERROR("{}: Tracers section not found in configuration", TestName);
-      return;
-   }
-
-   std::vector<std::string> DebugTracers = {"Debug1", "Debug2", "Debug3"};
-   bool HasAllDebugTracers               = false;
-
-   if (TracersConfig.existsVar("Debug")) {
-      std::vector<std::string> ConfiguredDebugTracers;
-      Error DebugErr = TracersConfig.get("Debug", ConfiguredDebugTracers);
-      if (DebugErr.isSuccess()) {
-         auto hasTracer =
-             [&ConfiguredDebugTracers](const std::string &TracerName) {
-                for (const auto &Name : ConfiguredDebugTracers) {
-                   if (Name == TracerName)
-                      return true;
-                }
-                return false;
-             };
-
-         HasAllDebugTracers =
-             hasTracer("Debug1") && hasTracer("Debug2") && hasTracer("Debug3");
-      }
-   }
-
-   if (!HasAllDebugTracers) {
-      if (TracersConfig.existsVar("Debug")) {
-         TracersConfig.set("Debug", DebugTracers);
-      } else {
-         TracersConfig.add("Debug", DebugTracers);
-      }
-      LOG_INFO("{}: Configured debug tracers (Debug1, Debug2, Debug3)",
-               TestName);
-   } else {
-      LOG_INFO("{}: Debug tracers Debug1/Debug2/Debug3 are already configured",
-               TestName);
-   }
-}
 
 // check if two real numbers are equal with a given relative tolerance
 KOKKOS_INLINE_FUNCTION

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -1035,7 +1035,7 @@ int testSurfaceTracerRestoringOnCell(int NVertLayers, int NTracers, Real RTol) {
    // Test multiple cases with different combinations of tracers being restored
    const char *CaseLabels[3] = {"SurfaceTracerRestoringSalinityOnly",
                                 "SurfaceTracerRestoringTemperatureOnly",
-                                "SurfaceTracerRestoringTempSaltDebug"};
+                                "SurfaceTracerRestoringTempSalt"};
 
    const std::vector<std::vector<I4>> CaseTracerIds = {
        {1},    // Salinity Only

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -35,7 +35,6 @@
 #include "VertCoord.h"
 #include "mpi.h"
 
-#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <vector>
@@ -1149,45 +1148,8 @@ void initTendTest(const std::string &MeshFile, int NVertLayers) {
    Config::Initialize();
    Config::readAll("omega.yml");
 
-   // Check if debug tracers are configured in the Tracers section.
-   // If missing or incomplete, add/reset them directly in the config.
-   Config *OmegaConfig = Config::getOmegaConfig();
-   Config TracersConfig("Tracers");
-   Err = OmegaConfig->get(TracersConfig);
-   if (Err.isSuccess()) {
-      std::vector<std::string> DebugTracers = {"Debug1", "Debug2", "Debug3"};
-
-      bool HasAllDebugTracers = false;
-      if (TracersConfig.existsVar("Debug")) {
-         std::vector<std::string> ConfiguredDebugTracers;
-         Error DebugErr = TracersConfig.get("Debug", ConfiguredDebugTracers);
-         if (DebugErr.isSuccess()) {
-            HasAllDebugTracers =
-                std::find(ConfiguredDebugTracers.begin(),
-                          ConfiguredDebugTracers.end(),
-                          "Debug1") != ConfiguredDebugTracers.end() &&
-                std::find(ConfiguredDebugTracers.begin(),
-                          ConfiguredDebugTracers.end(),
-                          "Debug2") != ConfiguredDebugTracers.end() &&
-                std::find(ConfiguredDebugTracers.begin(),
-                          ConfiguredDebugTracers.end(),
-                          "Debug3") != ConfiguredDebugTracers.end();
-         }
-      }
-
-      if (!HasAllDebugTracers) {
-         if (TracersConfig.existsVar("Debug")) {
-            TracersConfig.set("Debug", DebugTracers);
-         } else {
-            TracersConfig.add("Debug", DebugTracers);
-         }
-         LOG_INFO("TendencyTermsTest: Configured debug tracers (Debug1, "
-                  "Debug2, Debug3)");
-      } else {
-         LOG_INFO("TendencyTermsTest: Debug tracers Debug1/Debug2/Debug3 are "
-                  "already configured");
-      }
-   }
+   // Ensure required debug tracers are configured in the Omega configuration
+   ensureDebugTracersConfigured("TendencyTermsTest");
 
    // Initialize time stepping and get model clock
    TimeStepper::init1();

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -1025,8 +1025,8 @@ int testSurfaceTracerRestoringOnCell(int NVertLayers, int NTracers, Real RTol) {
 
    const auto Mesh = HorzMesh::getDefault();
 
-   if (NTracers < 3) {
-      LOG_ERROR("TendencyTermsTest: SurfaceTracerRestoring requires at least 3 "
+   if (NTracers < 2) {
+      LOG_ERROR("TendencyTermsTest: SurfaceTracerRestoring requires at least 2 "
                 "tracers, found {}",
                 NTracers);
       return 1;
@@ -1038,9 +1038,9 @@ int testSurfaceTracerRestoringOnCell(int NVertLayers, int NTracers, Real RTol) {
                                 "SurfaceTracerRestoringTempSaltDebug"};
 
    const std::vector<std::vector<I4>> CaseTracerIds = {
-       {1},       // Salinity Only
-       {0},       // Temperature Only
-       {0, 1, 2}, // Temperature, Salinity, and a Debug Tracer
+       {1},    // Salinity Only
+       {0},    // Temperature Only
+       {0, 1}, // Temperature and Salinity
    };
 
    // Loop over cases, computing exact result, numerical result, and
@@ -1147,9 +1147,6 @@ void initTendTest(const std::string &MeshFile, int NVertLayers) {
    // Open config file
    Config::Initialize();
    Config::readAll("omega.yml");
-
-   // Ensure required debug tracers are configured in the Omega configuration
-   ensureDebugTracersConfigured("TendencyTermsTest");
 
    // Initialize time stepping and get model clock
    TimeStepper::init1();

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -35,6 +35,7 @@
 #include "VertCoord.h"
 #include "mpi.h"
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <vector>
@@ -1147,6 +1148,46 @@ void initTendTest(const std::string &MeshFile, int NVertLayers) {
    // Open config file
    Config::Initialize();
    Config::readAll("omega.yml");
+
+   // Check if debug tracers are configured in the Tracers section.
+   // If missing or incomplete, add/reset them directly in the config.
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config TracersConfig("Tracers");
+   Err = OmegaConfig->get(TracersConfig);
+   if (Err.isSuccess()) {
+      std::vector<std::string> DebugTracers = {"Debug1", "Debug2", "Debug3"};
+
+      bool HasAllDebugTracers = false;
+      if (TracersConfig.existsVar("Debug")) {
+         std::vector<std::string> ConfiguredDebugTracers;
+         Error DebugErr = TracersConfig.get("Debug", ConfiguredDebugTracers);
+         if (DebugErr.isSuccess()) {
+            HasAllDebugTracers =
+                std::find(ConfiguredDebugTracers.begin(),
+                          ConfiguredDebugTracers.end(),
+                          "Debug1") != ConfiguredDebugTracers.end() &&
+                std::find(ConfiguredDebugTracers.begin(),
+                          ConfiguredDebugTracers.end(),
+                          "Debug2") != ConfiguredDebugTracers.end() &&
+                std::find(ConfiguredDebugTracers.begin(),
+                          ConfiguredDebugTracers.end(),
+                          "Debug3") != ConfiguredDebugTracers.end();
+         }
+      }
+
+      if (!HasAllDebugTracers) {
+         if (TracersConfig.existsVar("Debug")) {
+            TracersConfig.set("Debug", DebugTracers);
+         } else {
+            TracersConfig.add("Debug", DebugTracers);
+         }
+         LOG_INFO("TendencyTermsTest: Configured debug tracers (Debug1, "
+                  "Debug2, Debug3)");
+      } else {
+         LOG_INFO("TendencyTermsTest: Debug tracers Debug1/Debug2/Debug3 are "
+                  "already configured");
+      }
+   }
 
    // Initialize time stepping and get model clock
    TimeStepper::init1();

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -20,6 +20,7 @@
 #include "IOStream.h"
 #include "Logging.h"
 #include "MachEnv.h"
+#include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
 #include "TimeStepper.h"
@@ -55,45 +56,8 @@ I4 initTracersTest() {
    Config("Omega");
    Config::readAll("omega.yml");
 
-   // Check if debug tracers are configured in the Tracers section.
-   // If missing or incomplete, add/reset them directly in the config.
-   Config *OmegaConfig = Config::getOmegaConfig();
-   Config TracersConfig("Tracers");
-   Error ConfigErr = OmegaConfig->get(TracersConfig);
-   if (ConfigErr.isSuccess()) {
-      std::vector<std::string> DebugTracers = {"Debug1", "Debug2", "Debug3"};
-
-      bool HasAllDebugTracers = false;
-      if (TracersConfig.existsVar("Debug")) {
-         std::vector<std::string> ConfiguredDebugTracers;
-         Error DebugErr = TracersConfig.get("Debug", ConfiguredDebugTracers);
-         if (DebugErr.isSuccess()) {
-            HasAllDebugTracers =
-                std::find(ConfiguredDebugTracers.begin(),
-                          ConfiguredDebugTracers.end(),
-                          "Debug1") != ConfiguredDebugTracers.end() &&
-                std::find(ConfiguredDebugTracers.begin(),
-                          ConfiguredDebugTracers.end(),
-                          "Debug2") != ConfiguredDebugTracers.end() &&
-                std::find(ConfiguredDebugTracers.begin(),
-                          ConfiguredDebugTracers.end(),
-                          "Debug3") != ConfiguredDebugTracers.end();
-         }
-      }
-
-      if (!HasAllDebugTracers) {
-         if (TracersConfig.existsVar("Debug")) {
-            TracersConfig.set("Debug", DebugTracers);
-         } else {
-            TracersConfig.add("Debug", DebugTracers);
-         }
-         LOG_INFO("TracersTest: Configured debug tracers (Debug1, Debug2, "
-                  "Debug3)");
-      } else {
-         LOG_INFO("TracersTest: Debug tracers Debug1/Debug2/Debug3 are already "
-                  "configured");
-      }
-   }
+   // Ensure required debug tracers are configured in the Omega configuration
+   ensureDebugTracersConfigured("TracersTest");
 
    // Initialize the default time stepper and model clock
    TimeStepper::init1();

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -20,14 +20,12 @@
 #include "IOStream.h"
 #include "Logging.h"
 #include "MachEnv.h"
-#include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
 #include "TimeStepper.h"
 #include "VertCoord.h"
 #include "mpi.h"
 
-#include <algorithm>
 #include <iostream>
 
 using namespace OMEGA;
@@ -55,9 +53,6 @@ I4 initTracersTest() {
    // Open config file
    Config("Omega");
    Config::readAll("omega.yml");
-
-   // Ensure required debug tracers are configured in the Omega configuration
-   ensureDebugTracersConfigured("TracersTest");
 
    // Initialize the default time stepper and model clock
    TimeStepper::init1();
@@ -167,7 +162,8 @@ int main(int argc, char *argv[]) {
          TotalLength += GroupLength;
 
          // Check if a group contains more than one tracers
-         if (GroupLength > 0) {
+         // Zero value allows a blank tracer group
+         if (GroupLength >= 0) {
             LOG_INFO("Tracers: {} tracers retrieval PASS", GroupName);
          } else {
             RetVal += 1;

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -26,6 +26,7 @@
 #include "VertCoord.h"
 #include "mpi.h"
 
+#include <algorithm>
 #include <iostream>
 
 using namespace OMEGA;
@@ -53,6 +54,46 @@ I4 initTracersTest() {
    // Open config file
    Config("Omega");
    Config::readAll("omega.yml");
+
+   // Check if debug tracers are configured in the Tracers section.
+   // If missing or incomplete, add/reset them directly in the config.
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config TracersConfig("Tracers");
+   Error ConfigErr = OmegaConfig->get(TracersConfig);
+   if (ConfigErr.isSuccess()) {
+      std::vector<std::string> DebugTracers = {"Debug1", "Debug2", "Debug3"};
+
+      bool HasAllDebugTracers = false;
+      if (TracersConfig.existsVar("Debug")) {
+         std::vector<std::string> ConfiguredDebugTracers;
+         Error DebugErr = TracersConfig.get("Debug", ConfiguredDebugTracers);
+         if (DebugErr.isSuccess()) {
+            HasAllDebugTracers =
+                std::find(ConfiguredDebugTracers.begin(),
+                          ConfiguredDebugTracers.end(),
+                          "Debug1") != ConfiguredDebugTracers.end() &&
+                std::find(ConfiguredDebugTracers.begin(),
+                          ConfiguredDebugTracers.end(),
+                          "Debug2") != ConfiguredDebugTracers.end() &&
+                std::find(ConfiguredDebugTracers.begin(),
+                          ConfiguredDebugTracers.end(),
+                          "Debug3") != ConfiguredDebugTracers.end();
+         }
+      }
+
+      if (!HasAllDebugTracers) {
+         if (TracersConfig.existsVar("Debug")) {
+            TracersConfig.set("Debug", DebugTracers);
+         } else {
+            TracersConfig.add("Debug", DebugTracers);
+         }
+         LOG_INFO("TracersTest: Configured debug tracers (Debug1, Debug2, "
+                  "Debug3)");
+      } else {
+         LOG_INFO("TracersTest: Debug tracers Debug1/Debug2/Debug3 are already "
+                  "configured");
+      }
+   }
 
    // Initialize the default time stepper and model clock
    TimeStepper::init1();


### PR DESCRIPTION
Adds in a check for whether `Debug1-3` are included in `omega.yml` for the Tracer and Tendency tests. If not, they are added. This fixes https://github.com/E3SM-Project/Omega/issues/436 after the debug tracers were removed as defaults in https://github.com/E3SM-Project/Omega/pull/416.

Passes all CTests on PM-CPU and PM-GPU and the polaris `omega_pr` test suite.

Checklist
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing
  * [x] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [x] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [x] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests

## Testing

### CTest unit tests
- Machine: PM-CPU, PM-GPU
- Compiler: gnu, gnugpu
- Build type: Relase
- Result: All tests passed
- 
### Polaris `omega_pr` suite
- Baseline workdir: `/pscratch/sd/k/katsmith/polaris_testing_pr437//baseline_omega_pr`
- Baseline build: `/pscratch/sd/k/katsmith/polaris-main/e3sm_submodules/Omega`
- PR build: `/pscratch/sd/k/katsmith/polaris-pr437/e3sm_submodules/Omega`
- PR workdir: `/pscratch/sd/k/katsmith/polaris_testing_pr437/pr437_omega_pr`
- Machine: `pm-cpu`
- Compiler: `gnu`
- Build type: `Release`
- Log: not found
- Result: All tests passed