### PR TITLE
Fix heap corruption reading non-distributed variables in single precision

### DIFF
--- a/components/omega/doc/devGuide/IO.md
+++ b/components/omega/doc/devGuide/IO.md
@@ -119,11 +119,21 @@ IO::writeArray(&Array, Size, &FillValue,   FileID, DecompID, VarID, Frame);
 For arrays or scalars that are not distributed, the non-distributed variable
 interface must be used:
 ```c++
-Error Err = IO::readNDVar(&Array, VariableName, FileID, VarID);
+Error Err = IO::readNDVar(&Array, VarType, VariableName, FileID, VarID);
 IO::writeNDVar(&Array, FileID, VarID);
 ```
-with arguments similar to the distributed array calls above. Note that
-when defining dimensions for these fields, the dimensions must be
+with arguments similar to the distributed array calls above. The read
+requires a VarType argument giving the data type of the destination array
+(``IO::IOTypeI4``, ``IOTypeI8``, ``IOTypeR4`` or ``IOTypeR8``). This need
+not be the type the variable has in the file and the values are converted
+on read. Supplying it is required rather than optional: without it the
+underlying SCORPIO call fills the destination using the type stored in the
+file, so reading a double variable into a single-precision array would
+write eight bytes per element into four-byte slots and run off the end of
+the array. Distributed reads get the same information from the
+decomposition, so ``readArray`` needs no equivalent argument.
+
+Note that when defining dimensions for these fields, the dimensions must be
 non-distributed. For scalars, the number of dimensions should be zero.
 Multiple time slices can be also be read/written for non-distributed fields,
 but require two additional arguments. As in the distributed array, the
@@ -131,7 +141,8 @@ Frame (index of the time slice) must be provided. In addition, a vector
 ``std::vector<int> DimLengths`` containing the length of the non-time
 dimensions must be provided:
 ```c++
-Error Err = IO::readNDVar(&Array, VariableName, FileID, VarID, Frame, DimLengths);
+Error Err = IO::readNDVar(&Array, VarType, VariableName, FileID, VarID, Frame,
+                          DimLengths);
 IO::writeNDVar(&Array, FileID, VarID, Frame, DimLengths);
 ```
 Note that the full arrays in this case are written so if any masking or

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -772,6 +772,7 @@ Error readArray(void *Array,                // [out] array to be read
 // All arrays are assumed to be in contiguous storage. Returns an error code so
 // that the calling routine can re-try on failure.
 Error readNDVar(void *Variable,             // [out] array to be read
+                IODataType VarType,         // [in] data type of the array
                 const std::string &VarName, // [in] name of variable to read
                 int FileID,                 // [in] ID of open file to read from
                 int &VarID, // [out] Id assigned to variable for later use
@@ -789,6 +790,13 @@ Error readNDVar(void *Variable,             // [out] array to be read
                    "IO::readArray: Error finding varid for variable {}",
                    VarName);
 
+   // The type-specific PIO read routines are used here rather than the
+   // generic PIOc_get_var/PIOc_get_vara. The generic forms fill the buffer
+   // using the type of the variable as stored in the file, so reading a
+   // double variable into a single-precision array would write eight bytes
+   // per element into four-byte slots and run off the end of the buffer.
+   // Passing the type of the destination array instead lets PIO convert.
+
    if (Frame >= 0) { // time dependent field so must use get_vara
 
       int NDims = DimLengths->size();
@@ -801,8 +809,30 @@ Error readNDVar(void *Variable,             // [out] array to be read
          Count[IDim] = DimLengths->at(IDim - 1);
       }
 
-      PIOErr =
-          PIOc_get_vara(FileID, VarID, Start.data(), Count.data(), Variable);
+      switch (VarType) {
+      case IOTypeI4:
+         PIOErr = PIOc_get_vara_int(FileID, VarID, Start.data(), Count.data(),
+                                    static_cast<int *>(Variable));
+         break;
+      case IOTypeI8:
+         PIOErr =
+             PIOc_get_vara_longlong(FileID, VarID, Start.data(), Count.data(),
+                                    static_cast<long long *>(Variable));
+         break;
+      case IOTypeR4:
+         PIOErr = PIOc_get_vara_float(FileID, VarID, Start.data(), Count.data(),
+                                      static_cast<R4 *>(Variable));
+         break;
+      case IOTypeR8:
+         PIOErr =
+             PIOc_get_vara_double(FileID, VarID, Start.data(), Count.data(),
+                                  static_cast<R8 *>(Variable));
+         break;
+      default:
+         RETURN_ERROR(Err, ErrorCode::Fail,
+                      "IO::readNDVar: Unsupported data type for variable {}",
+                      VarName);
+      }
       if (PIOErr != PIO_NOERR)
          RETURN_ERROR(Err, ErrorCode::Fail,
                       "IO::readNDVar: Error in PIO get_vara for variable {}",
@@ -811,7 +841,27 @@ Error readNDVar(void *Variable,             // [out] array to be read
    } else { // Not a time-dependent field, can use default get_var
 
       // PIO get call to read non-distributed array
-      PIOErr = PIOc_get_var(FileID, VarID, Variable);
+      switch (VarType) {
+      case IOTypeI4:
+         PIOErr = PIOc_get_var_int(FileID, VarID, static_cast<int *>(Variable));
+         break;
+      case IOTypeI8:
+         PIOErr = PIOc_get_var_longlong(FileID, VarID,
+                                        static_cast<long long *>(Variable));
+         break;
+      case IOTypeR4:
+         PIOErr =
+             PIOc_get_var_float(FileID, VarID, static_cast<R4 *>(Variable));
+         break;
+      case IOTypeR8:
+         PIOErr =
+             PIOc_get_var_double(FileID, VarID, static_cast<R8 *>(Variable));
+         break;
+      default:
+         RETURN_ERROR(Err, ErrorCode::Fail,
+                      "IO::readNDVar: Unsupported data type for variable {}",
+                      VarName);
+      }
       if (PIOErr != PIO_NOERR)
          RETURN_ERROR(Err, ErrorCode::Fail,
                       "IO::readNDVar: Error in PIO get_var for variable {}",

--- a/components/omega/src/base/IO.h
+++ b/components/omega/src/base/IO.h
@@ -324,12 +324,16 @@ Error readArray(void *Array,                ///< [out] array to be read
 /// Reads a non-distributed variable. We use a void pointer here to create
 /// a generic interface for all types. Arrays are assumed to be in contiguous
 /// storage so the arrays of any dimension are treated as a 1-d array with
-/// the full local size. The routine returns the variable as well as the id
-/// assigned to the variable should that be needed later. For time-dependent
-/// variables, the optional frame and dimension length information must be
-/// provided. An error code is also returned so that the calling routine can
-/// re-try the read on failure (eg due to name changes).
+/// the full local size. The data type of the destination array must be
+/// supplied; it need not match the type of the variable as stored in the
+/// file and the values are converted on read. The routine returns the
+/// variable as well as the id assigned to the variable should that be needed
+/// later. For time-dependent variables, the optional frame and dimension
+/// length information must be provided. An error code is also returned so
+/// that the calling routine can re-try the read on failure (eg due to name
+/// changes).
 Error readNDVar(void *Variable,             ///< [out] variable to be read
+                IODataType VarType,         ///< [in] data type of variable
                 const std::string &VarName, ///< [in] name of variable to read
                 int FileID,                 ///< [in] ID of open file for read
                 int &VarID,     ///< [out] variable ID in case metadata needed

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1694,7 +1694,14 @@ Error IOStream::readFieldData(
    // The IO routines require a pointer to a contiguous memory on the host
    // so we first read into a vector. Only one of the vectors below will
    // be used and resized appropriately.
+   // The IO data type is set alongside the buffer so that it always describes
+   // the buffer actually allocated, which need not be the type the variable
+   // has in the file. Distributed reads take this from the decomposition,
+   // but non-distributed reads must be told directly or PIO fills the buffer
+   // using the file's type, overrunning it whenever that type is the wider
+   // of the two.
    void *DataPtr;
+   IO::IODataType MyIOType;
    std::vector<I4> DataI4(1);
    std::vector<I8> DataI8(1);
    std::vector<R4> DataR4(1);
@@ -1703,19 +1710,23 @@ Error IOStream::readFieldData(
    switch (MyType) {
    case ArrayDataType::I4:
       DataI4.resize(LocSize);
-      DataPtr = DataI4.data();
+      DataPtr  = DataI4.data();
+      MyIOType = IO::IOTypeI4;
       break;
    case ArrayDataType::I8:
       DataI8.resize(LocSize);
-      DataPtr = DataI8.data();
+      DataPtr  = DataI8.data();
+      MyIOType = IO::IOTypeI8;
       break;
    case ArrayDataType::R4:
       DataR4.resize(LocSize);
-      DataPtr = DataR4.data();
+      DataPtr  = DataR4.data();
+      MyIOType = IO::IOTypeR4;
       break;
    case ArrayDataType::R8:
       DataR8.resize(LocSize);
-      DataPtr = DataR8.data();
+      DataPtr  = DataR8.data();
+      MyIOType = IO::IOTypeR8;
       break;
    case ArrayDataType::Unknown:
       ABORT_ERROR("IOStream readFieldData: Unknown data array type");
@@ -1728,7 +1739,7 @@ Error IOStream::readFieldData(
       Err =
           IO::readArray(DataPtr, LocSize, FieldName, FileID, DecompID, FieldID);
    } else {
-      Err = IO::readNDVar(DataPtr, FieldName, FileID, FieldID);
+      Err = IO::readNDVar(DataPtr, MyIOType, FieldName, FileID, FieldID);
    }
    // For back compatibility, try to read again with old field name
    if (Err.isFail()) {
@@ -1736,7 +1747,7 @@ Error IOStream::readFieldData(
          Err = IO::readArray(DataPtr, LocSize, OldFieldName, FileID, DecompID,
                              FieldID);
       } else {
-         Err = IO::readNDVar(DataPtr, OldFieldName, FileID, FieldID);
+         Err = IO::readNDVar(DataPtr, MyIOType, OldFieldName, FileID, FieldID);
       }
       if (Err.isFail()) {
          // If the field is optional, a missing variable is not an error. Leave
@@ -2586,8 +2597,8 @@ void IOStream::writeStream(
             int TmpID;
             std::vector<int> TmpDimLengths; // empty dim length for scalar time
             for (int IFrame = 0; IFrame < NFrames; ++IFrame) {
-               Err = IO::readNDVar(&FrameTime, "time", OutFileID, TmpID, IFrame,
-                                   &TmpDimLengths);
+               Err = IO::readNDVar(&FrameTime, IO::IOTypeR8, "time", OutFileID,
+                                   TmpID, IFrame, &TmpDimLengths);
                CHECK_ERROR_ABORT(Err, "Error reading frame time in {}",
                                  OutFileName);
                if (std::abs(ElapsedTimeR8 - FrameTime) < 1.e-5) { // overwrite

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -523,6 +523,14 @@ add_omega_test(
     "-n;8"
 )
 
+add_omega_test(
+    VERTCOORD_SINGLE_PRECISION_TEST
+    testVertCoordSinglePrecision.exe
+    ocn/VertCoordTest.cpp
+    "-n;8"
+    single_precision
+)
+
 ##################
 # Fill Value test
 ##################

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -485,25 +485,32 @@ int main(int argc, char *argv[]) {
       HostArray2DR8 NewR8Vrtx("NewR8Vrtx", NVerticesSize, NVertLayers);
 
       // Read non-distributed variables
-      Err = IO::readNDVar(&NewI4Scalar, "ScalarI4", InFileID, VarIDScalarI4);
+      Err = IO::readNDVar(&NewI4Scalar, IO::IOTypeI4, "ScalarI4", InFileID,
+                          VarIDScalarI4);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read scalar I4 NDVar")
 
-      Err = IO::readNDVar(&NewI8Scalar, "ScalarI8", InFileID, VarIDScalarI8);
+      Err = IO::readNDVar(&NewI8Scalar, IO::IOTypeI8, "ScalarI8", InFileID,
+                          VarIDScalarI8);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read scalar I8 NDVar")
 
-      Err = IO::readNDVar(&NewR4Scalar, "ScalarR4", InFileID, VarIDScalarR4);
+      Err = IO::readNDVar(&NewR4Scalar, IO::IOTypeR4, "ScalarR4", InFileID,
+                          VarIDScalarR4);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read scalar R4 NDVar")
 
-      Err = IO::readNDVar(&NewR8Scalar, "ScalarR8", InFileID, VarIDScalarR8);
+      Err = IO::readNDVar(&NewR8Scalar, IO::IOTypeR8, "ScalarR8", InFileID,
+                          VarIDScalarR8);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read scalar R8 NDVar")
 
-      Err = IO::readNDVar(NewI4Vert.data(), "I4Vert", InFileID, VarIDI4Vert);
+      Err = IO::readNDVar(NewI4Vert.data(), IO::IOTypeI4, "I4Vert", InFileID,
+                          VarIDI4Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read I4 vertical NDVar")
 
-      Err = IO::readNDVar(NewI8Vert.data(), "I8Vert", InFileID, VarIDI8Vert);
+      Err = IO::readNDVar(NewI8Vert.data(), IO::IOTypeI8, "I8Vert", InFileID,
+                          VarIDI8Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read I8 vertical NDVar")
 
-      Err = IO::readNDVar(NewR4Vert.data(), "R4Vert", InFileID, VarIDR4Vert);
+      Err = IO::readNDVar(NewR4Vert.data(), IO::IOTypeR4, "R4Vert", InFileID,
+                          VarIDR4Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R4 vertical NDVar")
 
       // Read non-distributed variables into buffers whose type differs from
@@ -521,18 +528,20 @@ int main(int argc, char *argv[]) {
       std::vector<R4> NewR4FromR8(2 * NVertLayers, GuardR4);
       std::vector<R8> NewR8FromR4(2 * NVertLayers, GuardR8);
 
-      Err = IO::readNDVar(NewR4FromR8.data(), "R8Vert", InFileID, VarIDR8Vert);
+      Err = IO::readNDVar(NewR4FromR8.data(), IO::IOTypeR4, "R8Vert", InFileID,
+                          VarIDR8Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R8 vertical NDVar as R4")
 
-      Err = IO::readNDVar(NewR8FromR4.data(), "R4Vert", InFileID, VarIDR4Vert);
+      Err = IO::readNDVar(NewR8FromR4.data(), IO::IOTypeR8, "R4Vert", InFileID,
+                          VarIDR4Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R4 vertical NDVar as R8")
 
       // Read R8 data as two time slices
-      Err = IO::readNDVar(NewR8Vert.data(), "R8Time", InFileID, VarIDR8Time, 0,
-                          &DimLengths);
+      Err = IO::readNDVar(NewR8Vert.data(), IO::IOTypeR8, "R8Time", InFileID,
+                          VarIDR8Time, 0, &DimLengths);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R8 NDVar time slice 0")
-      Err = IO::readNDVar(NewR8Time.data(), "R8Time", InFileID, VarIDR8Time, 1,
-                          &DimLengths);
+      Err = IO::readNDVar(NewR8Time.data(), IO::IOTypeR8, "R8Time", InFileID,
+                          VarIDR8Time, 1, &DimLengths);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R8 NDVar time slice 1")
 
       // Read distributed arrays

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -271,6 +271,11 @@ int main(int argc, char *argv[]) {
           IO::defineVar(OutFileID, "I8Vert", IO::IOTypeI8, 1, VertDimIDs);
       int VarIDR4Vert =
           IO::defineVar(OutFileID, "R4Vert", IO::IOTypeR4, 1, VertDimIDs);
+      // A double-precision counterpart of R4Vert, used below to check that
+      // a non-distributed variable can be read into a buffer whose type
+      // differs from the type stored in the file
+      int VarIDR8Vert =
+          IO::defineVar(OutFileID, "R8Vert", IO::IOTypeR8, 1, VertDimIDs);
       int VarIDR8Time =
           IO::defineVar(OutFileID, "R8Time", IO::IOTypeR8, 2, TimeDimIDs);
       int VarIDCellI4 =
@@ -328,6 +333,7 @@ int main(int argc, char *argv[]) {
       IO::writeNDVar(RefI4Vert.data(), OutFileID, VarIDI4Vert);
       IO::writeNDVar(RefI8Vert.data(), OutFileID, VarIDI8Vert);
       IO::writeNDVar(RefR4Vert.data(), OutFileID, VarIDR4Vert);
+      IO::writeNDVar(RefR8Vert.data(), OutFileID, VarIDR8Vert);
       // Write R8 arrays as two time slices - the first frame here with
       // the second frame written after re-open
       std::vector<int> DimLengths(1);
@@ -500,6 +506,27 @@ int main(int argc, char *argv[]) {
       Err = IO::readNDVar(NewR4Vert.data(), "R4Vert", InFileID, VarIDR4Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R4 vertical NDVar")
 
+      // Read non-distributed variables into buffers whose type differs from
+      // the type of the variable stored in the file. Mesh and initial state
+      // files are written in double precision, but the arrays they are read
+      // into are single precision in an OMEGA_SINGLE_PRECISION build, so the
+      // read must convert rather than assume the two types match. The buffers
+      // are allocated at twice the length needed and the unused half is set
+      // to a guard value; a read that fills eight bytes per element into a
+      // four-byte buffer then shows up as an overwritten guard instead of as
+      // an out-of-bounds write.
+      const R4 GuardR4 = -1.234e30;
+      const R8 GuardR8 = -1.23456789e30;
+
+      std::vector<R4> NewR4FromR8(2 * NVertLayers, GuardR4);
+      std::vector<R8> NewR8FromR4(2 * NVertLayers, GuardR8);
+
+      Err = IO::readNDVar(NewR4FromR8.data(), "R8Vert", InFileID, VarIDR8Vert);
+      CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R8 vertical NDVar as R4")
+
+      Err = IO::readNDVar(NewR8FromR4.data(), "R4Vert", InFileID, VarIDR4Vert);
+      CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R4 vertical NDVar as R8")
+
       // Read R8 data as two time slices
       Err = IO::readNDVar(NewR8Vert.data(), "R8Time", InFileID, VarIDR8Time, 0,
                           &DimLengths);
@@ -593,6 +620,31 @@ int main(int argc, char *argv[]) {
          ABORT_ERROR("IOTest: read/write vert R8 vector test frame 0 FAIL");
       if (Err5 > 0)
          ABORT_ERROR("IOTest: read/write vert R8 vector test frame 1 FAIL");
+
+      // Check the cross-type reads. The values must be converted from the
+      // type in the file to the type of the destination buffer and nothing
+      // may be written past the end of the data, which the guard values in
+      // the second half of each buffer detect.
+      int ErrR4FromR8 = 0;
+      int ErrR8FromR4 = 0;
+
+      for (int k = 0; k < NVertLayers; ++k) {
+         if (NewR4FromR8[k] != static_cast<R4>(RefR8Vert(k)))
+            ErrR4FromR8++;
+         if (NewR8FromR4[k] != static_cast<R8>(RefR4Vert(k)))
+            ErrR8FromR4++;
+      }
+      for (int k = NVertLayers; k < 2 * NVertLayers; ++k) {
+         if (NewR4FromR8[k] != GuardR4)
+            ErrR4FromR8++;
+         if (NewR8FromR4[k] != GuardR8)
+            ErrR8FromR4++;
+      }
+
+      if (ErrR4FromR8 > 0)
+         ABORT_ERROR("IOTest: read vert R8 variable into R4 buffer FAIL");
+      if (ErrR8FromR4 > 0)
+         ABORT_ERROR("IOTest: read vert R4 variable into R8 buffer FAIL");
 
       Err1 = 0;
       Err2 = 0;

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -20,6 +20,7 @@
 #include "IOStream.h"
 #include "Logging.h"
 #include "MachEnv.h"
+#include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
 #include "TimeMgr.h"
@@ -108,6 +109,19 @@ int main(int argc, char *argv[]) {
       I4 VertexDegree   = DefMesh->VertexDegree;
       I4 NVertLayers    = DefVertCoord->NVertLayers;
 
+      // Tolerances for the comparisons below. In double precision these
+      // reproduce the fixed 1e-10 absolute tolerance this test has always
+      // used. Single precision cannot hold that: the expected values reach a
+      // few thousand once cell and layer indices accumulate down a column, and
+      // several of them (the sea surface height, the target thicknesses) are
+      // arrived at by cancelling contributions from every layer, so the error
+      // is set by the magnitude of the whole column rather than by the size of
+      // the result. Hence a relative tolerance with an absolute floor. Both
+      // stay far below the smallest separation any of these checks has to
+      // resolve, which is the 0.5 between a layer midpoint and its interface.
+      const Real RTol = sizeof(Real) == 4 ? 1.0e-4_Real : 0.0_Real;
+      const Real ATol = sizeof(Real) == 4 ? 1.0e-2_Real : 1.0e-10_Real;
+
       // Rest bottom depth successful read
       R8 MaxBathy = -1e10;
       R8 MinBathy = 1e10;
@@ -167,15 +181,13 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             // Interface pressure at layer K should be K+1
             Real Expected = K + 1;
-            Real Diff     = std::abs(PressInterfH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(PressInterfH(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
             // Mid pressures at layer K should be K+1.5
             Expected = K + 1.5;
-            Diff     = std::abs(PressMidH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
-               Err += Err + 1;
+            if (!isApprox(PressMidH(ICell, K), Expected, RTol, ATol)) {
+               Err += 1;
             }
          }
       }
@@ -212,8 +224,7 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// Interface pressure should be (K+1)*K/2 + the cell number
             Real Expected = ((K + 1.0_Real) * K) / 2.0_Real + ICell;
-            Real Diff     = std::abs(PressInterfH2(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(PressInterfH2(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
          }
@@ -264,21 +275,18 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// Z value at interface K should be -K
             Real Expected = -K;
-            Real Diff     = std::abs(GeomZInterfH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(GeomZInterfH(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
             /// Z value at mid point of layer K should be -(K + .5)
             Expected = -K - 0.5;
-            Diff     = std::abs(GeomZMidH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(GeomZMidH(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
          }
          /// SshCell should equal ZInterface at the top of the active column
          Real Expected = -DefVertCoord->MinLayerCellH(ICell);
-         Real Diff     = std::abs(SshCellH(ICell) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(SshCellH(ICell), Expected, RTol, ATol)) {
             Err += 1;
          }
       }
@@ -317,8 +325,7 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// Z value at interface should be -(K+1)*K/2
             Real Expected = -((K + 1.0_Real) * K) / 2.0_Real;
-            Real Diff     = std::abs(ZInterfH2(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(ZInterfH2(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
          }
@@ -326,8 +333,7 @@ int main(int argc, char *argv[]) {
          /// which is -((MinLayer+1)*MinLayer)/2
          I4 MinK       = DefVertCoord->MinLayerCellH(ICell);
          Real Expected = -((MinK + 1.0_Real) * MinK) / 2.0_Real;
-         Real Diff     = std::abs(SshCellH2(ICell) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(SshCellH2(ICell), Expected, RTol, ATol)) {
             Err += 1;
          }
       }
@@ -372,8 +378,7 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// Geopotential should be cell number + layer number
             Real Expected = ICell + K;
-            Real Diff     = std::abs(GeopotentialMidH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(GeopotentialMidH(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
          }
@@ -416,8 +421,8 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// target thickness should be 2
             Real Expected = 2.0;
-            Real Diff = std::abs(PseudoThicknessTargetH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(PseudoThicknessTargetH(ICell, K), Expected, RTol,
+                          ATol)) {
                Err += 1;
             }
          }
@@ -472,8 +477,8 @@ int main(int argc, char *argv[]) {
                /// target thickness is 1 in all other layer
                Expected = 1.0;
             }
-            Real Diff = std::abs(PseudoThicknessTargetH2(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(PseudoThicknessTargetH2(ICell, K), Expected, RTol,
+                          ATol)) {
                LOG_INFO("PseudoThicknessTargetH({},{}) = {}, {}", ICell, K,
                         PseudoThicknessTargetH2(ICell, K), Expected);
                Err += 1;
@@ -524,27 +529,27 @@ int main(int argc, char *argv[]) {
          I4 CellID1 = DefDecomp->CellIDH(DefMesh->CellsOnEdgeH(IEdge, 0));
          I4 CellID2 = DefDecomp->CellIDH(DefMesh->CellsOnEdgeH(IEdge, 1));
          /// MinLayerEdgeTop is the min of the min cell values on edge
-         Expected  = std::min(-2 * CellID1, -2 * CellID2);
-         Real Diff = std::abs(DefVertCoord->MinLayerEdgeTopH(IEdge) - Expected);
-         if (Diff > 1e-10) {
+         Expected = std::min(-2 * CellID1, -2 * CellID2);
+         if (!isApprox(DefVertCoord->MinLayerEdgeTopH(IEdge), Expected, RTol,
+                       ATol)) {
             Err += 1;
          }
          /// MinLayerEdgeBot is the max of the min cell values on edge
          Expected = std::max(-2 * CellID1, -2 * CellID2);
-         Diff     = std::abs(DefVertCoord->MinLayerEdgeBotH(IEdge) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MinLayerEdgeBotH(IEdge), Expected, RTol,
+                       ATol)) {
             Err += 1;
          }
          /// MaxLayerEdgeTop is the min of the max cell values on edge
          Expected = std::min(2 * CellID1, 2 * CellID2);
-         Diff     = std::abs(DefVertCoord->MaxLayerEdgeTopH(IEdge) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MaxLayerEdgeTopH(IEdge), Expected, RTol,
+                       ATol)) {
             Err += 1;
          }
          /// MaxLayerEdgeBot is the max of the max cell values on edge
          Expected = std::max(2 * CellID1, 2 * CellID2);
-         Diff     = std::abs(DefVertCoord->MaxLayerEdgeBotH(IEdge) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MaxLayerEdgeBotH(IEdge), Expected, RTol,
+                       ATol)) {
             Err += 1;
          }
       }
@@ -590,9 +595,8 @@ int main(int argc, char *argv[]) {
          for (int I = 0; I < VertexDegree; I++) {
             Expected = std::min(Expected, -2 * CellIDs[I]);
          }
-         Real Diff =
-             std::abs(DefVertCoord->MinLayerVertexTopH(IVertex) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MinLayerVertexTopH(IVertex), Expected,
+                       RTol, ATol)) {
             Err += 1;
          }
 
@@ -601,8 +605,8 @@ int main(int argc, char *argv[]) {
          for (int I = 0; I < VertexDegree; I++) {
             Expected = std::max(Expected, -2 * CellIDs[I]);
          }
-         Diff = std::abs(DefVertCoord->MinLayerVertexBotH(IVertex) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MinLayerVertexBotH(IVertex), Expected,
+                       RTol, ATol)) {
             Err += 1;
          }
 
@@ -611,8 +615,8 @@ int main(int argc, char *argv[]) {
          for (int I = 0; I < VertexDegree; I++) {
             Expected = std::min(Expected, 2 * CellIDs[I]);
          }
-         Diff = std::abs(DefVertCoord->MaxLayerVertexTopH(IVertex) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MaxLayerVertexTopH(IVertex), Expected,
+                       RTol, ATol)) {
             Err += 1;
          }
 
@@ -621,8 +625,8 @@ int main(int argc, char *argv[]) {
          for (int I = 0; I < VertexDegree; I++) {
             Expected = std::max(Expected, 2 * CellIDs[I]);
          }
-         Diff = std::abs(DefVertCoord->MaxLayerVertexBotH(IVertex) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MaxLayerVertexBotH(IVertex), Expected,
+                       RTol, ATol)) {
             Err += 1;
          }
       }
@@ -675,8 +679,7 @@ int main(int argc, char *argv[]) {
             Sum += DefVertCoord->CellMaskH(ICell, K);
          }
 
-         Real Diff = std::abs(Sum - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(Sum, Expected, RTol, ATol)) {
             Err += 1;
          }
       }
@@ -697,8 +700,7 @@ int main(int argc, char *argv[]) {
          for (int K = 0; K < NVertLayers; ++K) {
             Sum += DefVertCoord->EdgeMaskH(IEdge, K);
          }
-         Real Diff = std::abs(Sum - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(Sum, Expected, RTol, ATol)) {
             Err += 1;
          }
       }
@@ -711,8 +713,7 @@ int main(int argc, char *argv[]) {
          for (int K = 0; K < NVertLayers; ++K) {
             Sum += DefVertCoord->VertexMaskH(IVertex, K);
          }
-         Real Diff = std::abs(Sum - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(Sum, Expected, RTol, ATol)) {
             Err += 1;
          }
       }


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->
`IO::readNDVar` filled the caller's buffer using the data type of the variable as stored in the file rather than the type of the buffer itself. Reading a double variable into a single-precision array wrote eight bytes per element into four-byte slots, overrunning the buffer and corrupting the heap. This affected every `OMEGA_SINGLE_PRECISION` build that initialized `VertCoord` and blocked any single-precision test needing a vertical coordinate. Pass the destination type to `readNDVar` so the values are converted on read, and add a single-precision` VertCoord` test now that one can run.

---
## The defect

`IO::readNDVar` called `PIOc_get_var` and `PIOc_get_vara`. Both pass `PIO_NAT` to SCORPIO, which means "fill the buffer using the type the variable has in the file". There is no conversion to the caller's buffer type.

`VertCoordMovementWeights` is dimensioned on `NVertLayers` alone, making it the only non-distributed real field Omega reads from the mesh file, and it is stored there in double precision. In a single-precision build `IOStream::readFieldData` allocates a 60-element `std::vector<R4>` (240 bytes) and SCORPIO writes 60 doubles (480 bytes) into it — a 240-byte overrun on every read.

The damage was silent where it happened and surfaced later as a segmentation fault during an unrelated read, an invalid free inside PnetCDF during teardown, or occasionally nothing at all. Double-precision builds were unaffected because the two types have the same width there.

## The fix

`readNDVar` now takes an `IODataType` describing the destination buffer and dispatches to the type-specific SCORPIO calls (`PIOc_get_var_int`, `_longlong`, `_float`, `_double`, and the `_vara_` forms), which convert on read. Distributed reads already carry this information in the decomposition and are unchanged.

In `IOStream::readFieldData` the type is assigned in the same `switch` that allocates the buffer, so the two cannot drift apart. Note this is deliberately not `getFieldIOType()`, which folds in the stream's `ReducePrecision` flag — that describes the file, not the buffer.

This also corrects the frame-time read in `IOStream::writeStream`, which read the file's `time` variable into an `R8` and would have produced garbage for a stream written with reduced precision.

## Tests

`IO_TEST` gains a cross-type check: a double variable read into a single-precision buffer and a float variable read into a double buffer. Both destination buffers are allocated at twice the length needed with the spare half set to a guard value, so the defect reports as wrong values and overwritten guards rather than as an out-of-bounds write. It is precision-independent and fails in a default double-precision build, which is where it is most likely to be noticed.

`VERTCOORD_SINGLE_PRECISION_TEST` is new — a single-precision build of the existing VertCoord driver, following `TEND_PLANE_SINGLE_PRECISION_TEST`. This is the coverage the fix makes possible.

The VertCoord checks were written as a fixed `1e-10` absolute tolerance, which single precision cannot meet: expected values reach a few thousand once cell and layer indices accumulate down a column, and the sea surface height and target thicknesses are arrived at by cancelling contributions from every layer. The hand-rolled comparisons are replaced with `isApprox()` from `OceanTestCommon.h` and a per-precision relative tolerance plus absolute floor.

Double precision is unchanged by construction: with `RTol = 0` and `ATol = 1e-10`, `isApprox()` reduces to exactly the previous comparison. The one behavioral difference is that `isApprox()` rejects NaN, which the old form silently accepted since a NaN difference is not greater than the tolerance.

Also corrects `Err += Err + 1` to `Err += 1` in the mid-pressure check. The doubling affected only the reported count, not pass or fail, but it overflows a signed int after about thirty failures.

## Verification

Chrysalis, intel, Release:
- at the test-only commit, `IO_TEST` fails and the other 46 pass;
- with the fix, 47/47 pass;
- with the single-precision test added, 48/48 pass.

## Documentation

`doc/devGuide/IO.md` documents the new argument and why it is required rather than optional.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Documentation:
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [x] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.
* [x] New tests:
  * [x] CTest unit tests for new features have been added per the approved design.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


