### PR TITLE
Add initial implementation of MCT-based coupler driver 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
         args: ["--config=components/omega/python_lint.cfg", "--show-error-codes"]
         verbose: true
         additional_dependencies: ['types-requests']
+        exclude: ^components/omega/cime_config/build.*
 
   # Can run individually with `pre-commit run fortitude --all-files`
   - repo: https://github.com/PlasmaFAIR/fortitude-pre-commit

--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -17,7 +17,7 @@
     ATM  = [EAM, EAMXX, SATM, SCREAM]
     LND  = [ELM,  SLND]
     ICE  = [MPASSI, CICE, DICE, SICE]
-    OCN  = [MPASO, DOCN, SOCN]
+    OCN  = [OMEGA, MPASO, DOCN, SOCN]
     ROF  = [MOSART, SROF]
     GLC  = [MALI, SGLC]
     WAV  = [WW3, DWAV, XWAV, SWAV]

--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -121,6 +121,22 @@
     </test_file_names>
   </comp_archive_spec>
 
+  <comp_archive_spec compname="omega" compclass="ocn" exclude_testing="true">
+    <rest_file_extension>r</rest_file_extension>
+    <rest_history_varname>unset</rest_history_varname>
+    <rpointer>
+      <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>
+      <rpointer_content>$CASE.omega.r.$DATENAME.nc</rpointer_content>
+    </rpointer>
+    <!-- TODO: no analysis members yet, so only restarts are archived for
+         now; add hist_file_extension entries once History/Highfreq output
+         should be archived -->
+    <test_file_names>
+      <tfile disposition="copy">rpointer.ocn</tfile>
+      <tfile disposition="copy">casename.omega.r.1976-01-01-00000.nc</tfile>
+    </test_file_names>
+  </comp_archive_spec>
+
   <comp_archive_spec compname="mali" compclass="glc">
     <rest_file_extension>rst</rest_file_extension>
     <hist_file_extension>hist</hist_file_extension>

--- a/cime_config/config_files.xml
+++ b/cime_config/config_files.xml
@@ -194,6 +194,7 @@
       <value component="socn"                         >$SRCROOT/components/stub_comps/socn</value>
       <value component="xocn"                         >$SRCROOT/components/xcpl_comps/xocn</value>
       <value component="mpaso"                        >$SRCROOT/components/mpas-ocean</value>
+      <value component="omega"                        >$SRCROOT/components/omega</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -270,6 +271,7 @@
       <value component="elm"      >$COMP_ROOT_DIR_LND/cime_config/config_compsets.xml</value>
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="mpaso"    >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
+      <value component="omega"    >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
       <value component="mali"     >$COMP_ROOT_DIR_GLC/cime_config/config_compsets.xml</value>
       <value component="mpassi"   >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/config_compsets.xml</value>

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -642,6 +642,7 @@
       <directives>
         <directive> -l select={{ num_nodes }} </directive>
         <directive> -l filesystems=home:flare </directive>
+        <directive> -V </directive>
       </directives>
       <queues>
         <queue walltimemax="01:00:00"  nodemin="1"    nodemax="2"     strict="true" default="true">debug</queue>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -297,6 +297,8 @@
       <env name="SZ_ROOT">$SHELL{if [ -z "$SZ_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/sz/2.1.12.5/intel-2023.2.0; else echo "$SZ_ROOT"; fi}</env>
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/zfp/1.0.1/intel-2023.2.0; else echo "$ZFP_ROOT"; fi}</env>
       <!--env name="H5Z_ZFP_ROOT">$SHELL{if [ -z "$H5Z_ZFP_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/h5z-zfp/1.1.1/intel-2024.1.0; else echo "$H5Z_ZFP_ROOT"; fi}</env-->
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_intel_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_intel_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="gnu" mpilib="mpich">
       <env name="PKG_CONFIG_PATH">/global/cfs/cdirs/e3sm/3rdparty/protobuf/21.6/gcc-native-12.3/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}</env>
@@ -308,6 +310,8 @@
       <env name="BLA_VENDOR">Generic</env>
       <env name="Albany_ROOT">$SHELL{if [ -z "$Albany_ROOT" ]; then echo /global/common/software/e3sm/albany/2025.11.14/gcc/12.3; else echo "$Albany_ROOT"; fi}</env>
       <env name="Trilinos_ROOT">$SHELL{if [ -z "$Trilinos_ROOT" ]; then echo /global/common/software/e3sm/trilinos/2025.10.01/gcc/12.3; else echo "$Trilinos_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="nvidia" mpilib="mpich">
       <env name="PKG_CONFIG_PATH">/global/cfs/cdirs/e3sm/3rdparty/protobuf/21.6/nvidia-24.5/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}</env>
@@ -515,8 +519,6 @@
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_mpich/.spack-env/view; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_mpich/.spack-env/view; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables DEBUG="TRUE">
       <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
@@ -560,6 +562,10 @@
       <env name="MGARD_ROOT">$SHELL{if [ -z "$MGARD_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/mgard/1.5.2/gcc-native-12.3; else echo "$MGARD_ROOT"; fi}</env>
       <env name="SZ_ROOT">$SHELL{if [ -z "$SZ_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/sz/2.1.12.5/gcc-native-12.3; else echo "$SZ_ROOT"; fi}</env>
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/zfp/1.0.1/gcc-native-12.3; else echo "$ZFP_ROOT"; fi}</env>
+    </environment_variables>
+    <environment_variables compiler="gnugpu*" mpilib="mpich">
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnugpu_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnugpu_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="nvidia.*" mpilib="mpich">
       <env name="PKG_CONFIG_PATH">/global/cfs/cdirs/e3sm/3rdparty/protobuf/21.6/nvidia-24.5/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}</env>
@@ -1613,6 +1619,8 @@
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/zfp/1.0.1/craygnu; else echo "$ZFP_ROOT"; fi}</env>
       <env name="H5Z_ZFP_ROOT">$SHELL{if [ -z "$H5Z_ZFP_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/h5z-zfp/1.1.1/craygnu; else echo "$H5Z_ZFP_ROOT"; fi}</env>
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/moab/master; else echo "$MOAB_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_craygnu_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_craygnu_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="craycray.*" mpilib="mpich">
       <env name="PKG_CONFIG_PATH">/ccs/proj/cli115/software/frontier/3rdparty/protobuf/21.6/craycray/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}</env>
@@ -1622,6 +1630,8 @@
       <env name="SZ_ROOT">$SHELL{if [ -z "$SZ_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/sz/2.1.12.5/craycray; else echo "$SZ_ROOT"; fi}</env>
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/zfp/1.0.1/craycray; else echo "$ZFP_ROOT"; fi}</env>
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/moab/craymaster; else echo "$MOAB_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_craycray_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_craycray_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
   </machine>
 
@@ -2638,6 +2648,8 @@
       <env name="BLOSC2_ROOT">$SHELL{if [ -z "$BLOSC2_ROOT" ]; then echo /lcrc/soft/climate/c-blosc2/2.15.2/intel-20.0.4; else echo "$BLOSC2_ROOT"; fi}</env>
       <env name="SZ_ROOT">$SHELL{if [ -z "$SZ_ROOT" ]; then echo /lcrc/soft/climate/sz/2.1.12.5/intel-20.0.4; else echo "$SZ_ROOT"; fi}</env>
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /lcrc/soft/climate/zfp/1.0.1/intel-20.0.4; else echo "$ZFP_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_intel_openmpi/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_intel_openmpi/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="gnu" mpilib="openmpi">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/gnu; else echo "$MOAB_ROOT"; fi}</env>
@@ -2647,6 +2659,8 @@
       <env name="BLOSC2_ROOT">$SHELL{if [ -z "$BLOSC2_ROOT" ]; then echo /lcrc/soft/climate/c-blosc2/2.15.2/gcc-11.2.0; else echo "$BLOSC2_ROOT"; fi}</env>
       <env name="SZ_ROOT">$SHELL{if [ -z "$SZ_ROOT" ]; then echo /lcrc/soft/climate/sz/2.1.12.5/gcc-11.2.0; else echo "$SZ_ROOT"; fi}</env>
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /lcrc/soft/climate/zfp/1.0.1/gcc-11.2.0; else echo "$ZFP_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_openmpi/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_openmpi/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="oneapi-ifx" mpilib="openmpi">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/intel-oneapi-compilers-2025.2.0; else echo "$MOAB_ROOT"; fi}</env>
@@ -3509,6 +3523,10 @@
         <env name="FI_LOG_PROV">cxi</env><!--log cassini fabric interface events-->
         <env name="FI_LOG_LEVEL">warn</env>
         <env name="RLIMITS">--rlimits CORE</env>
+    </environment_variables>
+    <environment_variables compiler="oneapi-ifx" mpilib="default">
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <resource_limits DEBUG="TRUE">
         <resource name="RLIMIT_CORE">-1</resource>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -297,8 +297,8 @@
       <env name="SZ_ROOT">$SHELL{if [ -z "$SZ_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/sz/2.1.12.5/intel-2023.2.0; else echo "$SZ_ROOT"; fi}</env>
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/zfp/1.0.1/intel-2023.2.0; else echo "$ZFP_ROOT"; fi}</env>
       <!--env name="H5Z_ZFP_ROOT">$SHELL{if [ -z "$H5Z_ZFP_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/h5z-zfp/1.1.1/intel-2024.1.0; else echo "$H5Z_ZFP_ROOT"; fi}</env-->
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_intel_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_intel_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_intel_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_intel_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="gnu" mpilib="mpich">
       <env name="PKG_CONFIG_PATH">/global/cfs/cdirs/e3sm/3rdparty/protobuf/21.6/gcc-native-12.3/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}</env>
@@ -310,8 +310,8 @@
       <env name="BLA_VENDOR">Generic</env>
       <env name="Albany_ROOT">$SHELL{if [ -z "$Albany_ROOT" ]; then echo /global/common/software/e3sm/albany/2025.11.14/gcc/12.3; else echo "$Albany_ROOT"; fi}</env>
       <env name="Trilinos_ROOT">$SHELL{if [ -z "$Trilinos_ROOT" ]; then echo /global/common/software/e3sm/trilinos/2025.10.01/gcc/12.3; else echo "$Trilinos_ROOT"; fi}</env>
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_gnu_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_gnu_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="nvidia" mpilib="mpich">
       <env name="PKG_CONFIG_PATH">/global/cfs/cdirs/e3sm/3rdparty/protobuf/21.6/nvidia-24.5/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}</env>
@@ -564,8 +564,8 @@
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/zfp/1.0.1/gcc-native-12.3; else echo "$ZFP_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="gnugpu*" mpilib="mpich">
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnugpu_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnugpu_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_gnugpu_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-gpu/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_gnugpu_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="nvidia.*" mpilib="mpich">
       <env name="PKG_CONFIG_PATH">/global/cfs/cdirs/e3sm/3rdparty/protobuf/21.6/nvidia-24.5/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}</env>
@@ -1619,8 +1619,8 @@
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/zfp/1.0.1/craygnu; else echo "$ZFP_ROOT"; fi}</env>
       <env name="H5Z_ZFP_ROOT">$SHELL{if [ -z "$H5Z_ZFP_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/h5z-zfp/1.1.1/craygnu; else echo "$H5Z_ZFP_ROOT"; fi}</env>
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/moab/master; else echo "$MOAB_ROOT"; fi}</env>
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_craygnu_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_craygnu_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_craygnu_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_craygnu_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="craycray.*" mpilib="mpich">
       <env name="PKG_CONFIG_PATH">/ccs/proj/cli115/software/frontier/3rdparty/protobuf/21.6/craycray/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}</env>
@@ -1630,8 +1630,8 @@
       <env name="SZ_ROOT">$SHELL{if [ -z "$SZ_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/sz/2.1.12.5/craycray; else echo "$SZ_ROOT"; fi}</env>
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/zfp/1.0.1/craycray; else echo "$ZFP_ROOT"; fi}</env>
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /ccs/proj/cli115/software/frontier/3rdparty/moab/craymaster; else echo "$MOAB_ROOT"; fi}</env>
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_craycray_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_craycray_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_craycray_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /ccs/proj/cli115/software/polaris/frontier/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_craycray_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
   </machine>
 
@@ -2639,8 +2639,8 @@
     </environment_variables>
     <environment_variables compiler="intel" mpilib="openmpi">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/intel-oneapi-compilers-2025.2.0; else echo "$MOAB_ROOT"; fi}</env>
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_openmpi/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_openmpi/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_intel_openmpi/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_intel_openmpi/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="intel-classic" mpilib="openmpi">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/intel; else echo "$MOAB_ROOT"; fi}</env>
@@ -2650,8 +2650,8 @@
       <env name="BLOSC2_ROOT">$SHELL{if [ -z "$BLOSC2_ROOT" ]; then echo /lcrc/soft/climate/c-blosc2/2.15.2/intel-20.0.4; else echo "$BLOSC2_ROOT"; fi}</env>
       <env name="SZ_ROOT">$SHELL{if [ -z "$SZ_ROOT" ]; then echo /lcrc/soft/climate/sz/2.1.12.5/intel-20.0.4; else echo "$SZ_ROOT"; fi}</env>
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /lcrc/soft/climate/zfp/1.0.1/intel-20.0.4; else echo "$ZFP_ROOT"; fi}</env>
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_intel_openmpi/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_intel_openmpi/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_intel-classic_openmpi/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_intel-classic_openmpi/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="gnu" mpilib="openmpi">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/gnu; else echo "$MOAB_ROOT"; fi}</env>
@@ -2661,8 +2661,8 @@
       <env name="BLOSC2_ROOT">$SHELL{if [ -z "$BLOSC2_ROOT" ]; then echo /lcrc/soft/climate/c-blosc2/2.15.2/gcc-11.2.0; else echo "$BLOSC2_ROOT"; fi}</env>
       <env name="SZ_ROOT">$SHELL{if [ -z "$SZ_ROOT" ]; then echo /lcrc/soft/climate/sz/2.1.12.5/gcc-11.2.0; else echo "$SZ_ROOT"; fi}</env>
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /lcrc/soft/climate/zfp/1.0.1/gcc-11.2.0; else echo "$ZFP_ROOT"; fi}</env>
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_openmpi/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_openmpi/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_gnu_openmpi/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_gnu_openmpi/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="oneapi-ifx" mpilib="openmpi">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/intel-oneapi-compilers-2025.2.0; else echo "$MOAB_ROOT"; fi}</env>
@@ -3527,8 +3527,8 @@
         <env name="RLIMITS">--rlimits CORE</env>
     </environment_variables>
     <environment_variables compiler="oneapi-ifx" mpilib="default">
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <resource_limits DEBUG="TRUE">
         <resource name="RLIMIT_CORE">-1</resource>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -515,6 +515,8 @@
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_mpich/.spack-env/view; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_gnu_mpich/.spack-env/view; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables DEBUG="TRUE">
       <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3477,6 +3477,7 @@
         <command name="load">netcdf-fortran/4.6.2</command>
         <command name="load">moab/5.6.0</command>
         <command name="load">mpich-config/collective-tuning/1024</command>
+        <command name="load">py-pyyaml/6.0.3</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -3526,9 +3527,13 @@
         <env name="FI_LOG_LEVEL">warn</env>
         <env name="RLIMITS">--rlimits CORE</env>
     </environment_variables>
-    <environment_variables compiler="oneapi-ifx" mpilib="default">
-      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
-      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.1.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+    <environment_variables compiler="oneapi-ifx" mpilib="mpich">
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
+    </environment_variables>
+    <environment_variables compiler="oneapi-ifxgpu" mpilib="mpich">
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifxgpu_mpich/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifxgpu_mpich/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <resource_limits DEBUG="TRUE">
         <resource name="RLIMIT_CORE">-1</resource>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2639,6 +2639,8 @@
     </environment_variables>
     <environment_variables compiler="intel" mpilib="openmpi">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/intel-oneapi-compilers-2025.2.0; else echo "$MOAB_ROOT"; fi}</env>
+      <env name="METIS_ROOT">$SHELL{if [ -z "$METIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_openmpi/.spack-env/view/; else echo "$METIS_ROOT"; fi}</env>
+      <env name="PARMETIS_ROOT">$SHELL{if [ -z "$PARMETIS_ROOT" ]; then echo /lcrc/soft/climate/polaris/chrysalis/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_openmpi/.spack-env/view/; else echo "$PARMETIS_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="intel-classic" mpilib="openmpi">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/intel; else echo "$MOAB_ROOT"; fi}</env>

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -108,6 +108,7 @@ endforeach()
 # Include function definitions
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_util.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_mpas_model.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_omega.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_eamxx.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_emulator_comps.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_model.cmake)
@@ -132,6 +133,9 @@ set(BUILDCONF ${CASEROOT}/Buildconf)
 
 build_mpas_models()
 
+# omega manages its own build
+build_omega()
+
 # Set global cmake settings
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/..)
 
@@ -144,7 +148,7 @@ endif()
 # Build E3SM components
 set(IDX 0)
 set(COMP_CLASSES cpl atm lnd ice ocn rof glc wav iac esp)
-set(SKIP_COMPS "scream" "mpaso" "mpassi" "mali")
+set(SKIP_COMPS "scream" "omega" "mpaso" "mpassi" "mali")
 # Append emulator components (set by build_emulator_comps.cmake)
 if(EMULATOR_COMP_NAMES)
   list(APPEND SKIP_COMPS ${EMULATOR_COMP_NAMES})

--- a/components/cmake/build_omega.cmake
+++ b/components/cmake/build_omega.cmake
@@ -1,0 +1,8 @@
+function(build_omega)
+
+  # Set CIME source path relative to components
+  set(CIMESRC_PATH "../cime/src")
+
+  add_subdirectory("omega")
+
+endfunction(build_omega)

--- a/components/omega/cime_config/buildlib_cmake
+++ b/components/omega/cime_config/buildlib_cmake
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+_CIMEROOT = os.environ.get("CIMEROOT")
+if _CIMEROOT is None:
+    raise SystemExit("ERROR: must set CIMEROOT environment variable")
+
+_LIBDIR = os.path.join(_CIMEROOT, "CIME", "Tools")
+sys.path.append(_LIBDIR)
+
+from CIME.buildlib import parse_input
+from CIME.case import Case
+from standard_script_setup import *
+
+logger = logging.getLogger(__name__)  # noqa: F405
+
+
+def buildlib(bldroot, installpath, case):
+    """
+    """
+    print("building omega")
+
+    cmake_args = ""
+
+    cmake_args += " -DOMEGA_BUILD_MODE=E3SM"
+
+    print(f"omega cmake options: '{cmake_args}'")
+
+    return cmake_args
+
+
+def _main(argv, documentation):
+    """
+    """
+    caseroot, libroot, bldroot = parse_input(sys.argv)
+    with Case(caseroot, read_only=False) as case:
+        buildlib(bldroot, libroot, case)
+
+
+if (__name__ == "__main__"):
+    _main(sys.argv, __doc__)

--- a/components/omega/cime_config/buildlib_cmake
+++ b/components/omega/cime_config/buildlib_cmake
@@ -22,9 +22,14 @@ def buildlib(bldroot, installpath, case):
     """
     print("building omega")
 
-    cmake_args = ""
+    metis_root = os.environ['METIS_ROOT']
+    parmetis_root = os.environ['PARMETIS_ROOT']
 
-    cmake_args += " -DOMEGA_BUILD_MODE=E3SM"
+    cmake_args = (
+        f' -DOMEGA_BUILD_MODE=E3SM'
+        f' -DOMEGA_METIS_ROOT="{metis_root}"'
+        f' -DOMEGA_PARMETIS_ROOT="{parmetis_root}"'
+    )
 
     print(f"omega cmake options: '{cmake_args}'")
 

--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -31,52 +31,66 @@ OrderedSafeDumper.add_representer(dict, _dict_representer)
 
 
 # Helper function to build the various sections of the omega streams
-def _build_initial_state_file_name(case):
+def _get_file_name(case, stream):
     """ """
-    # TODO: this will be condtional set based on grid and compset
-    return "OmegaMesh.nc"
+    # TODO: this will be conditional set based on grid and compset. It
+    # also needs to check RUN_TYPE: for "hybrid"/"branch" runs this must
+    # point at the RUN_REFCASE restart file (see mpas-ocean's
+    # cime_config/buildnml, which swaps in run_refcase's restart file
+    # when run_type in ("hybrid", "branch")), not the default IC file.
+
+    din_loc = Path(case.get_value("DIN_LOC_ROOT"))
+    ocn_grid = case.get_value("OCN_GRID")
+
+    if ocn_grid != "oQU240":
+        raise ValueError(f"Unsupported OCN_GRID: {ocn_grid}")
+
+    # TODO: this will return a different value based on the stream name
+
+    # For now mesh file contains all information needed in single file
+    return str(din_loc /
+               "../polaris/ocean/realistic_global/" /
+               "omega/ocean.QU240km.151209.teos10.nc")
 
 
-def _build_horz_mesh_file_name(case):
-    """ """
-    # TODO: this will be condtional set based on grid
-    return "OmegaMesh.nc"
+def _update_read_io_streams(config, case, stream):
+    """Update the read streams
 
+    RUN_TYPE stays fixed for the life of a case, so it cannot tell us
+    whether *this* job submission should read the initial state or a
+    restart file. CONTINUE_RUN is FALSE only for the very first job of
+    a run (including hybrid/branch runs) and TRUE for every subsequent
+    continuation, so it is the correct flag to gate on here.
+    """
+    continue_run = case.get_value("CONTINUE_RUN")
 
-def _build_initial_state_read_io_stream(case):
-    """Reading initial state only happens for startup runs"""
-    # TODO: do we need to check CONTINUE_RUN here?
-    run_type = case.get_value("RUN_TYPE")
+    # RestartRead has inverse logic compared to InitialState and
+    # InitialVertCoord, so negate the value of continue_run
+    if stream == "RestartRead":
+        continue_run = not continue_run
 
-    file_name = _build_initial_state_file_name(case)
+    config[stream]['Filename'] = _get_file_name(case, stream)
 
-    return {
-        "UsePointerFile": False,
-        "Filename": file_name,
-        "Mode": "read",
-        "Precision": "double",
-        "Freq": 1,
-        "FreqUnits": "OnStartUp" if run_type == "startup" else "Never",
-        "UseStartEnd": False,
-        "Contents": ["State", "Base"],
-    }
+    # Leave `OnstartUp` default for HorzMeshIn stream
+    if stream not in ["HorzMeshIn"]:  # "InitialVertCoord"]:
+        config[stream]["FreqUnits"] = "Never" if continue_run else "OnStartUp"
 
+    # Make sure pointer, with the correct filename, is used by restart reads
+    if stream == "RestartRead":
+        config[stream]["UsePointerFile"] = True
+        config[stream]["PointerFilename"] = "rpointer.ocn"
 
-def _build_restart_read_io_stream(case):
-    """Restart reads happen for any run type that is not startup"""
-    # TODO: do we need to check CONTINUE_RUN here?
-    run_type = case.get_value("RUN_TYPE")
+        # Default.yml sets UseStartEnd/StartTime/EndTime for RestartRead as a
+        # workaround so the standalone driver (whose FreqUnits is always
+        # "OnStartup") can still skip reading a restart on the very first
+        # startup job. The coupled driver already gates this explicitly via
+        # CONTINUE_RUN above, so the UseStartEnd gate must be disabled here:
+        # otherwise it depends on the model clock's StartAlarm/EndAlarm
+        # already reflecting the coupler-provided current time, which is not
+        # guaranteed to be true this early in ocnInit1.
+        config[stream]["UseStartEnd"] = False
 
-    return {
-        "UsePointerFile": True,
-        "PointerFilename": "rpointer.ocn",
-        "Mode": "read",
-        "Precision": "double",
-        "Freq": 1,
-        "FreqUnits": "Never" if run_type == "startup" else "OnStartUp",
-        "UseStartEnd": False,
-        "Contents": ["Restart"],
-    }
+    return config
 
 
 def _build_restart_write_io_stream(case):
@@ -93,7 +107,7 @@ def _build_restart_write_io_stream(case):
         "IfExists": "replace",
         "Precision": "double",
         "Freq": 1,
-        "FreqUnits": "Never",
+        "FreqUnits": "OnDemand",
         "UseStartEnd": False,
         "Contents": ["Restart"],
     }
@@ -103,11 +117,11 @@ def _build_io_streams_config(default_io_streams, case):
     """Build the io_streams section of the omega config file"""
     io_streams = default_io_streams.copy()
 
-    # Add initial state read stream
-    io_streams["InitialState"] = _build_initial_state_read_io_stream(case)
-
-    # Add restart read stream
-    io_streams["RestartRead"] = _build_restart_read_io_stream(case)
+    # Update InitialState, HorzMeshIn, InitialVertCoord, and RestartRead
+    io_streams = _update_read_io_streams(io_streams, case, "InitialState")
+    io_streams = _update_read_io_streams(io_streams, case, "HorzMeshIn")
+    io_streams = _update_read_io_streams(io_streams, case, "InitialVertCoord")
+    io_streams = _update_read_io_streams(io_streams, case, "RestartRead")
 
     # Add restart write stream
     io_streams["RestartWrite"] = _build_restart_write_io_stream(case)

--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -42,15 +42,19 @@ def _get_file_name(case, stream):
     din_loc = Path(case.get_value("DIN_LOC_ROOT"))
     ocn_grid = case.get_value("OCN_GRID")
 
-    if ocn_grid != "oQU240":
+    if ocn_grid not in ["oQU240", "EC30to60E2r2"]:
         raise ValueError(f"Unsupported OCN_GRID: {ocn_grid}")
 
     # TODO: this will return a different value based on the stream name
-
     # For now mesh file contains all information needed in single file
-    return str(din_loc /
-               "../polaris/ocean/realistic_global/" /
-               "omega/ocean.QU240km.151209.teos10.nc")
+    polaris_dir = din_loc / "../polaris/ocean/realistic_global/omega"
+
+    if ocn_grid == "oQU240":
+        return str(polaris_dir / "ocean.QU240km.151209.teos10.nc")
+    elif ocn_grid == "EC30to60E2r2":
+        return str(polaris_dir / "ocean.EC30to60E2r2.200908.teos10.nc")
+    else:
+        raise ValueError(f"Unsupported OCN_GRID: {ocn_grid}")
 
 
 def _update_read_io_streams(config, case, stream):
@@ -136,7 +140,7 @@ def _build_time_integration_config(default_time_integration, case):
     """Start and stop time are set by the coupler.
        The time step is mesh dependent.
     """
-    # ocn_grid = case.get_value("OCN_GRID")
+    ocn_grid = case.get_value("OCN_GRID")
     calendar = case.get_value("CALENDAR")
 
     time_integration = default_time_integration.copy()
@@ -154,7 +158,10 @@ def _build_time_integration_config(default_time_integration, case):
     # RunDuration is not used in coupled runs
     time_integration["RunDuration"] = "none"
 
-    # TODO: set time step based on grid
+    if ocn_grid == "EC30to60E2r2":
+        time_integration["TimeStepper"] = "RungeKutta4"
+        time_integration["TimeStep"] = "0000_00:01:00"
+
     return time_integration
 
 

--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -50,9 +50,9 @@ def _get_file_name(case, stream):
     polaris_dir = din_loc / "../polaris/ocean/realistic_global/omega"
 
     if ocn_grid == "oQU240":
-        return str(polaris_dir / "ocean.QU240km.151209.teos10.nc")
+        return str(polaris_dir / "ocean.QU.240km.151209.teos10.260720.nc")
     elif ocn_grid == "EC30to60E2r2":
-        return str(polaris_dir / "ocean.EC30to60E2r2.200908.teos10.nc")
+        return str(polaris_dir / "ocean.EC30to60E2r2.200908.teos10.260720.nc")
     else:
         raise ValueError(f"Unsupported OCN_GRID: {ocn_grid}")
 

--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -7,9 +7,141 @@ Namelist creator for E3SM's omega component
 import sys
 from pathlib import Path
 
+import yaml
 from CIME.buildnml import parse_input
 from CIME.case import Case
 from CIME.utils import SharedArea, expect, safe_copy
+
+nan_time_instant_str = "9999-12-31_00:00:00"
+
+
+# YAML representer to preserve order of dicts when dumping to yaml
+class OrderedSafeDumper(yaml.SafeDumper):
+    pass
+
+
+def _dict_representer(dumper, data):
+    return dumper.represent_mapping(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items()
+    )
+
+
+OrderedSafeDumper.add_representer(dict, _dict_representer)
+# end of YAML representer related code
+
+
+# Helper function to build the various sections of the omega streams
+def _build_initial_state_file_name(case):
+    """ """
+    # TODO: this will be condtional set based on grid and compset
+    return "OmegaMesh.nc"
+
+
+def _build_horz_mesh_file_name(case):
+    """ """
+    # TODO: this will be condtional set based on grid
+    return "OmegaMesh.nc"
+
+
+def _build_initial_state_read_io_stream(case):
+    """Reading initial state only happens for startup runs"""
+    # TODO: do we need to check CONTINUE_RUN here?
+    run_type = case.get_value("RUN_TYPE")
+
+    file_name = _build_initial_state_file_name(case)
+
+    return {
+        "UsePointerFile": False,
+        "Filename": file_name,
+        "Mode": "read",
+        "Precision": "double",
+        "Freq": 1,
+        "FreqUnits": "OnStartUp" if run_type == "startup" else "Never",
+        "UseStartEnd": False,
+        "Contents": ["State", "Base"],
+    }
+
+
+def _build_restart_read_io_stream(case):
+    """Restart reads happen for any run type that is not startup"""
+    # TODO: do we need to check CONTINUE_RUN here?
+    run_type = case.get_value("RUN_TYPE")
+
+    return {
+        "UsePointerFile": True,
+        "PointerFilename": "rpointer.ocn",
+        "Mode": "read",
+        "Precision": "double",
+        "Freq": 1,
+        "FreqUnits": "Never" if run_type == "startup" else "OnStartUp",
+        "UseStartEnd": False,
+        "Contents": ["Restart"],
+    }
+
+
+def _build_restart_write_io_stream(case):
+    """Coupler dictates when to write restart files, so we just need to set up
+       the stream here.
+    """
+    case_name = case.get_value("CASE")
+
+    return {
+        "UsePointerFile": True,
+        "PointerFilename": "rpointer.ocn",
+        "Filename": f"{case_name}.omega.r.$Y-$M-$D_$h.$m.$s",
+        "Mode": "write",
+        "IfExists": "replace",
+        "Precision": "double",
+        "Freq": 1,
+        "FreqUnits": "Never",
+        "UseStartEnd": False,
+        "Contents": ["Restart"],
+    }
+
+
+def _build_io_streams_config(default_io_streams, case):
+    """Build the io_streams section of the omega config file"""
+    io_streams = default_io_streams.copy()
+
+    # Add initial state read stream
+    io_streams["InitialState"] = _build_initial_state_read_io_stream(case)
+
+    # Add restart read stream
+    io_streams["RestartRead"] = _build_restart_read_io_stream(case)
+
+    # Add restart write stream
+    io_streams["RestartWrite"] = _build_restart_write_io_stream(case)
+
+    # Never read forcing stream in coupled runs
+    io_streams["Forcing"]["FreqUnits"] = "Never"
+
+    return io_streams
+
+
+def _build_time_integration_config(default_time_integration, case):
+    """Start and stop time are set by the coupler.
+       The time step is mesh dependent.
+    """
+    # ocn_grid = case.get_value("OCN_GRID")
+    calendar = case.get_value("CALENDAR")
+
+    time_integration = default_time_integration.copy()
+
+    # conver from CIME calendar to Omega calendar names
+    if calendar == "NO_LEAP":
+        time_integration["CalendarType"] = "No Leap"
+    elif calendar == "GREGORIAN":
+        time_integration["CalendarType"] = "Gregorian"
+
+    # Set start and stop time to invalid values in order to make clear to users
+    # these values come from the coupler at runtime
+    time_integration["StartTime"] = nan_time_instant_str
+    time_integration["StopTime"] = nan_time_instant_str
+    # RunDuration is not used in coupled runs
+    time_integration["RunDuration"] = "none"
+
+    # TODO: set time step based on grid
+    return time_integration
 
 
 def buildnml(case, caseroot, compname):
@@ -21,16 +153,41 @@ def buildnml(case, caseroot, compname):
     case_root = Path(case.get_value("CASEROOT"))
     omega_root = Path(case.get_value("SRCROOT")) / "components/omega"
 
+    with open(omega_root / "configs/Default.yml", "r") as file:
+        default_config = yaml.load(file, Loader=yaml.SafeLoader)
+        # unpack the Omega section of the default config
+        default_config = default_config["Omega"]
+
+    # start with a copy of the default config, unpack the Omega section
+    config = default_config.copy()
+
+    # update the TimeIntegration section of the config
+    config["TimeIntegration"] = _build_time_integration_config(
+        default_config["TimeIntegration"], case
+    )
+
+    # update the IOStreams section of the config
+    config["IOStreams"] = _build_io_streams_config(
+        default_config["IOStreams"], case
+    )
+
+    # repack everything withn a top-level Omega section
+    config = {"Omega": config}
+
+    # write yaml file and copy to CaseDocs within a SharedArea context so that
+    # correct file permissions are set
     with SharedArea():
 
-        src = omega_root / "configs/Default.yml"
+        output_file = run_dir / "omega.yml"
 
-        safe_copy(src, run_dir / "omega.yml")
+        # write the updated yaml file to the run directory
+        with open(output_file, "w") as file:
+            yaml.dump(config, file, Dumper=OrderedSafeDumper)
 
         # archive yaml file in CaseDocs
         case_docs = case_root / 'CaseDocs'
         if case_docs.exists():
-            safe_copy(src, case_docs / "omega.yml")
+            safe_copy(output_file, case_docs / "omega.yml")
 
 
 def _main_func():

--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -47,12 +47,14 @@ def _get_file_name(case, stream):
 
     # TODO: this will return a different value based on the stream name
     # For now mesh file contains all information needed in single file
-    polaris_dir = din_loc / "../polaris/ocean/realistic_global/omega"
+    omega_dir = din_loc / "ocn/omega"
 
     if ocn_grid == "oQU240":
-        return str(polaris_dir / "ocean.QU.240km.151209.teos10.260720.nc")
+        mesh_dir = omega_dir / "oQU240"
+        return str(mesh_dir / "ocean.QU.240km.151209.teos10.260720.nc")
     elif ocn_grid == "EC30to60E2r2":
-        return str(polaris_dir / "ocean.EC30to60E2r2.200908.teos10.260720.nc")
+        mesh_dir = omega_dir / "EC30to60E2r2"
+        return str(mesh_dir / "ocean.EC30to60E2r2.200908.teos10.260720.nc")
     else:
         raise ValueError(f"Unsupported OCN_GRID: {ocn_grid}")
 
@@ -165,6 +167,33 @@ def _build_time_integration_config(default_time_integration, case):
     return time_integration
 
 
+def build_input_data_list(case, compname):
+    """
+    Add files to omega.input_data_list so they can be automatically downloaded
+    """
+    expect(compname == "omega", compname)
+
+    casebuild = case.get_value("CASEBUILD")
+    input_data_list = []
+
+    # Add the initial state file to the input data list
+    initial_state_file = _get_file_name(case, "InitialState")
+    input_data_list.append(f"initial_state = {initial_state_file}")
+
+    # TODO: For now all information is contained in a single input file
+    # # Add the horizontal mesh file to the input data list
+    # horz_mesh_file = _get_file_name(case, "HorzMeshIn")
+    # input_data_list.append(horz_mesh_file)
+
+    # # Add the initial vertical coordinate file to the input data list
+    # initial_vert_coord_file = _get_file_name(case, "InitialVertCoord")
+    # input_data_list.append(initial_vert_coord_file)
+
+    with open(Path(casebuild) / "omega.input_data_list", "w") as f:
+        for input_file in input_data_list:
+            f.write(f"{input_file}\n")
+
+
 def buildnml(case, caseroot, compname):
     """
     """
@@ -209,6 +238,9 @@ def buildnml(case, caseroot, compname):
         case_docs = case_root / 'CaseDocs'
         if case_docs.exists():
             safe_copy(output_file, case_docs / "omega.yml")
+
+        # needs to be called within buildnml
+        build_input_data_list(case, compname)
 
 
 def _main_func():

--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -14,6 +14,7 @@ from CIME.utils import SharedArea, expect, safe_copy
 
 nan_time_instant_str = "9999-12-31_00:00:00"
 
+omega_supported_grids = ["oQU240", "EC30to60E2r2"]
 
 # YAML representer to preserve order of dicts when dumping to yaml
 class OrderedSafeDumper(yaml.SafeDumper):
@@ -30,6 +31,116 @@ OrderedSafeDumper.add_representer(dict, _dict_representer)
 # end of YAML representer related code
 
 
+def buildnml(case, caseroot, compname):
+    """
+    Build the omega.yml config file based on case configuration
+
+    Additionally, writes an omega.input_data_list file so that any required
+    data missing from DIN_LOC_ROOT/ocn/omega will be automatically downloaded.
+
+    Parameters
+    ----------
+    case : Case
+        The case object containing the configuration for the current run.
+    caseroot : str
+        The root directory of the case.
+    compname : str
+        The name of the component (should be "omega" for this function).
+    """
+    expect(compname == "omega", compname)
+
+    run_dir = Path(case.get_value("RUNDIR"))
+    case_root = Path(case.get_value("CASEROOT"))
+    omega_root = Path(case.get_value("SRCROOT")) / "components/omega"
+
+    path_to_default_config = omega_root / "configs/Default.yml"
+
+    config = _build_omega_config(path_to_default_config, case)
+
+    # write yaml file and copy to CaseDocs within a SharedArea context so that
+    # correct file permissions are set
+    with SharedArea():
+
+        output_file = run_dir / "omega.yml"
+
+        # write the updated yaml file to the run directory
+        with open(output_file, "w") as file:
+            yaml.dump(config, file, Dumper=OrderedSafeDumper)
+
+        # archive yaml file in CaseDocs
+        case_docs = case_root / 'CaseDocs'
+        if case_docs.exists():
+            safe_copy(output_file, case_docs / "omega.yml")
+
+        # needs to be called within buildnml
+        build_input_data_list(case, compname)
+
+
+def build_input_data_list(case, compname):
+    """
+    Add files to omega.input_data_list so they can be automatically downloaded
+    """
+    expect(compname == "omega", compname)
+
+    casebuild = case.get_value("CASEBUILD")
+    input_data_list = []
+
+    # Add the initial state file to the input data list
+    initial_state_file = _get_file_name(case, "InitialState")
+    input_data_list.append(f"initial_state = {initial_state_file}")
+
+    # TODO: For now all information is contained in a single input file
+    # # Add the horizontal mesh file to the input data list
+    # horz_mesh_file = _get_file_name(case, "HorzMeshIn")
+    # input_data_list.append(horz_mesh_file)
+
+    # # Add the initial vertical coordinate file to the input data list
+    # initial_vert_coord_file = _get_file_name(case, "InitialVertCoord")
+    # input_data_list.append(initial_vert_coord_file)
+
+    with open(Path(casebuild) / "omega.input_data_list", "w") as f:
+        for input_file in input_data_list:
+            f.write(f"{input_file}\n")
+
+
+def _build_omega_config(path_to_default, case):
+    """
+    Build the omega config file based on case configuration
+
+    Parameters
+    ----------
+    path_to_default : str
+        Path to the default omega config file.
+    case : Case
+        The case object containing the configuration for the current run.
+
+    Returns
+    -------
+    dict
+        The updated omega config dictionary.
+    """
+    with open(path_to_default, "r") as file:
+        default_config = yaml.load(file, Loader=yaml.SafeLoader)
+        # unpack the Omega section of the default config
+        default_config = default_config["Omega"]
+
+    # start with a copy of the default config, unpack the Omega section
+    config = default_config.copy()
+
+    # update the TimeIntegration section of the config
+    config["TimeIntegration"] = _build_time_integration_config(
+        default_config["TimeIntegration"], case
+    )
+
+    # update the IOStreams section of the config
+    config["IOStreams"] = _build_io_streams_config(
+        default_config["IOStreams"], case
+    )
+
+    # repack everything withn a top-level Omega section
+    return {"Omega": config}
+
+
 # Helper function to build the various sections of the omega streams
 def _get_file_name(case, stream):
     """ """
@@ -42,7 +153,7 @@ def _get_file_name(case, stream):
     din_loc = Path(case.get_value("DIN_LOC_ROOT"))
     ocn_grid = case.get_value("OCN_GRID")
 
-    if ocn_grid not in ["oQU240", "EC30to60E2r2"]:
+    if ocn_grid not in omega_supported_grids:
         raise ValueError(f"Unsupported OCN_GRID: {ocn_grid}")
 
     # TODO: this will return a different value based on the stream name
@@ -146,11 +257,13 @@ def _build_time_integration_config(default_time_integration, case):
 
     time_integration = default_time_integration.copy()
 
-    # conver from CIME calendar to Omega calendar names
+    # convert from CIME calendar to Omega calendar names
     if calendar == "NO_LEAP":
         time_integration["CalendarType"] = "No Leap"
     elif calendar == "GREGORIAN":
         time_integration["CalendarType"] = "Gregorian"
+    else:
+        raise ValueError(f"Unsupported calendar type: {calendar}")
 
     # Set start and stop time to invalid values in order to make clear to users
     # these values come from the coupler at runtime
@@ -164,82 +277,6 @@ def _build_time_integration_config(default_time_integration, case):
         time_integration["TimeStep"] = "0000_00:01:00"
 
     return time_integration
-
-
-def build_input_data_list(case, compname):
-    """
-    Add files to omega.input_data_list so they can be automatically downloaded
-    """
-    expect(compname == "omega", compname)
-
-    casebuild = case.get_value("CASEBUILD")
-    input_data_list = []
-
-    # Add the initial state file to the input data list
-    initial_state_file = _get_file_name(case, "InitialState")
-    input_data_list.append(f"initial_state = {initial_state_file}")
-
-    # TODO: For now all information is contained in a single input file
-    # # Add the horizontal mesh file to the input data list
-    # horz_mesh_file = _get_file_name(case, "HorzMeshIn")
-    # input_data_list.append(horz_mesh_file)
-
-    # # Add the initial vertical coordinate file to the input data list
-    # initial_vert_coord_file = _get_file_name(case, "InitialVertCoord")
-    # input_data_list.append(initial_vert_coord_file)
-
-    with open(Path(casebuild) / "omega.input_data_list", "w") as f:
-        for input_file in input_data_list:
-            f.write(f"{input_file}\n")
-
-
-def buildnml(case, caseroot, compname):
-    """
-    """
-    expect(compname == "omega", compname)
-
-    run_dir = Path(case.get_value("RUNDIR"))
-    case_root = Path(case.get_value("CASEROOT"))
-    omega_root = Path(case.get_value("SRCROOT")) / "components/omega"
-
-    with open(omega_root / "configs/Default.yml", "r") as file:
-        default_config = yaml.load(file, Loader=yaml.SafeLoader)
-        # unpack the Omega section of the default config
-        default_config = default_config["Omega"]
-
-    # start with a copy of the default config, unpack the Omega section
-    config = default_config.copy()
-
-    # update the TimeIntegration section of the config
-    config["TimeIntegration"] = _build_time_integration_config(
-        default_config["TimeIntegration"], case
-    )
-
-    # update the IOStreams section of the config
-    config["IOStreams"] = _build_io_streams_config(
-        default_config["IOStreams"], case
-    )
-
-    # repack everything withn a top-level Omega section
-    config = {"Omega": config}
-
-    # write yaml file and copy to CaseDocs within a SharedArea context so that
-    # correct file permissions are set
-    with SharedArea():
-
-        output_file = run_dir / "omega.yml"
-
-        # write the updated yaml file to the run directory
-        with open(output_file, "w") as file:
-            yaml.dump(config, file, Dumper=OrderedSafeDumper)
-
-        # archive yaml file in CaseDocs
-        case_docs = case_root / 'CaseDocs'
-        if case_docs.exists():
-            safe_copy(output_file, case_docs / "omega.yml")
-
-        # needs to be called within buildnml
-        build_input_data_list(case, compname)
 
 
 def _main_func():

--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+"""
+Namelist creator for E3SM's omega component
+"""
+
+import sys
+from pathlib import Path
+
+from CIME.buildnml import parse_input
+from CIME.case import Case
+from CIME.utils import SharedArea, expect, safe_copy
+
+
+def buildnml(case, caseroot, compname):
+    """
+    """
+    expect(compname == "omega", compname)
+
+    run_dir = Path(case.get_value("RUNDIR"))
+    case_root = Path(case.get_value("CASEROOT"))
+    omega_root = Path(case.get_value("SRCROOT")) / "components/omega"
+
+    with SharedArea():
+
+        src = omega_root / "configs/Default.yml"
+
+        safe_copy(src, run_dir / "omega.yml")
+
+        # archive yaml file in CaseDocs
+        case_docs = case_root / 'CaseDocs'
+        if case_docs.exists():
+            safe_copy(src, case_docs / "omega.yml")
+
+
+def _main_func():
+    """
+    """
+    caseroot = parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "omega")
+
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -70,15 +70,14 @@ def _update_read_io_streams(config, case, stream):
     """
     continue_run = case.get_value("CONTINUE_RUN")
 
-    # RestartRead has inverse logic compared to InitialState and
-    # InitialVertCoord, so negate the value of continue_run
+    # RestartRead has inverse logic to InitialState so negate value
     if stream == "RestartRead":
         continue_run = not continue_run
 
     config[stream]['Filename'] = _get_file_name(case, stream)
 
-    # Leave `OnstartUp` default for HorzMeshIn stream
-    if stream not in ["HorzMeshIn"]:  # "InitialVertCoord"]:
+    # Leave `OnstartUp` default for HorzMeshIn and InitialVertCoord streams
+    if stream not in ["HorzMeshIn", "InitialVertCoord"]:
         config[stream]["FreqUnits"] = "Never" if continue_run else "OnStartUp"
 
     # Make sure pointer, with the correct filename, is used by restart reads

--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -273,8 +273,12 @@ def _build_time_integration_config(default_time_integration, case):
     # RunDuration is not used in coupled runs
     time_integration["RunDuration"] = "none"
 
-    if ocn_grid == "EC30to60E2r2":
-        time_integration["TimeStepper"] = "RungeKutta4"
+    # All meshes use RK4 timestepping (for now)
+    time_integration["TimeStepper"] = "RungeKutta4"
+
+    if ocn_grid == "oQU240":
+        time_integration["TimeStep"] = "0000_00:05:00"
+    elif ocn_grid == "EC30to60E2r2":
         time_integration["TimeStep"] = "0000_00:01:00"
 
     return time_integration

--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -16,6 +16,7 @@ nan_time_instant_str = "9999-12-31_00:00:00"
 
 omega_supported_grids = ["oQU240", "EC30to60E2r2"]
 
+
 # YAML representer to preserve order of dicts when dumping to yaml
 class OrderedSafeDumper(yaml.SafeDumper):
     pass

--- a/components/omega/cime_config/config_component.xml
+++ b/components/omega/cime_config/config_component.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+
+<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+
+<definitions_variables>
+
+  <entry id="COMP_OCN">
+    <type>char</type>
+    <valid_values>omega</valid_values>
+    <default_value>omega</default_value>
+    <group>case_comp</group>
+    <file>env_case.xml</file>
+    <desc>Name of ocean component</desc>
+  </entry>
+
+  <entry id="OMEGA_FORCING">
+        <type>char</type>
+        <valid_values>active_atm,datm_forced</valid_values>
+        <default_value>active_atm</default_value>
+        <values>
+           <value compset="OMEGA_">active_atm</value>
+           <value compset="_OMEGA%.*DATMFORCED">datm_forced</value>
+        </values>
+        <group>case_comp</group>
+        <file>env_case.xml</file>
+        <desc>Option to describe the OMEGA surface forcing</desc>
+  </entry>
+
+  <description>
+    <desc compset="_OMEGA">omega ocean default:</desc>
+  </description>
+
+  <help>
+    =========================================
+    omega naming conventions
+    =========================================
+  </help>
+
+</definitions_variables>

--- a/components/omega/cime_config/config_compsets.xml
+++ b/components/omega/cime_config/config_compsets.xml
@@ -10,6 +10,12 @@
   <!-- E3SM C/G compsets -->
 
   <compset>
+    <alias>COMEGA-IAF</alias>
+    <lname>2000_DATM%IAF_SLND_DICE%IAF_OMEGA%DATMFORCED_DROF%IAF_SGLC_SWAV</lname>
+    <support_level>Experimental, under development</support_level>
+  </compset>
+
+  <compset>
     <alias>COMEGA-JRA1p4</alias>
     <lname>2000_DATM%JRA-1p4-2018_SLND_DICE%SSMI_OMEGA%DATMFORCED_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
     <support_level>Experimental, under development</support_level>

--- a/components/omega/cime_config/config_compsets.xml
+++ b/components/omega/cime_config/config_compsets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<compsets>
+
+  <help>
+  Compset format is explained in cime/config/e3sm/allactive/config_compsets.xml
+  or in the CIME documenation
+  </help>
+
+  <!-- E3SM C/G compsets -->
+
+  <compset>
+    <alias>COMEGA-JRA1p4</alias>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_DICE%SSMI_OMEGA%DATMFORCED_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
+    <support_level>Experimental, under development</support_level>
+  </compset>
+
+</compsets>

--- a/components/omega/cime_config/user_nl_omega
+++ b/components/omega/cime_config/user_nl_omega
@@ -1,0 +1,11 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes after these comments
+! in the form of
+!   namelist_var = new_namelist_value
+! *** EXCEPT FOR ***
+! TODO: Change to OMEGA config names
+! 1. DO NOT CHANGE config_start_time, config_run_duration, config_stop_time,
+!    config_do_restart, config_Restart_timestamp_filename, config_calendar_type
+! 2. To preview the namelists, invoke $CASEROOT preview-namelists and look at
+!    $CASEROOT/CaseDocs/omega_in
+!----------------------------------------------------------------------------------

--- a/components/omega/doc/devGuide/CMakeBuild.md
+++ b/components/omega/doc/devGuide/CMakeBuild.md
@@ -172,7 +172,8 @@ script that you can run to build Omega:
 ./omega_build.sh
 ```
 
-Note: Until the Omega build is integrated into the E3SM build, specific
-modifications are required to trigger the Omega build within the E3SM
-build process. Please see [Omega Build User Guide](../userGuide/OmegaBuild.md)
-for details.
+When `OMEGA_BUILD_MODE` is `E3SM`, `src/CMakeLists.txt` additionally
+builds an `ocn` library from the sources in `src/drivers/coupled/`
+(the Fortran/C++ bridge and MCT cap), linked against `OmegaLib` and
+`csm_share`. This is the library CIME builds and links into the E3SM
+executable when Omega is used as the ocean component of a coupled case.

--- a/components/omega/doc/devGuide/Driver.md
+++ b/components/omega/doc/devGuide/Driver.md
@@ -2,57 +2,112 @@
 
 ## Driver
 
-The Omega Driver consists of methods to run the Omega ocean model in either
-standalone mode or as a component of E3SM. In both cases, the execution of Omega
-is divided into three phases, carried out by the `ocnInit`, `ocnRun`, and
-`ocnFinalize` methods. An interface layer to translate data types of the parent
-model to and from internal Omega data types will also be needed for running
-Omega as a component. For standalone mode, a `main` function is defined to
-serve as the top-level driver. The driver methods will evolve as more modules
-are developed and as Omega is integrated with E3SM.
+The Omega Driver runs Omega either as a standalone model or as the ocean
+component of E3SM (currently via the MCT coupler). In both modes execution
+is divided into init, run, and finalize phases, but the coupled driver
+splits init into two phases and calls run once per coupling interval
+instead of once for the whole simulation. All entry points below are
+declared in `OceanDriver.h`.
 
-### ocnInit
+### Standalone driver
 
-The `ocnInit` method initializes everything needed to run the Omega ocean model,
-and has the following interface:
+`ocnInit` reads `omega.yml`, calls `initOmegaModules` to initialize every
+Omega module (including the default `TimeStepper`, which owns the model
+`Clock` and `EndAlarm`), reads the `InitialState` or `RestartRead` IOStream,
+and updates halo/host arrays for the resulting state:
 ```c++
-int ocnInit(MPI_Comm Comm, Calendar &OmegaCal, TimeInstant &StartTime, Alarm &EndAlarm);
+int ocnInit(MPI_Comm Comm);
 ```
-It requires an MPI communicator as input, as well as a yaml configuration file
-named `omega.yml` in the directory Omega is launched from. Default configuration
-files are currently kept in the `configs` directory, eventually an automated
-tool will extract default configuration options from module header files and
-build the default config file. The `ocnInit` method will read the configuration
-options into the static `ConfigAll` object. The time management options that
-determine the duration of the simulation are read from the Config object and
-stored in `OmegaCal`, `StartTime`, and `EndAlarm`, which are output by the
-method. The `init()` methods for each Omega module necessary to run the ocean
-model are called. An integer error code is returned.
-
-### ocnRun
-
-The `ocnRun` method advances the model over the interval defined by time
-management options, integrating from the start time until the `EndAlarm` is
-ringing. The interface is:
+`ocnRun` advances the model, calling the default `TimeStepper`'s `doStep`
+once per ocean time step, until the `EndAlarm` attached to the model
+`Clock` rings:
 ```c++
-int ocnRun(TimeInstant &CurrTime, Alarm &EndAlarm);
+int ocnRun(TimeInstant &CurrTime);
 ```
-The `TimeStep` is retrieved from the default `TimeStepper` object initialized
-during `ocnInit` and used with the value of `CurrTime` on input to construct
-a `Clock` object which manages the time loop. The `EndAlarm` is attached to
-the `Clock` to signal the end of the time loop. Eventually, there will be
-periodic alarms also attached to the `Clock` to trigger forcings, writing
-output, restarts, etc. As the time loop advances, the `doStep` method of the
-`TimeStepper` object is called to update the ocean model until the `EndAlarm`
-is triggered. The updated `CurrTime` and status of `EndAlarm` are returned,
-along with an integer error code.
-
-### ocnFinalize
-
-The `ocnFinalize` method is needed to clean up all the objects allocated by the
-model. The interface is:
+`ocnFinalize` cleans up all Omega objects; `CurrTime` is passed in case a
+final restart needs to be written:
 ```c++
-int ocnFinalize(TimeInstant &CurrTime);
+int ocnFinalize(const TimeInstant &CurrTime);
 ```
-The `CurrTime` is input in case a restart file needs to be written. An integer
-error code is returned.
+The standalone `main` (`src/drivers/standalone/OceanDriver.cpp`) wraps
+these three calls with `MPI_Init`/`Kokkos::initialize` and their shutdown
+counterparts.
+
+### Coupled driver
+
+The coupled driver (`src/drivers/coupled/`) runs Omega as the `ocn`
+component of an MCT-based E3SM system. `ocn_comp_mct.F90` is the MCT cap,
+exposing `ocn_init_mct`/`ocn_run_mct`/`ocn_final_mct` to the coupler. It
+calls `bind(c)` interfaces declared in `omega_f2cxx_interface.F90` and
+implemented in `omega_cxx2f_interface.cpp`, which call the C++ entry
+points below.
+
+#### Init
+
+Init is split into two phases because the coupler needs Omega's
+decomposition (`NCellsOwned`) before it can size and allocate the MCT
+attribute vectors (`x2o`/`o2x`) that `SfcCoupling` attaches to:
+```c++
+int ocnInit1(MPI_Comm Comm, const int OcnId, const std::string &ConfigFile,
+             const std::string &LogFile, const StartType StartType,
+             const TimeInitParams &TimeParams,
+             const CouplingInitParams &CouplingParams);
+int ocnInit2(const Real *CplToOcnData, Real *OcnToCplData);
+```
+`ocnInit1` initializes every Omega module, using the coupled overload of
+`initOmegaModules(Comm, TimeParams, CouplingParams)`, which also calls
+`SfcCoupling::init`. It then reads the `InitialState` or `RestartRead`
+IOStream based on `StartType`:
+```c++
+enum class StartType { StartUp, Continue, Branch };
+```
+converted from the coupler's integer start-type code by
+`safeIntToStartType`. On restart/branch, the simulation time is taken from
+the restart file rather than the coupler (which only knows the case start
+time). On a cold start, `ocnInit1` advances the model `Clock` to the first
+coupling-interval boundary so it is in sync with the coupler's clock.
+
+`ocnInit2` runs once the coupler has allocated `x2o`/`o2x`: it attaches
+them to `SfcCoupling` (`SfcCoupling::attachData`), does the initial
+export/import exchange with the coupler, and updates halo/host arrays.
+
+#### Run
+
+The coupled overload of `ocnRun` advances the model one coupling interval,
+rather than to the end of the simulation: it imports coupler fields into
+`Forcing` at the start of the interval, steps until `SfcCoupling`'s
+`CouplingAlarm` rings (updating `SfcCoupling`'s export accumulators every
+ocean time step), and exports the accumulated fields back to the coupler.
+`WriteRestart` is set by the coupler (from its own restart alarm) to force
+a restart write at the end of the interval:
+```c++
+int ocnRun(TimeInstant &CurrTime, bool WriteRestart);
+```
+
+#### Finalize
+
+`ocnFinalize` is shared with the standalone driver; it additionally clears
+all `SfcCoupling` instances.
+
+#### Field name/index mapping
+
+`omega_cpl_indices.F90` builds the import (`x2o`) and export (`o2x`) field
+name and coupler-column-index arrays from a dummy MCT attribute vector,
+before Omega (and its `HorzMesh`) exists. `omega_ocn_init1` passes these
+arrays through to `omega_cxx2f_interface.cpp`'s `buildFieldIndexMap`, which
+builds the `std::map<std::string, int>` (`ImportIdx`/`ExportIdx`) required
+by `CouplingInitParams`; see [Surface Coupling](#omega-dev-sfc-coupling)
+for how those maps are used.
+
+#### Mesh/decomposition queries
+
+Before the coupler-owned buffers exist, the Fortran bridge needs Omega's
+decomposition to build its MCT `gsMap` and domain. These bridge-only
+queries expose that information and have no dependency on `SfcCoupling`:
+```c++
+int omega_get_ncells_local();
+int omega_get_ncells_global();
+void omega_get_index_to_cell_id(int *CellID);
+void omega_get_lonlat_cell(double *LonCell, double *LatCell);
+void omega_get_area_cell(double *AreaCell);
+```

--- a/components/omega/doc/devGuide/IOStreams.md
+++ b/components/omega/doc/devGuide/IOStreams.md
@@ -62,6 +62,9 @@ outside of this routine, a single-stream write can take place using:
 ```c++
    IOStream::write(StreamName, ModelClock);
 ```
+Streams configured with `FreqUnits: OnDemand` are registered but never fire
+via writeAll; use `IOStream::write(StreamName, ModelClock, true)` to force
+them (eg the coupled driver's coupler-triggered restart writes).
 
 Reading files (eg for initialization, restart or forcing) does not often
 take place all at once, so no readAll interface is provided. Instead, each

--- a/components/omega/doc/devGuide/TimeStepping.md
+++ b/components/omega/doc/devGuide/TimeStepping.md
@@ -23,6 +23,8 @@ time stepping method as well as some time tracking variables, including
 a Clock, TimeStep, StartTime, StopTime (optional) and an EndAlarm (optional).
 The StopTime and EndAlarm are optional, because in coupled E3SM simulations the
 components do not know the StopTime and therefore no EndAlarm can be created.
+It also stores a StepCount, the number of `doStep` calls made on the
+instance since creation.
 Its `doStep` method defines the interface that every time stepper needs to
 implement. In addition to this method, it provides a number of other methods
 that can divided into two groups. The first group is for general time stepper
@@ -41,6 +43,10 @@ TimeStep`. Classes implementing concrete time stepping schemes need to provide
 implementations of this method. As part of the time step, this routine advances
 the Clock associated with the time stepper and returns the current simulation
 time. For the default time stepper, this is advances the primary model clock.
+Each implementation also increments StepCount, a member variable that
+persists on the instance across calls, so it can be used to identify the
+first `doStep` call even when `doStep` is invoked repeatedly across
+separate calls to `ocnRun`, as is done by the coupled driver.
 
 ### Time stepper management methods
 

--- a/components/omega/doc/userGuide/Driver.md
+++ b/components/omega/doc/userGuide/Driver.md
@@ -37,3 +37,11 @@ simulation. The supported calendar types are:
 | 360 Day | 12 months, 30 days each |
 | Custom | user-defined calendar |
 | No Calendar | tracks elapsed time only |
+
+## Coupled mode
+
+When Omega runs as the `ocn` component of E3SM, `StartTime`, `StopTime`,
+and `RunDuration` are not read from `omega.yml`; the E3SM case's start
+time and the coupler's clock control the simulation instead, and
+`omega/cime_config/buildnml` writes placeholder values for these three options.
+`CalendarType` is still set, from the case's `CALENDAR` XML variable.

--- a/components/omega/doc/userGuide/IOStreams.md
+++ b/components/omega/doc/userGuide/IOStreams.md
@@ -120,6 +120,8 @@ a template can be:
      at the time specified in the StartTime entry
    - Never if the stream should not be used but you wish to retain the
      entry in the config file (a warning will be output to log file)
+   - OnDemand for streams registered but never written/read automatically;
+     only a forced `IOStream::write`/`read` call triggers them
    - Years for a frequency every Freq years (*not* Freq times per year)
    - Months for a frequency every Freq months (*not* Freq times per month)
    - Days for a frequency every Freq days (*not* Freq times per day)

--- a/components/omega/doc/userGuide/OmegaBuild.md
+++ b/components/omega/doc/userGuide/OmegaBuild.md
@@ -174,54 +174,9 @@ Total Test time (real) =   0.04 sec
 
 ## E3SM Component Build
 
-In the E3SM component build, the compilation is triggered by
-the E3SM build system.
-
-### Manual Preparation for E3SM Component Build
-
-Although all the build configurations in the E3SM component build
-should ideally be managed through the E3SM build configuration,
-the current Omega build is not yet integrated into the E3SM build.
-Therefore, users need to make specific modifications to enable
-the Omega build within the E3SM build process.
-
-Step 1: Modify `${E3SM_ROOT}/components/CMakeLists.txt`
-
-Add the lines indicated as "added" in the `CMakeLists.txt` file.
-
-```bash
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_util.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_mpas_model.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_omega.cmake) # <= added
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_eamxx.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_model.cmake)
-...
-set(BUILDCONF ${CASEROOT}/Buildconf)
-
-build_mpas_models()
-build_omega() # <= added
-```
-
-Step 2: Create `${E3SM_ROOT}/components/cmake/build_omega.cmake`
-
-Create the `cmake` file and copy the following content into it.
-
-```cmake
-function(build_omega)
-
-  # Set CIME source path relative to components
-  set(CIMESRC_PATH "../cime/src")
-
-  add_subdirectory("omega")
-
-endfunction(build_omega)
-```
-
-Step 3: Create an E3SM Case
-
-At this stage, a user can create any E3SM case as usual without
-requiring any specific configuration for Omega.
-
-NOTE: In this version, the compiled library file for Omega,
-"libOmegaLib.a", is not linked to the E3SM executable. You can
-find the Omega library file at `${E3SM_BLD_DIRECTORY}/cmake-bld/omega/src`.
+Omega can be built and run as the `ocn` component of a coupled E3SM simulation,
+using a compset where Omega is the ocean component (see
+`omega/cime_config/config_compsets.xml` for the currently supported compsets).
+Creating such a case and running `case.build`  builds Omega
+automatically: CIME's `omega/cime_config/buildlib_cmake` configures Omega with
+`OMEGA_BUILD_MODE=E3SM` so that the coupler (c.f. standalone) driver is built.

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -68,6 +68,11 @@ if (NOT TARGET pioc)
 
 	option(PIO_ENABLE_TOOLS "" OFF)
 
+	# Locally shadow ADIOS2_FOUND, which leaks in from E3SM's top-level
+	# find_package. Workaround for scorpio/src/clib/CMakeLists.txt:498, which
+	# should test WITH_ADIOS2 (OFF here) instead of ADIOS2_FOUND.
+	set(ADIOS2_FOUND FALSE)
+
 	add_subdirectory(
 	  ${E3SM_EXTERNALS_ROOT}/scorpio
 	  ${CMAKE_CURRENT_BINARY_DIR}/scorpio

--- a/components/omega/external/CMakeLists.txt
+++ b/components/omega/external/CMakeLists.txt
@@ -135,6 +135,9 @@ endif()
 
 # Add the cpptrace library
 if (NOT TARGET cpptrace::cpptrace)
+	# Unset PACKAGE_VERSION before adding cpptrace to prevent ADIOS2's
+	# PACKAGE_VERSION (e.g. 2.10.2) from leaking into libdwarf's configure_file
+	unset(PACKAGE_VERSION)
 	option(CPPTRACE_INHERIT_HOST_STANDARD "" ON)
 	add_subdirectory(
 	  ${OMEGA_SOURCE_DIR}/external/cpptrace

--- a/components/omega/python_lint.cfg
+++ b/components/omega/python_lint.cfg
@@ -8,6 +8,7 @@ max-line-length = 79
 max-complexity = 18
 per-file-ignores =
     */__init__.py: F401
+    components/omega/cime_config/buildlib_cmake: E402, F403
 exclude =
     .git,
     docs,

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -114,6 +114,7 @@ if(DEFINED E3SM_SOURCE_DIR)
       drivers/coupled/ocn_comp_mct.F90
       drivers/coupled/omega_cxx2f_interface.cpp
       drivers/coupled/omega_f2cxx_interface.F90
+      drivers/coupled/omega_cpl_indices.F90
     )
 
     # create ocn lib

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -107,6 +107,36 @@ if(OMEGA_BUILD_TEST AND NOT OMEGA_SINGLE_PRECISION)
 endif()
 
 
+# build Omega as an E3SM component
+if(DEFINED E3SM_SOURCE_DIR)
+
+    set(OCN_SRC
+      drivers/coupled/ocn_comp_mct.F90
+    )
+
+    # create ocn lib
+    add_library(ocn ${OCN_SRC})
+
+    # Set f90 compiled modules dir
+    set_target_properties(
+      ocn
+      PROPERTIES
+      Fortran_MODULE_DIRECTORY
+      ${CMAKE_BINARY_DIR}/cmake/ocn
+    )
+    target_include_directories(ocn PUBLIC ${CMAKE_BINARY_DIR}/cmake/ocn)
+
+    # Link libraries
+    target_link_libraries(
+      ocn
+      PRIVATE
+      ${OMEGA_LIB_NAME}
+      OmegaLibFlags
+      csm_share
+    )
+
+endif()
+
 # build Omega executable
 if(OMEGA_BUILD_EXECUTABLE)
 

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -108,7 +108,7 @@ endif()
 
 
 # build Omega as an E3SM component
-if(DEFINED E3SM_SOURCE_DIR)
+if("${OMEGA_BUILD_MODE}" STREQUAL "E3SM")
 
     set(OCN_SRC
       drivers/coupled/ocn_comp_mct.F90

--- a/components/omega/src/CMakeLists.txt
+++ b/components/omega/src/CMakeLists.txt
@@ -112,6 +112,8 @@ if(DEFINED E3SM_SOURCE_DIR)
 
     set(OCN_SRC
       drivers/coupled/ocn_comp_mct.F90
+      drivers/coupled/omega_cxx2f_interface.cpp
+      drivers/coupled/omega_f2cxx_interface.F90
     )
 
     # create ocn lib

--- a/components/omega/src/drivers/coupled/ocn_comp_mct.F90
+++ b/components/omega/src/drivers/coupled/ocn_comp_mct.F90
@@ -1,11 +1,24 @@
 module ocn_comp_mct
 
+   ! shr mods
+   use shr_kind_mod, only: &
+      IN => SHR_KIND_IN, &
+      CS => SHR_KIND_CS, &  ! short char
+      CL => SHR_KIND_CX, &  ! long char
+      CX => SHR_KIND_CX     ! extra-long char
+
    ! seq mods
-   use seq_cdata_mod, only: seq_cdata
+   use seq_cdata_mod, only: seq_cdata, seq_cdata_setptrs
+   use seq_infodata_mod, only: seq_infodata_type, seq_infodata_GetData
+   use seq_timemgr_mod, only: seq_timemgr_EClockGetData
 
    ! toolkits mods
    use esmf, only: ESMF_Clock
-   use mct_mod, only: mct_aVect
+   use mct_mod, only: mct_aVect, mct_gsMap, mct_gGrid
+
+   ! MPI
+   ! allow(use-all)
+   use mpi
 
    implicit none
    save
@@ -18,13 +31,135 @@ module ocn_comp_mct
    public :: ocn_run_mct
    public :: ocn_final_mct
 
+   !--------------------------------------------------------------------------
+   ! Private module data
+   !--------------------------------------------------------------------------
+   integer :: ocn_log_unit
+   integer(IN), parameter :: master_task = 0       ! task number of master task
+
 contains
    subroutine ocn_init_mct(EClock, cdata, x2o, o2x, NLFilename)
+      use, intrinsic :: iso_c_binding, only: c_null_char
+      use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_int, c_char
+
+      use seq_comm_mct, only: seq_comm_suffix
+      use seq_infodata_mod, only: &
+         seq_infodata_start_type_start, &
+         seq_infodata_start_type_cont, &
+         seq_infodata_start_type_brnch
+      use shr_sys_mod, only: shr_sys_flush
+      use shr_cal_mod, only: shr_cal_noleap, shr_cal_gregorian
+      use shr_file_mod, only: shr_file_getunit, shr_file_setIO
+
       ! !INPUT/OUTPUT PARAMETERS:
       type(ESMF_Clock), intent(inout) :: EClock
       type(seq_cdata), intent(inout) :: cdata
       type(mct_aVect), intent(inout) :: x2o, o2x
       character(len=*), optional, intent(in) :: NLFilename
+
+      !--- local variables ---
+      integer           :: mpicom_ocn  ! mpi communicator
+      integer(IN)       :: my_task     ! my task in mpi communicator mpicom
+      integer           :: inst_index  ! number of current instance (ie. 1)
+      character(len=16), save :: &
+         inst_suffix = ""  ! char str for instance (ie. "_0001" or "")
+      integer(IN)       :: OCN_ID          ! mct comp id
+
+      character(len=CS) :: start_type      ! "startup" | "hybrid" | "branch"
+      character(len=CX) :: cpl_seq_option  ! coupling sequence option
+      character(len=CX) :: ocn_log_fname   ! name of ocn log file
+      character(len=CL) :: calendar        ! calendar string
+
+      type(seq_infodata_type), pointer :: infodata
+      type(mct_gsMap), pointer :: gsMap_ocn
+      type(mct_gGrid), pointer :: dom_ocn
+      integer(IN) :: ierr, mpi_ierr  ! error codes
+      integer(IN) :: case_start_tod, case_start_ymd, cur_tod, cur_ymd
+      integer(kind=c_int) :: start_type_c
+      character(kind=c_char, len=CL), target :: calendar_c
+      character(kind=c_char, len=CL), target :: ocn_log_fname_c
+
+      ! set cdata pointers
+      call seq_cdata_setptrs( &
+         cdata, &
+         ID=OCN_ID, &
+         mpicom=mpicom_ocn, &
+         gsMap=gsMap_ocn, &
+         dom=dom_ocn, &
+         infodata=infodata &
+         )
+
+      ! determine start type and coupling type
+      call seq_infodata_GetData( &
+         infodata, start_type=start_type, cpl_seq_option=cpl_seq_option &
+         )
+
+      ! Determine instance information
+      inst_suffix = seq_comm_suffix(OCN_ID)
+
+      ! Determine communicator group
+      call mpi_comm_rank(mpicom_ocn, my_task, ierr)
+
+      !------------------------------------------------------------------------
+      ! Init ocn.log
+      !------------------------------------------------------------------------
+      if (my_task == master_task) then
+         ocn_log_unit = shr_file_getUnit()
+         call shr_file_setIO( &
+            "ocn_modelio.nml"//trim(inst_suffix), ocn_log_unit &
+            )
+         inquire (unit=ocn_log_unit, name=ocn_log_fname)
+      end if
+
+      call mpi_bcast( &
+         ocn_log_unit, 1, MPI_INTEGER, master_task, mpicom_ocn, mpi_ierr &
+         )
+      if (ierr /= 0) then
+         print *, "[omega] ERROR broadcasting ocn.log unit"
+         call mpi_abort(mpicom_ocn, ierr, mpi_ierr)
+      end if
+
+      call mpi_bcast( &
+         ocn_log_fname, 256, MPI_CHARACTER, master_task, mpicom_ocn, ierr &
+         )
+      if (ierr /= 0) then
+         print *, "[omega] ERROR broadcasting ocn.log file name"
+         call mpi_abort(mpicom_ocn, ierr, mpi_ierr)
+      end if
+
+      !------------------------------------------------------------------------
+      ! Initialize atm
+      !------------------------------------------------------------------------
+      if (trim(start_type) == trim(seq_infodata_start_type_start)) then
+         start_type_c = 0
+      else if (trim(start_type) == trim(seq_infodata_start_type_cont)) then
+         start_type_c = 1
+      else if (trim(start_type) == trim(seq_infodata_start_type_brnch)) then
+         start_type_c = 2
+      else
+         print *, "[omega] ERROR! Unsupported run type: "//trim(start_type)
+         call mpi_abort(mpicom_ocn, ierr, mpi_ierr)
+      end if
+
+      ! Get clock and calendar information
+      call seq_timemgr_EClockGetData( &
+         EClock, &
+         calendar=calendar, &
+         curr_ymd=cur_ymd, &
+         curr_tod=cur_tod, &
+         start_ymd=case_start_ymd, &
+         start_tod=case_start_tod &
+         )
+
+      ! convert CIME calendar string to a C string with a CF-compliant name
+      if (trim(calendar) == trim(shr_cal_noleap)) then
+         calendar_c = "no_leap"//c_null_char
+      else if (trim(calendar) == trim(shr_cal_gregorian)) then
+         calendar_c = "gregorian"//c_null_char
+      else
+         print *, "[omega] ERROR! Unsupported calendar: "//trim(calendar)
+         call mpi_abort(mpicom_ocn, ierr, mpi_ierr)
+      end if
    end subroutine ocn_init_mct
 
    subroutine ocn_run_mct(EClock, cdata, x2o, o2x)

--- a/components/omega/src/drivers/coupled/ocn_comp_mct.F90
+++ b/components/omega/src/drivers/coupled/ocn_comp_mct.F90
@@ -219,12 +219,6 @@ contains
 
       lsize = mct_gsMap_lsize(gsMap_ocn, mpicom_ocn)
 
-      ! TODO: Remove print statement after debugging
-      if (my_task == master_task) then
-         print *, "[omega] gsMap initialization done"
-         print *, "[omega] lsize = ", lsize
-      end if
-
       call ocn_set_domain_mct(lsize, gsMap_ocn, gGrid_ocn)
 
       ! Init import/export mct attribute vectors
@@ -240,13 +234,10 @@ contains
          ocn_c2_glcshelf=.false. &
          )
 
+      ! TODO: Get case config info and add as MetaData to Omega
+
       ! TODO: ifdef HAVE_MOAB
       call omega_ocn_init2(c_loc(x2o%rAttr), c_loc(o2x%rAttr))
-
-      ! TODO: Remove print statement after debugging
-      if (my_task == master_task) then
-         print *, "[omega] omega_ocn_init2 done"
-      end if
 
    end subroutine ocn_init_mct
 
@@ -308,17 +299,9 @@ contains
       ncells_local = omega_get_ncells_local()
       ncells_global = omega_get_ncells_global()
 
-      ! TODO: Remove print statement after debugging
-      print *, "[omega] ncells_local = ", ncells_local
-      print *, "[omega] ncells_global = ", ncells_global
-
       allocate (index_to_cell_id(ncells_local))
 
       call omega_get_index_to_cell_id(index_to_cell_id)
-
-      ! TODO: Remove print statement after debugging
-      print *, "[omega] index_to_cell_id[ 1] =", index_to_cell_id(1)
-      print *, "[omega] index_to_cell_id[-1] =", index_to_cell_id(ncells_local)
 
       call mct_gsMap_init( &
          gsmap_ocn, &
@@ -375,22 +358,8 @@ contains
       call mct_gGrid_importRAttr(ggrid_ocn, "lon", data1, lsize)
       call mct_gGrid_importRAttr(ggrid_ocn, "lat", data2, lsize)
 
-      ! TODO: Remove print statement after debugging
-      if (my_task == master_task) then
-         print *, "[omega] lon[ 1] = ", data1(1)
-         print *, "[omega] lon[-1] = ", data1(lsize)
-         print *, "[omega] lat[ 1] = ", data2(1)
-         print *, "[omega] lat[-1] = ", data2(lsize)
-      end if
-
       call omega_get_area_cell(data1)
       call mct_gGrid_importRAttr(ggrid_ocn, "area", data1, lsize)
-
-      ! TODO: Remove print statement after debugging
-      if (my_task == master_task) then
-         print *, "[omega] area[ 1] = ", data1(1)
-         print *, "[omega] area[-1] = ", data1(lsize)
-      end if
 
       ! mask and frac are both exactly 1, until landIceMask is suported
       data1(:) = real(1.0, kind=c_double)

--- a/components/omega/src/drivers/coupled/ocn_comp_mct.F90
+++ b/components/omega/src/drivers/coupled/ocn_comp_mct.F90
@@ -267,7 +267,7 @@ contains
 
       ! check if coupler is requesting a restart write
       write_restart = logical( &
-        seq_timemgr_RestartAlarmIsOn(EClock), kind=c_bool)
+                      seq_timemgr_RestartAlarmIsOn(EClock), kind=c_bool)
 
       ! run omega for one coupling interval
       call omega_ocn_run(write_restart)

--- a/components/omega/src/drivers/coupled/ocn_comp_mct.F90
+++ b/components/omega/src/drivers/coupled/ocn_comp_mct.F90
@@ -258,10 +258,15 @@ contains
    end subroutine ocn_run_mct
 
    subroutine ocn_final_mct(EClock, cdata, x2o, o2x)
+      use omega_f2cxx_mod, only: omega_ocn_finalize
+
       ! !INPUT/OUTPUT PARAMETERS:
       type(ESMF_Clock), intent(inout) :: EClock
       type(seq_cdata), intent(inout) :: cdata
       type(mct_aVect), intent(inout) :: x2o, o2x
+
+      call omega_ocn_finalize()
+
    end subroutine ocn_final_mct
 
    subroutine ocn_set_gsmap_mct(mpicom_ocn, ocn_id, gsMap_ocn)

--- a/components/omega/src/drivers/coupled/ocn_comp_mct.F90
+++ b/components/omega/src/drivers/coupled/ocn_comp_mct.F90
@@ -1,0 +1,43 @@
+module ocn_comp_mct
+
+   ! seq mods
+   use seq_cdata_mod, only: seq_cdata
+
+   ! toolkits mods
+   use esmf, only: ESMF_Clock
+   use mct_mod, only: mct_aVect
+
+   implicit none
+   save
+   private
+
+   !---------------------------------------------------------------------------
+   ! Public interfaces
+   !---------------------------------------------------------------------------
+   public :: ocn_init_mct
+   public :: ocn_run_mct
+   public :: ocn_final_mct
+
+contains
+   subroutine ocn_init_mct(EClock, cdata, x2o, o2x, NLFilename)
+      ! !INPUT/OUTPUT PARAMETERS:
+      type(ESMF_Clock), intent(inout) :: EClock
+      type(seq_cdata), intent(inout) :: cdata
+      type(mct_aVect), intent(inout) :: x2o, o2x
+      character(len=*), optional, intent(in) :: NLFilename
+   end subroutine ocn_init_mct
+
+   subroutine ocn_run_mct(EClock, cdata, x2o, o2x)
+      ! !INPUT/OUTPUT PARAMETERS:
+      type(ESMF_Clock), intent(inout) :: EClock
+      type(seq_cdata), intent(inout) :: cdata
+      type(mct_aVect), intent(inout) :: x2o, o2x
+   end subroutine ocn_run_mct
+
+   subroutine ocn_final_mct(EClock, cdata, x2o, o2x)
+      ! !INPUT/OUTPUT PARAMETERS:
+      type(ESMF_Clock), intent(inout) :: EClock
+      type(seq_cdata), intent(inout) :: cdata
+      type(mct_aVect), intent(inout) :: x2o, o2x
+   end subroutine ocn_final_mct
+end module ocn_comp_mct

--- a/components/omega/src/drivers/coupled/ocn_comp_mct.F90
+++ b/components/omega/src/drivers/coupled/ocn_comp_mct.F90
@@ -14,7 +14,7 @@ module ocn_comp_mct
 
    ! toolkits mods
    use esmf, only: ESMF_Clock
-   use mct_mod, only: mct_aVect, mct_gsMap, mct_gGrid
+   use mct_mod, only: mct_aVect, mct_gsMap, mct_gGrid, mct_aVect_init
 
    ! MPI
    ! allow(use-all)
@@ -35,7 +35,8 @@ module ocn_comp_mct
    ! Private module data
    !--------------------------------------------------------------------------
    integer :: ocn_log_unit
-   integer(IN), parameter :: master_task = 0       ! task number of master task
+   integer(IN) :: my_task ! my task in mpi communicator mpicom
+   integer(IN), parameter :: master_task = 0 ! task number of master task
 
 contains
    subroutine ocn_init_mct(EClock, cdata, x2o, o2x, NLFilename)
@@ -43,7 +44,9 @@ contains
       use, intrinsic :: iso_c_binding, only: c_null_char
       use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_int, c_char
 
+      use mct_mod, only: mct_gsMap_lsize
       use seq_comm_mct, only: seq_comm_suffix
+      use seq_flds_mod, only: seq_flds_o2x_fields, seq_flds_x2o_fields
       use seq_infodata_mod, only: &
          seq_infodata_start_type_start, &
          seq_infodata_start_type_cont, &
@@ -60,7 +63,6 @@ contains
 
       !--- local variables ---
       integer           :: mpicom_ocn  ! mpi communicator
-      integer(IN)       :: my_task     ! my task in mpi communicator mpicom
       integer           :: inst_index  ! number of current instance (ie. 1)
       character(len=16), save :: &
          inst_suffix = ""  ! char str for instance (ie. "_0001" or "")
@@ -73,7 +75,8 @@ contains
 
       type(seq_infodata_type), pointer :: infodata
       type(mct_gsMap), pointer :: gsMap_ocn
-      type(mct_gGrid), pointer :: dom_ocn
+      type(mct_gGrid), pointer :: gGrid_ocn
+      integer :: lsize
       integer(IN) :: ierr, mpi_ierr  ! error codes
       integer(IN) :: case_start_tod, case_start_ymd, cur_tod, cur_ymd
       integer(kind=c_int) :: start_type_c
@@ -86,7 +89,7 @@ contains
          ID=OCN_ID, &
          mpicom=mpicom_ocn, &
          gsMap=gsMap_ocn, &
-         dom=dom_ocn, &
+         dom=gGrid_ocn, &
          infodata=infodata &
          )
 
@@ -129,7 +132,7 @@ contains
       end if
 
       !------------------------------------------------------------------------
-      ! Initialize atm
+      ! Initialize ocn
       !------------------------------------------------------------------------
       if (trim(start_type) == trim(seq_infodata_start_type_start)) then
          start_type_c = 0
@@ -172,6 +175,25 @@ contains
          case_start_tod &
          )
 
+      !-------------------------------------------------------------------------
+      ! initialize MCT gsmap, domain, and attribute vectors
+      !-------------------------------------------------------------------------
+      call ocn_set_gsmap_mct(mpicom_ocn, ocn_id, gsMap_ocn)
+
+      lsize = mct_gsMap_lsize(gsMap_ocn, mpicom_ocn)
+
+      ! TODO: Remove print statement after debugging
+      if (my_task == master_task) then
+         print *, "[omega] gsMap initialization done"
+         print *, "[omega] lsize = ", lsize
+      end if
+
+      call ocn_set_domain_mct(lsize, gsMap_ocn, gGrid_ocn)
+
+      ! Init import/export mct attribute vectors
+      call mct_aVect_init(x2o, rList=seq_flds_x2o_fields, lsize=lsize)
+      call mct_aVect_init(o2x, rList=seq_flds_o2x_fields, lsize=lsize)
+
    end subroutine ocn_init_mct
 
    subroutine ocn_run_mct(EClock, cdata, x2o, o2x)
@@ -187,4 +209,121 @@ contains
       type(seq_cdata), intent(inout) :: cdata
       type(mct_aVect), intent(inout) :: x2o, o2x
    end subroutine ocn_final_mct
+
+   subroutine ocn_set_gsmap_mct(mpicom_ocn, ocn_id, gsMap_ocn)
+      use, intrinsic :: iso_c_binding, only: c_int
+      use mct_mod, only: mct_gsMap_init
+      use omega_f2cxx_mod, only: &
+         omega_get_ncells_local, &
+         omega_get_ncells_global, &
+         omega_get_index_to_cell_id
+
+      ! !INPUT/OUTPUT PARAMETERS:
+      integer(IN), intent(in) :: mpicom_ocn
+      integer(in), intent(in) :: OCN_ID
+      type(mct_gsMap), intent(out) :: gsMap_ocn
+
+      !--- local variables ---
+      integer(kind=c_int), allocatable, target :: index_to_cell_id(:)
+      integer(kind=c_int) :: ncells_local, ncells_global
+
+      ! build the ocn cell numbering scheme for mct
+
+      ncells_local = omega_get_ncells_local()
+      ncells_global = omega_get_ncells_global()
+
+      ! TODO: Remove print statement after debugging
+      print *, "[omega] ncells_local = ", ncells_local
+      print *, "[omega] ncells_global = ", ncells_global
+
+      allocate (index_to_cell_id(ncells_local))
+
+      call omega_get_index_to_cell_id(index_to_cell_id)
+
+      ! TODO: Remove print statement after debugging
+      print *, "[omega] index_to_cell_id[ 1] =", index_to_cell_id(1)
+      print *, "[omega] index_to_cell_id[-1] =", index_to_cell_id(ncells_local)
+
+      call mct_gsMap_init( &
+         gsmap_ocn, &
+         index_to_cell_id, &
+         mpicom_ocn, &
+         ocn_id, &
+         ncells_local, &
+         ncells_global &
+         )
+
+      deallocate (index_to_cell_id)
+   end subroutine ocn_set_gsmap_mct
+
+   subroutine ocn_set_domain_mct(lsize, gsmap_ocn, ggrid_ocn)
+      use, intrinsic :: iso_c_binding, only: c_int, c_double
+      use mct_mod, only: &
+         mct_gsMap, &
+         mct_gGrid, &
+         mct_gGrid_init, &
+         mct_gGrid_importIAttr, &
+         mct_gGrid_importRAttr, &
+         mct_gsMap_orderedPoints
+      use omega_f2cxx_mod, only: &
+         omega_get_area_cell, &
+         omega_get_lonlat_cell
+      use seq_flds_mod, only: seq_flds_dom_coord, seq_flds_dom_other
+
+      ! !INPUT/OUTPUT PARAMETERS:
+      integer(IN), intent(in) :: lsize
+      type(mct_gsMap), intent(in) :: gsmap_ocn
+      type(mct_gGrid), intent(out) :: ggrid_ocn
+
+      !--- local variables ---
+      integer, pointer :: idata(:)
+      real(kind=c_double), pointer :: data1(:), data2(:)
+
+      allocate (data1(lsize))
+      allocate (data2(lsize))
+
+      ! initialize mct ocn domain
+      call mct_gGrid_init( &
+         GGrid=ggrid_ocn, &
+         CoordChars=trim(seq_flds_dom_coord), &
+         OtherChars=trim(seq_flds_dom_other), &
+         lsize=lsize &
+         )
+
+      ! Initialize attribute vector with special value
+      call mct_gsMap_orderedPoints(gsmap_ocn, my_task, idata)
+      call mct_gGrid_importIAttr(ggrid_ocn, "GlobGridNum", idata, lsize)
+
+      ! Fill in correct values for domain components
+      call omega_get_lonlat_cell(data1, data2)
+      call mct_gGrid_importRAttr(ggrid_ocn, "lon", data1, lsize)
+      call mct_gGrid_importRAttr(ggrid_ocn, "lat", data2, lsize)
+
+      ! TODO: Remove print statement after debugging
+      if (my_task == master_task) then
+         print *, "[omega] lon[ 1] = ", data1(1)
+         print *, "[omega] lon[-1] = ", data1(lsize)
+         print *, "[omega] lat[ 1] = ", data2(1)
+         print *, "[omega] lat[-1] = ", data2(lsize)
+      end if
+
+      call omega_get_area_cell(data1)
+      call mct_gGrid_importRAttr(ggrid_ocn, "area", data1, lsize)
+
+      ! TODO: Remove print statement after debugging
+      if (my_task == master_task) then
+         print *, "[omega] area[ 1] = ", data1(1)
+         print *, "[omega] area[-1] = ", data1(lsize)
+      end if
+
+      ! mask and frac are both exactly 1, until landIceMask is suported
+      data1(:) = real(1.0, kind=c_double)
+      call mct_gGrid_importRAttr(ggrid_ocn, "mask", data1, lsize)
+      call mct_gGrid_importRAttr(ggrid_ocn, "frac", data1, lsize)
+
+      ! aream is computed by mct, so give invalid initial value
+      data1(:) = real(-9999.0, kind=c_double)
+      call mct_gGrid_importRAttr(ggrid_ocn, "aream", data1, lsize)
+
+   end subroutine ocn_set_domain_mct
 end module ocn_comp_mct

--- a/components/omega/src/drivers/coupled/ocn_comp_mct.F90
+++ b/components/omega/src/drivers/coupled/ocn_comp_mct.F90
@@ -39,6 +39,7 @@ module ocn_comp_mct
 
 contains
    subroutine ocn_init_mct(EClock, cdata, x2o, o2x, NLFilename)
+      use omega_f2cxx_mod, only: omega_ocn_init
       use, intrinsic :: iso_c_binding, only: c_null_char
       use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_int, c_char
 
@@ -151,15 +152,26 @@ contains
          start_tod=case_start_tod &
          )
 
-      ! convert CIME calendar string to a C string with a CF-compliant name
+      ! convert CIME calendar to a C string using Omega naming conventions
       if (trim(calendar) == trim(shr_cal_noleap)) then
-         calendar_c = "no_leap"//c_null_char
+         calendar_c = "No Leap"//c_null_char
       else if (trim(calendar) == trim(shr_cal_gregorian)) then
-         calendar_c = "gregorian"//c_null_char
+         calendar_c = "Gregorian"//c_null_char
       else
          print *, "[omega] ERROR! Unsupported calendar: "//trim(calendar)
          call mpi_abort(mpicom_ocn, ierr, mpi_ierr)
       end if
+
+      call omega_ocn_init( &
+         mpicom_ocn, &
+         OCN_ID, &
+         "omega.yml"//c_null_char, &
+         trim(ocn_log_fname)//c_null_char, &
+         calendar_c, &
+         case_start_ymd, &
+         case_start_tod &
+         )
+
    end subroutine ocn_init_mct
 
    subroutine ocn_run_mct(EClock, cdata, x2o, o2x)

--- a/components/omega/src/drivers/coupled/ocn_comp_mct.F90
+++ b/components/omega/src/drivers/coupled/ocn_comp_mct.F90
@@ -40,14 +40,29 @@ module ocn_comp_mct
 
 contains
    subroutine ocn_init_mct(EClock, cdata, x2o, o2x, NLFilename)
-      use omega_f2cxx_mod, only: omega_ocn_init
       use, intrinsic :: iso_c_binding, only: c_null_char
       use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_int, c_char
+
+      use omega_f2cxx_mod, only: &
+         omega_ocn_init1, &
+         omega_ocn_init2, &
+         omega_get_layout_mct, &
+         omega_get_layout_moab
+
+      use omega_cpl_indices, only: &
+         num_coupler_imports, &
+         num_coupler_exports, &
+         import_field_names, &
+         export_field_names, &
+         import_field_indices, &
+         export_field_indices, &
+         omega_set_cpl_indices
 
       use mct_mod, only: mct_gsMap_lsize
       use seq_comm_mct, only: seq_comm_suffix
       use seq_flds_mod, only: seq_flds_o2x_fields, seq_flds_x2o_fields
       use seq_infodata_mod, only: &
+         seq_infodata_PutData, &
          seq_infodata_start_type_start, &
          seq_infodata_start_type_cont, &
          seq_infodata_start_type_brnch
@@ -78,8 +93,10 @@ contains
       type(mct_gGrid), pointer :: gGrid_ocn
       integer :: lsize
       integer(IN) :: ierr, mpi_ierr  ! error codes
-      integer(IN) :: case_start_tod, case_start_ymd, cur_tod, cur_ymd
+      integer(IN) :: &
+         coupling_time_step, case_start_tod, case_start_ymd, cur_tod, cur_ymd
       integer(kind=c_int) :: start_type_c
+      integer(kind=c_int) :: layout
       character(kind=c_char, len=CL), target :: calendar_c
       character(kind=c_char, len=CL), target :: ocn_log_fname_c
 
@@ -148,6 +165,7 @@ contains
       ! Get clock and calendar information
       call seq_timemgr_EClockGetData( &
          EClock, &
+         dtime=coupling_time_step, &
          calendar=calendar, &
          curr_ymd=cur_ymd, &
          curr_tod=cur_tod, &
@@ -165,14 +183,33 @@ contains
          call mpi_abort(mpicom_ocn, ierr, mpi_ierr)
       end if
 
-      call omega_ocn_init( &
+      ! populate the import/export field name and index arrays
+      call omega_set_cpl_indices()
+
+#ifdef HAVE_MOAB
+      layout = omega_get_layout_moab()
+#else
+      layout = omega_get_layout_mct()
+#endif
+
+      call omega_ocn_init1( &
          mpicom_ocn, &
          OCN_ID, &
          "omega.yml"//c_null_char, &
          trim(ocn_log_fname)//c_null_char, &
+         start_type_c, &
          calendar_c, &
          case_start_ymd, &
-         case_start_tod &
+         case_start_tod, &
+         coupling_time_step, &
+         num_coupler_imports, &
+         num_coupler_exports, &
+         size(import_field_names), &
+         size(export_field_names), &
+         c_loc(import_field_names), &
+         c_loc(export_field_names), &
+         c_loc(import_field_indices), &
+         c_loc(export_field_indices) &
          )
 
       !-------------------------------------------------------------------------
@@ -193,6 +230,23 @@ contains
       ! Init import/export mct attribute vectors
       call mct_aVect_init(x2o, rList=seq_flds_x2o_fields, lsize=lsize)
       call mct_aVect_init(o2x, rList=seq_flds_o2x_fields, lsize=lsize)
+
+      ! coupler needs Omega's decomposition before it can size x2o/o2x, so
+      ! attach/export/import/halo-update must wait until they're allocated
+      call seq_infodata_PutData( &
+         infodata, &
+         ocn_prognostic=.true., &
+         ocnrof_prognostic=.true., &
+         ocn_c2_glcshelf=.false. &
+         )
+
+      ! TODO: ifdef HAVE_MOAB
+      call omega_ocn_init2(c_loc(x2o%rAttr), c_loc(o2x%rAttr))
+
+      ! TODO: Remove print statement after debugging
+      if (my_task == master_task) then
+         print *, "[omega] omega_ocn_init2 done"
+      end if
 
    end subroutine ocn_init_mct
 

--- a/components/omega/src/drivers/coupled/ocn_comp_mct.F90
+++ b/components/omega/src/drivers/coupled/ocn_comp_mct.F90
@@ -251,10 +251,27 @@ contains
    end subroutine ocn_init_mct
 
    subroutine ocn_run_mct(EClock, cdata, x2o, o2x)
+
+      use, intrinsic :: iso_c_binding, only: c_bool
+
+      use omega_f2cxx_mod, only: omega_ocn_run
+      use seq_timemgr_mod, only: seq_timemgr_RestartAlarmIsOn
+
       ! !INPUT/OUTPUT PARAMETERS:
       type(ESMF_Clock), intent(inout) :: EClock
       type(seq_cdata), intent(inout) :: cdata
       type(mct_aVect), intent(inout) :: x2o, o2x
+
+      !--- local variables ---
+      logical(kind=c_bool) :: write_restart
+
+      ! check if coupler is requesting a restart write
+      write_restart = logical( &
+        seq_timemgr_RestartAlarmIsOn(EClock), kind=c_bool)
+
+      ! run omega for one coupling interval
+      call omega_ocn_run(write_restart)
+
    end subroutine ocn_run_mct
 
    subroutine ocn_final_mct(EClock, cdata, x2o, o2x)

--- a/components/omega/src/drivers/coupled/omega_cpl_indices.F90
+++ b/components/omega/src/drivers/coupled/omega_cpl_indices.F90
@@ -30,16 +30,15 @@ contains
 
       type(mct_aVect) :: x2o, o2x
 
-      ! Better to use: mct_avect_nRattr?
-      ! total number of import/export fields in coupler data arrays
-      num_coupler_imports = size(x2o%rAttr, 1)
-      num_coupler_exports = size(x2o%rAttr, 1)
-
       ! Create dummy mct_aVect objects, so that we can inquire about field
       ! indices prior to the omega instance, and therefore the HorzMesh
       ! instance which has the real lsize value, is created.
       call mct_aVect_init(x2o, rList=seq_flds_x2o_fields, lsize=1)
       call mct_aVect_init(o2x, rList=seq_flds_o2x_fields, lsize=1)
+
+      ! total number of import/export fields in coupler data arrays
+      num_coupler_imports = size(x2o%rAttr, 1)
+      num_coupler_exports = size(o2x%rAttr, 1)
 
       ! Import (x2o) Coupler field names
       import_field_names(1) = "Foxx_taux"

--- a/components/omega/src/drivers/coupled/omega_cpl_indices.F90
+++ b/components/omega/src/drivers/coupled/omega_cpl_indices.F90
@@ -1,0 +1,107 @@
+module omega_cpl_indices
+
+   use, intrinsic :: iso_c_binding, only: c_int, c_char
+
+   implicit none
+   private
+
+   integer, parameter, public :: num_omega_imports = 2
+   integer, parameter, public :: num_omega_exports = 5
+   integer, public :: num_coupler_imports, num_coupler_exports
+
+   ! Names of import/export fields as defined by seq_flds_mod
+   character(len=32, kind=c_char), public, target :: &
+      import_field_names(num_omega_imports), &
+      export_field_names(num_omega_exports)
+
+   ! Coupler indices for import/export fields
+   integer(kind=c_int), public, target :: &
+      import_field_indices(num_omega_imports), &
+      export_field_indices(num_omega_exports)
+
+   public :: omega_set_cpl_indices
+
+contains
+
+   subroutine omega_set_cpl_indices()
+
+      use mct_mod, only: mct_aVect, mct_aVect_init, mct_aVect_clean
+      use seq_flds_mod, only: seq_flds_o2x_fields, seq_flds_x2o_fields
+
+      type(mct_aVect) :: x2o, o2x
+
+      ! Better to use: mct_avect_nRattr?
+      ! total number of import/export fields in coupler data arrays
+      num_coupler_imports = size(x2o%rAttr, 1)
+      num_coupler_exports = size(x2o%rAttr, 1)
+
+      ! Create dummy mct_aVect objects, so that we can inquire about field
+      ! indices prior to the omega instance, and therefore the HorzMesh
+      ! instance which has the real lsize value, is created.
+      call mct_aVect_init(x2o, rList=seq_flds_x2o_fields, lsize=1)
+      call mct_aVect_init(o2x, rList=seq_flds_o2x_fields, lsize=1)
+
+      ! Import (x2o) Coupler field names
+      import_field_names(1) = "Foxx_taux"
+      import_field_names(2) = "Foxx_tauy"
+
+      ! get mct_avect_index value for each import field name
+      call get_indices_from_names( &
+         import_field_indices, import_field_names, x2o &
+         )
+
+      ! append null_char to each import field name for C interoperability
+      call append_null_char_to_names(import_field_names)
+
+      ! Export (o2x) Coupler field names
+      export_field_names(1) = "So_t"
+      export_field_names(2) = "So_s"
+      export_field_names(3) = "So_u"
+      export_field_names(4) = "So_v"
+      export_field_names(5) = "So_ssh"
+
+      ! get mct_avect_index value for each export field name
+      call get_indices_from_names( &
+         export_field_indices, export_field_names, o2x &
+         )
+
+      ! append null_char to each import field name for C interoperability
+      call append_null_char_to_names(export_field_names)
+
+      ! clean up the dummy mct_aVect objects
+      call mct_aVect_clean(x2o)
+      call mct_aVect_clean(o2x)
+
+   end subroutine omega_set_cpl_indices
+
+   subroutine get_indices_from_names(field_indices, field_names, data)
+
+      use, intrinsic :: iso_c_binding, only: c_char, c_int
+      use mct_mod, only: mct_aVect, mct_avect_indexra
+
+      integer(kind=c_int), intent(inout) :: field_indices(:)
+      character(len=32, kind=c_char), intent(in) :: field_names(:)
+      type(mct_aVect), intent(in) :: data
+
+      integer :: i
+
+      do i = 1, size(field_names)
+         field_indices(i) = mct_avect_indexra(data, trim(field_names(i)))
+      end do
+
+   end subroutine get_indices_from_names
+
+   subroutine append_null_char_to_names(field_names)
+
+      use, intrinsic :: iso_c_binding, only: c_char, c_null_char
+
+      character(len=32, kind=c_char), intent(inout) :: field_names(:)
+      integer :: i
+
+      do i = 1, size(field_names)
+         field_names(i) = trim(field_names(i))//c_null_char
+      end do
+
+   end subroutine append_null_char_to_names
+
+end module omega_cpl_indices

--- a/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
+++ b/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
@@ -44,19 +44,19 @@ std::map<std::string, int> buildFieldIndexMap(const char *FieldNames,
 extern "C" {
 
 void omega_ocn_init1(
-    const MPI_Fint FComm,           // [in] MPI communicator from Fortran
-    const int OcnID,                // [in] mct comp id for ocn mode
-    const char *YamlConfigFile,     // [in] yaml file name for ocean model
-    const char *OcnLogFile,         // [in] log file name for ocean model
-    const int StartType,            // [in] 0=startup, 1=continue, 2=branch
-    const char *CalendarName,       // [in] CIME calendar name
-    const int RunStartYMD,          // [in] run start date in YYYYMMDD
-    const int RunStartTOD,          // [in] run start time in seconds of day
-    const int CouplingTimeStep,     // [in] coupling time step in seconds
-    const int NCouplerImports,      // [in] number of coupler import fields
-    const int NCouplerExports,      // [in] number of coupler export fields
-    const int NOmegaImports,        // [in] number of omega import fields
-    const int NOmegaExports,        // [in] number of omega export fields
+    const MPI_Fint FComm,          // [in] MPI communicator from Fortran
+    const int OcnID,               // [in] mct comp id for ocn mode
+    const char *YamlConfigFile,    // [in] yaml file name for ocean model
+    const char *OcnLogFile,        // [in] log file name for ocean model
+    const int StartType,           // [in] 0=startup, 1=continue, 2=branch
+    const char *CalendarName,      // [in] CIME calendar name
+    const int RunStartYMD,         // [in] run start date in YYYYMMDD
+    const int RunStartTOD,         // [in] run start time in seconds of day
+    const int CouplingTimeStep,    // [in] coupling time step in seconds
+    const int NCouplerImports,     // [in] number of coupler import fields
+    const int NCouplerExports,     // [in] number of coupler export fields
+    const int NOmegaImports,       // [in] number of omega import fields
+    const int NOmegaExports,       // [in] number of omega export fields
     const char *ImportFieldNames,  // [in] array of import field names
     const char *ExportFieldNames,  // [in] array of export field names
     const int *ImportFieldIndices, // [in] array of import field indices

--- a/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
+++ b/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
@@ -1,0 +1,72 @@
+//===-- drivers/standalone/OceanDriver.cpp - Coupled driver --*- C++ -*-===//
+//
+//
+//===----------------------------------------------------------------------===//
+#include "DataTypes.h"
+#include "Logging.h"
+#include "MachEnv.h"
+#include "OceanDriver.h"
+#include "OceanState.h"
+#include "OmegaKokkos.h"
+#include "Pacer.h"
+#include "TimeMgr.h"
+#include "TimeStepper.h"
+#include <cstdio>
+#include <mpi.h>
+
+extern "C" {
+
+void omega_ocn_init(
+    const MPI_Fint FComm,       // [in] MPI communicator from Fortran
+    const int OcnID,            // [in] mct comp id for ocn mode
+    const char *YamlConfigFile, // [in] yaml file name for ocean model
+    const char *OcnLogFile,     // [in] log file name for ocean model
+    const char *CalendarName,   // [in] CIME calendar name
+    const int RunStartYMD,      // [in] run start date in YYYYMMDD
+    const int RunStartTOD       // [in] run start time in seconds of day
+) {
+
+   // Create the C MPI_Comm from the Fortran one
+   MPI_Comm Comm = MPI_Comm_f2c(FComm);
+
+   // initialize Kokkos
+   Kokkos::initialize();
+
+   // initialize Pacer timing in coupled mode
+   Pacer::initialize(Comm, Pacer::PACER_INTEGRATED);
+
+   // Convert calendar from char to string
+   std::string CalendarKindStr = CalendarName;
+   std::string LogFileStr      = OcnLogFile;
+
+   // Recall that e3sm uses the int YYYYMMDD to store a date
+   OMEGA::I8 Year   = (RunStartYMD / 100) / 100;
+   OMEGA::I8 Month  = (RunStartYMD / 100) % 100;
+   OMEGA::I8 Day    = RunStartYMD % 100;
+   OMEGA::I8 Hour   = (RunStartTOD / 60) / 60;
+   OMEGA::I8 Minute = (RunStartTOD / 60) % 60;
+   OMEGA::R8 Second = RunStartTOD % 60;
+
+   // Initialize machine environment and logging before initializing
+   // the calendar to ensure all output goes to the correct log file
+   OMEGA::MachEnv::init(Comm);
+   OMEGA::MachEnv *DefEnv = OMEGA::MachEnv::getDefault();
+
+   initLogging(DefEnv, LogFileStr);
+
+   // Initialize the Calendar prior to creating the TimeInstant
+   OMEGA::Calendar::init(CalendarKindStr);
+
+   OMEGA::TimeInstant StartTime(Year, Month, Day, Hour, Minute, Second);
+
+   // Pacer::start("Init", 0);
+
+   OMEGA::ocnInit(Comm, OcnID, YamlConfigFile, OcnLogFile, StartTime);
+
+   // Pacer::stop("Init", 0);
+
+   LOG_INFO("ocnInit: Finished initializing ocean model");
+   int ErrAll;
+}
+
+} // extern "C"

--- a/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
+++ b/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
@@ -57,10 +57,10 @@ void omega_ocn_init1(
     const int NCouplerExports,      // [in] number of coupler export fields
     const int NOmegaImports,        // [in] number of omega import fields
     const int NOmegaExports,        // [in] number of omega export fields
-    const char *&ImportFieldNames,  // [in] array of import field names
-    const char *&ExportFieldNames,  // [in] array of export field names
-    const int *&ImportFieldIndices, // [in] array of import field indices
-    const int *&ExportFieldIndices  // [in] array of export field indices
+    const char *ImportFieldNames,  // [in] array of import field names
+    const char *ExportFieldNames,  // [in] array of export field names
+    const int *ImportFieldIndices, // [in] array of import field indices
+    const int *ExportFieldIndices  // [in] array of export field indices
 ) {
 
    // Create the C MPI_Comm from the Fortran one

--- a/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
+++ b/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
@@ -95,7 +95,7 @@ void omega_ocn_init1(
    std::map<std::string, int> ExportIdxMap =
        buildFieldIndexMap(ExportFieldNames, ExportFieldIndices, NOmegaExports);
 
-   // Pacer::start("Init", 0);
+   Pacer::start("Init1", 0);
 
    OMEGA::StartType StartTypeEnum = OMEGA::safeIntToStartType(StartType);
    OMEGA::TimeInitParams TimeParams{StartTime, std::nullopt};
@@ -106,14 +106,16 @@ void omega_ocn_init1(
    OMEGA::ocnInit1(Comm, OcnID, YamlConfigFile, OcnLogFile, StartTypeEnum,
                    TimeParams, CouplingParams);
 
-   // Pacer::stop("Init", 0);
+   Pacer::stop("Init1", 0);
 
    LOG_INFO("ocnInit: Finished initializing ocean model");
    int ErrAll;
 }
 
 void omega_ocn_init2(const double *cpl_to_ocn_data, double *ocn_to_cpl_data) {
+   Pacer::start("Init2", 0);
    OMEGA::ocnInit2(cpl_to_ocn_data, ocn_to_cpl_data);
+   Pacer::stop("Init2", 0);
 }
 
 int omega_ocn_run(bool WriteRestart) {
@@ -124,9 +126,9 @@ int omega_ocn_run(bool WriteRestart) {
    OMEGA::Clock *ModelClock       = DefStepper->getClock();
    OMEGA::TimeInstant CurrTime    = ModelClock->getCurrentTime();
 
-   // Pacer::start("Run", 0);
+   Pacer::start("Run", 0);
    ErrRun = OMEGA::ocnRun(CurrTime, WriteRestart);
-   // Pacer::stop("Run", 0);
+   Pacer::stop("Run", 0);
 
    return ErrRun;
 }
@@ -139,14 +141,14 @@ int omega_ocn_finalize() {
    OMEGA::Clock *ModelClock       = DefStepper->getClock();
    OMEGA::TimeInstant CurrTime    = ModelClock->getCurrentTime();
 
-   // Pacer::start("Finalize", 0);
+   Pacer::start("Finalize", 0);
    OMEGA::ocnFinalize(CurrTime);
    if (ErrFinalize != 0) {
       LOG_ERROR("Error finalizing OMEGA");
    } else {
       LOG_INFO("OMEGA successfully completed");
    }
-   // Pacer::stop("Finalize", 0);
+   Pacer::stop("Finalize", 0);
 
    // no Pacer::print or Pacer::finalize in coupled mode; cpl will handle it
 

--- a/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
+++ b/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
@@ -116,6 +116,31 @@ void omega_ocn_init2(const double *cpl_to_ocn_data, double *ocn_to_cpl_data) {
    OMEGA::ocnInit2(cpl_to_ocn_data, ocn_to_cpl_data);
 }
 
+int omega_ocn_finalize() {
+
+   int ErrFinalize;
+
+   OMEGA::TimeStepper *DefStepper = OMEGA::TimeStepper::getDefault();
+   OMEGA::Clock *ModelClock       = DefStepper->getClock();
+   OMEGA::TimeInstant CurrTime    = ModelClock->getCurrentTime();
+
+   // Pacer::start("Finalize", 0);
+   OMEGA::ocnFinalize(CurrTime);
+   if (ErrFinalize != 0) {
+      LOG_ERROR("Error finalizing OMEGA");
+   } else {
+      LOG_INFO("OMEGA successfully completed");
+   }
+   // Pacer::stop("Finalize", 0);
+
+   // no Pacer::print or Pacer::finalize in coupled mode; cpl will handle it
+
+   // finalize Kokkos
+   Kokkos::finalize();
+
+   return ErrFinalize;
+}
+
 int omega_get_layout_mct() {
    return static_cast<int>(OMEGA::CouplingLayout::MCT);
 }

--- a/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
+++ b/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
@@ -201,13 +201,14 @@ void omega_get_lonlat_cell(double *LonCell, double *LatCell) {
 void omega_get_area_cell(double *AreaCell) {
    OMEGA::HorzMesh *HMesh = OMEGA::HorzMesh::getDefault();
 
+   OMEGA::R8 SphereRadius = HMesh->SphereRadius;
+
    // Sync device array back to host mirror
    OMEGA::deepCopy(HMesh->AreaCellH, HMesh->AreaCell);
 
    for (int Cell = 0; Cell < HMesh->NCellsOwned; ++Cell) {
-      // TODO: Use the HMesh->SphereRadius attribute once PR#382 is merged
       AreaCell[Cell] = static_cast<double>(HMesh->AreaCellH[Cell] /
-                                           (OMEGA::REarth * OMEGA::REarth));
+                                           (SphereRadius * SphereRadius));
    }
 }
 

--- a/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
+++ b/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
@@ -11,7 +11,6 @@
 #include "Pacer.h"
 #include "TimeMgr.h"
 #include "TimeStepper.h"
-#include <cstdio>
 #include <mpi.h>
 
 extern "C" {
@@ -69,4 +68,50 @@ void omega_ocn_init(
    int ErrAll;
 }
 
+int omega_get_ncells_local() {
+   OMEGA::Decomp *OcnDecomp = OMEGA::Decomp::getDefault();
+
+   return static_cast<int>(OcnDecomp->NCellsOwned);
+}
+
+int omega_get_ncells_global() {
+   OMEGA::Decomp *OcnDecomp = OMEGA::Decomp::getDefault();
+
+   return static_cast<int>(OcnDecomp->NCellsGlobal);
+}
+
+void omega_get_index_to_cell_id(int *CellID) {
+   OMEGA::Decomp *OcnDecomp = OMEGA::Decomp::getDefault();
+
+   // Sync device array back to host mirror
+   OMEGA::deepCopy(OcnDecomp->CellIDH, OcnDecomp->CellID);
+
+   for (int Cell = 0; Cell < OcnDecomp->NCellsOwned; ++Cell) {
+      CellID[Cell] = static_cast<int>(OcnDecomp->CellIDH[Cell]);
+   }
+}
+
+void omega_get_lonlat_cell(double *LonCell, double *LatCell) {
+   OMEGA::HorzMesh *HMesh = OMEGA::HorzMesh::getDefault();
+
+   for (int Cell = 0; Cell < HMesh->NCellsOwned; ++Cell) {
+      LonCell[Cell] =
+          static_cast<double>(HMesh->LonCellH[Cell] * OMEGA::Rad2Deg);
+      LatCell[Cell] =
+          static_cast<double>(HMesh->LatCellH[Cell] * OMEGA::Rad2Deg);
+   }
+}
+
+void omega_get_area_cell(double *AreaCell) {
+   OMEGA::HorzMesh *HMesh = OMEGA::HorzMesh::getDefault();
+
+   // Sync device array back to host mirror
+   OMEGA::deepCopy(HMesh->AreaCellH, HMesh->AreaCell);
+
+   for (int Cell = 0; Cell < HMesh->NCellsOwned; ++Cell) {
+      // TODO: Use the HMesh->SphereRadius attribute once PR#382 is merged
+      AreaCell[Cell] = static_cast<double>(HMesh->AreaCellH[Cell] /
+                                           (OMEGA::REarth * OMEGA::REarth));
+   }
+}
 } // extern "C"

--- a/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
+++ b/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
@@ -13,16 +13,54 @@
 #include "TimeStepper.h"
 #include <mpi.h>
 
+// helper C++ functions
+namespace {
+
+// coupler provides (year, month, day) and (time of day) as ints
+OMEGA::TimeInstant buildStartTime(int RunStartYMD, int RunStartTOD) {
+   OMEGA::I8 Year   = (RunStartYMD / 100) / 100;
+   OMEGA::I8 Month  = (RunStartYMD / 100) % 100;
+   OMEGA::I8 Day    = RunStartYMD % 100;
+   OMEGA::I8 Hour   = (RunStartTOD / 60) / 60;
+   OMEGA::I8 Minute = (RunStartTOD / 60) % 60;
+   OMEGA::R8 Second = RunStartTOD % 60;
+   return OMEGA::TimeInstant(Year, Month, Day, Hour, Minute, Second);
+}
+
+std::map<std::string, int> buildFieldIndexMap(const char *FieldNames,
+                                              const int *FieldIndices,
+                                              const int NFields) {
+   std::map<std::string, int> FieldIdx;
+   for (int I = 0; I < NFields; ++I) {
+      // null-terminator stops string, so only start index is needed
+      std::string FieldName(FieldNames + I * 32);
+      // convert from 1-based index (Fortran) to 0-based index (C++)
+      FieldIdx[FieldName] = FieldIndices[I] - 1;
+   }
+   return FieldIdx;
+}
+} // namespace
+
 extern "C" {
 
-void omega_ocn_init(
-    const MPI_Fint FComm,       // [in] MPI communicator from Fortran
-    const int OcnID,            // [in] mct comp id for ocn mode
-    const char *YamlConfigFile, // [in] yaml file name for ocean model
-    const char *OcnLogFile,     // [in] log file name for ocean model
-    const char *CalendarName,   // [in] CIME calendar name
-    const int RunStartYMD,      // [in] run start date in YYYYMMDD
-    const int RunStartTOD       // [in] run start time in seconds of day
+void omega_ocn_init1(
+    const MPI_Fint FComm,           // [in] MPI communicator from Fortran
+    const int OcnID,                // [in] mct comp id for ocn mode
+    const char *YamlConfigFile,     // [in] yaml file name for ocean model
+    const char *OcnLogFile,         // [in] log file name for ocean model
+    const int StartType,            // [in] 0=startup, 1=continue, 2=branch
+    const char *CalendarName,       // [in] CIME calendar name
+    const int RunStartYMD,          // [in] run start date in YYYYMMDD
+    const int RunStartTOD,          // [in] run start time in seconds of day
+    const int CouplingTimeStep,     // [in] coupling time step in seconds
+    const int NCouplerImports,      // [in] number of coupler import fields
+    const int NCouplerExports,      // [in] number of coupler export fields
+    const int NOmegaImports,        // [in] number of omega import fields
+    const int NOmegaExports,        // [in] number of omega export fields
+    const char *&ImportFieldNames,  // [in] array of import field names
+    const char *&ExportFieldNames,  // [in] array of export field names
+    const int *&ImportFieldIndices, // [in] array of import field indices
+    const int *&ExportFieldIndices  // [in] array of export field indices
 ) {
 
    // Create the C MPI_Comm from the Fortran one
@@ -38,14 +76,6 @@ void omega_ocn_init(
    std::string CalendarKindStr = CalendarName;
    std::string LogFileStr      = OcnLogFile;
 
-   // Recall that e3sm uses the int YYYYMMDD to store a date
-   OMEGA::I8 Year   = (RunStartYMD / 100) / 100;
-   OMEGA::I8 Month  = (RunStartYMD / 100) % 100;
-   OMEGA::I8 Day    = RunStartYMD % 100;
-   OMEGA::I8 Hour   = (RunStartTOD / 60) / 60;
-   OMEGA::I8 Minute = (RunStartTOD / 60) % 60;
-   OMEGA::R8 Second = RunStartTOD % 60;
-
    // Initialize machine environment and logging before initializing
    // the calendar to ensure all output goes to the correct log file
    OMEGA::MachEnv::init(Comm);
@@ -53,19 +83,45 @@ void omega_ocn_init(
 
    initLogging(DefEnv, LogFileStr);
 
-   // Initialize the Calendar prior to creating the TimeInstant
+   // Init Calendar prior to creating the TimeInstant/TimeInterval objects
    OMEGA::Calendar::init(CalendarKindStr);
 
-   OMEGA::TimeInstant StartTime(Year, Month, Day, Hour, Minute, Second);
+   OMEGA::TimeInstant StartTime = buildStartTime(RunStartYMD, RunStartTOD);
+   OMEGA::TimeInterval CouplingInterval(CouplingTimeStep,
+                                        OMEGA::TimeUnits::Seconds);
+
+   std::map<std::string, int> ImportIdxMap =
+       buildFieldIndexMap(ImportFieldNames, ImportFieldIndices, NOmegaImports);
+   std::map<std::string, int> ExportIdxMap =
+       buildFieldIndexMap(ExportFieldNames, ExportFieldIndices, NOmegaExports);
 
    // Pacer::start("Init", 0);
 
-   OMEGA::ocnInit(Comm, OcnID, YamlConfigFile, OcnLogFile, StartTime);
+   OMEGA::StartType StartTypeEnum = OMEGA::safeIntToStartType(StartType);
+   OMEGA::TimeInitParams TimeParams{StartTime, std::nullopt};
+   OMEGA::CouplingInitParams CouplingParams{
+       NCouplerImports, NCouplerExports,  ImportIdxMap,
+       ExportIdxMap,    CouplingInterval, OMEGA::CouplingLayout::MCT};
+
+   OMEGA::ocnInit1(Comm, OcnID, YamlConfigFile, OcnLogFile, StartTypeEnum,
+                   TimeParams, CouplingParams);
 
    // Pacer::stop("Init", 0);
 
    LOG_INFO("ocnInit: Finished initializing ocean model");
    int ErrAll;
+}
+
+void omega_ocn_init2(const double *cpl_to_ocn_data, double *ocn_to_cpl_data) {
+   OMEGA::ocnInit2(cpl_to_ocn_data, ocn_to_cpl_data);
+}
+
+int omega_get_layout_mct() {
+   return static_cast<int>(OMEGA::CouplingLayout::MCT);
+}
+
+int omega_get_layout_moab() {
+   return static_cast<int>(OMEGA::CouplingLayout::MOAB);
 }
 
 int omega_get_ncells_local() {
@@ -114,4 +170,5 @@ void omega_get_area_cell(double *AreaCell) {
                                            (OMEGA::REarth * OMEGA::REarth));
    }
 }
+
 } // extern "C"

--- a/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
+++ b/components/omega/src/drivers/coupled/omega_cxx2f_interface.cpp
@@ -116,6 +116,21 @@ void omega_ocn_init2(const double *cpl_to_ocn_data, double *ocn_to_cpl_data) {
    OMEGA::ocnInit2(cpl_to_ocn_data, ocn_to_cpl_data);
 }
 
+int omega_ocn_run(bool WriteRestart) {
+
+   int ErrRun;
+
+   OMEGA::TimeStepper *DefStepper = OMEGA::TimeStepper::getDefault();
+   OMEGA::Clock *ModelClock       = DefStepper->getClock();
+   OMEGA::TimeInstant CurrTime    = ModelClock->getCurrentTime();
+
+   // Pacer::start("Run", 0);
+   ErrRun = OMEGA::ocnRun(CurrTime, WriteRestart);
+   // Pacer::stop("Run", 0);
+
+   return ErrRun;
+}
+
 int omega_ocn_finalize() {
 
    int ErrFinalize;

--- a/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
+++ b/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
@@ -68,6 +68,16 @@ module omega_f2cxx_mod
 
       end subroutine omega_ocn_init2
 
+      subroutine omega_ocn_run(write_restart) bind(c)
+
+         use, intrinsic :: iso_c_binding, only: c_bool
+
+         implicit none
+
+         logical(kind=c_bool), value, intent(in) :: write_restart
+
+      end subroutine omega_ocn_run
+
       subroutine omega_ocn_finalize() bind(c)
 
          implicit none

--- a/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
+++ b/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
@@ -23,5 +23,58 @@ module omega_f2cxx_mod
             yaml_config_name, ocn_log_name, calendar_name
 
       end subroutine omega_ocn_init
+
+      function omega_get_ncells_local() result(ncells_local) bind(c)
+
+         use, intrinsic :: iso_c_binding, only: c_int
+
+         implicit none
+
+         integer(kind=c_int) :: ncells_local
+
+      end function omega_get_ncells_local
+
+      function omega_get_ncells_global() result(ncells_global) bind(c)
+
+         use, intrinsic :: iso_c_binding, only: c_int
+
+         implicit none
+
+         integer(kind=c_int) :: ncells_global
+
+      end function omega_get_ncells_global
+
+      subroutine omega_get_index_to_cell_id( &
+         local_index_to_cell_id &
+         ) bind(c)
+
+         use, intrinsic :: iso_c_binding, only: c_int
+
+         implicit none
+
+         ! allow(assumed-size)
+         integer(kind=c_int), intent(out) :: local_index_to_cell_id(*)
+
+      end subroutine omega_get_index_to_cell_id
+
+      subroutine omega_get_lonlat_cell(lon_cell, lat_cell) bind(c)
+
+         use, intrinsic :: iso_c_binding, only: c_double
+
+         implicit none
+
+         ! allow(assumed-size)
+         real(kind=c_double), intent(out) :: lon_cell(*), lat_cell(*)
+      end subroutine omega_get_lonlat_cell
+
+      subroutine omega_get_area_cell(area_cell) bind(c)
+
+         use, intrinsic :: iso_c_binding, only: c_double
+
+         implicit none
+
+         ! allow(assumed-size)
+         real(kind=c_double), intent(out) :: area_cell(*)
+      end subroutine omega_get_area_cell
    end interface
 end module omega_f2cxx_mod

--- a/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
+++ b/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
@@ -4,25 +4,83 @@ module omega_f2cxx_mod
    public
 
    interface
-      subroutine omega_ocn_init( &
+      subroutine omega_ocn_init1( &
          f_comm, &
          ocn_id, &
          yaml_config_name, &
          ocn_log_name, &
+         start_type, &
          calendar_name, &
          run_start_ymd, &
-         run_start_tod) bind(c)
+         run_start_tod, &
+         coupler_time_step, &
+         n_coupler_imports, &
+         n_coupler_exports, &
+         n_omega_imports, &
+         n_omega_exports, &
+         import_field_names, &
+         export_field_names, &
+         import_field_indices, &
+         export_field_indices) bind(c)
 
-         use, intrinsic :: iso_c_binding, only: c_int, c_char
+         use, intrinsic :: iso_c_binding, only: c_int, c_char, c_ptr
 
          implicit none
 
          integer(kind=c_int), value, intent(in) :: &
-            f_comm, ocn_id, run_start_ymd, run_start_tod
+            f_comm, &
+            ocn_id, &
+            start_type, &
+            run_start_ymd, &
+            run_start_tod, &
+            coupler_time_step, &
+            n_coupler_imports, &
+            n_coupler_exports, &
+            n_omega_imports, &
+            n_omega_exports
+
          character(kind=c_char), target, intent(in) :: &
             yaml_config_name, ocn_log_name, calendar_name
 
-      end subroutine omega_ocn_init
+         type(c_ptr), target, intent(in) :: &
+            import_field_names, &
+            export_field_names, &
+            import_field_indices, &
+            export_field_indices
+
+      end subroutine omega_ocn_init1
+
+      subroutine omega_ocn_init2(cpl_to_ocn_data, ocn_to_cpl_data &
+                                 ) bind(c)
+
+         use, intrinsic :: iso_c_binding, only: c_ptr
+
+         implicit none
+
+         type(c_ptr), target, intent(in) :: &
+            cpl_to_ocn_data, ocn_to_cpl_data
+
+      end subroutine omega_ocn_init2
+
+      function omega_get_layout_mct() result(layout_mct) bind(c)
+
+         use, intrinsic :: iso_c_binding, only: c_int
+
+         implicit none
+
+         integer(kind=c_int) :: layout_mct
+
+      end function omega_get_layout_mct
+
+      function omega_get_layout_moab() result(layout_moab) bind(c)
+
+         use, intrinsic :: iso_c_binding, only: c_int
+
+         implicit none
+
+         integer(kind=c_int) :: layout_moab
+
+      end function omega_get_layout_moab
 
       function omega_get_ncells_local() result(ncells_local) bind(c)
 

--- a/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
+++ b/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
@@ -3,6 +3,12 @@ module omega_f2cxx_mod
    implicit none
    public
 
+   ! All type(c_ptr) dummy args below use VALUE: c_loc() already yields the
+   ! address to pass, so VALUE hands that address straight through as a
+   ! plain C/C++ pointer, matching the raw-pointer C++ signatures. None of
+   ! these callees reseat the pointer, so a reference-to-pointer is not
+   ! needed on the C++ side.
+
    interface
       subroutine omega_ocn_init1( &
          f_comm, &
@@ -42,7 +48,7 @@ module omega_f2cxx_mod
          character(kind=c_char), target, intent(in) :: &
             yaml_config_name, ocn_log_name, calendar_name
 
-         type(c_ptr), target, intent(in) :: &
+         type(c_ptr), value, intent(in) :: &
             import_field_names, &
             export_field_names, &
             import_field_indices, &
@@ -57,7 +63,7 @@ module omega_f2cxx_mod
 
          implicit none
 
-         type(c_ptr), target, intent(in) :: &
+         type(c_ptr), value, intent(in) :: &
             cpl_to_ocn_data, ocn_to_cpl_data
 
       end subroutine omega_ocn_init2

--- a/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
+++ b/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
@@ -62,6 +62,12 @@ module omega_f2cxx_mod
 
       end subroutine omega_ocn_init2
 
+      subroutine omega_ocn_finalize() bind(c)
+
+         implicit none
+
+      end subroutine omega_ocn_finalize
+
       function omega_get_layout_mct() result(layout_mct) bind(c)
 
          use, intrinsic :: iso_c_binding, only: c_int

--- a/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
+++ b/components/omega/src/drivers/coupled/omega_f2cxx_interface.F90
@@ -1,0 +1,27 @@
+module omega_f2cxx_mod
+
+   implicit none
+   public
+
+   interface
+      subroutine omega_ocn_init( &
+         f_comm, &
+         ocn_id, &
+         yaml_config_name, &
+         ocn_log_name, &
+         calendar_name, &
+         run_start_ymd, &
+         run_start_tod) bind(c)
+
+         use, intrinsic :: iso_c_binding, only: c_int, c_char
+
+         implicit none
+
+         integer(kind=c_int), value, intent(in) :: &
+            f_comm, ocn_id, run_start_ymd, run_start_tod
+         character(kind=c_char), target, intent(in) :: &
+            yaml_config_name, ocn_log_name, calendar_name
+
+      end subroutine omega_ocn_init
+   end interface
+end module omega_f2cxx_mod

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -529,6 +529,10 @@ void IOStream::create(const std::string &StreamName, //< [in] name of stream
                      StreamName);
       }
 
+   } else if (IOFreqUnits == "ondemand") { // registered, manual-write only
+
+      // No alarm, no OnStartup/OnShutdown - only fires via forced write/read
+
    } else if (IOFreqUnits == "never") { // special never case
 
       LOG_WARN("Stream {} has IO frequency of never and will be skipped",

--- a/components/omega/src/ocn/OceanDriver.h
+++ b/components/omega/src/ocn/OceanDriver.h
@@ -26,6 +26,13 @@ bool printTimingAllRanks();
 /// for each Omega module
 int ocnInit(MPI_Comm Comm);
 
+int ocnInit(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
+            const int OcnId,               ///< [in] mct comp id for ocean
+            const std::string &ConfigFile, ///< [in] path to yaml config file
+            const std::string &LogFile,    ///< [in] path to log file
+            const TimeInstant &StartTime   ///< [in] simulation start time
+);
+
 /// Advance the model from starting from CurrTime until EndAlarm rings
 int ocnRun(TimeInstant &CurrTime);
 

--- a/components/omega/src/ocn/OceanDriver.h
+++ b/components/omega/src/ocn/OceanDriver.h
@@ -12,12 +12,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "Config.h"
+#include "SfcCoupling.h"
 #include "TimeMgr.h"
 #include "TimeStepper.h"
 
 #include "mpi.h"
 
 namespace OMEGA {
+
+/// enumeration for the different "start_type"s supported by the coupler
+enum class StartType { StartUp, Continue, Branch };
+
+/// Convienvence converter of an int to a StartType enum, with error checking
+StartType safeIntToStartType(int val);
 
 /// Should timing info be printed from all ranks
 bool printTimingAllRanks();
@@ -26,11 +33,22 @@ bool printTimingAllRanks();
 /// for each Omega module
 int ocnInit(MPI_Comm Comm);
 
-int ocnInit(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
-            const int OcnId,               ///< [in] mct comp id for ocean
-            const std::string &ConfigFile, ///< [in] path to yaml config file
-            const std::string &LogFile,    ///< [in] path to log file
-            const TimeInstant &StartTime   ///< [in] simulation start time
+/// Coupled init phase 1: everything up through mesh/decomp/state, before the
+/// coupler-owned MCT buffers exist for attachData
+int ocnInit1(
+    MPI_Comm Comm,                           ///< [in] ocean MPI communicator
+    const int OcnId,                         ///< [in] mct comp id for ocean
+    const std::string &ConfigFile,           ///< [in] path to yaml config file
+    const std::string &LogFile,              ///< [in] path to log file
+    const StartType StartType,               ///< [in] simulation start type
+    const TimeInitParams &TimeParams,        ///< [in] time parameters
+    const CouplingInitParams &CouplingParams ///< [in] coupling parameters
+);
+
+/// Coupled init phase 2: runs once the coupler has allocated its MCT buffers;
+/// attaches them and exchanges the initial coupled state
+int ocnInit2(const Real *CplToOcnData, ///< [in] coupler import data pointer
+             Real *OcnToCplData        ///< [out] coupler export data pointer
 );
 
 /// Advance the model from starting from CurrTime until EndAlarm rings
@@ -43,7 +61,11 @@ int ocnFinalize(const TimeInstant &CurrTime);
 int initOmegaModules(MPI_Comm Comm);
 
 /// Initialize Omega modules with coupler-provided time parameters
-int initOmegaModules(MPI_Comm Comm, const TimeInitParams &TParams);
+int initOmegaModules(MPI_Comm Comm, const TimeInitParams &TParams,
+                     const CouplingInitParams &CParams);
+
+/// Update Halo/Host arrays with new state, auxiliary state, and tracer fields
+int initUpdateHaloAndHostArrays();
 
 } // end namespace OMEGA
 

--- a/components/omega/src/ocn/OceanDriver.h
+++ b/components/omega/src/ocn/OceanDriver.h
@@ -54,6 +54,9 @@ int ocnInit2(const Real *CplToOcnData, ///< [in] coupler import data pointer
 /// Advance the model from starting from CurrTime until EndAlarm rings
 int ocnRun(TimeInstant &CurrTime);
 
+/// Advance the model from CurrTime until the CouplingAlarm rings
+int ocnRun(TimeInstant &CurrTime, bool WriteRestart);
+
 /// Clean up all Omega objects
 int ocnFinalize(const TimeInstant &CurrTime);
 

--- a/components/omega/src/ocn/OceanFinal.cpp
+++ b/components/omega/src/ocn/OceanFinal.cpp
@@ -19,6 +19,7 @@
 #include "OceanDriver.h"
 #include "OceanState.h"
 #include "PGrad.h"
+#include "SfcCoupling.h"
 #include "Tendencies.h"
 #include "TimeMgr.h"
 #include "TimeStepper.h"
@@ -42,6 +43,7 @@ int ocnFinalize(const TimeInstant &CurrTime ///< [in] current sim time
       IOStream::finalize(TimeStepper::getDefault()->getClock());
 
    Analysis::finalize();
+   SfcCoupling::clear();
    Tracers::clear();
    TimeStepper::clear();
    PressureGrad::clear();

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -223,7 +223,7 @@ int ocnInit1(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
    // Advance clock one coupling interval, to be in sync with couplers clock
    if (StartType == StartType::StartUp) {
       SfcCoupling *DefCoupling = SfcCoupling::getDefault();
-      while (!DefCoupling->CouplingAlarm.isRinging()) {
+      while (!DefCoupling->getCouplingAlarm()->isRinging()) {
          ModelClock->advance();
       }
    }

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -155,6 +155,7 @@ int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
    }
 
    // If reading from restart, reset the current time to the input time
+   SimTimeStr = std::any_cast<std::string>(ReqMeta["SimulationTime"]);
    if (SimTimeStr != " ") {
       TimeInstant NewCurrentTime(SimTimeStr);
       ModelClock->setCurrentTime(NewCurrentTime);
@@ -212,12 +213,23 @@ int ocnInit1(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
    } else if (StartType == StartType::Continue ||
               StartType == StartType::Branch) {
       // read restart if starting from restart
-      ReqMeta["SimulationTime"] = " ";
+      ReqMeta["SimulationTime"] = std::string(" ");
       Error IOError = IOStream::read("RestartRead", ModelClock, ReqMeta);
       if (IOError.isFail()) {
          ABORT_ERROR("Errors encountered reading RestartRead");
       }
-      // TODO: check restat time matches coupler time.
+
+      // Coupler only provides case start time, so on restart get the
+      // simulation time from the restart file
+      std::string SimTimeStr =
+          std::any_cast<std::string>(ReqMeta["SimulationTime"]);
+      if (SimTimeStr == " ") {
+         ABORT_ERROR("RestartRead stream did not provide SimulationTime");
+      }
+
+      // Set the model clock to the simulation time read from the restart file
+      TimeInstant NewCurrentTime(SimTimeStr);
+      ModelClock->setCurrentTime(NewCurrentTime);
    };
 
    // Advance clock one coupling interval, to be in sync with couplers clock

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -26,6 +26,7 @@
 #include "OceanState.h"
 #include "PGrad.h"
 #include "Pacer.h"
+#include "SfcCoupling.h"
 #include "Tendencies.h"
 #include "TimeMgr.h"
 #include "TimeStepper.h"
@@ -37,6 +38,20 @@
 #include "mpi.h"
 
 namespace OMEGA {
+
+// Convienvence converter of an int to a StartType enum, with error checking
+StartType safeIntToStartType(int val) {
+   switch (val) {
+   case 0:
+      return StartType::StartUp;
+   case 1:
+      return StartType::Continue;
+   case 2:
+      return StartType::Branch;
+   default:
+      ABORT_ERROR("Invalid start type value: {}", val);
+   }
+}
 
 namespace Timing {
 // Flag to determine if timing info should be printed from all ranks
@@ -145,43 +160,19 @@ int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
       ModelClock->setCurrentTime(NewCurrentTime);
    }
 
-   // Update Halos and Host arrays with new state, auxiliary state, and tracer
-   // fields
-
-   OceanState *DefState = OceanState::getDefault();
-   I4 CurTimeLevel      = 0;
-   DefState->exchangeHalo(CurTimeLevel);
-
-   // Enforce layer masks on state and tracer variables: fully-inactive layers
-   // get FillValueReal, boundary layers get 0, active layers keep their
-   // IC/restart value.
-   DefState->applyLayerMasks(CurTimeLevel);
-
-   DefState->copyToHost(CurTimeLevel);
-   VertCoord::getDefault()->initSurfacePressure(Halo::getDefault());
-
-   Forcing *DefForcing = Forcing::getDefault();
-   DefForcing->exchangeHalo();
-
-   AuxiliaryState *DefAuxState = AuxiliaryState::getDefault();
-   DefAuxState->exchangeHalo();
-
-   // Now update tracers - assume using same time level index
-   Err = Tracers::exchangeHalo(CurTimeLevel);
-   if (Err != 0) {
-      ABORT_ERROR("Error updating tracer halo after restart");
-   }
-   Tracers::copyToHost(CurTimeLevel);
+   // Update Halo/Host arrays with new state, auxiliary state, and tracer fields
+   Err = initUpdateHaloAndHostArrays();
 
    return Err;
-
 } // end ocnInit
 
-int ocnInit(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
-            const int OcnId,               ///< [in] mct comp id for ocean
-            const std::string &ConfigFile, ///< [in] path to yaml config file
-            const std::string &LogFile,    ///< [in] path to log file
-            const TimeInstant &StartTime   ///< [in] simulation start time
+int ocnInit1(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
+             const int OcnId,               ///< [in] mct comp id for ocean
+             const std::string &ConfigFile, ///< [in] path to yaml config file
+             const std::string &LogFile,    ///< [in] path to log file
+             const StartType StartType,     ///< [in] simulation start type
+             const TimeInitParams &TimeParams, ///< [in] simulation start time
+             const CouplingInitParams &CouplingParams ///< [in] coupler info
 ) {
 
    I4 Err = 0; // return error code
@@ -195,17 +186,64 @@ int ocnInit(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
 
    readTimingConfig();
 
-   // coupler decides the stop time
-   TimeInitParams TimeParams{StartTime, std::nullopt};
-
    // initialize remaining Omega modules
-   Err = initOmegaModules(Comm, TimeParams);
+   Err = initOmegaModules(Comm, TimeParams, CouplingParams);
    if (Err != 0)
       ABORT_ERROR("ocnInit: Error initializing Omega modules");
 
-   return Err;
+   TimeStepper *DefStepper = TimeStepper::getDefault();
+   Clock *ModelClock       = DefStepper->getClock();
 
-} // end ocnInit
+   // Now that all fields have been defined, validate all the streams
+   // contents
+   bool StreamsValid = IOStream::validateAll();
+
+   if (!StreamsValid) {
+      ABORT_ERROR("ocnInit: Error validating IO Streams");
+   }
+
+   Metadata ReqMeta;
+   if (StartType == StartType::StartUp) {
+      // read from initial state if this is starting a new simulation
+      Error IOError = IOStream::read("InitialState", ModelClock, ReqMeta);
+      if (IOError.isFail()) {
+         ABORT_ERROR("Errors encountered reading InitialState");
+      }
+   } else if (StartType == StartType::Continue ||
+              StartType == StartType::Branch) {
+      // read restart if starting from restart
+      ReqMeta["SimulationTime"] = " ";
+      Error IOError = IOStream::read("RestartRead", ModelClock, ReqMeta);
+      if (IOError.isFail()) {
+         ABORT_ERROR("Errors encountered reading RestartRead");
+      }
+      // TODO: check restat time matches coupler time.
+   };
+
+   // Advance clock one coupling interval, to be in sync with couplers clock
+   if (StartType == StartType::StartUp) {
+      SfcCoupling *DefCoupling = SfcCoupling::getDefault();
+      while (!DefCoupling->CouplingAlarm.isRinging()) {
+         ModelClock->advance();
+      }
+   }
+
+   return Err;
+} // end ocnInit1
+
+// Coupled init phase 2: attach the coupler's MCT buffers and exchange the
+// initial coupled state; split from ocnInit1 since these buffers don't exist
+// until the coupler has sized/allocated them using Omega's decomposition
+int ocnInit2(const Real *CplToOcnData, Real *OcnToCplData) {
+   SfcCoupling *DefCoupling = SfcCoupling::getDefault();
+   DefCoupling->attachData(CplToOcnData, OcnToCplData);
+
+   DefCoupling->exportToCoupler();
+   DefCoupling->importFromCoupler();
+   DefCoupling->applyImportFields(Forcing::getDefault());
+
+   return initUpdateHaloAndHostArrays();
+} // end ocnInit2
 
 // Call init routines for remaining Omega modules
 // Internal helper — all module init after TimeStepper::init1 is called.
@@ -271,12 +309,49 @@ int initOmegaModules(MPI_Comm Comm) {
    return initOmegaModulesImpl(Comm);
 }
 
-int initOmegaModules(MPI_Comm Comm, const TimeInitParams &TParams) {
+int initOmegaModules(MPI_Comm Comm, const TimeInitParams &TParams,
+                     const CouplingInitParams &CParams) {
+   int Err = 0;
    // Initialize time stepper (phase 1) using coupler provided time parameters
    // Calendar should have already been initalized
    TimeStepper::init1(TParams);
-   return initOmegaModulesImpl(Comm);
+   Err = initOmegaModulesImpl(Comm);
+   SfcCoupling::init(CParams);
+
+   return Err;
 }
+
+int initUpdateHaloAndHostArrays() {
+   // Update Halo/Host arrays with new state, auxiliary state, and tracer fields
+   int Err = 0;
+
+   OceanState *DefState = OceanState::getDefault();
+   I4 CurTimeLevel      = 0;
+   DefState->exchangeHalo(CurTimeLevel);
+
+   // Enforce layer masks on state and tracer variables: fully-inactive layers
+   // get FillValueReal, boundary layers get 0, active layers keep their
+   // IC/restart value.
+   DefState->applyLayerMasks(CurTimeLevel);
+
+   DefState->copyToHost(CurTimeLevel);
+   VertCoord::getDefault()->initSurfacePressure(Halo::getDefault());
+
+   Forcing *DefForcing = Forcing::getDefault();
+   DefForcing->exchangeHalo();
+
+   AuxiliaryState *DefAuxState = AuxiliaryState::getDefault();
+   DefAuxState->exchangeHalo();
+
+   // Now update tracers - assume using same time level index
+   Err = Tracers::exchangeHalo(CurTimeLevel);
+   if (Err != 0) {
+      ABORT_ERROR("Error updating tracer halo");
+   }
+   Tracers::copyToHost(CurTimeLevel);
+
+   return Err;
+} // end initUpdateHaloAndHostArrays
 
 } // end namespace OMEGA
 //===----------------------------------------------------------------------===//

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -177,6 +177,36 @@ int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
 
 } // end ocnInit
 
+int ocnInit(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
+            const int OcnId,               ///< [in] mct comp id for ocean
+            const std::string &ConfigFile, ///< [in] path to yaml config file
+            const std::string &LogFile,    ///< [in] path to log file
+            const TimeInstant &StartTime   ///< [in] simulation start time
+) {
+
+   I4 Err = 0; // return error code
+
+   MachEnv *DefEnv = MachEnv::getDefault();
+
+   // Read config file into Config object
+   Config("Omega");
+   Config::readAll(ConfigFile);
+   Config *OmegaConfig = Config::getOmegaConfig();
+
+   readTimingConfig();
+
+   // coupler decides the stop time
+   TimeInitParams TimeParams{StartTime, std::nullopt};
+
+   // initialize remaining Omega modules
+   Err = initOmegaModules(Comm, TimeParams);
+   if (Err != 0)
+      ABORT_ERROR("ocnInit: Error initializing Omega modules");
+
+   return Err;
+
+} // end ocnInit
+
 // Call init routines for remaining Omega modules
 // Internal helper — all module init after TimeStepper::init1 is called.
 // Called by both initOmegaModules overloads.

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -195,8 +195,7 @@ int ocnInit1(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
    TimeStepper *DefStepper = TimeStepper::getDefault();
    Clock *ModelClock       = DefStepper->getClock();
 
-   // Now that all fields have been defined, validate all the streams
-   // contents
+   // Now that all fields are defined, validate all stream contents
    bool StreamsValid = IOStream::validateAll();
 
    if (!StreamsValid) {

--- a/components/omega/src/ocn/OceanRun.cpp
+++ b/components/omega/src/ocn/OceanRun.cpp
@@ -144,6 +144,10 @@ int ocnRun(TimeInstant &CurrTime, ///< [inout] current sim time
                SimTime.getString(4, 4, "-"));
    }
 
+   // Minus 1 because we want to print completed coupling interval
+   const I8 CoupledIntervalCount =
+       DefTimeStepper->getStepCount() / DefSfcCoupling->getNAccumSteps() - 1;
+
    // export o2x fields to coupler at endof coupling interval
    DefSfcCoupling->exportToCoupler();
 
@@ -151,6 +155,9 @@ int ocnRun(TimeInstant &CurrTime, ///< [inout] current sim time
    if (WriteRestart) {
       IOStream::write("RestartWrite", OmegaClock, true);
    }
+
+   LOG_INFO("ocnRun: ------ Completed coupling interval {} ------",
+            CoupledIntervalCount);
 
    return Err;
 

--- a/components/omega/src/ocn/OceanRun.cpp
+++ b/components/omega/src/ocn/OceanRun.cpp
@@ -82,7 +82,7 @@ int ocnRun(TimeInstant &CurrTime ///< [inout] current sim time
 } // end ocnRun
 
 int ocnRun(TimeInstant &CurrTime, ///< [inout] current sim time
-           bool WriteRestart      ///< [in] write restart at end of coupling interval
+           bool WriteRestart ///< [in] write restart at end of coupling interval
 ) {
 
    // error code
@@ -100,7 +100,6 @@ int ocnRun(TimeInstant &CurrTime, ///< [inout] current sim time
    TimeInterval TimeStep = DefTimeStepper->getTimeStep();
    TimeInstant SimTime   = OmegaClock->getCurrentTime();
 
-
    // Reset coupling alarm at the start of the coupling interval
    CouplingAlarm->reset(SimTime);
 
@@ -117,29 +116,28 @@ int ocnRun(TimeInstant &CurrTime, ///< [inout] current sim time
    // time loop, integrate until CouplingAlarm or error encountered
    while (Err == 0 && !(CouplingAlarm->isRinging())) {
 
-      // get step count, over the whole simulation, not just the coupling interval
+      // get step count, over the whole simulation
       const I8 IStep = DefTimeStepper->getStepCount();
 
       // do forward time step
       // first call to doStep can sometimes take very long
       // we want to time it separately and disable child timers
       // for that timer
-       if (IStep == 0) {
-          Pacer::start("Stepper:firstDoStep", 1);
-          Pacer::disableTiming();
-          DefTimeStepper->doStep(DefOceanState, SimTime);
-          Pacer::enableTiming();
-          Pacer::stop("Stepper:firstDoStep", 1);
-       } else {
+      if (IStep == 0) {
+         Pacer::start("Stepper:firstDoStep", 1);
+         Pacer::disableTiming();
+         DefTimeStepper->doStep(DefOceanState, SimTime);
+         Pacer::enableTiming();
+         Pacer::stop("Stepper:firstDoStep", 1);
+      } else {
          Pacer::start("Stepper:doStep", 1);
          DefTimeStepper->doStep(DefOceanState, SimTime);
          Pacer::stop("Stepper:doStep", 1);
-       }
+      }
 
       // Write any IOStreams with their alarms ringing
       IOStream::writeAll(OmegaClock);
 
-      // Is 0 the right argument for getAll, since it's after the step?
       DefSfcCoupling->updateExportFields(DefOceanState, Tracers::getAll(0));
 
       LOG_INFO("ocnRun: Time step {} complete, clock time: {}", IStep,
@@ -150,7 +148,9 @@ int ocnRun(TimeInstant &CurrTime, ///< [inout] current sim time
    DefSfcCoupling->exportToCoupler();
 
    // force write a restart at end of coupling interval if cpl tell us to
-   if (WriteRestart) { IOStream::write("RestartWrite", OmegaClock, true); }
+   if (WriteRestart) {
+      IOStream::write("RestartWrite", OmegaClock, true);
+   }
 
    return Err;
 

--- a/components/omega/src/ocn/OceanRun.cpp
+++ b/components/omega/src/ocn/OceanRun.cpp
@@ -10,8 +10,10 @@
 #include "IOStream.h"
 #include "OceanDriver.h"
 #include "OceanState.h"
+#include "SfcCoupling.h"
 #include "TimeMgr.h"
 #include "TimeStepper.h"
+#include "Tracers.h"
 
 namespace OMEGA {
 
@@ -39,11 +41,10 @@ int ocnRun(TimeInstant &CurrTime ///< [inout] current sim time
    std::shared_ptr<Field> SimInfo = Field::get(SimMeta);
 
    // time loop, integrate until EndAlarm or error encountered
-   I8 IStep = 0;
    while (Err == 0 && !(EndAlarm->isRinging())) {
 
-      // track step count
-      ++IStep;
+      // get step count
+      const I8 IStep = DefTimeStepper->getStepCount();
 
       // placeholder: call needed pre-timestep compute here
       // (e.g. forcing routine)
@@ -52,7 +53,7 @@ int ocnRun(TimeInstant &CurrTime ///< [inout] current sim time
       // first call to doStep can sometimes take very long
       // we want to time it separately and disable child timers
       // for that timer
-      if (IStep == 1) {
+      if (IStep == 0) {
          Pacer::start("Stepper:firstDoStep", 1);
          Pacer::disableTiming();
          DefTimeStepper->doStep(DefOceanState, SimTime);
@@ -80,4 +81,78 @@ int ocnRun(TimeInstant &CurrTime ///< [inout] current sim time
 
 } // end ocnRun
 
+int ocnRun(TimeInstant &CurrTime, ///< [inout] current sim time
+           bool WriteRestart      ///< [in] write restart at end of coupling interval
+) {
+
+   // error code
+   I4 Err = 0;
+
+   // fetch default OceanState and TimeStepper
+   OceanState *DefOceanState   = OceanState::getDefault();
+   TimeStepper *DefTimeStepper = TimeStepper::getDefault();
+   Forcing *DefForcing         = Forcing::getDefault();
+   SfcCoupling *DefSfcCoupling = SfcCoupling::getDefault();
+
+   // get simulation time and other time info
+   Clock *OmegaClock     = DefTimeStepper->getClock();
+   Alarm *CouplingAlarm  = DefSfcCoupling->getCouplingAlarm();
+   TimeInterval TimeStep = DefTimeStepper->getTimeStep();
+   TimeInstant SimTime   = OmegaClock->getCurrentTime();
+
+
+   // Reset coupling alarm at the start of the coupling interval
+   CouplingAlarm->reset(SimTime);
+
+   DefSfcCoupling->importFromCoupler();
+   DefSfcCoupling->applyImportFields(DefForcing);
+
+   // TODO: move somewhere more apropriate
+   I4 HaloErr = DefForcing->exchangeHalo();
+   if (HaloErr != 0) {
+      ABORT_ERROR("Error updating forcing halos after coupler import");
+   }
+   DefForcing->computeAll();
+
+   // time loop, integrate until CouplingAlarm or error encountered
+   while (Err == 0 && !(CouplingAlarm->isRinging())) {
+
+      // get step count, over the whole simulation, not just the coupling interval
+      const I8 IStep = DefTimeStepper->getStepCount();
+
+      // do forward time step
+      // first call to doStep can sometimes take very long
+      // we want to time it separately and disable child timers
+      // for that timer
+       if (IStep == 0) {
+          Pacer::start("Stepper:firstDoStep", 1);
+          Pacer::disableTiming();
+          DefTimeStepper->doStep(DefOceanState, SimTime);
+          Pacer::enableTiming();
+          Pacer::stop("Stepper:firstDoStep", 1);
+       } else {
+         Pacer::start("Stepper:doStep", 1);
+         DefTimeStepper->doStep(DefOceanState, SimTime);
+         Pacer::stop("Stepper:doStep", 1);
+       }
+
+      // Write any IOStreams with their alarms ringing
+      IOStream::writeAll(OmegaClock);
+
+      // Is 0 the right argument for getAll, since it's after the step?
+      DefSfcCoupling->updateExportFields(DefOceanState, Tracers::getAll(0));
+
+      LOG_INFO("ocnRun: Time step {} complete, clock time: {}", IStep,
+               SimTime.getString(4, 4, "-"));
+   }
+
+   // export o2x fields to coupler at endof coupling interval
+   DefSfcCoupling->exportToCoupler();
+
+   // force write a restart at end of coupling interval if cpl tell us to
+   if (WriteRestart) { IOStream::write("RestartWrite", OmegaClock, true); }
+
+   return Err;
+
+} // end ocnRun
 } // end namespace OMEGA

--- a/components/omega/src/ocn/SfcCoupling.cpp
+++ b/components/omega/src/ocn/SfcCoupling.cpp
@@ -232,6 +232,9 @@ void SfcCoupling::exportToCoupler() {
    auto AvgSfcVelocityMerid_ = OcnToCpl.AvgSfcVelocityMeridH;
    auto InstSshCellH_        = OcnToCpl.InstSshCellH;
 
+   // Initalize all o2x fields to 0.0 for next coupling interval
+   deepCopy(OcnToCplView_, 0.0_Real);
+
    /// TODO: Shouldn't be making direct calls to Kokkos here.
    auto Policy = Kokkos::RangePolicy<HostExecSpace, Kokkos::IndexType<int>>(
        0, NCellsOwned);

--- a/components/omega/src/ocn/SfcCoupling.cpp
+++ b/components/omega/src/ocn/SfcCoupling.cpp
@@ -148,6 +148,9 @@ void SfcCoupling::clear() {
 // Getter for private member NAccumSteps
 I4 SfcCoupling::getNAccumSteps() const { return NAccumSteps; }
 
+// Getter for private member CouplingAlarm
+Alarm *SfcCoupling::getCouplingAlarm() { return &CouplingAlarm; }
+
 // Create views of the raw coupling data arrays
 void SfcCoupling::attachData(const Real *CplToOcnData, Real *OcnToCplData) {
 

--- a/components/omega/src/ocn/SfcCoupling.h
+++ b/components/omega/src/ocn/SfcCoupling.h
@@ -136,6 +136,8 @@ class SfcCoupling {
    std::map<std::string, int> ImportIdxMap;
    std::map<std::string, int> ExportIdxMap;
 
+   Alarm CouplingAlarm; ///< Alarm for coupling interval
+
  public:
    std::string Name;
 
@@ -150,8 +152,6 @@ class SfcCoupling {
    // Coupling Variable containers
    CplToOcnFields CplToOcn; ///< Coupler to Ocean (x2o)
    OcnToCplFields OcnToCpl; ///< Ocean to Coupler (o2x)
-
-   Alarm CouplingAlarm; ///< Alarm for coupling interval
 
    /// View of Coupler to Ocean (x2o) raw data
    Kokkos::View<const Real **, Kokkos::LayoutStride, Kokkos::HostSpace,
@@ -196,6 +196,9 @@ class SfcCoupling {
    /// Getter for the number of ocean timesteps accumulated over the coupling
    /// interval
    I4 getNAccumSteps() const;
+
+   /// Get a pointer to the coupling alarm
+   Alarm *getCouplingAlarm();
 
    /// Create views of the coupling data arrays
    void attachData(const Real *CplToOcnData, Real *OcnToCplData);

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -103,6 +103,7 @@ void ForwardBackwardStepper::doStep(
    // Advance the clock and update the simulation time
    StepClock->advance();
    SimTime = StepClock->getCurrentTime();
+   ++StepCount;
 }
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -87,6 +87,7 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    // Advance the clock and update the simulation time
    StepClock->advance();
    SimTime = StepClock->getCurrentTime();
+   ++StepCount;
 }
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -151,6 +151,7 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
    // Advance the clock and update the simulation time
    StepClock->advance();
    SimTime = StepClock->getCurrentTime();
+   ++StepCount;
 }
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -383,6 +383,10 @@ void TimeStepper::changeTimeStep(const TimeInterval &TimeStepIn) {
 }
 
 //------------------------------------------------------------------------------
+// Get number of doStep calls made on this instance
+I8 TimeStepper::getStepCount() const { return StepCount; }
+
+//------------------------------------------------------------------------------
 // Retrieval functions
 
 // Get the default time stepper

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -194,6 +194,9 @@ class TimeStepper {
    void changeTimeStep(const TimeInterval &TimeStepIn ///< [in] new time step
    );
 
+   /// Get number of doStep calls made on this instance
+   I8 getStepCount() const;
+
    // these should be protected, they are public only because of CUDA
    // limitations
 
@@ -320,6 +323,9 @@ class TimeStepper {
    /// Clock for this time stepper
    /// For the default time stepper, this is the model clock
    std::unique_ptr<Clock> StepClock;
+
+   /// Number of doStep calls made on this instance since creation
+   mutable I8 StepCount = 0;
 
    // Pointers to objects needed by every time stepper
    Tendencies *Tend;         /// Ptr to tendency terms

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -35,7 +35,10 @@
 #include "VertCoord.h"
 #include "VertMix.h"
 #include "mpi.h"
+#include "yaml-cpp/yaml.h"
 #include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <thread>
 #include <vector>
 
@@ -50,6 +53,36 @@ void TestEval(const std::string &TestName, T TestVal, T ExpectVal, Error &Err) {
       Err += Error(ErrorCode::Fail, ErrMsg);
    }
 }
+
+//------------------------------------------------------------------------------
+// Clones RestartWrite into a new "RestartWriteOnDemand" stream (FreqUnits:
+// OnDemand) inside a copy of the input config file, then returns the new
+// file name. This mirrors how the coupled driver's buildnml assembles the
+// config file before Omega ever reads it, so it exercises Config::readAll
+// rather than mutating the already-parsed in-memory config. Only task 0
+// writes the file; all tasks then read the same copy.
+std::string addOnDemandStreamConfig(const std::string &InFile, MachEnv *Env) {
+
+   std::string OutFile = "omega.ondemand.yml";
+
+   if (Env->getMyTask() == 0) {
+      YAML::Node Root                 = YAML::LoadFile(InFile);
+      YAML::Node Streams              = Root["Omega"]["IOStreams"];
+      YAML::Node OnDemand             = YAML::Clone(Streams["RestartWrite"]);
+      OnDemand["UsePointerFile"]      = false;
+      OnDemand["Filename"]            = "ocn.restart.ondemand.nc";
+      OnDemand["FreqUnits"]           = "OnDemand";
+      Streams["RestartWriteOnDemand"] = OnDemand;
+
+      std::ofstream OutStream(OutFile);
+      OutStream << Root;
+   }
+   MPI_Barrier(Env->getComm());
+
+   return OutFile;
+
+} // End addOnDemandStreamConfig
+
 //------------------------------------------------------------------------------
 // Initialization routine to create reference Fields
 void initIOStreamTest(Clock *&ModelClock // Model clock
@@ -65,10 +98,10 @@ void initIOStreamTest(Clock *&ModelClock // Model clock
    initLogging(DefEnv);
    LOG_INFO("------ IOStream Unit Tests ------");
 
-   // Read the model configuration
+   // Read the model configuration, adding a cloned OnDemand stream
    Config("Omega");
-   Config::readAll("omega.yml");
-   Config *OmegaConfig = Config::getOmegaConfig();
+   std::string ConfigFile = addOnDemandStreamConfig("omega.yml", DefEnv);
+   Config::readAll(ConfigFile);
 
    // Initialize the default time stepper (phase 1) that includes the
    // num time levels, calendar, model clock and start/stop times and alarms
@@ -245,6 +278,16 @@ int main(int argc, char **argv) {
 
          IOStream::writeAll(ModelClock);
       }
+
+      // FreqUnits: OnDemand streams must never fire via writeAll
+      bool NotWritten = !std::filesystem::exists("ocn.restart.ondemand.nc");
+      TestEval("OnDemand not written by writeAll ", NotWritten, true, Err);
+
+      // A forced write is the only way an OnDemand stream is written
+      IOStream::write("RestartWriteOnDemand", ModelClock, true);
+      std::this_thread::sleep_for(std::chrono::seconds(5));
+      bool NowWritten = std::filesystem::exists("ocn.restart.ondemand.nc");
+      TestEval("OnDemand forced write ", NowWritten, true, Err);
 
       // Force read the latest restart and check the results
       // A delay is needed here to make sure the restart file is completely

--- a/components/omega/test/ocn/SfcCouplingTest.cpp
+++ b/components/omega/test/ocn/SfcCouplingTest.cpp
@@ -271,7 +271,7 @@ int testUpdateExportFields(const I4 NSteps) {
    Tracers::getIndex(TempIdx, "Temperature");
    Tracers::getIndex(SalinIdx, "Salinity");
 
-   while (!DefCoupling->CouplingAlarm.isRinging()) {
+   while (!DefCoupling->getCouplingAlarm()->isRinging()) {
       Real CurrStep = static_cast<Real>(DefCoupling->getNAccumSteps());
 
       HostArray2DReal TempH  = Tracers::getHostByIndex(0, TempIdx);

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -424,6 +424,13 @@ int testOptionalStopTime(const std::string &Name, TimeStepperType Type) {
                 Name);
    }
 
+   if (Stepper->getStepCount() != 0) {
+      Err++;
+      LOG_ERROR("TimeStepperTest: {}: getStepCount() should be 0 before any "
+                "doStep calls",
+                Name);
+   }
+
    // Verify doStep works without an EndAlarm (coupled run loop never uses it)
    Stepper->attachData(TestTendencies, TestAuxState, DefMesh, DefVCoord,
                        DefHalo);
@@ -431,7 +438,25 @@ int testOptionalStopTime(const std::string &Name, TimeStepperType Type) {
    initState();
    TimeInstant CurTime = TimeStart;
    Stepper->doStep(State, CurTime);
+
+   if (Stepper->getStepCount() != 1) {
+      Err++;
+      LOG_ERROR("TimeStepperTest: {}: getStepCount() should be 1 after one "
+                "doStep call",
+                Name);
+   }
+
+   // Coupled driver calls doStep repeatedly across separate ocnRun
+   // invocations, so StepCount must persist and keep incrementing rather
+   // than reset
    Stepper->doStep(State, CurTime);
+
+   if (Stepper->getStepCount() != 2) {
+      Err++;
+      LOG_ERROR("TimeStepperTest: {}: getStepCount() should be 2 after two "
+                "doStep calls",
+                Name);
+   }
 
    TimeStepper::erase("CoupledTestStepper");
 


### PR DESCRIPTION
Initial implementation the MCT-based coupled driver for Omega. Includes necessary CIME configuration files (`buildnml`, `buildlib_cmake`, `config_component`/`config_compsets`), `omega_cxx2f_interface`/`omega_f2cxx_interface` bridges, a complete `ocn_comp_mct.F90`, split `ocnInit1`/`ocnInit2`, a coupled `ocnRun` overload, and an `ocnFinalize` bridge.

The purpose of this initial PR is to confirm we can pass data to and from the coupler across the Fortran $\Longleftrightarrow$ C++ bridge and apply this data to the Omega `Forcing` class. In this PR we are not concerned with fully functional coupling or scientifically validated results; those will come in follow up PRs over the next few weeks. Therefore out target deliverable for the PR is a wind-driven C-Case using Omega run through the coupled driver. 

## Design choices made during implementation 
### Splitting `ocnInit` into `ocnInit1` / `ocnInit2` for coupled simulations

The coupler needs mesh information (i.e. `lsize`/`NCellsOwned`), which is avail to allocate MCT attribute vectors (`x2o`/`o2x`). And the attribute vectors are needed complete Omega's initialization (i.e. attach MCT pointers) and exchange the initial coupled state. Therefore init split into two phases:
- **`ocnInit1`**: everything up through mesh/decomp/state setup — runs before the coupler-owned MCT buffers exist.
- **`ocnInit2`**: runs once the coupler has allocated its MCT buffers; attaches them via `SfcCoupling::attachData` and exchanges the initial coupled state.

### Passing `c_ptr` coupler args by value in Fortran $\Longleftrightarrow$ C++ bridge

`type(c_ptr)` dummy args in `omega_f2cxx_interface.F90` are declared `VALUE` rather than `TARGET`, matched with plain (non-reference) pointers on the C++ side. `c_loc()` already produces the address to pass, so `VALUE` hands that address straight through as a raw pointer; none of the C++ callees reseat the pointer, so a reference-to-pointer isn't needed. 
## Changes outside the coupled driver code

- **TimeStepper**: `StepCount` is now tracked as a member variable (`getStepCount()`), incremented in `doStep` for the FB/RK2/RK4 steppers. The existing standalone `ocnRun` was updated to use `TimeStepper::getStepCount()` instead of a local step counter.
  - The coupled `ocnRun` overload only advances the model one coupling interval per call, so a step counter local to `ocnRun` would reset every call. Moving it onto `TimeStepper` gives a step count that persists across calls, which the coupled driver needs to know it's on the very first step of the whole run (e.g. for the one-time timer setup).
- **IOStream**: added an `OnDemand` `IOFreqUnits` option, which registers a stream with no alarm and no `OnStartup`/`OnShutdown` behavior, so it only writes when explicitly forced.
  - The coupler drives export/restart writes on its own schedule rather than Omega's normal alarm cadence, so the coupled driver needs a stream it can write on demand instead of one that fires automatically.
  - Because the `ocn` component can be lagged from the rest of the coupled system it is **not** safe for the `ocn` component to control it's own restart alarm. 
- **OceanInit**: fixed a restart bug where `IOStream::read` updates the `SimulationTime` entry in the `ReqMeta` map, but the local `SimTimeStr` variable was never reassigned from that map.
  - While fixing this for the coupled driver, we applied the same fix to the standalone `ocnInit`.

## Outstanding Issues
 - `METIS_ROOT` / `PARMETIS_ROOT` only set on pm-gpu. What the plan? Continue to point to `polaris` spack build for now? 
 - ~`ERS_Ld5.T62_oQU240.COMEGA-IAF` fails with issue initializing `VertCoord` on restart (when `InitVertCoord`'s `FreqUnit` is set to `never`)~
 - MOAB support will be a follow on PR. 
 - Support for `user_nl_omega` will come in a follow on PR. To make custom changes to the config file for now: locally edit the `Default.yml` in the omega clone prior to `./case.build`/ `./case.submit`. 
----
<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
#### Checklist
* [x] Documentation:
  * [x] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [x] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.
* [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
* [ ] New tests:
  * [ ] CTest unit tests for new features have been added per the approved design.
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
* Stealth Features
  * [ ] If any stealth features are included in the PR, please confirm that they have been documented.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


