### PR TITLE
Fix a bug affecting monotonic vertical advection

### DIFF
--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -1,5 +1,6 @@
 #include "AuxiliaryState.h"
 #include "Config.h"
+#include "Error.h"
 #include "Field.h"
 #include "Logging.h"
 #include "Pacer.h"
@@ -129,6 +130,10 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
    TimeStep.get(TimeStepSeconds, TimeUnits::Seconds);
    R8 ProjDtSeconds;
    ProjDt.get(ProjDtSeconds, TimeUnits::Seconds);
+
+   // Sanity checks for the time steps
+   OMEGA_REQUIRE(TimeStepSeconds > 0, "TimeStepSeconds has to be positive");
+   OMEGA_REQUIRE(ProjDtSeconds > 0, "ProjDtSeconds has to be positive");
 
    Pacer::start("AuxState:computeMomAux", 1);
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -28,7 +28,8 @@ AuxiliaryState::AuxiliaryState(const std::string &Name, const HorzMesh *Mesh,
       VorticityAux(stripDefault(Name), Mesh, VCoord),
       VelocityDel2Aux(stripDefault(Name), Mesh, VCoord),
       SurfTracerRestAux(stripDefault(Name), Mesh, NTracers),
-      TracerAux(stripDefault(Name), Mesh, VCoord, NTracers) {
+      TracerAux(stripDefault(Name), Mesh, VCoord, NTracers),
+      TimeStep(TimeStep) {
 
    GroupName = "AuxiliaryState";
    if (Name != "Default") {

--- a/components/omega/src/ocn/auxiliaryVars/PseudoThicknessAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/PseudoThicknessAuxVars.h
@@ -69,26 +69,31 @@ class PseudoThicknessAuxVars {
                                            const Array2DReal &NormalVelEdge,
                                            const Real Dt) const {
 
-      // Temporary for stacked shallow water
-      const int KStart = chunkStart(KChunk, MinLayerCell(ICell));
-      const int KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
+      const I4 KStartCell = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLenCell = chunkLength(KChunk, KStartCell, MaxLayerCell(ICell));
+      const I4 KEndCell = KStartCell + KLenCell - 1;
 
       Real TmpProv[VecLength] = {0.};
 
       Real DtInvAreaCell = Dt / AreaCell(ICell);
       for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
          const I4 JEdge = EdgesOnCell(ICell, J);
+
+         const I4 KStartEdge = Kokkos::max(KStartCell, MinLayerEdgeBot(JEdge));
+         const I4 KEndEdge   = Kokkos::min(KEndCell, MaxLayerEdgeTop(JEdge));
+
          const Real Factor =
              DtInvAreaCell * DvEdge(JEdge) * EdgeSignOnCell(ICell, J);
-         for (int KVec = 0; KVec < KLen; ++KVec) {
-            const int K = KStart + KVec;
+
+         for (int K = KStartEdge; K <= KEndEdge; ++K) {
+            const I4 KVec = K - KStartCell;
             TmpProv[KVec] += Factor * FluxPseudoThickEdge(JEdge, K) *
                              NormalVelEdge(JEdge, K);
          }
       }
 
-      for (int KVec = 0; KVec < KLen; ++KVec) {
-         const int K = KStart + KVec;
+      for (int KVec = 0; KVec < KLenCell; ++KVec) {
+         const int K = KStartCell + KVec;
          ProvPseudoThickness(ICell, K) =
              PseudoThickCell(ICell, K) + TmpProv[KVec];
       }

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -186,6 +186,7 @@ int testAuxState() {
 
    deepCopy(DefAuxState->PseudoThicknessAux.FluxPseudoThickEdge, NAN);
    deepCopy(DefAuxState->PseudoThicknessAux.MeanPseudoThickEdge, NAN);
+   deepCopy(DefAuxState->PseudoThicknessAux.ProvPseudoThickness, NAN);
 
    deepCopy(DefAuxState->VorticityAux.RelVortVertex, NAN);
    deepCopy(DefAuxState->VorticityAux.NormRelVortVertex, NAN);
@@ -241,6 +242,14 @@ int testAuxState() {
    if (!Kokkos::isfinite(MeanPseudoThickSum)) {
       Err++;
       LOG_ERROR("AuxStateTest: MeanPseudoThickEdge FAIL");
+   }
+
+   const Real ProvPseudoThickSum =
+       sum(DefAuxState->PseudoThicknessAux.ProvPseudoThickness, NCellsOwned,
+           VCoord->MinLayerCell, VCoord->MaxLayerCell);
+   if (!Kokkos::isfinite(ProvPseudoThickSum)) {
+      Err++;
+      LOG_ERROR("AuxStateTest: ProvPseudoThickness FAIL");
    }
 
    const Real RelVortVSum =

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -218,10 +218,11 @@ int initTimeStepperTest(const std::string &mesh) {
       LOG_ERROR("TimeStepperTest: error creating test state");
    }
 
-   TimeInterval ZeroTimeStep; // Zero-length time step placeholder
+   TimeInterval PosTimeStep(
+       1, TimeUnits::Seconds); // Arbitrary positive time step (unused)
    auto *TestAuxState =
        AuxiliaryState::create("TestAuxState", DefMesh, DefHalo, DefVertCoord,
-                              DefVAdv, NTracers, ZeroTimeStep);
+                              DefVAdv, NTracers, PosTimeStep);
 
    Config *OmegaConfig = Config::getOmegaConfig();
    TestAuxState->readConfigOptions(OmegaConfig);
@@ -236,7 +237,7 @@ int initTimeStepperTest(const std::string &mesh) {
    // Creating non-default tendencies with custom velocity tendencies
    auto *TestTendencies = Tendencies::create(
        "TestTendencies", DefMesh, DefVertCoord, DefVAdv, DefPGrad, DefEos,
-       DefVMix, NTracers, ZeroTimeStep, &Options,
+       DefVMix, NTracers, PosTimeStep, &Options,
        Tendencies::CustomTendencyType{}, DecayVelocityTendency{});
    if (!TestTendencies) {
       Err++;


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
This PR fixes a bug in `AuxiliaryState` where the `TimeStep` member variable was not initialized in the constructor. The time step is used to compute `ProvPseudoThickness`, which is only used in the vertical advection with FCT. This bug caused `ProvPseudoThickness` to be equal to the input pseudo thickness. In addition to fixing the bug, I made a couple of improvements in this PR. I changed the computation of `ProvPseudoThickness` to prevent accesses to inactive layers, added a check for this variable in the auxiliary state test, and added sanity checks for the time step values in `AuxiliaryState`.


<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


