### PR TITLE
Add implicit bottom drag

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -53,8 +53,11 @@ Omega:
     DivFactor: 1.0
     SfcStressForcingTendencyEnable: false
     SurfaceTracerRestoringEnable: false
-    BottomDragTendencyEnable: false
-    BottomDragCoeff: 0.0
+    BottomDragTendency:
+      Enable: true
+      Mode: Implicit
+      Type: Constant
+      BottomDragCoeff: 1.0e-3
     TracerHorzAdvTendencyEnable: true
     TracerDiffTendencyEnable: true
     EddyDiff2: 10.0

--- a/components/omega/doc/design/Tendencies.md
+++ b/components/omega/doc/design/Tendencies.md
@@ -51,7 +51,7 @@ class Tendencies{
    VelocityDiffusionOnEdge VelocityDiffusion;
    VelocityHyperDiffOnEdge VelocityHyperDiff;
    SfcStressForcingOnEdge SfcStressForcing;
-   BottomDragOnEdge BottomDrag;
+   BottomDragOnEdge ExplicitBottomDrag;
    TracerDiffOnCell TracerDiffusion;
    TracerHyperDiffOnCell TracerHyperDiff;
    TracerHorzAdvOnCell TracerHorzAdv;

--- a/components/omega/doc/userGuide/TendencyTerms.md
+++ b/components/omega/doc/userGuide/TendencyTerms.md
@@ -53,8 +53,10 @@ the currently available tendency terms:
 | TracerHyperDiffOnCell | TracerHyperDiffTendencyEnable | enable/disable term
 | | EddyDiff4 | biharmonic horizontal mixing coeffienct for tracers
 | SfcStressForcingOnEdge | SfcStressForcingTendencyEnable | enable/disable term
-| BottomDragOnEdge | BottomDragTendencyEnable | enable/disable term
-| | BottomDragCoeff | bottom drag coefficient
+| BottomDragOnEdge | BottomDragTendency | enable/disable term
+| | BottomDragTendency:Mode | bottom drag mode; `Implicit` or `Explicit`
+| | BottomDragTendency:Type | bottom drag type; `Constant`
+| | BottomDragTendency:BottomDragCoeff | bottom drag coefficient
 | SurfaceTracerRestoringOnCell | SurfaceTracerRestoringEnable | enable/disable term
 
 ## Second Order Horizontal Advection Algorithm

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -263,7 +263,7 @@ void Tendencies::readConfig(Config *OmegaConfig ///< [in] Omega config
    CHECK_ERROR_ABORT(Err, "Tendencies: BottomDragTendency BottomDragCoeff not "
                           "found in TendConfig");
 
-   if (BottomDragType != "Constant") {
+   if (BottomDragType != "Constant" || BottomDragType != "constant") {
       ABORT_ERROR("Tendencies: only Constant BottomDragTendency Type is "
                   "currently supported");
    }
@@ -274,9 +274,9 @@ void Tendencies::readConfig(Config *OmegaConfig ///< [in] Omega config
    this->VMix->VelVertMixSetup.BottomDragCoeff           = BottomDragCoeff;
 
    if (BottomDragTendencyEnabled) {
-      if (BottomDragMode == "Explicit") {
+      if (BottomDragMode == "Explicit" || BottomDragMode == "explicit") {
          this->ExplicitBottomDrag.Enabled = true;
-      } else if (BottomDragMode == "Implicit") {
+      } else if (BottomDragMode == "Implicit" || BottomDragMode == "implicit") {
          this->VMix->VelVertMixSetup.ImplicitBottomDragEnabled = true;
       } else {
          ABORT_ERROR("Tendencies: BottomDragTendency Mode must be Explicit or "

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -238,13 +238,51 @@ void Tendencies::readConfig(Config *OmegaConfig ///< [in] Omega config
        Err,
        "Tendencies: SfcStressForcingTendencyEnable not found in TendConfig");
 
-   Err += TendConfig.get("BottomDragTendencyEnable", this->BottomDrag.Enabled);
+   Config BottomDragConfig("BottomDragTendency");
+   Err += TendConfig.get(BottomDragConfig);
    CHECK_ERROR_ABORT(
-       Err, "Tendencies: BottomDragTendencyEnable not found in TendConfig");
+       Err, "Tendencies: BottomDragTendency group not found in TendConfig");
 
-   Err += TendConfig.get("BottomDragCoeff", this->BottomDrag.Coeff);
-   CHECK_ERROR_ABORT(Err,
-                     "Tendencies: BottomDragCoeff not found in TendConfig");
+   bool BottomDragTendencyEnabled = false;
+   Err += BottomDragConfig.get("Enable", BottomDragTendencyEnabled);
+   CHECK_ERROR_ABORT(
+       Err, "Tendencies: BottomDragTendency Enable not found in TendConfig");
+
+   std::string BottomDragMode;
+   Err += BottomDragConfig.get("Mode", BottomDragMode);
+   CHECK_ERROR_ABORT(
+       Err, "Tendencies: BottomDragTendency Mode not found in TendConfig");
+
+   std::string BottomDragType;
+   Err += BottomDragConfig.get("Type", BottomDragType);
+   CHECK_ERROR_ABORT(
+       Err, "Tendencies: BottomDragTendency Type not found in TendConfig");
+
+   Real BottomDragCoeff = 0.0_Real;
+   Err += BottomDragConfig.get("BottomDragCoeff", BottomDragCoeff);
+   CHECK_ERROR_ABORT(Err, "Tendencies: BottomDragTendency BottomDragCoeff not "
+                          "found in TendConfig");
+
+   if (BottomDragType != "Constant") {
+      ABORT_ERROR("Tendencies: only Constant BottomDragTendency Type is "
+                  "currently supported");
+   }
+
+   this->ExplicitBottomDrag.Enabled = false;
+   this->VMix->VelVertMixSetup.ImplicitBottomDragEnabled = false;
+   this->ExplicitBottomDrag.Coeff = BottomDragCoeff;
+   this->VMix->VelVertMixSetup.BottomDragCoeff = BottomDragCoeff;
+
+   if (BottomDragTendencyEnabled) {
+      if (BottomDragMode == "Explicit") {
+         this->ExplicitBottomDrag.Enabled = true;
+      } else if (BottomDragMode == "Implicit") {
+         this->VMix->VelVertMixSetup.ImplicitBottomDragEnabled = true;
+      } else {
+         ABORT_ERROR("Tendencies: BottomDragTendency Mode must be Explicit or "
+                     "Implicit");
+      }
+   }
 
    if (this->TracerDiffusion.Enabled) {
       Err += TendConfig.get("EddyDiff2", this->TracerDiffusion.EddyDiff2);
@@ -326,6 +364,12 @@ void Tendencies::readConfig(Config *OmegaConfig ///< [in] Omega config
                          this->VMix->VelVertMixSetup.Enabled);
    CHECK_ERROR_ABORT(
        Err, "Tendencies: VelVertMixTendencyEnable not found in TendConfig");
+
+   if (this->VMix->VelVertMixSetup.ImplicitBottomDragEnabled &&
+       !this->VMix->VelVertMixSetup.Enabled) {
+      ABORT_ERROR("Tendencies: BottomDragTendency Mode Implicit requires "
+                  "VelVertMixTendencyEnable to be true");
+   }
 
    Err += TendConfig.get("TracerVertMixTendencyEnable",
                          this->VMix->TracerVertMixSetup.Enabled);
@@ -417,7 +461,7 @@ Tendencies::Tendencies(const std::string &Name_, ///< [in] Name for tendencies
       PseudoThicknessFluxDiv(Mesh, VCoord), PotentialVortHAdv(Mesh, VCoord),
       KEGrad(Mesh, VCoord), SSHGrad(Mesh, VCoord),
       VelocityDiffusion(Mesh, VCoord), VelocityHyperDiff(Mesh, VCoord),
-      SfcStressForcing(Mesh, VCoord), BottomDrag(Mesh, VCoord),
+      SfcStressForcing(Mesh, VCoord), ExplicitBottomDrag(Mesh, VCoord),
       TracerDiffusion(Mesh, VCoord), TracerHyperDiff(Mesh, VCoord),
       TracerHorzAdv(Mesh, VCoord), SurfaceTracerRestoring(Mesh),
       CustomThicknessTend(InCustomThicknessTend),
@@ -540,7 +584,7 @@ void Tendencies::computeVelocityTendenciesOnly(
    OMEGA_SCOPE(LocVelocityDiffusion, VelocityDiffusion);
    OMEGA_SCOPE(LocVelocityHyperDiff, VelocityHyperDiff);
    OMEGA_SCOPE(LocSfcStressForcing, SfcStressForcing);
-   OMEGA_SCOPE(LocBottomDrag, BottomDrag);
+   OMEGA_SCOPE(LocExplicitBottomDrag, ExplicitBottomDrag);
    OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
    OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
    OMEGA_SCOPE(LocSshCell, VCoord->SshCell);
@@ -679,15 +723,15 @@ void Tendencies::computeVelocityTendenciesOnly(
       Pacer::stop("Tend:sfcStressForcing", 2);
    }
 
-   // Compute bottom drag
-   if (LocBottomDrag.Enabled) {
-      Pacer::start("Tend:bottomDrag", 2);
+   // Compute explicit bottom drag
+   if (LocExplicitBottomDrag.Enabled) {
+      Pacer::start("Tend:explicitBottomDrag", 2);
       parallelFor(
           {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
-             LocBottomDrag(LocNormalVelocityTend, IEdge, NormVelEdge, KECell,
-                           MeanPseudoThickEdge);
+             LocExplicitBottomDrag(LocNormalVelocityTend, IEdge, NormVelEdge,
+                                   KECell, MeanPseudoThickEdge);
           });
-      Pacer::stop("Tend:bottomDrag", 2);
+      Pacer::stop("Tend:explicitBottomDrag", 2);
    }
 
    if (CustomVelocityTend) {

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -265,7 +265,8 @@ void Tendencies::readConfig(Config *OmegaConfig ///< [in] Omega config
 
    if (BottomDragType != "Constant" && BottomDragType != "constant") {
       ABORT_ERROR("Tendencies: BottomDragTendency Type should be one of "
-                  " 'Constant' but got {}:", BottomDragType);
+                  " 'Constant' but got {}:",
+                  BottomDragType);
    }
 
    this->ExplicitBottomDrag.Enabled                      = false;

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -263,9 +263,9 @@ void Tendencies::readConfig(Config *OmegaConfig ///< [in] Omega config
    CHECK_ERROR_ABORT(Err, "Tendencies: BottomDragTendency BottomDragCoeff not "
                           "found in TendConfig");
 
-   if (BottomDragType != "Constant" || BottomDragType != "constant") {
-      ABORT_ERROR("Tendencies: only Constant BottomDragTendency Type is "
-                  "currently supported");
+   if (BottomDragType != "Constant" && BottomDragType != "constant") {
+      ABORT_ERROR("Tendencies: BottomDragTendency Type should be one of "
+                  " 'Constant' but got {}:", BottomDragType);
    }
 
    this->ExplicitBottomDrag.Enabled                      = false;

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -269,8 +269,8 @@ void Tendencies::readConfig(Config *OmegaConfig ///< [in] Omega config
                   BottomDragType);
    }
 
-   this->ExplicitBottomDrag.Coeff                        = BottomDragCoeff;
-   this->VMix->VelVertMixSetup.BottomDragCoeff           = BottomDragCoeff;
+   this->ExplicitBottomDrag.Coeff              = BottomDragCoeff;
+   this->VMix->VelVertMixSetup.BottomDragCoeff = BottomDragCoeff;
 
    if (BottomDragTendencyEnabled) {
       if (BottomDragMode == "Explicit" || BottomDragMode == "explicit") {

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -268,10 +268,10 @@ void Tendencies::readConfig(Config *OmegaConfig ///< [in] Omega config
                   "currently supported");
    }
 
-   this->ExplicitBottomDrag.Enabled = false;
+   this->ExplicitBottomDrag.Enabled                      = false;
    this->VMix->VelVertMixSetup.ImplicitBottomDragEnabled = false;
-   this->ExplicitBottomDrag.Coeff = BottomDragCoeff;
-   this->VMix->VelVertMixSetup.BottomDragCoeff = BottomDragCoeff;
+   this->ExplicitBottomDrag.Coeff                        = BottomDragCoeff;
+   this->VMix->VelVertMixSetup.BottomDragCoeff           = BottomDragCoeff;
 
    if (BottomDragTendencyEnabled) {
       if (BottomDragMode == "Explicit") {

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -269,8 +269,6 @@ void Tendencies::readConfig(Config *OmegaConfig ///< [in] Omega config
                   BottomDragType);
    }
 
-   this->ExplicitBottomDrag.Enabled                      = false;
-   this->VMix->VelVertMixSetup.ImplicitBottomDragEnabled = false;
    this->ExplicitBottomDrag.Coeff                        = BottomDragCoeff;
    this->VMix->VelVertMixSetup.BottomDragCoeff           = BottomDragCoeff;
 

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -20,6 +20,11 @@
 ///    VelHyperDiffTendencyEnable: true
 ///    ViscDel4: 1.2e11
 ///    DivFactor: 1.0
+///    BottomDragTendency:
+///       Enable: true
+///       Mode: Implicit
+///       Type: Constant
+///       BottomDragCoeff: 1.0e-3
 ///    TracerHorzAdvTendencyEnable: true
 ///    TracerDiffTendencyEnable: true
 ///    EddyDiff2: 10.0
@@ -68,7 +73,7 @@ class Tendencies {
    VelocityDiffusionOnEdge VelocityDiffusion;
    VelocityHyperDiffOnEdge VelocityHyperDiff;
    SfcStressForcingOnEdge SfcStressForcing;
-   BottomDragOnEdge BottomDrag;
+   BottomDragOnEdge ExplicitBottomDrag;
    TracerHorzAdvOnCell TracerHorzAdv;
    TracerDiffOnCell TracerDiffusion;
    TracerHyperDiffOnCell TracerHyperDiff;

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -43,7 +43,9 @@ OneTwoOneFilter::OneTwoOneFilter(const VertCoord *VCoord)
 
 VelVertMixSetupOnEdge::VelVertMixSetupOnEdge(const HorzMesh *Mesh,
                                              const VertCoord *VCoord)
-    : Enabled(false), LocRhoSw(RhoSw), NVertLayers(VCoord->NVertLayers),
+    : Enabled(false), ImplicitBottomDragEnabled(false),
+      BottomDragCoeff(0.0_Real),
+      LocRhoSw(RhoSw), NVertLayers(VCoord->NVertLayers),
       CellsOnEdge(Mesh->CellsOnEdge), EdgeMask(VCoord->EdgeMask),
       MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
       MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
@@ -458,6 +460,7 @@ void VertMix::applyVelVertMixImplicit(
 
       const auto &SpecVol  = EosInstance->SpecVol;
       const auto &VertVisc = VertMixInstance->VertVisc;
+      const auto &KineticEnergyCell = AuxState->KineticAux.KineticEnergyCell;
 
       const int NVertLayers  = VCoord->NVertLayers;
       const int LocVecLength = VecLength;
@@ -498,8 +501,8 @@ void VertMix::applyVelVertMixImplicit(
 
                    Real G, H, X;
                    LocVelVertMixSetup(IEdge, K, KMin, KMax, DT, SpecVol,
-                                      PseudoThickCell, VertVisc, NormalVelEdge,
-                                      G, H, X);
+                                      KineticEnergyCell, PseudoThickCell,
+                                      VertVisc, NormalVelEdge, G, H, X);
 
                    Scratch.G(K, IVec) = G;
                    Scratch.H(K, IVec) = H;
@@ -675,6 +678,30 @@ void VertMix::VertMixImplicit(OceanState *State, AuxiliaryState *AuxState,
                               NormalVelEdge);
               });
        });
+
+   // Refresh kinetic energy for the implicit bottom drag
+   // from the pre-vmix velocity
+   if (VelVertMixSetup.ImplicitBottomDragEnabled) {
+      OMEGA_SCOPE(LocKineticAux, AuxState->KineticAux);
+      OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+      OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
+      Pacer::start("VertMix:computeKineticAuxForBottomDrag", 2);
+      parallelForOuter(
+          "computeKineticAuxForBottomDrag", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocKineticAux.computeVarsOnCell(ICell, KChunk,
+                                                    NormalVelEdge);
+                 });
+          });
+      Pacer::stop("VertMix:computeKineticAuxForBottomDrag", 2);
+   }
 
    // Update Pressure, SpecVol
    AuxState->computeMomVertAux(State, TracerArray, TimeLevel, TimeLevel);

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -44,10 +44,9 @@ OneTwoOneFilter::OneTwoOneFilter(const VertCoord *VCoord)
 VelVertMixSetupOnEdge::VelVertMixSetupOnEdge(const HorzMesh *Mesh,
                                              const VertCoord *VCoord)
     : Enabled(false), ImplicitBottomDragEnabled(false),
-      BottomDragCoeff(0.0_Real),
-      LocRhoSw(RhoSw), NVertLayers(VCoord->NVertLayers),
-      CellsOnEdge(Mesh->CellsOnEdge), EdgeMask(VCoord->EdgeMask),
-      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      BottomDragCoeff(0.0_Real), LocRhoSw(RhoSw),
+      NVertLayers(VCoord->NVertLayers), CellsOnEdge(Mesh->CellsOnEdge),
+      EdgeMask(VCoord->EdgeMask), MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
       MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 TracerVertMixSetupOnCell::TracerVertMixSetupOnCell(const HorzMesh *Mesh,
@@ -458,8 +457,8 @@ void VertMix::applyVelVertMixImplicit(
       R8 DT;
       TimeStep.get(DT, TimeUnits::Seconds);
 
-      const auto &SpecVol  = EosInstance->SpecVol;
-      const auto &VertVisc = VertMixInstance->VertVisc;
+      const auto &SpecVol           = EosInstance->SpecVol;
+      const auto &VertVisc          = VertMixInstance->VertVisc;
       const auto &KineticEnergyCell = AuxState->KineticAux.KineticEnergyCell;
 
       const int NVertLayers  = VCoord->NVertLayers;

--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -232,12 +232,15 @@ class OneTwoOneFilter {
 class VelVertMixSetupOnEdge {
  public:
    bool Enabled;
+   bool ImplicitBottomDragEnabled;
+   Real BottomDragCoeff;
    Real LocRhoSw;
 
    VelVertMixSetupOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord);
 
    KOKKOS_FUNCTION void operator()(I4 IEdge, I4 K, I4 KMin, I4 KMax, Real DT,
                                    const Array2DReal &SpecVol,
+                                   const Array2DReal &KineticEnergyCell,
                                    const Array2DReal &PseudoThickCell,
                                    const Array2DReal &VertVisc,
                                    const Array2DReal &NormalVelEdge, Real &G,
@@ -271,7 +274,7 @@ class VelVertMixSetupOnEdge {
       //
       //   G_k = [DT * VertVisc_k^top / (Rho_0 * SpecVol_k^top)]
       //         / PseudoThick_k^top
-      //   H_k = PseudoThick_k
+      //   H_k = PseudoThick_k, plus implicit bottom-drag contribution
       //   X_k = PseudoThick_k * NormVel_k
 
       // Fill values
@@ -289,6 +292,17 @@ class VelVertMixSetupOnEdge {
 
       // Unknown is NormVel^{n+1}.
       X = PseudoThickEdgeK * NormalVelEdge(IEdge, K);
+
+      // Implicit bottom drag boundary condition (applied at the lowest layer)
+      // sqrt(2.0*(0.5*KECell0 + 0.5*KECell1)) = sqrt(KECell0 + KECell1)
+      if (ImplicitBottomDragEnabled && K == KMax) {
+         const Real SpecVolEdgeK =
+             0.5_Real * (SpecVol(JCell0, K) + SpecVol(JCell1, K));
+         const Real VelNormEdge = Kokkos::sqrt(KineticEnergyCell(JCell0, K) +
+                                               KineticEnergyCell(JCell1, K));
+
+         H += DT * BottomDragCoeff * VelNormEdge / (LocRhoSw * SpecVolEdgeK);
+      }
 
       if (K < KMax) {
          const Real PseudoThickEdgeKp1 =

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -865,6 +865,10 @@ int testExplicitBottomDrag(int NVertLayers, Real RTol) {
    Err += checkErrors("TendencyTermsTest", "ExplicitBottomDrag",
                       BottomDragErrors, Setup.ExpectedBottomDragErrors, RTol);
 
+   if (Err == 0) {
+      LOG_INFO("TendencyTermsTest: ExplicitBottomDrag PASS");
+   }
+
    return Err;
 } // end testExplicitBottomDrag
 
@@ -948,6 +952,10 @@ int testImplicitBottomDrag(int NVertLayers, Real RTol) {
    Err += checkErrors("TendencyTermsTest", "ImplicitBottomDrag",
                       ImplicitBottomDragErrors,
                       Setup.ExpectedBottomDragErrors, RTol);
+
+   if (Err == 0) {
+      LOG_INFO("TendencyTermsTest: ImplicitBottomDrag PASS");
+   }
 
    return Err;
 } // end testImplicitBottomDrag

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -33,6 +33,7 @@
 #include "TimeStepper.h"
 #include "Tracers.h"
 #include "VertCoord.h"
+#include "VertMix.h"
 #include "mpi.h"
 
 #include <cmath>
@@ -332,6 +333,56 @@ constexpr Geometry Geom          = Geometry::Spherical;
 constexpr char DefaultMeshFile[] = "OmegaSphereMesh.nc";
 using TestSetup                  = TestSetupSphere;
 #endif
+
+int setupBottomDragTestFields(const int NVertLayers, const Real Coeff,
+                              const Array2DReal &ExactBottomDrag,
+                              const Array2DReal &NormalVelEdge,
+                              const Array2DReal &KECell,
+                              const Array2DReal &PseudoThickEdge) {
+   int Err = 0;
+   TestSetup Setup;
+
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
+
+   // Note: this computes bottom drag at every layer.
+   Err += setVectorEdge(
+       KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
+          VecField[0] = Setup.bottomDragX(X, Y, Coeff);
+          VecField[1] = Setup.bottomDragY(X, Y, Coeff);
+       },
+       ExactBottomDrag, EdgeComponent::Normal, Geom, Mesh, ExchangeHalos::No);
+
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   // Reset bottom drag to zero above the lowest layer.
+   parallelFor(
+       "ResetExactBottomDrag", {Mesh->NEdgesOwned, NVertLayers},
+       KOKKOS_LAMBDA(int IEdge, int K) {
+          if (K != MaxLayerEdgeTop(IEdge)) {
+             ExactBottomDrag(IEdge, K) = 0.0_Real;
+          }
+       });
+
+   Err += setVectorEdge(
+       KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
+          VecField[0] = Setup.vectorX(X, Y);
+          VecField[1] = Setup.vectorY(X, Y);
+       },
+       NormalVelEdge, EdgeComponent::Normal, Geom, Mesh);
+
+   Err += setScalar(
+       KOKKOS_LAMBDA(Real X, Real Y) {
+          return Setup.scalarA(X, Y) * Setup.scalarA(X, Y) / 2;
+       },
+       KECell, Geom, Mesh, OnCell);
+
+   Err += setScalar(
+       KOKKOS_LAMBDA(Real X, Real Y) { return Setup.scalarB(X, Y); },
+       PseudoThickEdge, Geom, Mesh, OnEdge);
+
+   return Err;
+}
 
 int testThickFluxDiv(int NVertLayers, Real RTol) {
 
@@ -768,7 +819,7 @@ int testSfcStressForcing(int NVertLayers) {
    return Err;
 } // end testSfcStressForcing
 
-int testBottomDrag(int NVertLayers, Real RTol) {
+int testExplicitBottomDrag(int NVertLayers, Real RTol) {
 
    int Err = 0;
    TestSetup Setup;
@@ -782,43 +833,16 @@ int testBottomDrag(int NVertLayers, Real RTol) {
    Array2DReal ExactBottomDrag("ExactBottomDrag", Mesh->NEdgesOwned,
                                NVertLayers);
 
-   // Note: this computes bottom drag at every layer
-   Err += setVectorEdge(
-       KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
-          VecField[0] = Setup.bottomDragX(X, Y, Coeff);
-          VecField[1] = Setup.bottomDragY(X, Y, Coeff);
-       },
-       ExactBottomDrag, EdgeComponent::Normal, Geom, Mesh, ExchangeHalos::No);
-
-   // Reset bottom drag to zero above the lowest layer
-   deepCopy(Kokkos::subview(ExactBottomDrag, Kokkos::ALL,
-                            Kokkos::make_pair(0, NVertLayers - 1)),
-            0);
-
    // Set input arrays
    Array2DReal NormalVelEdge("NormalVelEdge", Mesh->NEdgesSize, NVertLayers);
 
-   Err += setVectorEdge(
-       KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
-          VecField[0] = Setup.vectorX(X, Y);
-          VecField[1] = Setup.vectorY(X, Y);
-       },
-       NormalVelEdge, EdgeComponent::Normal, Geom, Mesh);
-
    Array2DReal KECell("KECell", Mesh->NCellsSize, NVertLayers);
-
-   Err += setScalar(
-       KOKKOS_LAMBDA(Real X, Real Y) {
-          return Setup.scalarA(X, Y) * Setup.scalarA(X, Y) / 2;
-       },
-       KECell, Geom, Mesh, OnCell);
 
    Array2DReal PseudoThickEdge("PseudoThickEdge", Mesh->NEdgesSize,
                                NVertLayers);
 
-   Err += setScalar(
-       KOKKOS_LAMBDA(Real X, Real Y) { return Setup.scalarB(X, Y); },
-       PseudoThickEdge, Geom, Mesh, OnEdge);
+   Err += setupBottomDragTestFields(NVertLayers, Coeff, ExactBottomDrag,
+                                    NormalVelEdge, KECell, PseudoThickEdge);
 
    // Compute numerical result
    Array2DReal NumBottomDrag("NumBottomDrag", Mesh->NEdgesOwned, NVertLayers);
@@ -838,11 +862,95 @@ int testBottomDrag(int NVertLayers, Real RTol) {
                         OnEdge);
 
    // Check error values
-   Err += checkErrors("TendencyTermsTest", "BottomDrag", BottomDragErrors,
+   Err += checkErrors("TendencyTermsTest", "ExplicitBottomDrag",
+                      BottomDragErrors, Setup.ExpectedBottomDragErrors, RTol);
+
+   return Err;
+} // end testExplicitBottomDrag
+
+int testImplicitBottomDrag(int NVertLayers, Real RTol) {
+
+   int Err = 0;
+   TestSetup Setup;
+
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
+
+   const Real Coeff = 1.123456789_Real;
+   const Real DT    = 5.0_Real;
+
+   Array2DReal SpecVol("SpecVol", Mesh->NCellsSize, NVertLayers);
+   Array2DReal KineticEnergyCell("KineticEnergyCell", Mesh->NCellsSize,
+                                 NVertLayers);
+   Array2DReal PseudoThickCell("PseudoThickCell", Mesh->NCellsSize,
+                               NVertLayers);
+   Array2DReal PseudoThickEdge("PseudoThickEdge", Mesh->NEdgesSize,
+                               NVertLayers);
+   Array2DReal VertVisc("VertVisc", Mesh->NCellsSize, NVertLayers + 1);
+   Array2DReal NormalVelEdge("NormalVelEdge", Mesh->NEdgesSize, NVertLayers);
+   Array2DReal NumImplicitBottomDrag("NumImplicitBottomDrag",
+                                     Mesh->NEdgesOwned, NVertLayers);
+   Array2DReal ExactBottomDrag("ExactBottomDrag", Mesh->NEdgesOwned,
+                               NVertLayers);
+
+   VelVertMixSetupOnEdge ImplicitBottomDragOnE(Mesh, VCoord);
+   ImplicitBottomDragOnE.ImplicitBottomDragEnabled = true;
+   ImplicitBottomDragOnE.BottomDragCoeff   = Coeff;
+
+   Err += setupBottomDragTestFields(NVertLayers, Coeff, ExactBottomDrag,
+                                    NormalVelEdge, KineticEnergyCell,
+                                    PseudoThickEdge);
+
+   deepCopy(SpecVol, 1.0_Real / ImplicitBottomDragOnE.LocRhoSw);
+   deepCopy(VertVisc, 0.0_Real);
+   deepCopy(NumImplicitBottomDrag, 0.0_Real);
+
+   Err += setScalar(
+       KOKKOS_LAMBDA(Real X, Real Y) { return Setup.scalarB(X, Y); },
+       PseudoThickCell, Geom, Mesh, OnCell);
+
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+   OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
+
+   // Compute numerical result
+   parallelFor(
+       "NumImplicitBottomDrag", {Mesh->NEdgesOwned, NVertLayers},
+       KOKKOS_LAMBDA(int IEdge, int K) {
+          const int KMin = MinLayerEdgeBot(IEdge);
+          const int KMax = MaxLayerEdgeTop(IEdge);
+          if (K < KMin || K > KMax)
+             return;
+
+          Real G, H, X;
+          ImplicitBottomDragOnE(IEdge, K, KMin, KMax, DT, SpecVol,
+                                KineticEnergyCell, PseudoThickCell, VertVisc,
+                                NormalVelEdge, G, H, X);
+
+          const int JCell0 = CellsOnEdge(IEdge, 0);
+          const int JCell1 = CellsOnEdge(IEdge, 1);
+          const Real PseudoThickCellEdge =
+              0.5_Real *
+              (PseudoThickCell(JCell0, K) + PseudoThickCell(JCell1, K));
+          const Real DragDiagContribution = H - PseudoThickCellEdge;
+
+          NumImplicitBottomDrag(IEdge, K) =
+              -DragDiagContribution * NormalVelEdge(IEdge, K) /
+              (DT * PseudoThickEdge(IEdge, K));
+       });
+
+   // Compute errors
+   ErrorMeasures ImplicitBottomDragErrors;
+   Err += computeErrors(ImplicitBottomDragErrors, NumImplicitBottomDrag,
+                        ExactBottomDrag, Mesh, OnEdge);
+
+   // Check error values
+   Err += checkErrors("TendencyTermsTest", "ImplicitBottomDrag",
+                      ImplicitBottomDragErrors,
                       Setup.ExpectedBottomDragErrors, RTol);
 
    return Err;
-} // end testBottomDrag
+} // end testImplicitBottomDrag
 
 int testTracerHorzAdvOnCell(int NVertLayers, int NTracers, Real RTol) {
 
@@ -1213,7 +1321,9 @@ int tendencyTermsTest(const std::string &MeshFile = DefaultMeshFile) {
 
    Err += testSfcStressForcing(NVertLayers);
 
-   Err += testBottomDrag(NVertLayers, RTol);
+   Err += testExplicitBottomDrag(NVertLayers, RTol);
+
+   Err += testImplicitBottomDrag(NVertLayers, RTol);
 
    Err += testTracerHorzAdvOnCell(NVertLayers, NTracers, RTol);
 

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -892,14 +892,14 @@ int testImplicitBottomDrag(int NVertLayers, Real RTol) {
                                NVertLayers);
    Array2DReal VertVisc("VertVisc", Mesh->NCellsSize, NVertLayers + 1);
    Array2DReal NormalVelEdge("NormalVelEdge", Mesh->NEdgesSize, NVertLayers);
-   Array2DReal NumImplicitBottomDrag("NumImplicitBottomDrag",
-                                     Mesh->NEdgesOwned, NVertLayers);
+   Array2DReal NumImplicitBottomDrag("NumImplicitBottomDrag", Mesh->NEdgesOwned,
+                                     NVertLayers);
    Array2DReal ExactBottomDrag("ExactBottomDrag", Mesh->NEdgesOwned,
                                NVertLayers);
 
    VelVertMixSetupOnEdge ImplicitBottomDragOnE(Mesh, VCoord);
    ImplicitBottomDragOnE.ImplicitBottomDragEnabled = true;
-   ImplicitBottomDragOnE.BottomDragCoeff   = Coeff;
+   ImplicitBottomDragOnE.BottomDragCoeff           = Coeff;
 
    Err += setupBottomDragTestFields(NVertLayers, Coeff, ExactBottomDrag,
                                     NormalVelEdge, KineticEnergyCell,
@@ -938,9 +938,9 @@ int testImplicitBottomDrag(int NVertLayers, Real RTol) {
               (PseudoThickCell(JCell0, K) + PseudoThickCell(JCell1, K));
           const Real DragDiagContribution = H - PseudoThickCellEdge;
 
-          NumImplicitBottomDrag(IEdge, K) =
-              -DragDiagContribution * NormalVelEdge(IEdge, K) /
-              (DT * PseudoThickEdge(IEdge, K));
+          NumImplicitBottomDrag(IEdge, K) = -DragDiagContribution *
+                                            NormalVelEdge(IEdge, K) /
+                                            (DT * PseudoThickEdge(IEdge, K));
        });
 
    // Compute errors
@@ -950,8 +950,8 @@ int testImplicitBottomDrag(int NVertLayers, Real RTol) {
 
    // Check error values
    Err += checkErrors("TendencyTermsTest", "ImplicitBottomDrag",
-                      ImplicitBottomDragErrors,
-                      Setup.ExpectedBottomDragErrors, RTol);
+                      ImplicitBottomDragErrors, Setup.ExpectedBottomDragErrors,
+                      RTol);
 
    if (Err == 0) {
       LOG_INFO("TendencyTermsTest: ImplicitBottomDrag PASS");

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -255,7 +255,7 @@ int initTimeStepperTest(const std::string &mesh) {
    TestTendencies->TracerHyperDiff.Enabled        = false;
    TestTendencies->SfcStressForcing.Enabled       = false;
    TestTendencies->SurfaceTracerRestoring.Enabled = false;
-   TestTendencies->BottomDrag.Enabled             = false;
+   TestTendencies->ExplicitBottomDrag.Enabled     = false;
    DefVAdv->ThickVertAdvEnabled                   = false;
    DefVAdv->VelVertAdvEnabled                     = false;
    DefVAdv->TracerVertAdvEnabled                  = false;


### PR DESCRIPTION
This PR adds implicit bottom drag support to Omega.

- Applied implicit bottom drag as a bottom boundary condition in the implicit vertical mixing solver
- Updated bottom drag configuration options in `config/Default.yml`
```
    BottomDragTendency:
      Enable: true
      Mode: Implicit
      Type: Constant
      BottomDragCoeff: 1.0e-3
```
- Added a CTest for implicit bottom drag using the explicit bottom drag test setup
- Updated related documentation
- Renamed the existing `BottomDrag` to `ExplicitBottomDrag` for clearer separation between explicit and implicit bottom drag



Checklist
* [x] Documentation:
  * [x] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [x] Documentation has been [built locally](https://portal.nersc.gov/project/e3sm/hgkang/Omega/implicit_bottom_drag/html/) and changes look as expected
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing
  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass (with expected diffs)

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass (with expected diffs)

  **pm-cpu, gnu, mpich**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

* [x] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.