### PR TITLE
Fix `FillValueTest` failure in CTest

### DIFF
--- a/components/omega/test/ocn/FillValueTest.cpp
+++ b/components/omega/test/ocn/FillValueTest.cpp
@@ -25,6 +25,7 @@
 #include "DataTypes.h"
 #include "Decomp.h"
 #include "Dimension.h"
+#include "Eos.h"
 #include "Error.h"
 #include "Field.h"
 #include "Halo.h"
@@ -42,6 +43,7 @@
 #include "TimeStepper.h"
 #include "Tracers.h"
 #include "VertCoord.h"
+#include "VertMix.h"
 #include "mpi.h"
 
 #include <netcdf.h>
@@ -130,6 +132,8 @@ void initFillValueTest() {
    Tracers::init();
    AuxiliaryState::init();
    PressureGrad::init();
+   Eos::init();
+   VertMix::init();
    Tendencies::init();
    TimeStepper::init2();
 

--- a/components/omega/test/ocn/FillValueTest.cpp
+++ b/components/omega/test/ocn/FillValueTest.cpp
@@ -438,6 +438,8 @@ int main(int argc, char *argv[]) {
       // ------------------------------------------------------------------
       OceanState::clear();
       Tendencies::clear();
+      Eos::destroyInstance();
+      VertMix::destroyInstance();
       PressureGrad::clear();
       AuxiliaryState::clear();
       Tracers::clear();


### PR DESCRIPTION
This PR fixes the `FillValueTest` failure in CTests that appeared after merging the fill value PR (#428) and the vertical mixing tendency PR (#410). The test now initializes VertMix and Eos as required.

Checklist
* [ ] Linting
  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  * [ ] Add a comment to the PR titled `Testing` with the following:
    * [ ] Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
          have been run on and indicate that are all passing.
    * [ ] Indicate "All tests passed" or document failing tests