### PR TITLE
Adds a type check to Omega Config

### DIFF
--- a/components/omega/src/infra/Config.cpp
+++ b/components/omega/src/infra/Config.cpp
@@ -182,10 +182,11 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
          Value = Node[VarName].as<I4>();
          // Success - returns Value
       } catch (const YAML::TypedBadConversion<I4> &) { // bad conversion
-         // Return error message
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get I4: Expected an integer but encountered "
-                      "an incompatible data type in input config");
+         // Abort on bad conversion
+         ABORT_ERROR(
+             "Config get I4: Expected an integer for variable {} "
+             "but encountered an incompatible data type in input config",
+             VarName);
       }
    } else {
       // Do not modify value if not found to preserve any default value set
@@ -211,10 +212,11 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
          Value = Node[VarName].as<I8>();
          // Success - returns Value
       } catch (const YAML::TypedBadConversion<I8> &) { // bad conversion
-         // Return error message
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get I8: Expected an 8-byte integer but "
-                      "encountered an incompatible data type in input config");
+         // Abort on bad conversion
+         ABORT_ERROR(
+             "Config get I8: Expected an 8-byte integer for variable {} "
+             "but encountered an incompatible data type in input config",
+             VarName);
       }
    } else {
       // Do not modify value if not found to preserve any default value set
@@ -240,10 +242,11 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
          Value = Node[VarName].as<R4>();
          // Success - returns Value
       } catch (const YAML::TypedBadConversion<R4> &) { // bad conversion
-         // Return error message
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get R4: Expected a real variable but "
-                      "encountered an incompatible data type in input config");
+         // Abort on bad conversion
+         ABORT_ERROR(
+             "Config get R4: Expected a real variable for {} "
+             "but encountered an incompatible data type in input config",
+             VarName);
       }
    } else {
       // Do not modify value if not found to preserve any default value set
@@ -269,10 +272,11 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
          Value = Node[VarName].as<R8>();
          // Success - returns Value
       } catch (const YAML::TypedBadConversion<R8> &) { // check conversion
-         // Return error message
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get R8: Expected a double precision variable but "
-                      "encountered an incompatible data type in input config");
+         // Abort on bad conversion
+         ABORT_ERROR(
+             "Config get R8: Expected a double precision variable for {} "
+             "but encountered an incompatible data type in input config",
+             VarName);
       }
    } else {
       // Do not modify value if not found to preserve any default value set
@@ -297,10 +301,11 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
          Value = Node[VarName].as<bool>();
          // Success - returns Value
       } catch (const YAML::TypedBadConversion<bool> &) { // check bad conversion
-         // Return error message
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get bool: Expected a boolean variable but "
-                      "encountered an incompatible data type in input config");
+         // Abort on bad conversion
+         ABORT_ERROR(
+             "Config get bool: Expected a boolean variable for {} "
+             "but encountered an incompatible data type in input config",
+             VarName);
       }
    } else {
       // Do not modify value if not found to preserve any default value set
@@ -361,17 +366,16 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
                Vector[i] = Sequence[i].as<I4>();
                // Success - returns Value
             } catch (const YAML::TypedBadConversion<I4> &) { // bad conversion
-               // Return error message
-               RETURN_ERROR(
-                   Err, ErrorCode::Fail,
-                   "Config get I4 vector: Expected an integer but "
-                   "encountered an incompatible data type in input config");
+               // Abort on bad conversion
+               ABORT_ERROR(
+                   "Config get I4 vector: Expected an integer for variable {} "
+                   "but encountered an incompatible data type in input config",
+                   VarName);
             }
          }
 
-      } else { // not a sequence (vector) node so log an error
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get I4 vector: entry not a sequence {}", VarName);
+      } else { // not a sequence (vector) node so log an error and abort
+         ABORT_ERROR("Config get I4 vector: entry not a sequence {}", VarName);
       }
    } else { // node with that name does not exist
       RETURN_ERROR(Err, ErrorCode::Fail,
@@ -409,17 +413,16 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
                Vector[i] = Sequence[i].as<I8>();
                // Success - returns Value
             } catch (const YAML::TypedBadConversion<I8> &) { // bad conversion
-               // Return error message
-               RETURN_ERROR(
-                   Err, ErrorCode::Fail,
-                   "Config get I8 vector: Expected an 8-byte integer but "
-                   "encountered an incompatible data type in input config");
+               // Abort on bad conversion
+               ABORT_ERROR(
+                   "Config get I8 vector: Expected an 8-byte integer for {} "
+                   "but encountered an incompatible data type in input config",
+                   VarName);
             }
          }
 
-      } else { // not a sequence (vector) so log an error
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get I8 vector: entry not a sequence {}", VarName);
+      } else { // not a sequence (vector) node so log an error and abort
+         ABORT_ERROR("Config get I8 vector: entry not a sequence {}", VarName);
       }
    } else { // Node with that name does not exist
       RETURN_ERROR(Err, ErrorCode::Fail,
@@ -457,17 +460,16 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
                Vector[i] = Sequence[i].as<R4>();
                // Success - returns Value
             } catch (const YAML::TypedBadConversion<R4> &) { // bad conversion
-               // Return error message
-               RETURN_ERROR(
-                   Err, ErrorCode::Fail,
-                   "Config get R4 vector: Expected a real value but "
-                   "encountered an incompatible data type in input config");
+               // Abort on bad conversion
+               ABORT_ERROR(
+                   "Config get R4 vector: Expected a real value for {} but "
+                   "encountered an incompatible data type in input config",
+                   VarName);
             }
          }
 
-      } else { // not a sequence (vector) so log an error
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get R4 vector: entry not a sequence {}", VarName);
+      } else { // not a sequence (vector) node so log an error and abort
+         ABORT_ERROR("Config get R4 vector: entry not a sequence {}", VarName);
       }
    } else { // Node with that name does not exist
       RETURN_ERROR(Err, ErrorCode::Fail,
@@ -505,17 +507,17 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
                Vector[i] = Sequence[i].as<R8>();
                // Success - returns Value
             } catch (const YAML::TypedBadConversion<R8> &) { // bad conversion
-               // Return error message
-               RETURN_ERROR(
-                   Err, ErrorCode::Fail,
+               // Abort on bad conversion
+               ABORT_ERROR(
                    "Config get R8 vector: Expected a double precision value "
-                   "but encountered an incompatible data type in input config");
+                   "for {} but encountered an incompatible data type in input "
+                   "config",
+                   VarName);
             }
          }
 
-      } else { // not a sequence (vector) so log an error
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get R8 vector: entry not a sequence {}", VarName);
+      } else { // not a sequence (vector) node so log an error and abort
+         ABORT_ERROR("Config get R8 vector: entry not a sequence {}", VarName);
       }
    } else { // Node with that name does not exist
       RETURN_ERROR(Err, ErrorCode::Fail,
@@ -553,18 +555,17 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
                Vector[i] = Sequence[i].as<bool>();
                // Success - returns Value
             } catch (const YAML::TypedBadConversion<bool> &) { // bad conversion
-               // Return error message
-               RETURN_ERROR(
-                   Err, ErrorCode::Fail,
-                   "Config get bool vector: Expected a boolean value "
-                   "but encountered an incompatible data type in input config");
+               // Abort on bad conversion
+               ABORT_ERROR(
+                   "Config get bool vector: Expected a boolean value for {} "
+                   "but encountered an incompatible data type in input config",
+                   VarName);
             }
          }
 
-      } else { // not a sequence (vector) so log an error
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get bool vector: entry not a sequence {}",
-                      VarName);
+      } else { // not a sequence (vector) node so log an error and abort
+         ABORT_ERROR("Config get bool vector: entry not a sequence {}",
+                     VarName);
       }
    } else { // Node with that name does not exist
       RETURN_ERROR(Err, ErrorCode::Fail,
@@ -601,10 +602,9 @@ Error Config::get(const std::string &VarName,    // [in] name of variable to get
             List[i] = Sequence[i].as<std::string>();
          }
 
-      } else { // not a sequence (list) so log an error
-         RETURN_ERROR(Err, ErrorCode::Fail,
-                      "Config get string list: entry not a sequence {}",
-                      VarName);
+      } else { // not a sequence (vector) node so log an error and abort
+         ABORT_ERROR("Config get string list: entry not a sequence {}",
+                     VarName);
       }
    } else { // Node with that name does not exist
       RETURN_ERROR(Err, ErrorCode::Fail,

--- a/components/omega/src/infra/Config.cpp
+++ b/components/omega/src/infra/Config.cpp
@@ -177,7 +177,16 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
 
    // Extract variable from config
    if (Node[VarName]) { // the variable exists
-      Value = Node[VarName].as<I4>();
+      // Catch error if input an incompatible type
+      try {
+         Value = Node[VarName].as<I4>();
+         // Success - returns Value
+      } catch (const YAML::TypedBadConversion<I4> &) { // bad conversion
+         // Return error message
+         RETURN_ERROR(Err, ErrorCode::Fail,
+                      "Config get I4: Expected an integer but encountered "
+                      "an incompatible data type in input config");
+      }
    } else {
       // Do not modify value if not found to preserve any default value set
       RETURN_ERROR(Err, ErrorCode::Fail,
@@ -197,7 +206,16 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
 
    // Extract variable from config
    if (Node[VarName]) { // the variable exists
-      Value = Node[VarName].as<I8>();
+      // Catch error if input an incompatible type
+      try {
+         Value = Node[VarName].as<I8>();
+         // Success - returns Value
+      } catch (const YAML::TypedBadConversion<I8> &) { // bad conversion
+         // Return error message
+         RETURN_ERROR(Err, ErrorCode::Fail,
+                      "Config get I8: Expected an 8-byte integer but "
+                      "encountered an incompatible data type in input config");
+      }
    } else {
       // Do not modify value if not found to preserve any default value set
       RETURN_ERROR(Err, ErrorCode::Fail,
@@ -217,7 +235,16 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
 
    // Extract variable from config
    if (Node[VarName]) { // the variable exists
-      Value = Node[VarName].as<R4>();
+      // Catch error if input an incompatible type
+      try {
+         Value = Node[VarName].as<R4>();
+         // Success - returns Value
+      } catch (const YAML::TypedBadConversion<R4> &) { // bad conversion
+         // Return error message
+         RETURN_ERROR(Err, ErrorCode::Fail,
+                      "Config get R4: Expected a real variable but "
+                      "encountered an incompatible data type in input config");
+      }
    } else {
       // Do not modify value if not found to preserve any default value set
       RETURN_ERROR(Err, ErrorCode::Fail,
@@ -237,7 +264,16 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
 
    // Extract variable from config
    if (Node[VarName]) { // the variable exists
-      Value = Node[VarName].as<R8>();
+      // Catch error if input an incompatible type
+      try {
+         Value = Node[VarName].as<R8>();
+         // Success - returns Value
+      } catch (const YAML::TypedBadConversion<R8> &) { // check conversion
+         // Return error message
+         RETURN_ERROR(Err, ErrorCode::Fail,
+                      "Config get R8: Expected a double precision variable but "
+                      "encountered an incompatible data type in input config");
+      }
    } else {
       // Do not modify value if not found to preserve any default value set
       RETURN_ERROR(Err, ErrorCode::Fail,
@@ -257,7 +293,15 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
 
    // Extract variable from config
    if (Node[VarName]) { // the variable exists
-      Value = Node[VarName].as<bool>();
+      try {
+         Value = Node[VarName].as<bool>();
+         // Success - returns Value
+      } catch (const YAML::TypedBadConversion<bool> &) { // check bad conversion
+         // Return error message
+         RETURN_ERROR(Err, ErrorCode::Fail,
+                      "Config get bool: Expected a boolean variable but "
+                      "encountered an incompatible data type in input config");
+      }
    } else {
       // Do not modify value if not found to preserve any default value set
       RETURN_ERROR(Err, ErrorCode::Fail,
@@ -278,6 +322,8 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
    // Extract variable from config on master task
    std::string TmpVal;
    if (Node[VarName]) { // the variable exists
+      // No need to check for type conversion since YAML treats all
+      // values as string by default
       Value = Node[VarName].as<std::string>();
    } else {
       // Do not modify value if not found to preserve any default value set
@@ -310,7 +356,17 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
 
          // Now copy the sequence into the vector
          for (int i = 0; i < VecSize; ++i) {
-            Vector[i] = Sequence[i].as<I4>();
+            // Catch error if input an incompatible type
+            try {
+               Vector[i] = Sequence[i].as<I4>();
+               // Success - returns Value
+            } catch (const YAML::TypedBadConversion<I4> &) { // bad conversion
+               // Return error message
+               RETURN_ERROR(
+                   Err, ErrorCode::Fail,
+                   "Config get I4 vector: Expected an integer but "
+                   "encountered an incompatible data type in input config");
+            }
          }
 
       } else { // not a sequence (vector) node so log an error
@@ -348,7 +404,17 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
 
          // Now copy the sequence into the vector
          for (int i = 0; i < VecSize; ++i) {
-            Vector[i] = Sequence[i].as<I8>();
+            // Catch error if input an incompatible type
+            try {
+               Vector[i] = Sequence[i].as<I8>();
+               // Success - returns Value
+            } catch (const YAML::TypedBadConversion<I8> &) { // bad conversion
+               // Return error message
+               RETURN_ERROR(
+                   Err, ErrorCode::Fail,
+                   "Config get I8 vector: Expected an 8-byte integer but "
+                   "encountered an incompatible data type in input config");
+            }
          }
 
       } else { // not a sequence (vector) so log an error
@@ -386,7 +452,17 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
 
          // Now copy the sequence into the vector
          for (int i = 0; i < VecSize; ++i) {
-            Vector[i] = Sequence[i].as<R4>();
+            // Catch error if input an incompatible type
+            try {
+               Vector[i] = Sequence[i].as<R4>();
+               // Success - returns Value
+            } catch (const YAML::TypedBadConversion<R4> &) { // bad conversion
+               // Return error message
+               RETURN_ERROR(
+                   Err, ErrorCode::Fail,
+                   "Config get R4 vector: Expected a real value but "
+                   "encountered an incompatible data type in input config");
+            }
          }
 
       } else { // not a sequence (vector) so log an error
@@ -424,7 +500,17 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
 
          // Now copy the sequence into the vector
          for (int i = 0; i < VecSize; ++i) {
-            Vector[i] = Sequence[i].as<R8>();
+            // Catch error if input an incompatible type
+            try {
+               Vector[i] = Sequence[i].as<R8>();
+               // Success - returns Value
+            } catch (const YAML::TypedBadConversion<R8> &) { // bad conversion
+               // Return error message
+               RETURN_ERROR(
+                   Err, ErrorCode::Fail,
+                   "Config get R8 vector: Expected a double precision value "
+                   "but encountered an incompatible data type in input config");
+            }
          }
 
       } else { // not a sequence (vector) so log an error
@@ -462,7 +548,17 @@ Error Config::get(const std::string &VarName, // [in] name of variable to get
 
          // Now copy the sequence into the vector
          for (int i = 0; i < VecSize; ++i) {
-            Vector[i] = Sequence[i].as<bool>();
+            // Catch error if input an incompatible type
+            try {
+               Vector[i] = Sequence[i].as<bool>();
+               // Success - returns Value
+            } catch (const YAML::TypedBadConversion<bool> &) { // bad conversion
+               // Return error message
+               RETURN_ERROR(
+                   Err, ErrorCode::Fail,
+                   "Config get bool vector: Expected a boolean value "
+                   "but encountered an incompatible data type in input config");
+            }
          }
 
       } else { // not a sequence (vector) so log an error


### PR DESCRIPTION
Adds a data type check to Config retrievals in order to provide a clearer error message than the generic yaml-cpp message. When yaml-cpp cannot convert to the requested data type, Omega now aborts with a clear error message that includes the offending variable name.

Fixes #444

Checklist
* [x] Documentation: Does not impact existing documentation
* [x] Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [x] Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [x] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
       has passed, using the Polaris `e3sm_submodules/Omega` baseline
    * [ ] Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
    * [x] Indicate "All tests passed" or document failing tests
    * [x] Document testing used to verify the changes including any tests that are added/modified/impacted.
    * [x] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.

