### PR TITLE
Add boolean Omega build-mode macros

### DIFF
--- a/components/omega/OmegaBuild.cmake
+++ b/components/omega/OmegaBuild.cmake
@@ -540,7 +540,31 @@ macro(update_variables)
   # Set the build type
   set(CMAKE_BUILD_TYPE ${OMEGA_BUILD_TYPE})
 
-  add_definitions(-DOMEGA_BUILD_MODE=${OMEGA_BUILD_MODE})
+  # Expose the Omega build mode to C/C++ as compile-time macros.
+  #
+  # Use the boolean-style macros below in source code:
+  #   #if OMEGA_BUILD_MODE_STANDALONE
+  #   #if OMEGA_BUILD_MODE_E3SM_COUPLED
+  #
+  # OMEGA_BUILD_MODE is also kept as a numeric macro for code that needs a
+  # single build-mode value.
+  if("${OMEGA_BUILD_MODE}" STREQUAL "STANDALONE")
+    add_definitions(
+      -DOMEGA_BUILD_MODE=1
+      -DOMEGA_BUILD_MODE_STANDALONE=1
+      -DOMEGA_BUILD_MODE_E3SM_COUPLED=0
+    )
+
+  elseif("${OMEGA_BUILD_MODE}" STREQUAL "E3SM")
+    add_definitions(
+      -DOMEGA_BUILD_MODE=2
+      -DOMEGA_BUILD_MODE_STANDALONE=0
+      -DOMEGA_BUILD_MODE_E3SM_COUPLED=1
+    )
+
+  else()
+    message(FATAL_ERROR "OMEGA_BUILD_MODE is neither E3SM nor STANDALONE.")
+  endif()
 
   if(NOT DEFINED OMEGA_LOG_LEVEL)
     set(OMEGA_LOG_LEVEL "INFO")

--- a/components/omega/doc/devGuide/CMakeBuild.md
+++ b/components/omega/doc/devGuide/CMakeBuild.md
@@ -71,6 +71,26 @@ OMEGA_LOG_TASKS: set the tasks that generate log file. "0" is a default value.
 OMEGA_VECTOR_LENGTH: Vector length used for blocking inner loops for vectorization. "1" is a default value.
 ```
 
+Build-mode compile-time macros
+
+The selected `OMEGA_BUILD_MODE` is exposed to C/C++ source as preprocessor
+macros so code can be conditionally compiled for standalone or E3SM-coupled
+builds:
+
+```
+OMEGA_BUILD_MODE: numeric build-mode id (1 = STANDALONE, 2 = E3SM)
+OMEGA_BUILD_MODE_STANDALONE: 1 in standalone builds, 0 otherwise
+OMEGA_BUILD_MODE_E3SM_COUPLED: 1 in E3SM-coupled builds, 0 otherwise
+```
+
+Prefer the boolean-style macros in source code, e.g.
+
+```c++
+#if OMEGA_BUILD_MODE_STANDALONE
+   // standalone-only code (e.g. the driver's main())
+#endif
+```
+
 E3SM-specific variables
 
 ```

--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -14,6 +14,11 @@
 
 #include <iostream>
 
+// The standalone driver provides Omega's entry point and is only compiled in
+// standalone builds. In E3SM-coupled builds the coupler supplies main() and
+// drives Omega through the ocnInit/ocnRun/ocnFinalize interface instead.
+#if OMEGA_BUILD_MODE_STANDALONE
+
 int main(int argc, char **argv) {
 
    int ErrAll;
@@ -70,5 +75,7 @@ int main(int argc, char **argv) {
       ErrAll = 255;
    return ErrAll;
 }
+
+#endif // OMEGA_BUILD_MODE_STANDALONE
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Expose the Omega build mode to C/C++ as compile-time macros.

In addition to the numeric OMEGA_BUILD_MODE, define OMEGA_BUILD_MODE_STANDALONE and OMEGA_BUILD_MODE_E3SM_COUPLED so source can be conditionally compiled per build mode.

Document the new macros in the CMake build dev guide.

Checklist
* [X] Documentation:
  * [X] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
* [X] Linting
  * [X] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [X] Building
  * [X] CMake build does not produce any new warnings from changes in this PR


