### PR TITLE
Add horizontal mesh operator for reconstructing edge-normal vector fields at cell centers

### DIFF
--- a/components/omega/cime_config/buildnml
+++ b/components/omega/cime_config/buildnml
@@ -163,10 +163,10 @@ def _get_file_name(case, stream):
 
     if ocn_grid == "oQU240":
         mesh_dir = omega_dir / "oQU240"
-        return str(mesh_dir / "ocean.QU.240km.151209.teos10.260720.nc")
+        return str(mesh_dir / "ocean.QU.240km.151209.teos10.260807.nc")
     elif ocn_grid == "EC30to60E2r2":
         mesh_dir = omega_dir / "EC30to60E2r2"
-        return str(mesh_dir / "ocean.EC30to60E2r2.200908.teos10.260720.nc")
+        return str(mesh_dir / "ocean.EC30to60E2r2.200908.teos10.260807.nc")
     else:
         msg = f"Unsupported OCN_GRID: {ocn_grid}"
         raise ValueError(msg)

--- a/components/omega/doc/devGuide/Decomp.md
+++ b/components/omega/doc/devGuide/Decomp.md
@@ -87,9 +87,9 @@ described in the mesh specification above. In particular, it contains
     at a vertex
   - NEdgesOnCell(NCellsSize): the number of actual edges on each cell
   - NEdgesOnEdge(NEdgesSize): the number of actual edges on each edge
-  - NCellReconstructEdges(NCellsSize): number of edges in the vector
+  - NEdgesReconOnCell(NCellsSize): number of edges in the vector
     reconstruction stencil for each cell (spherical meshes only)
-  - ReconstructStencilCell(NCellsSize,MaxEdges2): edge indices in the
+  - ReconStencilCell(NCellsSize,MaxEdges2): edge indices in the
     vector reconstruction stencil for each cell (spherical meshes only)
   - OnSphere: whether the mesh is spherical, read from the mesh file to
     gate the reconstruction stencil arrays above

--- a/components/omega/doc/devGuide/Decomp.md
+++ b/components/omega/doc/devGuide/Decomp.md
@@ -67,6 +67,7 @@ described in the mesh specification above. In particular, it contains
   - NCellsHalo(i): the number of owned+halo cells for each halo layer
   - Analogous size variables for Edges and Vertices
   - MaxEdges: the max number of edges on a cell (and array size)
+  - MaxEdges2: the max number of edges on a edge
   - VertexDegree: the number of cells/edges at each vertex
   - CellID(NCellsSize): the global index for each local cell
   - CellLoc(NCellsSize,2): the task and local index for every local cell
@@ -86,6 +87,12 @@ described in the mesh specification above. In particular, it contains
     at a vertex
   - NEdgesOnCell(NCellsSize): the number of actual edges on each cell
   - NEdgesOnEdge(NEdgesSize): the number of actual edges on each edge
+  - NCellReconstructEdges(NCellsSize): number of edges in the vector
+    reconstruction stencil for each cell (spherical meshes only)
+  - ReconstructStencilCell(NCellsSize,MaxEdges2): edge indices in the
+    vector reconstruction stencil for each cell (spherical meshes only)
+  - OnSphere: whether the mesh is spherical, read from the mesh file to
+    gate the reconstruction stencil arrays above
 
 For each of the arrays above, there is a copy of the array on the host and
 device (GPU) with the host array named with an extra H on the end

--- a/components/omega/doc/devGuide/Decomp.md
+++ b/components/omega/doc/devGuide/Decomp.md
@@ -67,7 +67,7 @@ described in the mesh specification above. In particular, it contains
   - NCellsHalo(i): the number of owned+halo cells for each halo layer
   - Analogous size variables for Edges and Vertices
   - MaxEdges: the max number of edges on a cell (and array size)
-  - MaxEdges2: the max number of edges on a edge
+  - MaxEdges2: the max number of edges on a edge (2*MaxEdges)
   - VertexDegree: the number of cells/edges at each vertex
   - CellID(NCellsSize): the global index for each local cell
   - CellLoc(NCellsSize,2): the task and local index for every local cell

--- a/components/omega/doc/devGuide/HorzOperators.md
+++ b/components/omega/doc/devGuide/HorzOperators.md
@@ -37,7 +37,7 @@ Currently, the following operators are implemented:
 - `GradientOnEdge`
 - `CurlOnVertex`
 - `TangentialReconOnEdge`
-- `VectorReconstructOnCell`
+- `VectorReconOnCell`
 
 Some tendency terms in the Omega PDE solver could in principle be constructed
 using these operators as building blocks. However, very often tendency terms

--- a/components/omega/doc/devGuide/HorzOperators.md
+++ b/components/omega/doc/devGuide/HorzOperators.md
@@ -37,6 +37,7 @@ Currently, the following operators are implemented:
 - `GradientOnEdge`
 - `CurlOnVertex`
 - `TangentialReconOnEdge`
+- `VectorReconstructOnCell`
 
 Some tendency terms in the Omega PDE solver could in principle be constructed
 using these operators as building blocks. However, very often tendency terms

--- a/components/omega/doc/devGuide/QuickStart.md
+++ b/components/omega/doc/devGuide/QuickStart.md
@@ -124,14 +124,14 @@ Some tests require a valid Omega mesh file. Different tests require different
 meshes. At the moment, mesh files need to be copied or linked to specifically
 named files under the `test` directory. Appropriate mesh files can be
 downloaded from:
-- [Ocean Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/ocean.QU.240km.omega_vars.260518.nc)
-- [Global Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/cosine_bell_icos480.omega_vars.260518.nc)
-- [Planar Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/PlanarPeriodic48x48.omega_vars.260518.nc)
+- [Ocean Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/ocean.QU.240km.omega_vars.260727.nc)
+- [Global Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/cosine_bell_icos480.omega_vars.260727.nc)
+- [Planar Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/PlanarPeriodic48x48.omega_vars.260720.nc)
 ```sh
 cd test
-wget -O OmegaMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/ocean.QU.240km.omega_vars.260518.nc
-wget -O OmegaSphereMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/cosine_bell_icos480.omega_vars.260518.nc
-wget -O OmegaPlanarMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/PlanarPeriodic48x48.omega_vars.260518.nc
+wget -O OmegaMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/ocean.QU.240km.omega_vars.260727.nc
+wget -O OmegaSphereMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/cosine_bell_icos480.omega_vars.260727.nc
+wget -O OmegaPlanarMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/PlanarPeriodic48x48.omega_vars.260720.nc
 cd ..
 ```
 

--- a/components/omega/doc/devGuide/QuickStart.md
+++ b/components/omega/doc/devGuide/QuickStart.md
@@ -124,13 +124,13 @@ Some tests require a valid Omega mesh file. Different tests require different
 meshes. At the moment, mesh files need to be copied or linked to specifically
 named files under the `test` directory. Appropriate mesh files can be
 downloaded from:
-- [Ocean Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/ocean.QU.240km.omega_vars.260727.nc)
-- [Global Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/cosine_bell_icos480.omega_vars.260727.nc)
+- [Ocean Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/ocean.QU.240km.omega_vars.260807.nc)
+- [Global Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/cosine_bell_icos480.omega_vars.260807.nc)
 - [Planar Mesh](https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/PlanarPeriodic48x48.omega_vars.260720.nc)
 ```sh
 cd test
-wget -O OmegaMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/ocean.QU.240km.omega_vars.260727.nc
-wget -O OmegaSphereMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/cosine_bell_icos480.omega_vars.260727.nc
+wget -O OmegaMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/ocean.QU.240km.omega_vars.260807.nc
+wget -O OmegaSphereMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/cosine_bell_icos480.omega_vars.260807.nc
 wget -O OmegaPlanarMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/PlanarPeriodic48x48.omega_vars.260720.nc
 cd ..
 ```

--- a/components/omega/doc/userGuide/Decomp.md
+++ b/components/omega/doc/userGuide/Decomp.md
@@ -40,7 +40,7 @@ An input mesh file must be provided that contains at a minimum
   - the mesh connectivity contained in the arrays CellsOnCell, EdgesOnCell
     VerticesOnCell, CellsOnEdge, EdgesOnEdge, CellsOnVertex, EdgesOnVertex.
 For spherical meshes, the vector reconstruction stencil arrays
-NCellReconstructEdges and ReconstructStencilCell are also required.
+NEdgesReconOnCell and ReconStencilCell are also required.
 Again, a full description of the mesh is given in the
 [Developer's Guide](#omega-dev-decomp).
 The file name for this input file is extracted from the HorzMeshIn input

--- a/components/omega/doc/userGuide/Decomp.md
+++ b/components/omega/doc/userGuide/Decomp.md
@@ -39,6 +39,8 @@ An input mesh file must be provided that contains at a minimum
   - the total number of cells, edges and vertices (NCells, NEdges, NVertices)
   - the mesh connectivity contained in the arrays CellsOnCell, EdgesOnCell
     VerticesOnCell, CellsOnEdge, EdgesOnEdge, CellsOnVertex, EdgesOnVertex.
+For spherical meshes, the vector reconstruction stencil arrays
+NCellReconstructEdges and ReconstructStencilCell are also required.
 Again, a full description of the mesh is given in the
 [Developer's Guide](#omega-dev-decomp).
 The file name for this input file is extracted from the HorzMeshIn input

--- a/components/omega/doc/userGuide/HorzMesh.md
+++ b/components/omega/doc/userGuide/HorzMesh.md
@@ -54,7 +54,7 @@ variables:
 | AngleEdge | Angle the edge normal makes with local eastward direction | radians |
 | MeshDensity | Value of density function used to generate a particular mesh at cell centers | - |
 | WeightsOnEdge | Reconstruction weights associated with each of the edgesOnEdge | - |
-| ReconstructWeightsCell | Least-squares weights for reconstructing an edge-normal vector field at cell centers; spherical meshes only | - |
+| ReconWeightsCell | Least-squares weights for reconstructing an edge-normal vector field at cell centers; spherical meshes only | - |
 
 In addition, some mesh metadata are read from the file and stored as mesh
 variables. These include ``OnSphere`` (or ``on_a_sphere`` for backcompatibility),

--- a/components/omega/doc/userGuide/HorzMesh.md
+++ b/components/omega/doc/userGuide/HorzMesh.md
@@ -54,6 +54,7 @@ variables:
 | AngleEdge | Angle the edge normal makes with local eastward direction | radians |
 | MeshDensity | Value of density function used to generate a particular mesh at cell centers | - |
 | WeightsOnEdge | Reconstruction weights associated with each of the edgesOnEdge | - |
+| ReconstructWeightsCell | Least-squares weights for reconstructing an edge-normal vector field at cell centers; spherical meshes only | - |
 
 In addition, some mesh metadata are read from the file and stored as mesh
 variables. These include ``OnSphere`` (or ``on_a_sphere`` for backcompatibility),

--- a/components/omega/doc/userGuide/HorzOperators.md
+++ b/components/omega/doc/userGuide/HorzOperators.md
@@ -15,5 +15,6 @@ The following operators are currently implemented:
 - `GradientOnEdge`
 - `CurlOnVertex`
 - `TangentialReconOnEdge`
+- `VectorReconstructOnCell`
 
 There are no user-configurable options.

--- a/components/omega/doc/userGuide/HorzOperators.md
+++ b/components/omega/doc/userGuide/HorzOperators.md
@@ -15,6 +15,6 @@ The following operators are currently implemented:
 - `GradientOnEdge`
 - `CurlOnVertex`
 - `TangentialReconOnEdge`
-- `VectorReconstructOnCell`
+- `VectorReconOnCell`
 
 There are no user-configurable options.

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -105,22 +105,27 @@ I4 srchVector(HostArray1DI4 InVector, // vector to search
 // These are initially read into a uniform linear distribution across MPI tasks
 // and redistributed later after the decomposition is complete.
 
-void readMesh(const int MeshFileID, // file ID for open mesh file
-              const MachEnv *InEnv, // input machine environment for MPI layout
-              I4 &NCellsGlobal,     // total number of cells
-              I4 &NEdgesGlobal,     // total number of edges
-              I4 &NVerticesGlobal,  // total number of vertices
-              I4 &MaxEdges,         // max number of edges on a cell
-              I4 &MaxCellsOnEdge,   // max number of cells sharing edge
-              I4 &VertexDegree,     // number of cells/edges sharing vrtx
-              std::vector<I4> &CellsOnCellInit, // cell neighbors for each cell
-              std::vector<I4> &EdgesOnCellInit, // edge IDs for each cell edge
-              std::vector<I4> &VerticesOnCellInit, // vertices around each cell
-              std::vector<I4> &CellsOnEdgeInit,    // cell IDs sharing edge
-              std::vector<I4> &EdgesOnEdgeInit,    // all edges neighboring edge
-              std::vector<I4> &VerticesOnEdgeInit, // vertices on ends of edge
-              std::vector<I4> &CellsOnVertexInit,  // cells meeting at each vrtx
-              std::vector<I4> &EdgesOnVertexInit   // edges meeting at each vrtx
+void readMesh(
+    const int MeshFileID, // file ID for open mesh file
+    const MachEnv *InEnv, // input machine environment for MPI layout
+    I4 &NCellsGlobal,     // total number of cells
+    I4 &NEdgesGlobal,     // total number of edges
+    I4 &NVerticesGlobal,  // total number of vertices
+    I4 &MaxEdges,         // max number of edges on a cell
+    I4 &MaxCellsOnEdge,   // max number of cells sharing edge
+    I4 &VertexDegree,     // number of cells/edges sharing vrtx
+    I4 &MaxEdges2,        // twice max number of edges on a cell
+    bool &OnSphere,       // true if mesh is spherical
+    std::vector<I4> &CellsOnCellInit,           // cell neighbors for each cell
+    std::vector<I4> &EdgesOnCellInit,           // edge IDs for each cell edge
+    std::vector<I4> &VerticesOnCellInit,        // vertices around each cell
+    std::vector<I4> &CellsOnEdgeInit,           // cell IDs sharing edge
+    std::vector<I4> &EdgesOnEdgeInit,           // all edges neighboring edge
+    std::vector<I4> &VerticesOnEdgeInit,        // vertices on ends of edge
+    std::vector<I4> &CellsOnVertexInit,         // cells meeting at each vrtx
+    std::vector<I4> &EdgesOnVertexInit,         // edges meeting at each vrtx
+    std::vector<I4> &NCellReconstructEdgesInit, // num stencil edges per cell
+    std::vector<I4> &ReconstructStencilCellInit // stencil edge IDs per cell
 ) {
 
    Error Err; // error code for IO calls
@@ -205,7 +210,32 @@ void readMesh(const int MeshFileID, // file ID for open mesh file
          ABORT_ERROR("Decomp: Bad MaxCellsOnEdge/TWO ({}) read from file",
                      MaxCellsOnEdge);
    }
-   I4 MaxEdgesOnEdge = 2 * MaxEdges; // 2*MaxCellsOnEdge
+
+   DimName    = "MaxEdges2";
+   DimNameOld = "maxEdges2";
+   I4 MaxEdges2ID;
+   Err = IO::getDimFromFile(MeshFileID, DimName, MaxEdges2ID, MaxEdges2);
+   if (Err.isFail()) { // dim not found, try again with older MPAS name
+      Err = IO::getDimFromFile(MeshFileID, DimNameOld, MaxEdges2ID, MaxEdges2);
+      CHECK_ERROR_ABORT(Err, "Decomp: error reading MaxEdges2");
+      if (MaxEdges2 <= 0)
+         ABORT_ERROR("Decomp: Bad MaxEdges2 ({}) read from file", MaxEdges2);
+   }
+   I4 MaxEdgesOnEdge = MaxEdges2; // 2*MaxEdges, used below for
+                                  // EdgesOnEdge/WeightsOnEdge offsets
+
+   // Determine whether the mesh is spherical or planar. This duplicates
+   // (temporarily) the OnSphere/on_a_sphere attribute parsing HorzMesh
+   // does via the full IOStream mechanism - here we just need a quick
+   // answer to decide whether the reconstruction stencil arrays (currently
+   // only generated for spherical meshes) are present in the file.
+   std::string OnSphereStr;
+   Err = IO::readMeta("OnSphere", OnSphereStr, MeshFileID, IO::GlobalID);
+   if (Err.isFail())
+      Err = IO::readMeta("on_a_sphere", OnSphereStr, MeshFileID, IO::GlobalID);
+   std::transform(OnSphereStr.begin(), OnSphereStr.end(), OnSphereStr.begin(),
+                  [](unsigned char c) { return std::tolower(c); });
+   OnSphere = (OnSphereStr == "yes");
 
    // Create the linear decompositions for parallel IO
    // Determine the size of each block, divided as evenly as possible
@@ -276,16 +306,42 @@ void readMesh(const int MeshFileID, // file ID for open mesh file
       } // end loop VertexDegree
    } // end loop NVerticesLocal
 
+   // Offsets for the reconstruction stencil arrays. NCellReconstructEdges is
+   // a scalar per cell; ReconstructStencilCell is MaxEdges2-wide per cell.
+   // Both use the same linear cell chunking as the other XxOnCell arrays.
+   I4 OnCellSizeScalar = NCellsChunk;
+   I4 OnCellSize2      = NCellsChunk * MaxEdges2;
+   std::vector<I4> OnCellDimsScalar{NCellsGlobal};
+   std::vector<I4> OnCellDims2{NCellsGlobal, MaxEdges2};
+   std::vector<I4> OnCellOffsetScalar(OnCellSizeScalar, -1);
+   std::vector<I4> OnCellOffset2(OnCellSize2, -1);
+   for (int Cell = 0; Cell < NCellsLocal; ++Cell) {
+      I4 CellGlob              = MyTask * NCellsChunk + Cell;
+      OnCellOffsetScalar[Cell] = CellGlob;
+      for (int Edge = 0; Edge < MaxEdges2; ++Edge) {
+         OnCellOffset2[Cell * MaxEdges2 + Edge] = CellGlob * MaxEdges2 + Edge;
+      }
+   }
+
    // Create the parallel IO decompositions
-   IO::Rearranger Rearr = IO::RearrBox;
-   I4 OnCellDecomp      = IO::createDecomp(IO::IOTypeI4, NDims, OnCellDims,
-                                           OnCellSize, OnCellOffset, Rearr);
-   I4 OnEdgeDecomp      = IO::createDecomp(IO::IOTypeI4, NDims, OnEdgeDims,
-                                           OnEdgeSize, OnEdgeOffset, Rearr);
-   I4 OnEdgeDecomp2     = IO::createDecomp(IO::IOTypeI4, NDims, OnEdgeDims2,
-                                           OnEdgeSize2, OnEdgeOffset2, Rearr);
-   I4 OnVertexDecomp    = IO::createDecomp(IO::IOTypeI4, NDims, OnVertexDims,
-                                           OnVertexSize, OnVertexOffset, Rearr);
+   IO::Rearranger Rearr  = IO::RearrBox;
+   I4 OnCellDecomp       = IO::createDecomp(IO::IOTypeI4, NDims, OnCellDims,
+                                            OnCellSize, OnCellOffset, Rearr);
+   I4 OnEdgeDecomp       = IO::createDecomp(IO::IOTypeI4, NDims, OnEdgeDims,
+                                            OnEdgeSize, OnEdgeOffset, Rearr);
+   I4 OnEdgeDecomp2      = IO::createDecomp(IO::IOTypeI4, NDims, OnEdgeDims2,
+                                            OnEdgeSize2, OnEdgeOffset2, Rearr);
+   I4 OnVertexDecomp     = IO::createDecomp(IO::IOTypeI4, NDims, OnVertexDims,
+                                            OnVertexSize, OnVertexOffset, Rearr);
+   I4 OnCellDecompScalar = -1;
+   I4 OnCellDecomp2      = -1;
+   if (OnSphere) {
+      OnCellDecompScalar =
+          IO::createDecomp(IO::IOTypeI4, 1, OnCellDimsScalar, OnCellSizeScalar,
+                           OnCellOffsetScalar, Rearr);
+      OnCellDecomp2 = IO::createDecomp(IO::IOTypeI4, NDims, OnCellDims2,
+                                       OnCellSize2, OnCellOffset2, Rearr);
+   }
 
    // Now read the connectivity arrays. Try reading under the new Omega
    // name convention and the older MPAS mesh names.
@@ -386,11 +442,37 @@ void readMesh(const int MeshFileID, // file ID for open mesh file
       CHECK_ERROR_ABORT(Err, "Decomp: error reading EdgesOnVertex");
    }
 
+   // Vector reconstruction stencil - Omega-native fields, no legacy MPAS
+   // name to fall back on. These are mesh-dependent, precomputed as a
+   // preprocessing step (least-squares pseudo-inverse). Only spherical
+   // meshes currently have these fields, so require them only in that case.
+   if (OnSphere) {
+      NCellReconstructEdgesInit.resize(OnCellSizeScalar);
+      ReconstructStencilCellInit.resize(OnCellSize2);
+
+      VarName = "NCellReconstructEdges";
+      int NCellReconstructEdgesID;
+      Err = IO::readArray(&NCellReconstructEdgesInit[0], OnCellSizeScalar,
+                          VarName, MeshFileID, OnCellDecompScalar,
+                          NCellReconstructEdgesID);
+      CHECK_ERROR_ABORT(Err, "Decomp: error reading NCellReconstructEdges");
+
+      VarName = "ReconstructStencilCell";
+      int ReconstructStencilCellID;
+      Err = IO::readArray(&ReconstructStencilCellInit[0], OnCellSize2, VarName,
+                          MeshFileID, OnCellDecomp2, ReconstructStencilCellID);
+      CHECK_ERROR_ABORT(Err, "Decomp: error reading ReconstructStencilCell");
+   }
+
    // Initial decompositions are no longer needed so remove them now
    IO::destroyDecomp(OnCellDecomp);
    IO::destroyDecomp(OnEdgeDecomp);
    IO::destroyDecomp(OnEdgeDecomp2);
    IO::destroyDecomp(OnVertexDecomp);
+   if (OnSphere) {
+      IO::destroyDecomp(OnCellDecompScalar);
+      IO::destroyDecomp(OnCellDecomp2);
+   }
 
 } // end readMesh
 
@@ -492,13 +574,16 @@ Decomp::Decomp(
    std::vector<I4> VerticesOnEdgeInit;
    std::vector<I4> CellsOnVertexInit;
    std::vector<I4> EdgesOnVertexInit;
+   std::vector<I4> NCellReconstructEdgesInit;
+   std::vector<I4> ReconstructStencilCellInit;
    HaloWidth = InHaloWidth;
 
    readMesh(FileID, InEnv, NCellsGlobal, NEdgesGlobal, NVerticesGlobal,
-            MaxEdges, MaxCellsOnEdge, VertexDegree, CellsOnCellInit,
-            EdgesOnCellInit, VerticesOnCellInit, CellsOnEdgeInit,
-            EdgesOnEdgeInit, VerticesOnEdgeInit, CellsOnVertexInit,
-            EdgesOnVertexInit);
+            MaxEdges, MaxCellsOnEdge, VertexDegree, MaxEdges2, OnSphere,
+            CellsOnCellInit, EdgesOnCellInit, VerticesOnCellInit,
+            CellsOnEdgeInit, EdgesOnEdgeInit, VerticesOnEdgeInit,
+            CellsOnVertexInit, EdgesOnVertexInit, NCellReconstructEdgesInit,
+            ReconstructStencilCellInit);
 
    // Close file
    IO::closeFile(FileID);
@@ -545,6 +630,19 @@ Decomp::Decomp(
    rearrangeCellArrays(InEnv, CellsOnCellInit, EdgesOnCellInit,
                        VerticesOnCellInit);
    TimerFlag = Pacer::stop("Decomp rearrange cells", 2) && TimerFlag;
+
+   // Redistribute the vector reconstruction stencil arrays to the same
+   // final cell decomposition. This can happen as soon as CellID/CellLoc
+   // are finalized above - it does not participate in defining the
+   // decomposition itself, unlike CellsOnCellInit. Only spherical meshes
+   // currently have these arrays.
+   if (OnSphere) {
+      TimerFlag =
+          Pacer::start("Decomp rearrange recon stencil", 2) && TimerFlag;
+      rearrangeReconstructArrays(InEnv, NCellReconstructEdgesInit,
+                                 ReconstructStencilCellInit);
+      TimerFlag = Pacer::stop("Decomp rearrange recon stencil", 2) && TimerFlag;
+   }
 
    // Partition the edges
    TimerFlag = Pacer::start("Decomp part edges", 2) && TimerFlag;
@@ -629,6 +727,28 @@ Decomp::Decomp(
             GlobToLocEdge[GlobID] = NEdgesAll; // add an entry to map
          }
          EdgesOnCellH(Cell, Edge) = LocalAdd;
+      }
+   }
+
+   // ReconstructStencilCell - translated the same way as EdgesOnCell, but
+   // without compaction: column J must stay in place so it remains aligned
+   // with column J of ReconstructWeightsCell (read separately in HorzMesh).
+   // NCellReconstructEdgesH is a count, not an ID, and needs no translation.
+   // Only spherical meshes currently have this array.
+   if (OnSphere) {
+      for (int Cell = 0; Cell < NCellsSize; ++Cell) {
+         for (int Edge = 0; Edge < MaxEdges2; ++Edge) {
+            I4 GlobID = ReconstructStencilCellH(Cell, Edge);
+            auto it   = GlobToLocEdge.find(GlobID);
+            I4 LocalAdd;
+            if (it != GlobToLocEdge.end()) {
+               LocalAdd = it->second; // retrieve map entry if exists
+            } else {
+               LocalAdd = NEdgesAll; // otherwise set to bndy/unknown address
+               GlobToLocEdge[GlobID] = NEdgesAll; // add an entry to map
+            }
+            ReconstructStencilCellH(Cell, Edge) = LocalAdd;
+         }
       }
    }
 
@@ -759,8 +879,14 @@ Decomp::Decomp(
 
    CellsOnVertex = createDeviceMirrorCopy(CellsOnVertexH);
    EdgesOnVertex = createDeviceMirrorCopy(EdgesOnVertexH);
-   TimerFlag     = Pacer::stop("Decomp construct device copy", 2) && TimerFlag;
-   TimerFlag     = Pacer::stop("Decomp construct", 1) && TimerFlag;
+
+   // Only spherical meshes currently have the reconstruction stencil arrays
+   if (OnSphere) {
+      NCellReconstructEdges  = createDeviceMirrorCopy(NCellReconstructEdgesH);
+      ReconstructStencilCell = createDeviceMirrorCopy(ReconstructStencilCellH);
+   }
+   TimerFlag = Pacer::stop("Decomp construct device copy", 2) && TimerFlag;
+   TimerFlag = Pacer::stop("Decomp construct", 1) && TimerFlag;
    if (!TimerFlag)
       LOG_WARN("Decomp constructor: Error encounterd in timers");
 } // end decomposition constructor
@@ -2101,6 +2227,127 @@ void Decomp::rearrangeCellArrays(
    return;
 
 } // end function rearrangeCellArrays
+
+//------------------------------------------------------------------------------
+// Redistribute the vector reconstruction stencil arrays (NCellReconstructEdges
+// and ReconstructStencilCell) to the final cell decomposition. Follows the
+// same linear-chunk broadcast/search pattern as rearrangeCellArrays, but -
+// unlike EdgesOnCell - entries are copied verbatim without compaction: column
+// J of ReconstructStencilCell must stay aligned with column J of
+// ReconstructWeightsCell, which is read separately (and not reordered) in
+// HorzMesh. On exit, ReconstructStencilCellH still holds global edge IDs
+// (translation to local indices happens later, once GlobToLocEdge exists).
+
+void Decomp::rearrangeReconstructArrays(
+    const MachEnv *InEnv, //< [in] MachEnv for the new partition
+    const std::vector<I4>
+        &NCellReconstructEdgesInit, //< [in] num stencil edges per cell
+    const std::vector<I4>
+        &ReconstructStencilCellInit //< [in] stencil edge IDs per cell
+) {
+
+   bool TimerFlag = Pacer::start("rearrangeReconstructArrays", 3);
+
+   // Extract some MPI information
+   MPI_Comm Comm = InEnv->getComm();
+   I4 NumTasks   = InEnv->getNumTasks();
+   I4 MyTask     = InEnv->getMyTask();
+
+   // Define the chunk sizes for the initial linear distribution - same
+   // chunking used for CellsOnCellInit etc in rearrangeCellArrays
+   I4 NCellsChunk = (NCellsGlobal - 1) / NumTasks + 1;
+
+   // Buffer per cell holds the MaxEdges2 stencil entries plus the 1 count
+   I4 SizePerCell = MaxEdges2 + 1;
+   I4 BufSize     = NCellsChunk * SizePerCell;
+   std::vector<I4> CellBuf(BufSize);
+
+   // Create temporary arrays for holding the results. Initialize stencil
+   // entries to NEdgesGlobal+1 to denote a non-existent/padding entry -
+   // the same sentinel used (and already mapped in GlobToLocEdge) for
+   // EdgesOnCell.
+   HostArray2DI4 ReconstructStencilCellTmp("ReconstructStencilCell", NCellsSize,
+                                           MaxEdges2);
+   HostArray1DI4 NCellReconstructEdgesTmp("NCellReconstructEdges", NCellsSize);
+   deepCopy(ReconstructStencilCellTmp, NEdgesGlobal + 1);
+   deepCopy(NCellReconstructEdgesTmp, 0);
+
+   // For each cell this task owns, determine the task and local address
+   // of the cell in the initial linear distribution (identical computation
+   // to rearrangeCellArrays - kept local/self-contained here rather than
+   // shared, matching the existing convention where rearrangeEdgeArrays and
+   // rearrangeVertexArrays each recompute their own Task/Add arrays too)
+   std::vector<I4> TaskInit(NCellsSize, NumTasks);
+   std::vector<I4> AddInit(NCellsSize, NCellsGlobal + 1);
+   for (int Cell = 0; Cell < NCellsAll; ++Cell) {
+      int GlobalID = CellIDH(Cell); // one-based
+      if (validCellID(GlobalID)) {
+         TaskInit[Cell] = (GlobalID - 1) / NCellsChunk;
+         AddInit[Cell]  = GlobalID - 1 - TaskInit[Cell] * NCellsChunk;
+      }
+   }
+
+   // Each task will broadcast the cells it owns in the initial linear
+   // distribution and all tasks will search their list of cells to determine
+   // entries it needs.
+   for (int ITask = 0; ITask < NumTasks; ++ITask) {
+
+      TimerFlag = Pacer::start("rearrangeReconBcast", 3) && TimerFlag;
+      // If it is this task's turn to send, fill the buffer with the local
+      // chunk of both arrays.
+      if (MyTask == ITask) { // Fill buffer with local chunk
+         for (int Cell = 0; Cell < NCellsChunk; ++Cell) {
+            I4 BufAdd0       = Cell * SizePerCell;
+            CellBuf[BufAdd0] = NCellReconstructEdgesInit[Cell];
+            for (int Edge = 0; Edge < MaxEdges2; ++Edge) {
+               I4 ArrayAdd = Cell * MaxEdges2 + Edge;
+               CellBuf[BufAdd0 + 1 + Edge] =
+                   ReconstructStencilCellInit[ArrayAdd];
+            }
+         }
+      }
+      Broadcast(CellBuf, InEnv, ITask);
+      TimerFlag = Pacer::stop("rearrangeReconBcast", 3) && TimerFlag;
+
+      // For each cell needed locally, we can compute the task and address
+      // of the cell in the linear distribution and extract from the buffer
+      // if needed
+
+      TimerFlag = Pacer::start("rearrangeReconSearch", 3) && TimerFlag;
+      for (int Cell = 0; Cell < NCellsAll; ++Cell) {
+         if (TaskInit[Cell] == ITask) {
+            if (AddInit[Cell] < NCellsGlobal + 1) {
+
+               // Local cell needs the info so extract from the buffer into
+               // the local address. Unlike EdgesOnCell, we copy every slot
+               // verbatim in its original column position - no compaction -
+               // so the columns stay aligned with ReconstructWeightsCell.
+               I4 BufAdd0                     = AddInit[Cell] * SizePerCell;
+               NCellReconstructEdgesTmp(Cell) = CellBuf[BufAdd0];
+               for (int Edge = 0; Edge < MaxEdges2; ++Edge) {
+                  I4 NbrEdge = CellBuf[BufAdd0 + 1 + Edge];
+                  if (validEdgeID(NbrEdge)) {
+                     ReconstructStencilCellTmp(Cell, Edge) = NbrEdge;
+                  } else {
+                     ReconstructStencilCellTmp(Cell, Edge) = NEdgesGlobal + 1;
+                  }
+               }
+            }
+         }
+      }
+      TimerFlag = Pacer::stop("rearrangeReconSearch", 3) && TimerFlag;
+   } // end loop over MPI tasks
+
+   // Copy to final location on host - wait to create device copies until
+   // the entries are translated to local addresses rather than global IDs
+   ReconstructStencilCellH = ReconstructStencilCellTmp;
+   NCellReconstructEdgesH  = NCellReconstructEdgesTmp;
+
+   // All done
+   TimerFlag = Pacer::stop("rearrangeReconstructArrays", 3) && TimerFlag;
+   return;
+
+} // end function rearrangeReconstructArrays
 
 //------------------------------------------------------------------------------
 // Redistribute the various XxOnEdge index arrays to the final edge

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -116,16 +116,16 @@ void readMesh(
     I4 &VertexDegree,     // number of cells/edges sharing vrtx
     I4 &MaxEdges2,        // twice max number of edges on a cell
     bool &OnSphere,       // true if mesh is spherical
-    std::vector<I4> &CellsOnCellInit,           // cell neighbors for each cell
-    std::vector<I4> &EdgesOnCellInit,           // edge IDs for each cell edge
-    std::vector<I4> &VerticesOnCellInit,        // vertices around each cell
-    std::vector<I4> &CellsOnEdgeInit,           // cell IDs sharing edge
-    std::vector<I4> &EdgesOnEdgeInit,           // all edges neighboring edge
-    std::vector<I4> &VerticesOnEdgeInit,        // vertices on ends of edge
-    std::vector<I4> &CellsOnVertexInit,         // cells meeting at each vrtx
-    std::vector<I4> &EdgesOnVertexInit,         // edges meeting at each vrtx
-    std::vector<I4> &NCellReconstructEdgesInit, // num stencil edges per cell
-    std::vector<I4> &ReconstructStencilCellInit // stencil edge IDs per cell
+    std::vector<I4> &CellsOnCellInit,       // cell neighbors for each cell
+    std::vector<I4> &EdgesOnCellInit,       // edge IDs for each cell edge
+    std::vector<I4> &VerticesOnCellInit,    // vertices around each cell
+    std::vector<I4> &CellsOnEdgeInit,       // cell IDs sharing edge
+    std::vector<I4> &EdgesOnEdgeInit,       // all edges neighboring edge
+    std::vector<I4> &VerticesOnEdgeInit,    // vertices on ends of edge
+    std::vector<I4> &CellsOnVertexInit,     // cells meeting at each vrtx
+    std::vector<I4> &EdgesOnVertexInit,     // edges meeting at each vrtx
+    std::vector<I4> &NEdgesReconOnCellInit, // num stencil edges per cell
+    std::vector<I4> &ReconStencilCellInit   // stencil edge IDs per cell
 ) {
 
    Error Err; // error code for IO calls
@@ -306,8 +306,8 @@ void readMesh(
       } // end loop VertexDegree
    } // end loop NVerticesLocal
 
-   // Offsets for the reconstruction stencil arrays. NCellReconstructEdges is
-   // a scalar per cell; ReconstructStencilCell is MaxEdges2-wide per cell.
+   // Offsets for the reconstruction stencil arrays. NEdgesReconOnCell is
+   // a scalar per cell; ReconStencilCell is MaxEdges2-wide per cell.
    // Both use the same linear cell chunking as the other XxOnCell arrays.
    I4 OnCellSizeScalar = NCellsChunk;
    I4 OnCellSize2      = NCellsChunk * MaxEdges2;
@@ -447,20 +447,19 @@ void readMesh(
    // preprocessing step (least-squares pseudo-inverse). Only spherical
    // meshes currently have these fields, so require them only in that case.
    if (OnSphere) {
-      NCellReconstructEdgesInit.resize(OnCellSizeScalar);
-      ReconstructStencilCellInit.resize(OnCellSize2);
+      NEdgesReconOnCellInit.resize(OnCellSizeScalar);
+      ReconStencilCellInit.resize(OnCellSize2);
 
       VarName = "NCellReconstructEdges";
-      int NCellReconstructEdgesID;
-      Err = IO::readArray(&NCellReconstructEdgesInit[0], OnCellSizeScalar,
-                          VarName, MeshFileID, OnCellDecompScalar,
-                          NCellReconstructEdgesID);
+      int NEdgesReconOnCellID;
+      Err = IO::readArray(&NEdgesReconOnCellInit[0], OnCellSizeScalar, VarName,
+                          MeshFileID, OnCellDecompScalar, NEdgesReconOnCellID);
       CHECK_ERROR_ABORT(Err, "Decomp: error reading NCellReconstructEdges");
 
       VarName = "ReconstructStencilCell";
-      int ReconstructStencilCellID;
-      Err = IO::readArray(&ReconstructStencilCellInit[0], OnCellSize2, VarName,
-                          MeshFileID, OnCellDecomp2, ReconstructStencilCellID);
+      int ReconStencilCellID;
+      Err = IO::readArray(&ReconStencilCellInit[0], OnCellSize2, VarName,
+                          MeshFileID, OnCellDecomp2, ReconStencilCellID);
       CHECK_ERROR_ABORT(Err, "Decomp: error reading ReconstructStencilCell");
    }
 
@@ -574,16 +573,16 @@ Decomp::Decomp(
    std::vector<I4> VerticesOnEdgeInit;
    std::vector<I4> CellsOnVertexInit;
    std::vector<I4> EdgesOnVertexInit;
-   std::vector<I4> NCellReconstructEdgesInit;
-   std::vector<I4> ReconstructStencilCellInit;
+   std::vector<I4> NEdgesReconOnCellInit;
+   std::vector<I4> ReconStencilCellInit;
    HaloWidth = InHaloWidth;
 
    readMesh(FileID, InEnv, NCellsGlobal, NEdgesGlobal, NVerticesGlobal,
             MaxEdges, MaxCellsOnEdge, VertexDegree, MaxEdges2, OnSphere,
             CellsOnCellInit, EdgesOnCellInit, VerticesOnCellInit,
             CellsOnEdgeInit, EdgesOnEdgeInit, VerticesOnEdgeInit,
-            CellsOnVertexInit, EdgesOnVertexInit, NCellReconstructEdgesInit,
-            ReconstructStencilCellInit);
+            CellsOnVertexInit, EdgesOnVertexInit, NEdgesReconOnCellInit,
+            ReconStencilCellInit);
 
    // Close file
    IO::closeFile(FileID);
@@ -639,8 +638,7 @@ Decomp::Decomp(
    if (OnSphere) {
       TimerFlag =
           Pacer::start("Decomp rearrange recon stencil", 2) && TimerFlag;
-      rearrangeReconstructArrays(InEnv, NCellReconstructEdgesInit,
-                                 ReconstructStencilCellInit);
+      rearrangeReconArrays(InEnv, NEdgesReconOnCellInit, ReconStencilCellInit);
       TimerFlag = Pacer::stop("Decomp rearrange recon stencil", 2) && TimerFlag;
    }
 
@@ -730,13 +728,13 @@ Decomp::Decomp(
       }
    }
 
-   // ReconstructStencilCell - translated the same way as EdgesOnCell
-   // NCellReconstructEdgesH is a count, not an ID, and needs no translation.
+   // ReconStencilCell - translated the same way as EdgesOnCell
+   // NEdgeReconOnCellH is a count, not an ID, and needs no translation.
    // Only spherical meshes currently have this array.
    if (OnSphere) {
       for (int Cell = 0; Cell < NCellsSize; ++Cell) {
          for (int Edge = 0; Edge < MaxEdges2; ++Edge) {
-            I4 GlobID = ReconstructStencilCellH(Cell, Edge);
+            I4 GlobID = ReconStencilCellH(Cell, Edge);
             auto it   = GlobToLocEdge.find(GlobID);
             I4 LocalAdd;
             if (it != GlobToLocEdge.end()) {
@@ -745,7 +743,7 @@ Decomp::Decomp(
                LocalAdd = NEdgesAll; // otherwise set to bndy/unknown address
                GlobToLocEdge[GlobID] = NEdgesAll; // add an entry to map
             }
-            ReconstructStencilCellH(Cell, Edge) = LocalAdd;
+            ReconStencilCellH(Cell, Edge) = LocalAdd;
          }
       }
    }
@@ -880,8 +878,8 @@ Decomp::Decomp(
 
    // Only spherical meshes currently have the reconstruction stencil arrays
    if (OnSphere) {
-      NCellReconstructEdges  = createDeviceMirrorCopy(NCellReconstructEdgesH);
-      ReconstructStencilCell = createDeviceMirrorCopy(ReconstructStencilCellH);
+      NEdgesReconOnCell = createDeviceMirrorCopy(NEdgesReconOnCellH);
+      ReconStencilCell  = createDeviceMirrorCopy(ReconStencilCellH);
    }
    TimerFlag = Pacer::stop("Decomp construct device copy", 2) && TimerFlag;
    TimerFlag = Pacer::stop("Decomp construct", 1) && TimerFlag;
@@ -2227,24 +2225,24 @@ void Decomp::rearrangeCellArrays(
 } // end function rearrangeCellArrays
 
 //------------------------------------------------------------------------------
-// Redistribute the vector reconstruction stencil arrays (NCellReconstructEdges
-// and ReconstructStencilCell) to the final cell decomposition. Follows the
+// Redistribute the vector reconstruction stencil arrays (NEdgesReconOnCell
+// and ReconStencilCell) to the final cell decomposition. Follows the
 // same linear-chunk broadcast/search pattern as rearrangeCellArrays, but -
 // unlike EdgesOnCell - entries are copied verbatim without compaction: column
-// J of ReconstructStencilCell must stay aligned with column J of
-// ReconstructWeightsCell, which is read separately (and not reordered) in
-// HorzMesh. On exit, ReconstructStencilCellH still holds global edge IDs
+// J of ReconStencilCell must stay aligned with column J of
+// ReconWeightsCell, which is read separately (and not reordered) in
+// HorzMesh. On exit, ReconStencilCellH still holds global edge IDs
 // (translation to local indices happens later, once GlobToLocEdge exists).
 
-void Decomp::rearrangeReconstructArrays(
+void Decomp::rearrangeReconArrays(
     const MachEnv *InEnv, //< [in] MachEnv for the new partition
     const std::vector<I4>
-        &NCellReconstructEdgesInit, //< [in] num stencil edges per cell
+        &NEdgesReconOnCellInit, //< [in] num stencil edges per cell
     const std::vector<I4>
-        &ReconstructStencilCellInit //< [in] stencil edge IDs per cell
+        &ReconStencilCellInit //< [in] stencil edge IDs per cell
 ) {
 
-   bool TimerFlag = Pacer::start("rearrangeReconstructArrays", 3);
+   bool TimerFlag = Pacer::start("rearrangeReconArrays", 3);
 
    // Extract some MPI information
    MPI_Comm Comm = InEnv->getComm();
@@ -2264,11 +2262,10 @@ void Decomp::rearrangeReconstructArrays(
    // entries to NEdgesGlobal+1 to denote a non-existent/padding entry -
    // the same sentinel used (and already mapped in GlobToLocEdge) for
    // EdgesOnCell.
-   HostArray2DI4 ReconstructStencilCellTmp("ReconstructStencilCell", NCellsSize,
-                                           MaxEdges2);
-   HostArray1DI4 NCellReconstructEdgesTmp("NCellReconstructEdges", NCellsSize);
-   deepCopy(ReconstructStencilCellTmp, NEdgesGlobal + 1);
-   deepCopy(NCellReconstructEdgesTmp, 0);
+   HostArray2DI4 ReconStencilCellTmp("ReconStencilCell", NCellsSize, MaxEdges2);
+   HostArray1DI4 NEdgesReconOnCellTmp("NEdgesReconOnCell", NCellsSize);
+   deepCopy(ReconStencilCellTmp, NEdgesGlobal + 1);
+   deepCopy(NEdgesReconOnCellTmp, 0);
 
    // For each cell this task owns, determine the task and local address
    // of the cell in the initial linear distribution (identical computation
@@ -2296,11 +2293,10 @@ void Decomp::rearrangeReconstructArrays(
       if (MyTask == ITask) { // Fill buffer with local chunk
          for (int Cell = 0; Cell < NCellsChunk; ++Cell) {
             I4 BufAdd0       = Cell * SizePerCell;
-            CellBuf[BufAdd0] = NCellReconstructEdgesInit[Cell];
+            CellBuf[BufAdd0] = NEdgesReconOnCellInit[Cell];
             for (int Edge = 0; Edge < MaxEdges2; ++Edge) {
-               I4 ArrayAdd = Cell * MaxEdges2 + Edge;
-               CellBuf[BufAdd0 + 1 + Edge] =
-                   ReconstructStencilCellInit[ArrayAdd];
+               I4 ArrayAdd                 = Cell * MaxEdges2 + Edge;
+               CellBuf[BufAdd0 + 1 + Edge] = ReconStencilCellInit[ArrayAdd];
             }
          }
       }
@@ -2319,15 +2315,15 @@ void Decomp::rearrangeReconstructArrays(
                // Local cell needs the info so extract from the buffer into
                // the local address. Unlike EdgesOnCell, we copy every slot
                // verbatim in its original column position - no compaction -
-               // so the columns stay aligned with ReconstructWeightsCell.
-               I4 BufAdd0                     = AddInit[Cell] * SizePerCell;
-               NCellReconstructEdgesTmp(Cell) = CellBuf[BufAdd0];
+               // so the columns stay aligned with ReconWeightsCell.
+               I4 BufAdd0                 = AddInit[Cell] * SizePerCell;
+               NEdgesReconOnCellTmp(Cell) = CellBuf[BufAdd0];
                for (int Edge = 0; Edge < MaxEdges2; ++Edge) {
                   I4 NbrEdge = CellBuf[BufAdd0 + 1 + Edge];
                   if (validEdgeID(NbrEdge)) {
-                     ReconstructStencilCellTmp(Cell, Edge) = NbrEdge;
+                     ReconStencilCellTmp(Cell, Edge) = NbrEdge;
                   } else {
-                     ReconstructStencilCellTmp(Cell, Edge) = NEdgesGlobal + 1;
+                     ReconStencilCellTmp(Cell, Edge) = NEdgesGlobal + 1;
                   }
                }
             }
@@ -2338,14 +2334,14 @@ void Decomp::rearrangeReconstructArrays(
 
    // Copy to final location on host - wait to create device copies until
    // the entries are translated to local addresses rather than global IDs
-   ReconstructStencilCellH = ReconstructStencilCellTmp;
-   NCellReconstructEdgesH  = NCellReconstructEdgesTmp;
+   ReconStencilCellH  = ReconStencilCellTmp;
+   NEdgesReconOnCellH = NEdgesReconOnCellTmp;
 
    // All done
-   TimerFlag = Pacer::stop("rearrangeReconstructArrays", 3) && TimerFlag;
+   TimerFlag = Pacer::stop("rearrangeReconArrays", 3) && TimerFlag;
    return;
 
-} // end function rearrangeReconstructArrays
+} // end function rearrangeReconArrays
 
 //------------------------------------------------------------------------------
 // Redistribute the various XxOnEdge index arrays to the final edge

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -730,9 +730,7 @@ Decomp::Decomp(
       }
    }
 
-   // ReconstructStencilCell - translated the same way as EdgesOnCell, but
-   // without compaction: column J must stay in place so it remains aligned
-   // with column J of ReconstructWeightsCell (read separately in HorzMesh).
+   // ReconstructStencilCell - translated the same way as EdgesOnCell
    // NCellReconstructEdgesH is a count, not an ID, and needs no translation.
    // Only spherical meshes currently have this array.
    if (OnSphere) {

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -450,17 +450,17 @@ void readMesh(
       NEdgesReconOnCellInit.resize(OnCellSizeScalar);
       ReconStencilCellInit.resize(OnCellSize2);
 
-      VarName = "NCellReconstructEdges";
+      VarName = "NEdgesReconOnCell";
       int NEdgesReconOnCellID;
       Err = IO::readArray(&NEdgesReconOnCellInit[0], OnCellSizeScalar, VarName,
                           MeshFileID, OnCellDecompScalar, NEdgesReconOnCellID);
-      CHECK_ERROR_ABORT(Err, "Decomp: error reading NCellReconstructEdges");
+      CHECK_ERROR_ABORT(Err, "Decomp: error reading NEdgesReconOnCell");
 
-      VarName = "ReconstructStencilCell";
+      VarName = "ReconStencilCell";
       int ReconStencilCellID;
       Err = IO::readArray(&ReconStencilCellInit[0], OnCellSize2, VarName,
                           MeshFileID, OnCellDecomp2, ReconStencilCellID);
-      CHECK_ERROR_ABORT(Err, "Decomp: error reading ReconstructStencilCell");
+      CHECK_ERROR_ABORT(Err, "Decomp: error reading ReconStencilCell");
    }
 
    // Initial decompositions are no longer needed so remove them now

--- a/components/omega/src/base/Decomp.h
+++ b/components/omega/src/base/Decomp.h
@@ -141,18 +141,18 @@ class Decomp {
    );
 
    /// Redistribute the vector reconstruction stencil arrays
-   /// (NCellReconstructEdges, ReconstructStencilCell) to the final cell
+   /// (NEdgesReconOnCell, ReconStencilCell) to the final cell
    /// decomposition. Unlike rearrangeCellArrays, entries are copied verbatim
-   /// (no compaction of unused/padded slots) because ReconstructStencilCell
-   /// columns are positionally paired with the ReconstructWeightsCell array
+   /// (no compaction of unused/padded slots) because ReconStencilCell
+   /// columns are positionally paired with the ReconWeightsCell array
    /// read separately in HorzMesh. Must be called after rearrangeCellArrays
    /// has established CellID/CellLoc for the final partition.
-   void rearrangeReconstructArrays(
+   void rearrangeReconArrays(
        const MachEnv *InEnv, ///< [in] MachEnv for the new partition
        const std::vector<I4>
-           &NCellReconstructEdgesInit, ///< [in] num stencil edges per cell
+           &NEdgesReconOnCellInit, ///< [in] num stencil edges per cell
        const std::vector<I4>
-           &ReconstructStencilCellInit ///< [in] stencil edge IDs per cell
+           &ReconStencilCellInit ///< [in] stencil edge IDs per cell
    );
 
    /// Redistribute the various XxOnEdge index arrays to the final edge
@@ -276,18 +276,17 @@ class Decomp {
    HostArray2DI4 EdgesOnVertexH; ///< Indx of edges sharing vertex as endpoint
 
    // Vector reconstruction stencil (mesh-dependent, precomputed and stored
-   // in the mesh file - see HorzMesh for the paired ReconstructWeightsCell)
+   // in the mesh file - see HorzMesh for the paired ReconWeightsCell)
 
    bool OnSphere; ///< true if mesh is spherical (temporary local read of
                   ///< the OnSphere attribute - only spherical meshes
                   ///< currently have the reconstruction stencil below)
 
-   Array1DI4 NCellReconstructEdges; ///< Num of edges in reconstruction stencil
-   HostArray1DI4
-       NCellReconstructEdgesH; ///< Num of edges in reconstruction stencil
+   Array1DI4 NEdgesReconOnCell;      ///< Num of edges in reconstruction stencil
+   HostArray1DI4 NEdgesReconOnCellH; ///< Num of edges in reconstruction stencil
 
-   Array2DI4 ReconstructStencilCell;      ///< Local edge indices in the stencil
-   HostArray2DI4 ReconstructStencilCellH; ///< Local edge indices in the stencil
+   Array2DI4 ReconStencilCell;      ///< Local edge indices in the stencil
+   HostArray2DI4 ReconStencilCellH; ///< Local edge indices in the stencil
 
    // Methods
 

--- a/components/omega/src/base/Decomp.h
+++ b/components/omega/src/base/Decomp.h
@@ -140,6 +140,21 @@ class Decomp {
        const std::vector<I4> &VerticesOnCellInit ///< [in] vertices around cell
    );
 
+   /// Redistribute the vector reconstruction stencil arrays
+   /// (NCellReconstructEdges, ReconstructStencilCell) to the final cell
+   /// decomposition. Unlike rearrangeCellArrays, entries are copied verbatim
+   /// (no compaction of unused/padded slots) because ReconstructStencilCell
+   /// columns are positionally paired with the ReconstructWeightsCell array
+   /// read separately in HorzMesh. Must be called after rearrangeCellArrays
+   /// has established CellID/CellLoc for the final partition.
+   void rearrangeReconstructArrays(
+       const MachEnv *InEnv, ///< [in] MachEnv for the new partition
+       const std::vector<I4>
+           &NCellReconstructEdgesInit, ///< [in] num stencil edges per cell
+       const std::vector<I4>
+           &ReconstructStencilCellInit ///< [in] stencil edge IDs per cell
+   );
+
    /// Redistribute the various XxOnEdge index arrays to the final edge
    /// decomposition. The inputs are the various XxOnEdge arrays in the
    /// initial linear distribution. On exit, all the XxOnEdge arrays are
@@ -193,6 +208,7 @@ class Decomp {
    I4 NCellsAll;    ///< Total number of local cells (owned + all halo)
    I4 NCellsSize;   ///< Array size (incl padding, bndy cell) for cell arrays
    I4 MaxEdges;     ///< Max number of edges around a cell
+   I4 MaxEdges2;    ///< Twice max number of edges (2-edge-wide stencils)
 
    Array1DI4 NCellsHalo;      ///< num cells owned+halo for halo layer
    HostArray1DI4 NCellsHaloH; ///< num cells owned+halo for halo layer
@@ -258,6 +274,20 @@ class Decomp {
 
    Array2DI4 EdgesOnVertex;      ///< Indx of edges sharing vertex as endpoint
    HostArray2DI4 EdgesOnVertexH; ///< Indx of edges sharing vertex as endpoint
+
+   // Vector reconstruction stencil (mesh-dependent, precomputed and stored
+   // in the mesh file - see HorzMesh for the paired ReconstructWeightsCell)
+
+   bool OnSphere; ///< true if mesh is spherical (temporary local read of
+                  ///< the OnSphere attribute - only spherical meshes
+                  ///< currently have the reconstruction stencil below)
+
+   Array1DI4 NCellReconstructEdges; ///< Num of edges in reconstruction stencil
+   HostArray1DI4
+       NCellReconstructEdgesH; ///< Num of edges in reconstruction stencil
+
+   Array2DI4 ReconstructStencilCell;      ///< Local edge indices in the stencil
+   HostArray2DI4 ReconstructStencilCellH; ///< Local edge indices in the stencil
 
    // Methods
 

--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -1044,14 +1044,14 @@ void HorzMesh::defineMeshFields() {
       auto ReconstructWeightsCellField = Field::create(
           FieldName, // field name
           "weights to reconstruct Cartesian vector field from edge-"
-          "normal values at cell centers",  // long name
-          "",                               // units
-          "",                               // CF standard name
-          std::numeric_limits<Real>::min(), // min valid value
-          std::numeric_limits<Real>::max(), // max valid value
-          NDims,                            // num of dimensions
-          DimNames,                         // dimension names
-          false                             // not time dependent
+          "normal values at cell centers",     // long name
+          "",                                  // units
+          "",                                  // CF standard name
+          std::numeric_limits<Real>::lowest(), // min valid value
+          std::numeric_limits<Real>::max(),    // max valid value
+          NDims,                               // num of dimensions
+          DimNames,                            // dimension names
+          false                                // not time dependent
       );
       MeshGroupIn->addField(FieldName);
       Field::attachFieldData<Array3DReal>(FieldName, ReconstructWeightsCell);

--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -20,6 +20,8 @@
 #include "IOStream.h"
 #include "OmegaKokkos.h"
 
+#include <limits>
+
 namespace OMEGA {
 
 // create the static class members
@@ -69,7 +71,7 @@ HorzMesh::HorzMesh(const std::string &Name, //< [in] Name for new mesh
    NEdgesSize     = MeshDecomp->NEdgesSize;
    MaxCellsOnEdge = MeshDecomp->MaxCellsOnEdge;
    MaxEdges       = MeshDecomp->MaxEdges;
-   MaxEdges2      = 2 * MaxEdges;
+   MaxEdges2      = MeshDecomp->MaxEdges2;
    NEdgesGlobal   = MeshDecomp->NEdgesGlobal;
 
    NVerticesHalo  = MeshDecomp->NVerticesHalo;
@@ -83,34 +85,48 @@ HorzMesh::HorzMesh(const std::string &Name, //< [in] Name for new mesh
 
    CellID = MeshDecomp->CellID;
 
-   CellsOnCellH    = MeshDecomp->CellsOnCellH;
-   EdgesOnCellH    = MeshDecomp->EdgesOnCellH;
-   NEdgesOnCellH   = MeshDecomp->NEdgesOnCellH;
-   VerticesOnCellH = MeshDecomp->VerticesOnCellH;
-   CellsOnEdgeH    = MeshDecomp->CellsOnEdgeH;
-   EdgesOnEdgeH    = MeshDecomp->EdgesOnEdgeH;
-   NEdgesOnEdgeH   = MeshDecomp->NEdgesOnEdgeH;
-   VerticesOnEdgeH = MeshDecomp->VerticesOnEdgeH;
-   CellsOnVertexH  = MeshDecomp->CellsOnVertexH;
-   EdgesOnVertexH  = MeshDecomp->EdgesOnVertexH;
+   CellsOnCellH            = MeshDecomp->CellsOnCellH;
+   EdgesOnCellH            = MeshDecomp->EdgesOnCellH;
+   NEdgesOnCellH           = MeshDecomp->NEdgesOnCellH;
+   VerticesOnCellH         = MeshDecomp->VerticesOnCellH;
+   CellsOnEdgeH            = MeshDecomp->CellsOnEdgeH;
+   EdgesOnEdgeH            = MeshDecomp->EdgesOnEdgeH;
+   NEdgesOnEdgeH           = MeshDecomp->NEdgesOnEdgeH;
+   VerticesOnEdgeH         = MeshDecomp->VerticesOnEdgeH;
+   CellsOnVertexH          = MeshDecomp->CellsOnVertexH;
+   EdgesOnVertexH          = MeshDecomp->EdgesOnVertexH;
+   NCellReconstructEdgesH  = MeshDecomp->NCellReconstructEdgesH;
+   ReconstructStencilCellH = MeshDecomp->ReconstructStencilCellH;
 
-   CellsOnCell    = MeshDecomp->CellsOnCell;
-   EdgesOnCell    = MeshDecomp->EdgesOnCell;
-   NEdgesOnCell   = MeshDecomp->NEdgesOnCell;
-   VerticesOnCell = MeshDecomp->VerticesOnCell;
-   CellsOnEdge    = MeshDecomp->CellsOnEdge;
-   EdgesOnEdge    = MeshDecomp->EdgesOnEdge;
-   NEdgesOnEdge   = MeshDecomp->NEdgesOnEdge;
-   VerticesOnEdge = MeshDecomp->VerticesOnEdge;
-   CellsOnVertex  = MeshDecomp->CellsOnVertex;
-   EdgesOnVertex  = MeshDecomp->EdgesOnVertex;
+   CellsOnCell            = MeshDecomp->CellsOnCell;
+   EdgesOnCell            = MeshDecomp->EdgesOnCell;
+   NEdgesOnCell           = MeshDecomp->NEdgesOnCell;
+   VerticesOnCell         = MeshDecomp->VerticesOnCell;
+   CellsOnEdge            = MeshDecomp->CellsOnEdge;
+   EdgesOnEdge            = MeshDecomp->EdgesOnEdge;
+   NEdgesOnEdge           = MeshDecomp->NEdgesOnEdge;
+   VerticesOnEdge         = MeshDecomp->VerticesOnEdge;
+   CellsOnVertex          = MeshDecomp->CellsOnVertex;
+   EdgesOnVertex          = MeshDecomp->EdgesOnVertex;
+   NCellReconstructEdges  = MeshDecomp->NCellReconstructEdges;
+   ReconstructStencilCell = MeshDecomp->ReconstructStencilCell;
+
+   // OnSphere is needed early (before the mesh field definitions below)
+   // to decide whether to define the ReconstructWeightsCell field, so we
+   // use the value Decomp already read from the mesh file. It is
+   // redetermined below (with the rest of the sphere/plane attributes)
+   // once the full mesh stream is read, which is redundant but harmless
+   // since both come from the same file.
+   OnSphere = MeshDecomp->OnSphere;
 
    // Create Omega Dimensions associated with this mesh
    createDimensions(MeshDecomp);
 
-   // Allocate remaining device arrays and define all mesh fields for associated
-   // I/O and initialization.  Equivalent host arrays will be allocated and
-   // initialized after the fields are filled on the device.
+   // Allocate remaining device arrays and define all mesh fields for
+   // associated I/O and initialization. Equivalent host arrays will be
+   // allocated and initialized after the fields are filled on the device.
+   // This must happen before the mesh stream is read below, since the
+   // read populates the arrays attached to these fields.
    defineMeshFields();
 
    // Read the input mesh stream to fill most of the fields
@@ -275,6 +291,8 @@ void HorzMesh::createDimensions(Decomp *MeshDecomp) {
       auto MaxEdgesDim = Dimension::create("MaxEdges2", MaxEdges2);
    if (!Dimension::exists("VertexDegree"))
       auto VertexDegreeDim = Dimension::create("VertexDegree", VertexDegree);
+   if (!Dimension::exists("R3"))
+      auto R3Dim = Dimension::create("R3", 3);
 
    // For distributed dimensions we need to compute offsets along each
    // dimension (the global offset at each local point with -1 for non-owned
@@ -444,6 +462,19 @@ void HorzMesh::completeReadArrays() {
    HorzMeshHalo->exchangeFullArrayHalo(FCell, OnCell);
    HorzMeshHalo->exchangeFullArrayHalo(FEdge, OnEdge);
    HorzMeshHalo->exchangeFullArrayHalo(FVertex, OnVertex);
+   // ReconstructWeightsCell is (NCells, R3, MaxEdges2) to match the mesh
+   // file's on-disk dimension order. Halo's generic 3D exchange expects
+   // the mesh dimension in the middle (as in Tracers' [Tracer, Cell,
+   // Vert]), so exchange each R3 component as a 2D (Cell, MaxEdges2)
+   // slice instead of the full 3D array.
+   if (OnSphere) {
+      for (int IComp = 0; IComp < 3; ++IComp) {
+         auto ReconstructWeightsCellSlice = Kokkos::subview(
+             ReconstructWeightsCell, Kokkos::ALL, IComp, Kokkos::ALL);
+         HorzMeshHalo->exchangeFullArrayHalo(ReconstructWeightsCellSlice,
+                                             OnCell);
+      }
+   }
 
    // Create host copies
    XCellH             = createHostMirrorCopy(XCell);
@@ -472,6 +503,9 @@ void HorzMesh::completeReadArrays() {
    FCellH             = createHostMirrorCopy(FCell);
    FEdgeH             = createHostMirrorCopy(FEdge);
    FVertexH           = createHostMirrorCopy(FVertex);
+   if (OnSphere) {
+      ReconstructWeightsCellH = createHostMirrorCopy(ReconstructWeightsCell);
+   }
 
 } // end completeReadArrays
 
@@ -993,6 +1027,35 @@ void HorzMesh::defineMeshFields() {
        );
    MeshGroupIn->addField(FieldName);
    Field::attachFieldData<Array1DReal>(FieldName, FCell);
+
+   if (OnSphere) {
+      // Vector Reconstruction
+      // NCellReconstructEdges/ReconstructStencilCell come from Decomp (see
+      // constructor), not read here. ReconstructWeightsCell is pure data and
+      // is read as a normal mesh field below.
+      NDims = 3;
+      DimNames.resize(NDims);
+      DimNames[0] = "NCells";
+      DimNames[1] = "R3";
+      DimNames[2] = "MaxEdges2";
+      FieldName   = "ReconstructWeightsCell";
+      ReconstructWeightsCell =
+          Array3DReal("ReconstructWeightsCell", NCellsSize, 3, MaxEdges2);
+      auto ReconstructWeightsCellField = Field::create(
+          FieldName, // field name
+          "weights to reconstruct Cartesian vector field from edge-"
+          "normal values at cell centers",  // long name
+          "",                               // units
+          "",                               // CF standard name
+          std::numeric_limits<Real>::min(), // min valid value
+          std::numeric_limits<Real>::max(), // max valid value
+          NDims,                            // num of dimensions
+          DimNames,                         // dimension names
+          false                             // not time dependent
+      );
+      MeshGroupIn->addField(FieldName);
+      Field::attachFieldData<Array3DReal>(FieldName, ReconstructWeightsCell);
+   }
 
    // The sign and scaling fields are computed internally so are allocated
    // here. Because they are not read from a file or typically written to a

--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -85,34 +85,34 @@ HorzMesh::HorzMesh(const std::string &Name, //< [in] Name for new mesh
 
    CellID = MeshDecomp->CellID;
 
-   CellsOnCellH            = MeshDecomp->CellsOnCellH;
-   EdgesOnCellH            = MeshDecomp->EdgesOnCellH;
-   NEdgesOnCellH           = MeshDecomp->NEdgesOnCellH;
-   VerticesOnCellH         = MeshDecomp->VerticesOnCellH;
-   CellsOnEdgeH            = MeshDecomp->CellsOnEdgeH;
-   EdgesOnEdgeH            = MeshDecomp->EdgesOnEdgeH;
-   NEdgesOnEdgeH           = MeshDecomp->NEdgesOnEdgeH;
-   VerticesOnEdgeH         = MeshDecomp->VerticesOnEdgeH;
-   CellsOnVertexH          = MeshDecomp->CellsOnVertexH;
-   EdgesOnVertexH          = MeshDecomp->EdgesOnVertexH;
-   NCellReconstructEdgesH  = MeshDecomp->NCellReconstructEdgesH;
-   ReconstructStencilCellH = MeshDecomp->ReconstructStencilCellH;
+   CellsOnCellH       = MeshDecomp->CellsOnCellH;
+   EdgesOnCellH       = MeshDecomp->EdgesOnCellH;
+   NEdgesOnCellH      = MeshDecomp->NEdgesOnCellH;
+   VerticesOnCellH    = MeshDecomp->VerticesOnCellH;
+   CellsOnEdgeH       = MeshDecomp->CellsOnEdgeH;
+   EdgesOnEdgeH       = MeshDecomp->EdgesOnEdgeH;
+   NEdgesOnEdgeH      = MeshDecomp->NEdgesOnEdgeH;
+   VerticesOnEdgeH    = MeshDecomp->VerticesOnEdgeH;
+   CellsOnVertexH     = MeshDecomp->CellsOnVertexH;
+   EdgesOnVertexH     = MeshDecomp->EdgesOnVertexH;
+   NEdgesReconOnCellH = MeshDecomp->NEdgesReconOnCellH;
+   ReconStencilCellH  = MeshDecomp->ReconStencilCellH;
 
-   CellsOnCell            = MeshDecomp->CellsOnCell;
-   EdgesOnCell            = MeshDecomp->EdgesOnCell;
-   NEdgesOnCell           = MeshDecomp->NEdgesOnCell;
-   VerticesOnCell         = MeshDecomp->VerticesOnCell;
-   CellsOnEdge            = MeshDecomp->CellsOnEdge;
-   EdgesOnEdge            = MeshDecomp->EdgesOnEdge;
-   NEdgesOnEdge           = MeshDecomp->NEdgesOnEdge;
-   VerticesOnEdge         = MeshDecomp->VerticesOnEdge;
-   CellsOnVertex          = MeshDecomp->CellsOnVertex;
-   EdgesOnVertex          = MeshDecomp->EdgesOnVertex;
-   NCellReconstructEdges  = MeshDecomp->NCellReconstructEdges;
-   ReconstructStencilCell = MeshDecomp->ReconstructStencilCell;
+   CellsOnCell       = MeshDecomp->CellsOnCell;
+   EdgesOnCell       = MeshDecomp->EdgesOnCell;
+   NEdgesOnCell      = MeshDecomp->NEdgesOnCell;
+   VerticesOnCell    = MeshDecomp->VerticesOnCell;
+   CellsOnEdge       = MeshDecomp->CellsOnEdge;
+   EdgesOnEdge       = MeshDecomp->EdgesOnEdge;
+   NEdgesOnEdge      = MeshDecomp->NEdgesOnEdge;
+   VerticesOnEdge    = MeshDecomp->VerticesOnEdge;
+   CellsOnVertex     = MeshDecomp->CellsOnVertex;
+   EdgesOnVertex     = MeshDecomp->EdgesOnVertex;
+   NEdgesReconOnCell = MeshDecomp->NEdgesReconOnCell;
+   ReconStencilCell  = MeshDecomp->ReconStencilCell;
 
    // OnSphere is needed early (before the mesh field definitions below)
-   // to decide whether to define the ReconstructWeightsCell field, so we
+   // to decide whether to define the ReconWeightsCell field, so we
    // use the value Decomp already read from the mesh file. It is
    // redetermined below (with the rest of the sphere/plane attributes)
    // once the full mesh stream is read, which is redundant but harmless
@@ -462,17 +462,16 @@ void HorzMesh::completeReadArrays() {
    HorzMeshHalo->exchangeFullArrayHalo(FCell, OnCell);
    HorzMeshHalo->exchangeFullArrayHalo(FEdge, OnEdge);
    HorzMeshHalo->exchangeFullArrayHalo(FVertex, OnVertex);
-   // ReconstructWeightsCell is (NCells, R3, MaxEdges2) to match the mesh
+   // ReconWeightsCell is (NCells, R3, MaxEdges2) to match the mesh
    // file's on-disk dimension order. Halo's generic 3D exchange expects
    // the mesh dimension in the middle (as in Tracers' [Tracer, Cell,
    // Vert]), so exchange each R3 component as a 2D (Cell, MaxEdges2)
    // slice instead of the full 3D array.
    if (OnSphere) {
       for (int IComp = 0; IComp < 3; ++IComp) {
-         auto ReconstructWeightsCellSlice = Kokkos::subview(
-             ReconstructWeightsCell, Kokkos::ALL, IComp, Kokkos::ALL);
-         HorzMeshHalo->exchangeFullArrayHalo(ReconstructWeightsCellSlice,
-                                             OnCell);
+         auto ReconWeightsCellSlice =
+             Kokkos::subview(ReconWeightsCell, Kokkos::ALL, IComp, Kokkos::ALL);
+         HorzMeshHalo->exchangeFullArrayHalo(ReconWeightsCellSlice, OnCell);
       }
    }
 
@@ -504,7 +503,7 @@ void HorzMesh::completeReadArrays() {
    FEdgeH             = createHostMirrorCopy(FEdge);
    FVertexH           = createHostMirrorCopy(FVertex);
    if (OnSphere) {
-      ReconstructWeightsCellH = createHostMirrorCopy(ReconstructWeightsCell);
+      ReconWeightsCellH = createHostMirrorCopy(ReconWeightsCell);
    }
 
 } // end completeReadArrays
@@ -1030,8 +1029,8 @@ void HorzMesh::defineMeshFields() {
 
    if (OnSphere) {
       // Vector Reconstruction
-      // NCellReconstructEdges/ReconstructStencilCell come from Decomp (see
-      // constructor), not read here. ReconstructWeightsCell is pure data and
+      // NEdgesReconOnCell/ReconStencilCell come from Decomp (see
+      // constructor), not read here. ReconWeightsCell is pure data and
       // is read as a normal mesh field below.
       NDims = 3;
       DimNames.resize(NDims);
@@ -1039,9 +1038,9 @@ void HorzMesh::defineMeshFields() {
       DimNames[1] = "R3";
       DimNames[2] = "MaxEdges2";
       FieldName   = "ReconstructWeightsCell";
-      ReconstructWeightsCell =
-          Array3DReal("ReconstructWeightsCell", NCellsSize, 3, MaxEdges2);
-      auto ReconstructWeightsCellField = Field::create(
+      ReconWeightsCell =
+          Array3DReal("ReconWeightsCell", NCellsSize, 3, MaxEdges2);
+      auto ReconWeightsCellField = Field::create(
           FieldName, // field name
           "weights to reconstruct Cartesian vector field from edge-"
           "normal values at cell centers",     // long name
@@ -1054,7 +1053,7 @@ void HorzMesh::defineMeshFields() {
           false                                // not time dependent
       );
       MeshGroupIn->addField(FieldName);
-      Field::attachFieldData<Array3DReal>(FieldName, ReconstructWeightsCell);
+      Field::attachFieldData<Array3DReal>(FieldName, ReconWeightsCell);
    }
 
    // The sign and scaling fields are computed internally so are allocated

--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -1037,7 +1037,7 @@ void HorzMesh::defineMeshFields() {
       DimNames[0] = "NCells";
       DimNames[1] = "R3";
       DimNames[2] = "MaxEdges2";
-      FieldName   = "ReconstructWeightsCell";
+      FieldName   = "ReconWeightsCell";
       ReconWeightsCell =
           Array3DReal("ReconWeightsCell", NCellsSize, 3, MaxEdges2);
       auto ReconWeightsCellField = Field::create(

--- a/components/omega/src/ocn/HorzMesh.h
+++ b/components/omega/src/ocn/HorzMesh.h
@@ -254,6 +254,16 @@ class HorzMesh {
    Array1DReal MeshScalingDel4;      /// Coef to biharmonic mixing terms
    HostArray1DReal MeshScalingDel4H; /// Coef to biharmonic mixing terms
 
+   // Vector reconstruction
+   Array1DI4 NCellReconstructEdges;      /// Num of edges used in stencil
+   HostArray1DI4 NCellReconstructEdgesH; /// Num of edges used in stencil
+
+   Array2DI4 ReconstructStencilCell;      /// Two edge wide stencil
+   HostArray2DI4 ReconstructStencilCellH; /// Two edge wide stencil
+
+   Array3DReal ReconstructWeightsCell;      /// Least Squares Weights
+   HostArray3DReal ReconstructWeightsCellH; /// Least Squares Weights
+
    // Methods
 
    /// Initialize Omega local mesh and create default mesh

--- a/components/omega/src/ocn/HorzMesh.h
+++ b/components/omega/src/ocn/HorzMesh.h
@@ -255,14 +255,14 @@ class HorzMesh {
    HostArray1DReal MeshScalingDel4H; /// Coef to biharmonic mixing terms
 
    // Vector reconstruction
-   Array1DI4 NCellReconstructEdges;      /// Num of edges used in stencil
-   HostArray1DI4 NCellReconstructEdgesH; /// Num of edges used in stencil
+   Array1DI4 NEdgesReconOnCell;      /// Num of edges used in stencil
+   HostArray1DI4 NEdgesReconOnCellH; /// Num of edges used in stencil
 
-   Array2DI4 ReconstructStencilCell;      /// Two edge wide stencil
-   HostArray2DI4 ReconstructStencilCellH; /// Two edge wide stencil
+   Array2DI4 ReconStencilCell;      /// Two edge wide stencil
+   HostArray2DI4 ReconStencilCellH; /// Two edge wide stencil
 
-   Array3DReal ReconstructWeightsCell;      /// Least Squares Weights
-   HostArray3DReal ReconstructWeightsCellH; /// Least Squares Weights
+   Array3DReal ReconWeightsCell;      /// Least Squares Weights
+   HostArray3DReal ReconWeightsCellH; /// Least Squares Weights
 
    // Methods
 

--- a/components/omega/src/ocn/HorzOperators.cpp
+++ b/components/omega/src/ocn/HorzOperators.cpp
@@ -1,5 +1,6 @@
 #include "HorzOperators.h"
 #include "DataTypes.h"
+#include "Error.h"
 #include "HorzMesh.h"
 #include "VertCoord.h"
 
@@ -65,4 +66,16 @@ MasksAndCoefficients::MasksAndCoefficients(
       CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge),
       DvEdge(Mesh->DvEdge), AdvCoefs(AdvCoefs), AdvCoefs3rd(AdvCoefs3rd),
       BoundaryCell(VCoord->BoundaryCell), DerivTwo(DerivTwo) {}
+
+VectorReconstructOnCell::VectorReconstructOnCell(HorzMesh const *Mesh)
+    : OnSphere(Mesh->OnSphere),
+      NCellReconstructEdges(Mesh->NCellReconstructEdges),
+      ReconstructStencilCell(Mesh->ReconstructStencilCell),
+      ReconstructWeightsCell(Mesh->ReconstructWeightsCell),
+      LatCell(Mesh->LatCell), LonCell(Mesh->LonCell) {
+   if (!Mesh->OnSphere)
+      ABORT_ERROR("VectorReconstructOnCell: reconstruction stencil/weights "
+                  "are only available for spherical meshes");
+}
+
 } // namespace OMEGA

--- a/components/omega/src/ocn/HorzOperators.cpp
+++ b/components/omega/src/ocn/HorzOperators.cpp
@@ -67,14 +67,13 @@ MasksAndCoefficients::MasksAndCoefficients(
       DvEdge(Mesh->DvEdge), AdvCoefs(AdvCoefs), AdvCoefs3rd(AdvCoefs3rd),
       BoundaryCell(VCoord->BoundaryCell), DerivTwo(DerivTwo) {}
 
-VectorReconstructOnCell::VectorReconstructOnCell(HorzMesh const *Mesh)
-    : OnSphere(Mesh->OnSphere),
-      NCellReconstructEdges(Mesh->NCellReconstructEdges),
-      ReconstructStencilCell(Mesh->ReconstructStencilCell),
-      ReconstructWeightsCell(Mesh->ReconstructWeightsCell),
-      LatCell(Mesh->LatCell), LonCell(Mesh->LonCell) {
+VectorReconOnCell::VectorReconOnCell(HorzMesh const *Mesh)
+    : OnSphere(Mesh->OnSphere), NEdgesReconOnCell(Mesh->NEdgesReconOnCell),
+      ReconStencilCell(Mesh->ReconStencilCell),
+      ReconWeightsCell(Mesh->ReconWeightsCell), LatCell(Mesh->LatCell),
+      LonCell(Mesh->LonCell) {
    if (!Mesh->OnSphere)
-      ABORT_ERROR("VectorReconstructOnCell: reconstruction stencil/weights "
+      ABORT_ERROR("VectorReconOnCell: reconstruction stencil/weights "
                   "are only available for spherical meshes");
 }
 

--- a/components/omega/src/ocn/HorzOperators.h
+++ b/components/omega/src/ocn/HorzOperators.h
@@ -652,5 +652,50 @@ class MasksAndCoefficients {
    Array2DReal BoundaryCell;
    Array3DReal DerivTwo;
 };
+
+// Reconstruct edge normal vector field at cell centers
+class VectorReconstructOnCell {
+ public:
+   VectorReconstructOnCell(HorzMesh const *Mesh);
+   // Currently only support computing Zonal/Meridional (X/Y) for
+   // spherical (planar) meshes on a single vertical layer
+   KOKKOS_FUNCTION void operator()(const Array1DReal &UReconstructX,
+                                   const Array1DReal &UReconstructY, int ICell,
+                                   const Array1DReal &VecEdge) const {
+
+      Real Ux = 0._Real, Uy = 0._Real, Uz = 0._Real;
+
+      for (int J = 0; J < NCellReconstructEdges(ICell); ++J) {
+         const I4 JEdge   = ReconstructStencilCell(ICell, J);
+         const Real Field = VecEdge(JEdge);
+
+         Ux += ReconstructWeightsCell(ICell, 0, J) * Field;
+         Uy += ReconstructWeightsCell(ICell, 1, J) * Field;
+         Uz += ReconstructWeightsCell(ICell, 2, J) * Field;
+      }
+
+      if (OnSphere) {
+         const Real clat = Kokkos::cos(LatCell(ICell));
+         const Real slat = Kokkos::sin(LatCell(ICell));
+         const Real clon = Kokkos::cos(LonCell(ICell));
+         const Real slon = Kokkos::sin(LonCell(ICell));
+
+         // cartesian to local geographic
+         UReconstructX(ICell) = -slon * Ux + clon * Uy;
+         UReconstructY(ICell) = -(clon * Ux + slon * Uy) * slat + Uz * clat;
+      } else {
+         UReconstructX(ICell) = Ux;
+         UReconstructY(ICell) = Uy;
+      }
+   }
+
+ private:
+   bool OnSphere;
+   Array1DI4 NCellReconstructEdges;
+   Array2DI4 ReconstructStencilCell;
+   Array3DReal ReconstructWeightsCell;
+   Array1DReal LatCell;
+   Array1DReal LonCell;
+};
 } // namespace OMEGA
 #endif

--- a/components/omega/src/ocn/HorzOperators.h
+++ b/components/omega/src/ocn/HorzOperators.h
@@ -654,24 +654,24 @@ class MasksAndCoefficients {
 };
 
 // Reconstruct edge normal vector field at cell centers
-class VectorReconstructOnCell {
+class VectorReconOnCell {
  public:
-   VectorReconstructOnCell(HorzMesh const *Mesh);
+   VectorReconOnCell(HorzMesh const *Mesh);
    // Currently only support computing Zonal/Meridional (X/Y) for
    // spherical (planar) meshes on a single vertical layer
-   KOKKOS_FUNCTION void operator()(const Array1DReal &UReconstructX,
-                                   const Array1DReal &UReconstructY, int ICell,
+   KOKKOS_FUNCTION void operator()(const Array1DReal &UReconX,
+                                   const Array1DReal &UReconY, int ICell,
                                    const Array1DReal &VecEdge) const {
 
       Real Ux = 0._Real, Uy = 0._Real, Uz = 0._Real;
 
-      for (int J = 0; J < NCellReconstructEdges(ICell); ++J) {
-         const I4 JEdge   = ReconstructStencilCell(ICell, J);
+      for (int J = 0; J < NEdgesReconOnCell(ICell); ++J) {
+         const I4 JEdge   = ReconStencilCell(ICell, J);
          const Real Field = VecEdge(JEdge);
 
-         Ux += ReconstructWeightsCell(ICell, 0, J) * Field;
-         Uy += ReconstructWeightsCell(ICell, 1, J) * Field;
-         Uz += ReconstructWeightsCell(ICell, 2, J) * Field;
+         Ux += ReconWeightsCell(ICell, 0, J) * Field;
+         Uy += ReconWeightsCell(ICell, 1, J) * Field;
+         Uz += ReconWeightsCell(ICell, 2, J) * Field;
       }
 
       if (OnSphere) {
@@ -681,19 +681,19 @@ class VectorReconstructOnCell {
          const Real SLon = Kokkos::sin(LonCell(ICell));
 
          // cartesian to local geographic
-         UReconstructX(ICell) = -SLon * Ux + CLon * Uy;
-         UReconstructY(ICell) = -(CLon * Ux + SLon * Uy) * SLat + Uz * CLat;
+         UReconX(ICell) = -SLon * Ux + CLon * Uy;
+         UReconY(ICell) = -(CLon * Ux + SLon * Uy) * SLat + Uz * CLat;
       } else {
-         UReconstructX(ICell) = Ux;
-         UReconstructY(ICell) = Uy;
+         UReconX(ICell) = Ux;
+         UReconY(ICell) = Uy;
       }
    }
 
  private:
    bool OnSphere;
-   Array1DI4 NCellReconstructEdges;
-   Array2DI4 ReconstructStencilCell;
-   Array3DReal ReconstructWeightsCell;
+   Array1DI4 NEdgesReconOnCell;
+   Array2DI4 ReconStencilCell;
+   Array3DReal ReconWeightsCell;
    Array1DReal LatCell;
    Array1DReal LonCell;
 };

--- a/components/omega/src/ocn/HorzOperators.h
+++ b/components/omega/src/ocn/HorzOperators.h
@@ -675,14 +675,14 @@ class VectorReconstructOnCell {
       }
 
       if (OnSphere) {
-         const Real clat = Kokkos::cos(LatCell(ICell));
-         const Real slat = Kokkos::sin(LatCell(ICell));
-         const Real clon = Kokkos::cos(LonCell(ICell));
-         const Real slon = Kokkos::sin(LonCell(ICell));
+         const Real CLat = Kokkos::cos(LatCell(ICell));
+         const Real SLat = Kokkos::sin(LatCell(ICell));
+         const Real CLon = Kokkos::cos(LonCell(ICell));
+         const Real SLon = Kokkos::sin(LonCell(ICell));
 
          // cartesian to local geographic
-         UReconstructX(ICell) = -slon * Ux + clon * Uy;
-         UReconstructY(ICell) = -(clon * Ux + slon * Uy) * slat + Uz * clat;
+         UReconstructX(ICell) = -SLon * Ux + CLon * Uy;
+         UReconstructY(ICell) = -(CLon * Ux + SLon * Uy) * SLat + Uz * CLat;
       } else {
          UReconstructX(ICell) = Ux;
          UReconstructY(ICell) = Uy;

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -146,7 +146,7 @@ int main(int argc, char *argv[]) {
             for (int J = 0; J < MaxEdges2; ++J) {
                I4 StencilEdge = ReconstructStencilCellH(Cell, J);
                if (J < NStencil) {
-                  if (StencilEdge < 0 || StencilEdge > NEdgesAll)
+                  if (StencilEdge < 0 || StencilEdge >= NEdgesAll)
                      ++LocalReconErrors;
                } else if (StencilEdge != NEdgesAll) {
                   ++LocalReconErrors;

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -85,6 +85,7 @@ int main(int argc, char *argv[]) {
       I4 NCellsOwned     = DefDecomp->NCellsOwned;
       I4 NEdgesGlobal    = DefDecomp->NEdgesGlobal;
       I4 NEdgesOwned     = DefDecomp->NEdgesOwned;
+      I4 NEdgesAll       = DefDecomp->NEdgesAll;
       I4 NVerticesGlobal = DefDecomp->NVerticesGlobal;
       I4 NVerticesOwned  = DefDecomp->NVerticesOwned;
 
@@ -125,6 +126,39 @@ int main(int argc, char *argv[]) {
       if (SumVertices != RefSumVertices)
          ABORT_ERROR("DecompTest: Sum vertex ID test FAIL {} {}", SumVertices,
                      RefSumVertices);
+
+      // Test the vector-reconstruction stencil arrays (spherical meshes
+      // only): each owned cell's count is in range, active entries are
+      // resolvable local edges, and padding columns carry the NEdgesAll
+      // sentinel (confirms no compaction, so columns stay aligned with
+      // ReconstructWeightsCell).
+      if (DefDecomp->OnSphere) {
+         I4 MaxEdges2 = DefDecomp->MaxEdges2;
+         HostArray1DI4 NCellReconstructEdgesH =
+             DefDecomp->NCellReconstructEdgesH;
+         HostArray2DI4 ReconstructStencilCellH =
+             DefDecomp->ReconstructStencilCellH;
+         I4 LocalReconErrors = 0;
+         for (int Cell = 0; Cell < NCellsOwned; ++Cell) {
+            I4 NStencil = NCellReconstructEdgesH(Cell);
+            if (NStencil <= 0 || NStencil > MaxEdges2)
+               ++LocalReconErrors;
+            for (int J = 0; J < MaxEdges2; ++J) {
+               I4 StencilEdge = ReconstructStencilCellH(Cell, J);
+               if (J < NStencil) {
+                  if (StencilEdge < 0 || StencilEdge > NEdgesAll)
+                     ++LocalReconErrors;
+               } else if (StencilEdge != NEdgesAll) {
+                  ++LocalReconErrors;
+               }
+            }
+         }
+         I4 ReconErrors = globalSum(LocalReconErrors, Comm);
+         if (ReconErrors != 0)
+            ABORT_ERROR("DecompTest: ReconstructStencilCell consistency "
+                        "test FAIL {}",
+                        ReconErrors);
+      }
 
       // Clean up
       Decomp::clear();

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -131,20 +131,18 @@ int main(int argc, char *argv[]) {
       // only): each owned cell's count is in range, active entries are
       // resolvable local edges, and padding columns carry the NEdgesAll
       // sentinel (confirms no compaction, so columns stay aligned with
-      // ReconstructWeightsCell).
+      // ReconWeightsCell).
       if (DefDecomp->OnSphere) {
-         I4 MaxEdges2 = DefDecomp->MaxEdges2;
-         HostArray1DI4 NCellReconstructEdgesH =
-             DefDecomp->NCellReconstructEdgesH;
-         HostArray2DI4 ReconstructStencilCellH =
-             DefDecomp->ReconstructStencilCellH;
-         I4 LocalReconErrors = 0;
+         I4 MaxEdges2                     = DefDecomp->MaxEdges2;
+         HostArray1DI4 NEdgesReconOnCellH = DefDecomp->NEdgesReconOnCellH;
+         HostArray2DI4 ReconStencilCellH  = DefDecomp->ReconStencilCellH;
+         I4 LocalReconErrors              = 0;
          for (int Cell = 0; Cell < NCellsOwned; ++Cell) {
-            I4 NStencil = NCellReconstructEdgesH(Cell);
+            I4 NStencil = NEdgesReconOnCellH(Cell);
             if (NStencil <= 0 || NStencil > MaxEdges2)
                ++LocalReconErrors;
             for (int J = 0; J < MaxEdges2; ++J) {
-               I4 StencilEdge = ReconstructStencilCellH(Cell, J);
+               I4 StencilEdge = ReconStencilCellH(Cell, J);
                if (J < NStencil) {
                   if (StencilEdge < 0 || StencilEdge >= NEdgesAll)
                      ++LocalReconErrors;
@@ -155,7 +153,7 @@ int main(int argc, char *argv[]) {
          }
          I4 ReconErrors = globalSum(LocalReconErrors, Comm);
          if (ReconErrors != 0)
-            ABORT_ERROR("DecompTest: ReconstructStencilCell consistency "
+            ABORT_ERROR("DecompTest: ReconStencilCell consistency "
                         "test FAIL {}",
                         ReconErrors);
       }

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -380,11 +380,11 @@ int testTangentRecon(Real RTol) {
 // the magnitude of the reconstructed vector against the exact magnitude at
 // cell centers. This currently only supports spherical meshes, so it is a
 // no-op for planar meshes.
-int testVectorReconstruction(Real RTol) {
+int testVectorRecon(Real RTol) {
    int Err = 0;
 
    // Vector reconstruction weights/stencil are only available for spherical
-   // meshes (see VectorReconstructOnCell)
+   // meshes (see VectorReconOnCell)
    if constexpr (Geom != Geometry::Spherical) {
       return Err;
    }
@@ -394,7 +394,7 @@ int testVectorReconstruction(Real RTol) {
    const auto &Mesh = HorzMesh::getDefault();
 
    // Prepare operator input: edge-normal component of the exact vector field
-   // (VectorReconstructOnCell currently only supports a single vertical
+   // (VectorReconOnCell currently only supports a single vertical
    // layer, so we use rank-1 arrays here)
    Array1DReal VecEdge("VecEdge", Mesh->NEdgesSize);
    Err += setVectorEdge(
@@ -414,31 +414,30 @@ int testVectorReconstruction(Real RTol) {
        ExactMagCell, Geom, Mesh, OnCell, ExchangeHalos::No);
 
    // Compute numerical reconstruction at cell centers
-   Array1DReal UReconstructX("UReconstructX", Mesh->NCellsOwned);
-   Array1DReal UReconstructY("UReconstructY", Mesh->NCellsOwned);
-   VectorReconstructOnCell ReconstructCell(Mesh);
+   Array1DReal UReconX("UReconX", Mesh->NCellsOwned);
+   Array1DReal UReconY("UReconY", Mesh->NCellsOwned);
+   VectorReconOnCell ReconCell(Mesh);
    parallelFor(
        {Mesh->NCellsOwned}, KOKKOS_LAMBDA(int ICell) {
-          ReconstructCell(UReconstructX, UReconstructY, ICell, VecEdge);
+          ReconCell(UReconX, UReconY, ICell, VecEdge);
        });
 
    // Magnitude of the numerical reconstruction
    Array1DReal NumMagCell("NumMagCell", Mesh->NCellsOwned);
    parallelFor(
        {Mesh->NCellsOwned}, KOKKOS_LAMBDA(int ICell) {
-          NumMagCell(ICell) =
-              vecMagnitude(UReconstructX(ICell), UReconstructY(ICell));
+          NumMagCell(ICell) = vecMagnitude(UReconX(ICell), UReconY(ICell));
        });
 
    // Compute error measures
    ErrorMeasures ReconErrors;
    Err += computeErrors(ReconErrors, NumMagCell, ExactMagCell, Mesh, OnCell);
    // Check error values
-   Err += checkErrors("OperatorsTest", "VectorReconstruction", ReconErrors,
+   Err += checkErrors("OperatorsTest", "VectorRecon", ReconErrors,
                       Setup.ExpectedVectorReconErrors, RTol);
 
    if (Err == 0) {
-      LOG_INFO("OperatorsTest: VectorReconstruction PASS");
+      LOG_INFO("OperatorsTest: VectorRecon PASS");
    }
 
    return Err;
@@ -1056,7 +1055,7 @@ int operatorsTest(const std::string &MeshFile = DefaultMeshFile) {
    Err += testGradient(RTol);
    Err += testCurl(RTol);
    Err += testTangentRecon(RTol);
-   Err += testVectorReconstruction(RTol);
+   Err += testVectorRecon(RTol);
    Err += testInterpCellToEdge(RTol);
    Err += testsecondderivativeoncellconstructor(RTol);
    Err += testsecondderivativeoncellDeterminePlanerPatchGeometry(RTol);

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -31,14 +31,17 @@ struct TestSetupPlane {
    Real Lx = 1;
    Real Ly = SqrtThree / 2;
 
-   ErrorMeasures ExpectedDivErrors         = {0.00124886886594427027,
-                                              0.00124886886590974385};
-   ErrorMeasures ExpectedGradErrors        = {0.00125026071878537952,
-                                              0.00134354611117262204};
-   ErrorMeasures ExpectedCurlErrors        = {0.161365663569699946,
-                                              0.161348016897141039};
-   ErrorMeasures ExpectedReconErrors       = {0.00450897496974901352,
-                                              0.00417367308684470691};
+   ErrorMeasures ExpectedDivErrors   = {0.00124886886594427027,
+                                        0.00124886886590974385};
+   ErrorMeasures ExpectedGradErrors  = {0.00125026071878537952,
+                                        0.00134354611117262204};
+   ErrorMeasures ExpectedCurlErrors  = {0.161365663569699946,
+                                        0.161348016897141039};
+   ErrorMeasures ExpectedReconErrors = {0.00450897496974901352,
+                                        0.00417367308684470691};
+   // vector reconstruction is spherical-only; unused placeholder kept only
+   // so the (untemplated) test function compiles for all TestSetup variants
+   ErrorMeasures ExpectedVectorReconErrors = {0.0, 0.0};
    ErrorMeasures ExpectedAnisoInterpErrors = {0.0026762081503380526,
                                               0.003058198461518835};
    ErrorMeasures ExpectedIsoInterpErrors   = {0.004279097382993937,
@@ -88,6 +91,8 @@ struct TestSetupSphere1 {
                                               0.025202095212756463};
    ErrorMeasures ExpectedReconErrors       = {0.0206375134079833517,
                                               0.00692590524910695858};
+   ErrorMeasures ExpectedVectorReconErrors = {0.003308078126087204,
+                                              0.0029425911574823007};
    ErrorMeasures ExpectedAnisoInterpErrors = {0.0024015775047603197,
                                               0.0018490649516209202};
    ErrorMeasures ExpectedIsoInterpErrors   = {0.007438367234983312,
@@ -138,6 +143,8 @@ struct TestSetupSphere2 {
                                               0.00204725417666192042};
    ErrorMeasures ExpectedReconErrors       = {0.0254271921029878764,
                                               0.00419630561428921064};
+   ErrorMeasures ExpectedVectorReconErrors = {0.0006982813838413156,
+                                              0.0006104530488293548};
    ErrorMeasures ExpectedAnisoInterpErrors = {0.0014465229922953644,
                                               0.001643777653612931};
    ErrorMeasures ExpectedIsoInterpErrors   = {0.004755875091568591,
@@ -318,7 +325,7 @@ int testCurl(Real RTol) {
    return Err;
 }
 
-int testRecon(Real RTol) {
+int testTangentRecon(Real RTol) {
    int Err = 0;
    TestSetup Setup;
 
@@ -363,6 +370,75 @@ int testRecon(Real RTol) {
 
    if (Err == 0) {
       LOG_INFO("OperatorsTest: Recon PASS");
+   }
+
+   return Err;
+}
+
+// Reconstructs the Cartesian vector field at cell centers from edge-normal
+// values using the least-squares weights/stencil in the mesh and compares
+// the magnitude of the reconstructed vector against the exact magnitude at
+// cell centers. This currently only supports spherical meshes, so it is a
+// no-op for planar meshes.
+int testVectorReconstruction(Real RTol) {
+   int Err = 0;
+
+   // Vector reconstruction weights/stencil are only available for spherical
+   // meshes (see VectorReconstructOnCell)
+   if constexpr (Geom != Geometry::Spherical) {
+      return Err;
+   }
+
+   TestSetup Setup;
+
+   const auto &Mesh = HorzMesh::getDefault();
+
+   // Prepare operator input: edge-normal component of the exact vector field
+   // (VectorReconstructOnCell currently only supports a single vertical
+   // layer, so we use rank-1 arrays here)
+   Array1DReal VecEdge("VecEdge", Mesh->NEdgesSize);
+   Err += setVectorEdge(
+       KOKKOS_LAMBDA(Real(&VecField)[2], Real Lon, Real Lat) {
+          VecField[0] = Setup.exactVecX(Lon, Lat);
+          VecField[1] = Setup.exactVecY(Lon, Lat);
+       },
+       VecEdge, EdgeComponent::Normal, Geom, Mesh);
+
+   // Compute exact magnitude of the vector field at cell centers
+   Array1DReal ExactMagCell("ExactMagCell", Mesh->NCellsOwned);
+   Err += setScalar(
+       KOKKOS_LAMBDA(Real Lon, Real Lat) {
+          return vecMagnitude(Setup.exactVecX(Lon, Lat),
+                              Setup.exactVecY(Lon, Lat));
+       },
+       ExactMagCell, Geom, Mesh, OnCell, ExchangeHalos::No);
+
+   // Compute numerical reconstruction at cell centers
+   Array1DReal UReconstructX("UReconstructX", Mesh->NCellsOwned);
+   Array1DReal UReconstructY("UReconstructY", Mesh->NCellsOwned);
+   VectorReconstructOnCell ReconstructCell(Mesh);
+   parallelFor(
+       {Mesh->NCellsOwned}, KOKKOS_LAMBDA(int ICell) {
+          ReconstructCell(UReconstructX, UReconstructY, ICell, VecEdge);
+       });
+
+   // Magnitude of the numerical reconstruction
+   Array1DReal NumMagCell("NumMagCell", Mesh->NCellsOwned);
+   parallelFor(
+       {Mesh->NCellsOwned}, KOKKOS_LAMBDA(int ICell) {
+          NumMagCell(ICell) =
+              vecMagnitude(UReconstructX(ICell), UReconstructY(ICell));
+       });
+
+   // Compute error measures
+   ErrorMeasures ReconErrors;
+   Err += computeErrors(ReconErrors, NumMagCell, ExactMagCell, Mesh, OnCell);
+   // Check error values
+   Err += checkErrors("OperatorsTest", "VectorReconstruction", ReconErrors,
+                      Setup.ExpectedVectorReconErrors, RTol);
+
+   if (Err == 0) {
+      LOG_INFO("OperatorsTest: VectorReconstruction PASS");
    }
 
    return Err;
@@ -979,7 +1055,8 @@ int operatorsTest(const std::string &MeshFile = DefaultMeshFile) {
    Err += testDivergence(RTol);
    Err += testGradient(RTol);
    Err += testCurl(RTol);
-   Err += testRecon(RTol);
+   Err += testTangentRecon(RTol);
+   Err += testVectorReconstruction(RTol);
    Err += testInterpCellToEdge(RTol);
    Err += testsecondderivativeoncellconstructor(RTol);
    Err += testsecondderivativeoncellDeterminePlanerPatchGeometry(RTol);

--- a/components/omega/test/ocn/OceanTestCommon.h
+++ b/components/omega/test/ocn/OceanTestCommon.h
@@ -63,6 +63,11 @@ KOKKOS_INLINE_FUNCTION void tangentVector(Real (&TanVec)[3],
    }
 }
 
+// returns the magnitude of a 2D vector given its (X, Y) components
+KOKKOS_INLINE_FUNCTION Real vecMagnitude(Real X, Real Y) {
+   return Kokkos::sqrt(X * X + Y * Y);
+}
+
 enum class EdgeComponent { Normal, Tangential };
 enum class Geometry { Planar, Spherical };
 enum class ExchangeHalos { Yes, No };


### PR DESCRIPTION
Adds `VectorReconstructOnCell`: an operator for reconstructing an edge normal vector field at cell-centers. The operator uses pre-computed weights and stencil to perform the reconstuciton following section 2.5 from [Peixoto and Barros (2014)](https://doi.org/10.1016/j.jcp.2014.04.043). This PR requires the reconstruction variables (`NCellReconstructEdges`, `ReconstructStencilCell`, and `ReconstructWeightsCell`) to be present in spherical meshes. Support for reconstruction on planar meshes will come in a follow up PR. 

The "offline" computation of the weights and stencil is a deliberate design choice, because these variables only depend of the mesh. This way the reconstruction variables are present in mesh from it's definition and downstream analysis tool can do reconstruction without needing to run the forward model and write the weights to disk (i.e. what is currently required in MPAS-O). 

Polaris PR for computing weights/stencils and adding them to an existing mesh: https://github.com/E3SM-Project/polaris/pull/649.

The `VectorReconstructOnCell` currently only has a single overload, which returns the local geographic (i.e. zonal and meridional) components of the vector field. We need this functionality to pass the `So_u` and `So_v` fields to the coupler, which expect values at cell centers. As more uses for vector reconstruction come up, additional overloads can be set up (e.g. returning the local Cartesian components of the vector field). 

**Changes made**:
- `Decomp`: reads and redistributes the integer stencil arrays (`NCellReconstructEdges`, `ReconstructStencilCell`) and `MaxEdges2`, mirroring the existing `CellsOnCell`/`EdgesOnCell` handling. Adds an `OnSphere` flag (read from the mesh file) to gate this since planar weights/stencils are not yet supported.
- `HorzMesh`: reads the real-valued `ReconstructWeightsCell` field and halo-exchanges it component-by-component, since Halo's generic rank-3 exchange convention doesn't match this field's file-driven dimension order.
- `HorzOperators`: adds the `VectorReconstructOnCell` functor.
- Tests: `DecompTest` checks stencil array consistency; `HorzOperatorsTest`
  adds `testVectorReconstruction`, renames `testRecon` to `testTangentRecon` for clarity, and adds a `vecMagnitude` helper to `OceanTestCommon`.
- Docs: updated `devGuide`/`userGuide` entries for `Decomp`, `HorzMesh`, and `HorzOperators`.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
**Checklist**:
* [x] Documentation:
  * [x] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [x] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
    * Local build: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.anolan/Omega_PR480/
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.
* [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
* [ ] New tests:
  * [ ] CTest unit tests for new features have been added per the approved design.
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
* Stealth Features
  * [ ] If any stealth features are included in the PR, please confirm that they have been documented.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


