### PR TITLE
Fix bugs in calls to vertical mixing within timesteppers

### DIFF
--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -441,8 +441,9 @@ void VertMix::applyVelVertMixImplicit(
    OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
    OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
-   const Array2DReal &NormalVelEdge   = State->NormalVelocity[VelTimeLevel];
-   const Array2DReal &PseudoThickCell = State->PseudoThickness[ThickTimeLevel];
+   const Array2DReal &NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
+   const Array2DReal &PseudoThickCell =
+       State->getPseudoThickness(ThickTimeLevel);
 
    // Compute velocity vertical mixing
    if (LocVelVertMixSetup.Enabled) {
@@ -546,7 +547,8 @@ void VertMix::applyTracerVertMixImplicit(
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
-   const Array2DReal &PseudoThickCell = State->PseudoThickness[ThickTimeLevel];
+   const Array2DReal &PseudoThickCell =
+       State->getPseudoThickness(ThickTimeLevel);
 
    if (LocTracerVertMixSetup.Enabled) {
       Pacer::start("Tend:tracerVertMix", 1);

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -96,6 +96,13 @@ void ForwardBackwardStepper::doStep(
    if (VMix->VelVertMixSetup.Enabled or VMix->TracerVertMixSetup.Enabled) {
       VMix->VertMixImplicit(State, AuxState, CurTracerArray, NTracers,
                             VelCurLevel);
+
+      // Re-exchange halos after vertical mixing
+      Pacer::timingBarrier("ForwardBackward:vMixHaloExchBarrier", 3, Comm);
+      Pacer::start("ForwardBackward:vMixHaloExch", 3);
+      State->exchangeHalo(VelCurLevel);
+      Tracers::exchangeHalo(VelCurLevel);
+      Pacer::stop("ForwardBackward:vMixHaloExch", 3);
    }
 
    validateOceanState(State, AuxState, VertCoord::getDefault(), 0);

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -95,7 +95,7 @@ void ForwardBackwardStepper::doStep(
    CurTracerArray = Tracers::getAll(VelCurLevel);
    if (VMix->VelVertMixSetup.Enabled or VMix->TracerVertMixSetup.Enabled) {
       VMix->VertMixImplicit(State, AuxState, CurTracerArray, NTracers,
-                            State->CurTimeIndex);
+                            VelCurLevel);
    }
 
    validateOceanState(State, AuxState, VertCoord::getDefault(), 0);

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -79,7 +79,7 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    CurTracerArray = Tracers::getAll(CurLevel);
    if (VMix->VelVertMixSetup.Enabled or VMix->TracerVertMixSetup.Enabled) {
       VMix->VertMixImplicit(State, AuxState, CurTracerArray, NTracers,
-                            State->CurTimeIndex);
+                            CurLevel);
    }
 
    validateOceanState(State, AuxState, VertCoord::getDefault(), CurLevel);

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -80,6 +80,13 @@ void RungeKutta2Stepper::doStep(OceanState *State,   // model state
    if (VMix->VelVertMixSetup.Enabled or VMix->TracerVertMixSetup.Enabled) {
       VMix->VertMixImplicit(State, AuxState, CurTracerArray, NTracers,
                             CurLevel);
+
+      // Re-exchange halos after vertical mixing
+      Pacer::timingBarrier("RK2:vMixHaloExchBarrier", 3, Comm);
+      Pacer::start("RK2:vMixHaloExch", 3);
+      State->exchangeHalo(CurLevel);
+      Tracers::exchangeHalo(CurLevel);
+      Pacer::stop("RK2:vMixHaloExch", 3);
    }
 
    validateOceanState(State, AuxState, VertCoord::getDefault(), CurLevel);

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -144,6 +144,13 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
    if (VMix->VelVertMixSetup.Enabled or VMix->TracerVertMixSetup.Enabled) {
       VMix->VertMixImplicit(State, AuxState, CurTracerArray, NTracers,
                             CurLevel);
+
+      // Re-exchange halos after vertical mixing
+      Pacer::timingBarrier("RK4:vMixHaloExchBarrier", 3, Comm);
+      Pacer::start("RK4:vMixHaloExch", 3);
+      State->exchangeHalo(CurLevel);
+      Tracers::exchangeHalo(CurLevel);
+      Pacer::stop("RK4:vMixHaloExch", 3);
    }
 
    validateOceanState(State, AuxState, VertCoord::getDefault(), CurLevel);

--- a/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta4Stepper.cpp
@@ -143,7 +143,7 @@ void RungeKutta4Stepper::doStep(OceanState *State,   // model state
    CurTracerArray = Tracers::getAll(CurLevel);
    if (VMix->VelVertMixSetup.Enabled or VMix->TracerVertMixSetup.Enabled) {
       VMix->VertMixImplicit(State, AuxState, CurTracerArray, NTracers,
-                            State->CurTimeIndex);
+                            CurLevel);
    }
 
    validateOceanState(State, AuxState, VertCoord::getDefault(), CurLevel);


### PR DESCRIPTION
Addresses two issue when calling `VertMix` from the time stepping loop  which were causing ERS tests for fail:
  - raw buffer indices were passed as a logical time level to `VertMixImplicit`
  - missing halo exchange **after** `VertMixImplicit` modifies state variables. 

Fixes #487

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.


