### PR TITLE
Give each Omega unit test its own log file

### DIFF
--- a/components/omega/OmegaBuild.cmake
+++ b/components/omega/OmegaBuild.cmake
@@ -313,6 +313,9 @@ macro(init_standalone_build)
   set(_CtestScript ${OMEGA_BUILD_DIR}/omega_ctest.sh)
   file(WRITE ${_CtestScript}  "#!/usr/bin/env bash\n\n")
   file(APPEND ${_CtestScript} "source ./omega_env.sh\n\n")
+  # each test truncates its own log on startup, so this only removes logs left
+  # behind by tests that are no longer run
+  file(APPEND ${_CtestScript} "rm -f test/logs/*.log\n\n")
   if(OMEGA_DEBUG)
     file(APPEND ${_CtestScript} "ctest --output-on-failure --verbose $* # --rerun-failed\n\n")
   else()

--- a/components/omega/doc/devGuide/Logging.md
+++ b/components/omega/doc/devGuide/Logging.md
@@ -23,8 +23,32 @@ file, serves as a pivotal component for initializing the Omega logging system.
 
 The function establishes the default logger configuration, ensuring that
 logging messages are effectively saved to a designated file. The path to
-this file is determined by utilizing the `OMEGA_LOG_FILEPATH` macro, which
-allows users to specify the desired file location for logging purposes.
+this file can be passed as the second argument to `OMEGA::initLogging`. When
+it is omitted, the path comes from the `OMEGA_LOG_FILE` environment variable
+if that is set and non-empty, and from `OMEGA::OmegaDefaultLogfile`
+(`omega.log`) otherwise. The log file is truncated when it is opened, so it
+holds only the messages from the current run.
+
+## Log files in the unit tests
+
+Every unit test driver calls `OMEGA::initLogging(DefEnv)` without a file name,
+so without any further arrangement all of the tests would write to a single
+`omega.log` in the build's `test` directory, with nothing to say which test
+wrote which line. To avoid this, `test/CMakeLists.txt` sets `OMEGA_LOG_FILE`
+per test in `add_omega_test`, so that each test writes to
+`test/logs/<TEST_NAME>.log`. Note that the name comes from the CTest test
+name rather than the source file, because several tests are built from the
+same source (for example `TEND_PLANE_TEST` and
+`TEND_PLANE_SINGLE_PRECISION_TEST` both come from `TendencyTermsTest.cpp`).
+
+A new test added with `add_omega_test` gets its own log file automatically. A
+test driver that hard-codes a log file name would opt out of this, so pass no
+file name to `initLogging` unless the test manages its own log files, as
+`LoggingTest` does.
+
+The environment variable relies on the MPI launcher passing its environment
+to the ranks it starts, which is true of `srun`. If a launcher does not, the
+tests fall back to writing `omega.log`.
 
 ## Creating Logging Macros
 

--- a/components/omega/doc/userGuide/Error.md
+++ b/components/omega/doc/userGuide/Error.md
@@ -6,8 +6,10 @@ Omega includes an error handling facility that checks for potential errors
 and responds to those errors when encountered.
 It uses the [Logging](#omega-dev-logging) facility for writing the error
 messages so its behavior follows that of Logging. In particular, the error
-messages will be output to a single log file (omega.log) unless the option
-to write a log file for each MPI task is enabled at build time. Each message
+messages will be output to a single log file (omega.log by default, see the
+`OMEGA_LOG_FILE` environment variable) unless logging on more than one MPI
+task is requested with `OMEGA_LOG_TASKS`, in which case each logging task
+writes its own file. Each message
 will have the format
 ```
 [*level] [file:line number] error message

--- a/components/omega/doc/userGuide/Logging.md
+++ b/components/omega/doc/userGuide/Logging.md
@@ -65,6 +65,25 @@ LOG_TRACE("The value of MyInt is: {}", MyInt);
 
 By default, the logfile will be created in the build directory.
 
+## Log file name
+
+By default Omega writes its log messages to `omega.log` in the directory it is
+run from. A different name or path can be requested at run time with the
+`OMEGA_LOG_FILE` environment variable:
+
+```bash
+export OMEGA_LOG_FILE=mylogs/run1.log
+```
+
+When more than one MPI rank writes a log (see `OMEGA_LOG_TASKS`), the rank
+number is inserted into the name, so `omega.log` becomes `omega_0.log`,
+`omega_1.log` and so on. The log file is truncated when Omega starts, so it
+always contains only the messages from the current run.
+
+The Omega unit tests use this variable to give each test its own log file,
+`test/logs/<TEST_NAME>.log` in the build directory, rather than a single
+shared log for the whole test suite.
+
 ## E3SM Component Build
 
 T.B.D.

--- a/components/omega/src/infra/Logging.cpp
+++ b/components/omega/src/infra/Logging.cpp
@@ -24,6 +24,11 @@
 
 namespace OMEGA {
 
+// Stream that holds the log file to which stdout and stderr are redirected.
+// It must outlive the redirect, so it has static storage duration here rather
+// than being a local of initLogging.
+static std::ofstream LogFileStream;
+
 //------------------------------------------------------------------------------
 // Utility function to create a log message with prefix
 std::string

--- a/components/omega/src/infra/Logging.cpp
+++ b/components/omega/src/infra/Logging.cpp
@@ -13,6 +13,7 @@
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
+#include <ctime>
 #include <fstream>
 #include <iostream>
 #include <limits>
@@ -151,6 +152,42 @@ static std::string getLogTaskSelector() {
 }
 
 //------------------------------------------------------------------------------
+// Determine the log file name to use when the caller does not supply one.
+// The OMEGA_LOG_FILE environment variable takes precedence so that a harness
+// (eg CTest, which gives each unit test its own log) can name the file at run
+// time; otherwise the built-in default name is used.
+static std::string getDefaultLogFilePath() {
+   const char *Env = std::getenv("OMEGA_LOG_FILE");
+   if (Env != nullptr && Env[0] != '\0')
+      return std::string(Env);
+   return OmegaDefaultLogfile;
+}
+
+//------------------------------------------------------------------------------
+// Insert the MPI task id into a log file name so that each logging rank gets
+// its own file, eg omega.log -> omega_3.log. When the name has no extension,
+// the task id is simply appended.
+static std::string addTaskIdToPath(const std::string &LogFilePath,
+                                   OMEGA::I4 TaskId) {
+
+   const std::string Suffix = "_" + std::to_string(TaskId);
+
+   std::size_t DotPos = LogFilePath.find_last_of('.');
+   std::size_t SepPos = LogFilePath.find_last_of("\\/");
+
+   // only treat a dot as an extension when it is part of the file name and
+   // not part of a directory in the path
+   bool HasExtension = (DotPos != std::string::npos) &&
+                       (SepPos == std::string::npos || DotPos > SepPos);
+
+   if (HasExtension)
+      return LogFilePath.substr(0, DotPos) + Suffix +
+             LogFilePath.substr(DotPos);
+
+   return LogFilePath + Suffix;
+}
+
+//------------------------------------------------------------------------------
 // Resolve which sub-communicator ranks should log from the runtime selector,
 // emitting master-rank diagnostics for invalid or empty selections. Sets
 // NumLogging to the count of selected ranks that exist in this communicator.
@@ -248,18 +285,24 @@ int initLogging(
 
    if (ThisTaskLogs) {
       try {
-         std::size_t dotPos = LogFilePath.find_last_of('.');
-
          // create log file name/path and set default (*) logger. When more than
          // one rank logs, append the rank id to keep per-rank files distinct.
-         if (NumLogging > 1 && dotPos != std::string::npos) {
+         // An empty path means the caller wants the default name, which may be
+         // supplied by the environment.
+         NewLogFilePath =
+             LogFilePath.empty() ? getDefaultLogFilePath() : LogFilePath;
 
-            NewLogFilePath = LogFilePath.substr(0, dotPos) + "_" +
-                             std::to_string(TaskId) +
-                             LogFilePath.substr(dotPos);
-         } else {
-            NewLogFilePath = LogFilePath;
-         }
+         if (NumLogging > 1)
+            NewLogFilePath = addTaskIdToPath(NewLogFilePath, TaskId);
+
+         // Start the run with an empty log file so that it only ever holds
+         // messages from this run. Both the spdlog sink created below and the
+         // stdout/stderr stream opened at the end of this function append to
+         // the file, so that their writes interleave correctly rather than
+         // overwriting each other; the file is therefore truncated here, ahead
+         // of both, rather than by either of them.
+         std::ofstream Truncate(NewLogFilePath, std::ios::trunc);
+         Truncate.close();
 
          // Create default logger
          spdlog::set_default_logger(
@@ -293,6 +336,18 @@ int initLogging(
       // Set the stdout and stderr buffers to the file streambuffer
       std::cout.rdbuf(LogFileStream.rdbuf());
       std::cerr.rdbuf(LogFileStream.rdbuf());
+
+      // Open the log with a banner giving the file and the time it was
+      // opened, so the log can always be tied to the run that wrote it
+      std::time_t Now = std::time(nullptr);
+      char TimeStr[64];
+      if (std::strftime(TimeStr, sizeof(TimeStr), "%Y-%m-%d %H:%M:%S",
+                        std::localtime(&Now)) == 0)
+         TimeStr[0] = '\0';
+      spdlog::info(fmt::runtime("----- Omega log " + NewLogFilePath +
+                                " opened " + std::string(TimeStr) +
+                                " on task " + std::to_string(TaskId) +
+                                " -----"));
    }
 
    return RetVal;

--- a/components/omega/src/infra/Logging.h
+++ b/components/omega/src/infra/Logging.h
@@ -173,7 +173,6 @@ class MachEnv;
 
 // Public variables used for logging
 const std::string OmegaDefaultLogfile = "omega.log"; ///< Default log filename
-static std::ofstream LogFileStream;                  ///< Default log iostream
 
 /// Initializes Omega logging, including setting up which tasks will log
 /// and add redirection of stdout/stderr to log file. An empty LogFilePath

--- a/components/omega/src/infra/Logging.h
+++ b/components/omega/src/infra/Logging.h
@@ -157,6 +157,15 @@
 /// An invalid selector logs a warning on the master rank and falls back to
 /// master-rank-only logging.
 
+/// Log file naming
+/// When no log file name is supplied to initLogging, the name is taken from
+/// the OMEGA_LOG_FILE environment variable if it is set and non-empty, and
+/// from OmegaDefaultLogfile otherwise. This lets a harness (in particular the
+/// CTest harness, which gives every unit test its own file) name the log
+/// without recompiling. A name passed explicitly to initLogging always wins.
+/// The log file is truncated when it is opened, so it always holds exactly
+/// the messages from the current run.
+
 namespace OMEGA {
 
 // To prevent some circular dependencies between MachEnv and Logging
@@ -167,10 +176,10 @@ const std::string OmegaDefaultLogfile = "omega.log"; ///< Default log filename
 static std::ofstream LogFileStream;                  ///< Default log iostream
 
 /// Initializes Omega logging, including setting up which tasks will log
-/// and add redirection of stdout/stderr to log file
-int initLogging(
-    const OMEGA::MachEnv *DefEnv, ///< [in] MachEnv with MPI task info
-    std::string const &LogFilePath = OmegaDefaultLogfile ///< [in] file name
+/// and add redirection of stdout/stderr to log file. An empty LogFilePath
+/// selects the default name (see the log file naming notes above).
+int initLogging(const OMEGA::MachEnv *DefEnv, ///< [in] MachEnv w/ MPI task info
+                std::string const &LogFilePath = "" ///< [in] file name
 );
 
 /// Alternative Logging initialization using a pre-defined custom Logger

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -1,5 +1,10 @@
 # Omega Unit Tests
 
+# Directory holding one log file per test, created here so that it exists
+# before any test runs
+set(OMEGA_TEST_LOG_DIR logs)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${OMEGA_TEST_LOG_DIR})
+
 #####################
 # Omega Test Function
 #####################
@@ -69,7 +74,17 @@ function(add_omega_test test_name exe_name source_files mpi_args)
     )
   endif()
 
-  set_tests_properties(${test_name} PROPERTIES LABELS "${OMEGA_ARCH};Omega-0")
+  # Give each test its own log file (relative to the test working directory,
+  # which is this binary directory) so that the log of a test can be read on
+  # its own rather than mixed in with every other test's messages. The name
+  # comes from the test rather than the source file because several tests
+  # share a source file.
+  set_tests_properties(
+    ${test_name}
+    PROPERTIES
+    LABELS "${OMEGA_ARCH};Omega-0"
+    ENVIRONMENT "OMEGA_LOG_FILE=${OMEGA_TEST_LOG_DIR}/${test_name}.log"
+  )
 
 endfunction()
 


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

Every Omega unit test wrote into a single `omega.log` opened in append mode, so one run's log was the concatenation of all 47 tests with no test boundaries, repeated runs in the same build tree appended to each other, and messages logged from library code could not be attributed to a test at all. This makes `initLogging` take its default log file name from the `OMEGA_LOG_FILE` environment variable, sets that variable per test in add_omega_test so each test writes `test/logs/TEST_NAME.log`, and truncates the log when it is opened so it holds exactly one run. The standalone and coupled drivers still write omega.log or the coupler-supplied name.

---

## Problem

- All 47 unit tests call `initLogging(DefEnv)` with no file name, so all of them log to `<build>/test/omega.log`.
- The file is opened in append mode, so one run's log is the concatenation of all 47 tests with nothing marking where one test ends and the next begins, and a second `./omega_ctest.sh` in the same build tree appends again, mixing runs.
- Only the `[file:line]` prefix attributes a line to anything, which helps only for messages logged from a test driver; messages from library code such as `IOStream.cpp` or `VertCoord.cpp` are shared by many tests and cannot be attributed.
- CTest's own capture is not a substitute, since `initLogging` has redirected stdout and stderr into the log file before anything is logged.

## Changes

- Take the default log file name from the `OMEGA_LOG_FILE` environment variable when it is set and non-empty, falling back to `OmegaDefaultLogfile` (`omega.log`); a name passed explicitly to `initLogging` still wins, so the coupled driver is unaffected.
- Change the default argument of `initLogging` to an empty string so that "use the default name" can be distinguished from an explicitly supplied name.
- Set `OMEGA_LOG_FILE=logs/<TEST_NAME>.log` in `add_omega_test`, which covers every test with no change to the 39 test drivers; the name comes from the CTest test name rather than the source file because several tests share a source file, such as `TEND_PLANE_TEST` and `TEND_PLANE_SINGLE_PRECISION_TEST`.
- Truncate the log file when it is opened, so it always holds exactly the messages of the current run.
- Open the log with a banner giving the file name, the time and the MPI task, so a log can always be tied to the run that wrote it.
- Remove logs of tests that are no longer run from `test/logs` in the generated `omega_ctest.sh`.
- Insert the task id into per-rank log file names that have no extension, which was previously ignored.
- Move `LogFileStream` out of `Logging.h`, where it was declared `static` at namespace scope and so gave every translation unit including the header its own unused copy.
- Document `OMEGA_LOG_FILE` and the per-test log files in the user and developer guides, and drop the developer guide's reference to the `OMEGA_LOG_FILEPATH` macro, which no longer exists.

## Notes

- The truncation is done once, explicitly, before the spdlog sink and the stdout/stderr stream are opened, rather than by opening the spdlog sink with `truncate = true`; that would leave the sink writing at its own file offset while the redirect stream appends, and the two would overwrite each other.
- Passing the log file name in the environment relies on the MPI launcher forwarding its environment to the ranks it starts, which `srun` does. A launcher that does not forward it simply falls back to `omega.log`.

## Testing

Built on chrysalis with intel and ran `./omega_ctest.sh` twice in the same build tree:

- 47 of 47 tests passed, including `LOGGING_TEST`, which manages its own log files and is unchanged.
- `test/logs` holds 45 non-empty log files, one per test; the two tests without one are `GSWC_CALL_TEST`, which is not an Omega executable, and `LOGGING_TEST`, which writes `tmplog_<rank>.log`.
- No `omega.log` is left anywhere in the build tree.
- Every log holds exactly one banner, with a timestamp from the second run, so the second run replaced the first rather than appending to it.
- No log contains messages from more than one test driver, and library messages from `IOStream.cpp` and `VertCoord.cpp` now appear in the log of the test that produced them.


<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Documentation:
  * [x] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [x] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


