### PR TITLE
Reduce the number of PIO sync during IOStream write

### DIFF
--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -849,13 +849,6 @@ void writeArray(void *Array,     // [in] array to be written
    if (Err != PIO_NOERR)
       ABORT_ERROR("IO::writeArray: Error in PIO writing distributed array");
 
-   // Make sure write is complete before returning
-   // We may be able to remove this for efficiency later but it was
-   // needed during testing
-   Err = PIOc_sync(FileID);
-   if (Err != PIO_NOERR)
-      LOG_WARN("IO::writeArray: Error in PIO sychronizing file after write");
-
    return;
 
 } // end writeArray

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -972,7 +972,7 @@ void IOStream::writeFieldMeta(
 //------------------------------------------------------------------------------
 // Write a field's data array, performing any manipulations to reduce
 // precision or move data between host and device
-void IOStream::writeFieldData(
+int IOStream::writeFieldData(
     std::shared_ptr<Field> FieldPtr,      // [in] field to write
     int FileID,                           // [in] id assigned to open file
     int FieldID,                          // [in] id assigned to the field
@@ -1624,14 +1624,13 @@ void IOStream::writeFieldData(
       IO::writeArray(DataPtr, LocSize, FillValPtr, FileID, MyDecompID, FieldID,
                      FldFrame);
 
-      // Clean up the decomp
-      IO::destroyDecomp(MyDecompID);
+      return MyDecompID;
 
    } else {
       IO::writeNDVar(DataPtr, FileID, FieldID, FldFrame, &DimLengths);
    }
 
-   return;
+   return -1;
 
 } // end writeFieldData
 
@@ -2687,7 +2686,10 @@ void IOStream::writeStream(
    IO::endDefinePhase(OutFileID);
    DefineMode = false;
 
-   // Now write data arrays for all fields in contents
+   // Now write data arrays for all fields in contents. Each distributed
+   // field's PIO decomposition is not destroyed immediately since its write
+   // may still be buffered by PIO and not yet flushed to disk
+   std::vector<int> DecompIDsToFree;
    for (auto IFld = Contents.begin(); IFld != Contents.end(); ++IFld) {
 
       // Retrieve the field pointer and FieldID
@@ -2696,11 +2698,20 @@ void IOStream::writeStream(
       int FieldID                      = FieldIDs[FieldName];
 
       // Extract and write the data array
-      this->writeFieldData(ThisField, OutFileID, FieldID, AllDimIDs);
+      int DecompID =
+          this->writeFieldData(ThisField, OutFileID, FieldID, AllDimIDs);
+      if (DecompID >= 0)
+         DecompIDsToFree.push_back(DecompID);
    }
 
-   // Close output file
+   // Close output file - this syncs the file, guaranteeing all buffered
+   // writes above have been flushed before we free their decompositions
    IO::closeFile(OutFileID);
+
+   // Now that the file has been synced and closed, it is safe to destroy
+   // the decompositions used by the writes above
+   for (auto &DecompID : DecompIDsToFree)
+      IO::destroyDecomp(DecompID);
 
    // If using pointer files for this stream, write the filename to the pointer
    // after the file is successfully written

--- a/components/omega/src/infra/IOStream.h
+++ b/components/omega/src/infra/IOStream.h
@@ -206,8 +206,10 @@ class IOStream {
    );
 
    /// Write a field's data array, performing any manipulations to reduce
-   /// precision or move data between host and device
-   void
+   /// precision or move data between host and device. Returns the PIO
+   /// decomposition ID used for a distributed field, so the caller can
+   /// destroy it only once the write has been flushed
+   int
    writeFieldData(std::shared_ptr<Field> FieldPtr, ///< [in] field to write
                   int FileID,  ///< [in] id assigned to open file
                   int FieldID, ///< [in] id assigned to the field


### PR DESCRIPTION
This PR reduces the number of PIO sync operations performed during IOStream writes for field data.

Instead of executing a PIO sync for each field variable, it synchronizes the physical file only when the file is closed.

All CTest tests pass on pm-gpu, pm-cpu, and chrysalis.

The `IOSTREAM_TEST` on pm-cpu is approximately 30% faster than the original implementation.

This PR provides a partial fix for this issue. Additional performance optimizations may be achieved by implementing caching and reuse of decompositions.

Checklist
* [X] Linting
  * [X] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [x] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * [X] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)  have been run on and indicate that are all passing. : PM-CPU, PM-GPU, Chrysalis

