### PR TITLE
Fix out-of-bounds access in the explicit bottom drag tendency

### DIFF
--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -351,7 +351,7 @@ class BottomDragOnEdge {
       // other tendency terms, which are chunked over [MinLayerEdgeBot,
       // MaxLayerEdgeTop] and so skip such edges automatically, bottom drag
       // indexes the bottom layer directly and must exclude them explicitly.
-      if (KBot < 0 || KBot >= NVertLayers)
+      if (KBot < 0)
          return;
 
       const I4 JCell0 = CellsOnEdge(IEdge, 0);

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -346,6 +346,14 @@ class BottomDragOnEdge {
                                    const Array2DReal &PseudoThickEdge) const {
       const I4 KBot = MaxLayerEdgeTop(IEdge);
 
+      // Land edges and the outermost edges of the halo have no active layer
+      // on both sides, and MaxLayerEdgeTop is set to -1 for them. Unlike the
+      // other tendency terms, which are chunked over [MinLayerEdgeBot,
+      // MaxLayerEdgeTop] and so skip such edges automatically, bottom drag
+      // indexes the bottom layer directly and must exclude them explicitly.
+      if (KBot < 0 || KBot >= NVertLayers)
+         return;
+
       const I4 JCell0 = CellsOnEdge(IEdge, 0);
       const I4 JCell1 = CellsOnEdge(IEdge, 1);
 

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -844,6 +844,117 @@ int testBottomDrag(int NVertLayers, Real RTol) {
    return Err;
 } // end testBottomDrag
 
+/// Bottom drag must leave edges with no active layer on both sides alone.
+///
+/// VertCoord sets MaxLayerEdgeTop to -1 on land edges and on the outermost
+/// edges of the halo, and Tendencies applies bottom drag with a flat loop over
+/// all edges rather than over the chunked vertical range that the other
+/// tendency terms use. Without an explicit guard the functor indexes the
+/// bottom layer at -1, reading and writing outside the intended row: for a
+/// LayoutRight array Tend(IEdge, -1) aliases Tend(IEdge - 1, NVertLayers - 1),
+/// so an inactive edge silently corrupts its neighbor's deepest layer.
+///
+/// Mark a subset of edges inactive, then compare a pass over all edges against
+/// a reference pass over only the active ones. The two must agree exactly.
+int testBottomDragInactiveEdges(int NVertLayers) {
+
+   int Err = 0;
+   TestSetup Setup;
+
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
+
+   const Real Coeff = 1.123456789;
+
+   // Set input arrays
+   Array2DReal NormalVelEdge("NormalVelEdge", Mesh->NEdgesSize, NVertLayers);
+
+   Err += setVectorEdge(
+       KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
+          VecField[0] = Setup.vectorX(X, Y);
+          VecField[1] = Setup.vectorY(X, Y);
+       },
+       NormalVelEdge, EdgeComponent::Normal, Geom, Mesh);
+
+   Array2DReal KECell("KECell", Mesh->NCellsSize, NVertLayers);
+
+   Err += setScalar(
+       KOKKOS_LAMBDA(Real X, Real Y) {
+          return Setup.scalarA(X, Y) * Setup.scalarA(X, Y) / 2;
+       },
+       KECell, Geom, Mesh, OnCell);
+
+   Array2DReal PseudoThickEdge("PseudoThickEdge", Mesh->NEdgesSize,
+                               NVertLayers);
+
+   Err += setScalar(
+       KOKKOS_LAMBDA(Real X, Real Y) { return Setup.scalarB(X, Y); },
+       PseudoThickEdge, Geom, Mesh, OnEdge);
+
+   // Save the layer indices so they can be restored for the later tests
+   Array1DI4 SavedMaxLayerEdgeTop("SavedMaxLayerEdgeTop", Mesh->NEdgesSize);
+   deepCopy(SavedMaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   // Mark every third edge inactive, the way VertCoord marks land edges and
+   // the outermost edges of the halo
+   OMEGA_SCOPE(LocMaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+   parallelFor(
+       {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
+          if (IEdge % 3 == 0)
+             LocMaxLayerEdgeTop(IEdge) = -1;
+       });
+
+   // The functor keeps a shallow copy of MaxLayerEdgeTop, so construct it
+   // after the array has been modified to make the intent clear
+   BottomDragOnEdge BottomDragOnE(Mesh, VCoord);
+   BottomDragOnE.Coeff = Coeff;
+
+   // Reference: only the active edges contribute
+   Array2DReal RefBottomDrag("RefBottomDrag", Mesh->NEdgesSize, NVertLayers);
+   deepCopy(RefBottomDrag, 0);
+   parallelFor(
+       {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
+          if (LocMaxLayerEdgeTop(IEdge) >= 0)
+             BottomDragOnE(RefBottomDrag, IEdge, NormalVelEdge, KECell,
+                           PseudoThickEdge);
+       });
+
+   // What Tendencies actually does: loop over every edge unconditionally
+   Array2DReal NumBottomDrag("NumBottomDrag", Mesh->NEdgesSize, NVertLayers);
+   deepCopy(NumBottomDrag, 0);
+   parallelFor(
+       {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
+          BottomDragOnE(NumBottomDrag, IEdge, NormalVelEdge, KECell,
+                        PseudoThickEdge);
+       });
+
+   // Restore the layer indices before checking, so that returning early on
+   // failure cannot leave the vertical coordinate modified for later tests
+   deepCopy(VCoord->MaxLayerEdgeTop, SavedMaxLayerEdgeTop);
+
+   I4 NumBad = 0;
+   parallelReduce(
+       {Mesh->NEdgesAll, NVertLayers},
+       KOKKOS_LAMBDA(int IEdge, int K, I4 &Accum) {
+          const Real Num = NumBottomDrag(IEdge, K);
+          const Real Ref = RefBottomDrag(IEdge, K);
+          if (Num != Ref or Kokkos::isnan(Num) or Kokkos::isinf(Num))
+             Accum += 1;
+       },
+       NumBad);
+
+   if (NumBad > 0) {
+      LOG_ERROR("TendencyTermsTest: BottomDragInactiveEdges FAIL, {} entries "
+                "differ from the active-edge-only result",
+                NumBad);
+      Err += 1;
+   } else {
+      LOG_INFO("TendencyTermsTest: BottomDragInactiveEdges PASS");
+   }
+
+   return Err;
+} // end testBottomDragInactiveEdges
+
 int testTracerHorzAdvOnCell(int NVertLayers, int NTracers, Real RTol) {
 
    I4 Err = 0;
@@ -1214,6 +1325,8 @@ int tendencyTermsTest(const std::string &MeshFile = DefaultMeshFile) {
    Err += testSfcStressForcing(NVertLayers);
 
    Err += testBottomDrag(NVertLayers, RTol);
+
+   Err += testBottomDragInactiveEdges(NVertLayers);
 
    Err += testTracerHorzAdvOnCell(NVertLayers, NTracers, RTol);
 


### PR DESCRIPTION
`VertCoord` sets `MaxLayerEdgeTop` to -1 on land edges and on the outermost edges of the halo, marking edges with no active layer on both sides. Tendencies applies bottom drag with a flat parallelFor over every edge in `NEdgesAll`, whereas the other momentum tendency terms are chunked over [MinLayerEdgeBot, MaxLayerEdgeTop] and therefore skip those edges on their own. `BottomDragOnEdge` indexes the bottom layer directly, so on such an edge it read and wrote at layer -1.

For a `LayoutRight` array `Tend(IEdge, -1)` aliases `Tend(IEdge - 1, NVertLayers - 1)`, so an inactive edge corrupted its neighbor's deepest layer, and `1/PseudoThickEdge(IEdge, -1)` could divide by zero. The damage was invisible while `BottomDragCoeff` was left at its default of 0, since every contribution is scaled by the coefficient, but any run with bottom drag enabled produced `NaN` or `Inf` in the velocity tendency. A global `EC30to60E2r2` case with `BottomDragCoeff = 1.0e-3` aborted during the first time step once state validation caught the `NaN`.

Skip edges whose bottom layer index is outside the vertical range.

Add `testBottomDragInactiveEdges`, which marks a subset of edges inactive and checks that a pass over all edges matches a reference pass over only the active ones. The existing `testBottomDrag` loops over `NEdgesOwned` on a mesh where every edge is active, so it could not see this.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.
* [x] New tests:
  * [x] CTest unit tests for new features have been added per the approved design.
  * [x] Polaris tests for new features have been added per the approved design (and included in a test suite)

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


