### PR TITLE
Fix inaccurate state validation continue message

### DIFF
--- a/components/omega/src/ocn/StateValidation.cpp
+++ b/components/omega/src/ocn/StateValidation.cpp
@@ -287,11 +287,20 @@ void validateOceanState(const OceanState *State, const AuxiliaryState *AuxState,
           std::to_string(NaNs) + " NaNs and " + std::to_string(OOBs) +
           " OOBs." + "See critical messages above for details.");
    } else if ((NaNs + OOBs) > 0) {
-      LOG_CRITICAL(
-          "StateValidation: Ocean state validation failed with {} "
-          "NaNs and {} OOBs. AbortOnOOB and AbortOnNan are both false; "
-          "continuing after logging.",
-          NaNs, OOBs);
+      // Only report the flags that are actually suppressing an abort, i.e.
+      // those corresponding to the issues that were detected
+      std::string Flags;
+      if (NaNs > 0) {
+         Flags = "AbortOnNan is false";
+      }
+      if (OOBs > 0) {
+         if (!Flags.empty())
+            Flags += " and ";
+         Flags += "AbortOnOOB is false";
+      }
+      LOG_CRITICAL("StateValidation: Ocean state validation failed with {} "
+                   "NaNs and {} OOBs. {}; continuing after logging.",
+                   NaNs, OOBs, Flags);
    }
 }
 


### PR DESCRIPTION
The non-aborting branch of `validateOceanState()` claimed "AbortOnOOB and AbortOnNan are both false", which is wrong when only one issue type is detected.  With the default config (`AbortOnNan` true, `AbortOnOOB` false), a run with OOBs but no NaNs reported that `AbortOnNan` was false.

Report only the flags corresponding to the issues that were actually detected.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [x] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


