### PR TITLE
Add halo exchanges to ForwardBackward Timestepper

### DIFF
--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -45,6 +45,8 @@ void ForwardBackwardStepper::doStep(
 
    VertMix *VMix = VertMix::getInstance();
 
+   const MPI_Comm Comm = MeshHalo->getComm();
+
    if (State == nullptr)
       LOG_CRITICAL("Invalid State");
    if (AuxState == nullptr)
@@ -65,6 +67,13 @@ void ForwardBackwardStepper::doStep(
    prescribeVelocity(State, VelNextLevel, State, VelCurLevel,
                      SimTime + TimeStep);
 
+   // Exchange halo of u^{n+1} before it is used below
+   Array2DReal NextNormalVelocity = State->getNormalVelocity(VelNextLevel);
+   Pacer::timingBarrier("ForwardBackward:velHaloExchBarrier", 3, Comm);
+   Pacer::start("ForwardBackward:velHaloExch", 3);
+   MeshHalo->exchangeFullArrayHalo(NextNormalVelocity, OnEdge);
+   Pacer::stop("ForwardBackward:velHaloExch", 3);
+
    // R_h^{n} = RHS_h(u^{n+1}, h^{n}, t^{n})
    Tend->computePseudoThicknessTendencies(State, AuxState, ThickCurLevel,
                                           VelNextLevel, SimTime);
@@ -73,6 +82,13 @@ void ForwardBackwardStepper::doStep(
    updateThicknessByTend(State, ThickNextLevel, State, ThickCurLevel, TimeStep);
 
    prescribeThickness(State, ThickNextLevel, State, ThickCurLevel);
+
+   // Exchange halo of h^{n+1} before it is used below
+   Array2DReal NextPseudoThickness = State->getPseudoThickness(ThickNextLevel);
+   Pacer::timingBarrier("ForwardBackward:thickHaloExchBarrier", 3, Comm);
+   Pacer::start("ForwardBackward:thickHaloExch", 3);
+   MeshHalo->exchangeFullArrayHalo(NextPseudoThickness, OnCell);
+   Pacer::stop("ForwardBackward:thickHaloExch", 3);
 
    // R_phi^{n} = RHS_phi(u^{n+1}, h^{n+1}, phi^{n}, t^{n})
    Tend->computeTracerTendencies(State, AuxState, CurTracerArray,
@@ -84,7 +100,6 @@ void ForwardBackwardStepper::doStep(
 
    // Update time levels (New -> Old) of prognostic variables with halo
    // exchanges
-   const MPI_Comm Comm = MeshHalo->getComm();
    Pacer::timingBarrier("ForwardBackward:haloExchBarrier", 3, Comm);
    Pacer::start("ForwardBackward:haloExch", 3);
    State->updateTimeLevels();

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -62,8 +62,6 @@ void ForwardBackwardStepper::doStep(
    // u^{n+1} = u^{n} + R_u^{n}
    updateVelocityByTend(State, VelNextLevel, State, VelCurLevel, TimeStep);
 
-   updateVelocityByTend(State, VelNextLevel, State, VelCurLevel, TimeStep);
-
    prescribeVelocity(State, VelNextLevel, State, VelCurLevel,
                      SimTime + TimeStep);
 
@@ -82,13 +80,6 @@ void ForwardBackwardStepper::doStep(
    updateThicknessByTend(State, ThickNextLevel, State, ThickCurLevel, TimeStep);
 
    prescribeThickness(State, ThickNextLevel, State, ThickCurLevel);
-
-   // Exchange halo of h^{n+1} before it is used below
-   Array2DReal NextPseudoThickness = State->getPseudoThickness(ThickNextLevel);
-   Pacer::timingBarrier("ForwardBackward:thickHaloExchBarrier", 3, Comm);
-   Pacer::start("ForwardBackward:thickHaloExch", 3);
-   MeshHalo->exchangeFullArrayHalo(NextPseudoThickness, OnCell);
-   Pacer::stop("ForwardBackward:thickHaloExch", 3);
 
    // R_phi^{n} = RHS_phi(u^{n+1}, h^{n+1}, phi^{n}, t^{n})
    Tend->computeTracerTendencies(State, AuxState, CurTracerArray,


### PR DESCRIPTION
This PR add missing halo exchanges between sub steps for the `ForwardBackward` time stepper. Without these PEM test using `ForwardBackward` time stepping failed, even after rebasing onto #488 . 

Fixes #489. 

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


