### PR TITLE
Add finite-volume pressure gradient (phase 1 -- 2nd order)

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -41,6 +41,13 @@ Omega:
   PressureGrad:
     # Centered | FiniteVolume
     PressureGradType: Centered
+    # The remaining options apply to the FiniteVolume scheme only
+    # 2 = two-cell stencil (Phase 1); 4 = wide stencil (Phase 2)
+    HorzOrder: 2
+    # 'linear' (Phase 1) | 'ppm' (Phase 2)
+    VerticalReconstruction: linear
+    # quadrature points per edge layer; an accuracy setting only
+    QuadraturePoints: 2
   Tendencies:
     ThicknessFluxTendencyEnable: true
     PVTendencyEnable: true

--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -39,6 +39,7 @@ Omega:
     TracersToRestore: [Temperature, Salinity]
     PistonVelocity: 1.585e-5
   PressureGrad:
+    # Centered | FiniteVolume
     PressureGradType: Centered
   Tendencies:
     ThicknessFluxTendencyEnable: true

--- a/components/omega/doc/devGuide/EOS.md
+++ b/components/omega/doc/devGuide/EOS.md
@@ -96,14 +96,27 @@ water.
 
 The two methods are kept separate rather than always computing the derivatives
 because the derivatives roughly double the TEOS-10 arithmetic per cell and
-layer, and not every configuration needs them. A run using the higher-order
-pressure gradient will need them at every time step, and in that case
-`computeSpecVolAndDerivs` takes the place of the `computeSpecVol` call that
-would otherwise be made, so the equation of state is still evaluated only once
-per step. A run using the standard pressure gradient, or one that only needs
-`SpecVol` for `SpecVolDisplaced` or `BruntVaisalaFreqSq`, keeps calling
-`computeSpecVol` and does no extra work. Which method is called is therefore
-decided by the caller, not by the `Eos` class.
+layer, and not every call needs them. `AuxiliaryState::computeMomVertAux` is
+the only place that calls `computeSpecVol`; everything else consumes the
+`Eos::SpecVol` array rather than recomputing it, including
+`computeBruntVaisalaFreqSq`, which takes the specific volume as an argument.
+That one call site is reached once per time stepper stage through
+`computeMomAux` and `computeAll` in the tendency calculation, and once more
+from `VertMix::VertMixImplicit`, which refreshes the pressure and specific
+volume before the vertical mixing coefficients are formed.
+
+A run using the higher-order pressure gradient therefore needs the derivatives
+at every time step, and at those call sites `computeSpecVolAndDerivs` takes the
+place of the `computeSpecVol` call that would otherwise be made, leaving one
+evaluation of the equation of state where there was one before. Two things
+still call for the plain `computeSpecVol`. First, `PressureGradType` is a
+runtime option that defaults to `Centered`, so a run may never need the
+derivatives at all. Second, even with the higher-order pressure gradient
+selected, the `VertMix::VertMixImplicit` update feeds only
+`computeGeomZHeight` and `computeBruntVaisalaFreqSq`, neither of which reads
+the derivatives, so computing them there would be work that nothing consumes.
+Which method to call is thus a decision for each call site, not one the `Eos`
+class should make for it.
 
 There is no displaced counterpart to `computeSpecVolAndDerivs`. The pressure
 gradient needs the derivatives at the in-situ pressure of the layer, whereas

--- a/components/omega/doc/devGuide/EOS.md
+++ b/components/omega/doc/devGuide/EOS.md
@@ -70,6 +70,67 @@ volume arrays, do
 Eos.computeBruntVaisalaFreqSq(ConservTemp, AbsSalinity, Pressure, SpecVol);
 ```
 
+## First derivatives of specific volume
+
+The `Eos` class can also compute the first derivatives of the specific volume
+with respect to conservative temperature, absolute salinity, and pressure,
+together with the specific volume itself:
+
+```c++
+Eos.computeSpecVolAndDerivs(ConservTemp, AbsSalinity, Pressure);
+```
+
+`Pressure` is the relative pressure (gauge pressure in Pa) as elsewhere in
+`Eos`, and the derivatives are returned per `degC`, per `(g/kg)`, and per `Pa`
+respectively. Note the pressure derivative is per Pascal, not per decibar.
+
+The results are stored in the `SpecVolDCt`, `SpecVolDSa` and `SpecVolDP`
+members alongside `SpecVol`, and all three are registered as fields in the
+`Eos` group so they can be written to a stream. Because `SpecVol` is computed
+here as well, `computeSpecVolAndDerivs` replaces a call to `computeSpecVol`
+rather than accompanying one; calling both would evaluate the equation of state
+twice. The valid range of the derivative fields spans the full range of `Real`
+rather than starting at zero, since the salinity derivative is negative
+everywhere and the temperature derivative is negative in cold, nearly fresh
+water.
+
+The two methods are kept separate rather than always computing the derivatives
+because they roughly double the TEOS-10 arithmetic per cell and layer, and only
+the higher-order pressure gradient needs them.
+
+All four values come from a single pass over the equation of state. For
+`EosType::Teos10Eos` the derivatives are the analytic derivatives of the same
+75-term polynomial used for the specific volume, evaluated at the same
+normalized state, so no second call to the equation of state is made. The
+pressure derivative reuses the pressure coefficients already assembled for the
+specific volume; the temperature and salinity derivatives need coefficient sets
+of their own but share the normalization and the square root. For
+`EosType::LinearEos` the derivatives are `-DRhoDT` and `-DRhoDS` times the
+square of the specific volume, with no pressure dependence, and for
+`EosType::ConstantEos` all three vanish.
+
+The thermal expansion and haline contraction coefficients used by the
+`BruntVaisalaFreqSq` calculation are formed from these same derivatives,
+`alpha = SpecVolDCt / SpecVol` and `beta = -SpecVolDSa / SpecVol`, so the
+polynomial coefficients exist in only one place.
+
+### A note on GSW-C
+
+The GSW toolbox may be redistributed only without modification, so the
+derivative routines in GSW-C are not ported or adapted here; they also could
+not be called from a Kokkos device kernel. The implementation instead
+differentiates the published Roquet et al. 2015 polynomial that `Teos10Eos`
+already carries. GSW-C is used unmodified, through its public API, as an
+independent check in the unit test.
+
+That test compares against `gsw_specvol_first_derivatives` over a range of
+states and finds agreement of order `1e-14` for the temperature and salinity
+derivatives. The pressure derivative agrees only to about `2e-12`, and the
+difference is on the GSW-C side: its `v_P` is evaluated from coefficients that
+have been pre-multiplied by their pressure exponents and rounded, whereas the
+Omega implementation differentiates the full-precision coefficients and matches
+the exact derivative to roughly `1e-16`.
+
 ## Helper functions for conversion
 
 The TEOS-10 implementation includes helper functions for temperature

--- a/components/omega/doc/devGuide/EOS.md
+++ b/components/omega/doc/devGuide/EOS.md
@@ -95,8 +95,25 @@ everywhere and the temperature derivative is negative in cold, nearly fresh
 water.
 
 The two methods are kept separate rather than always computing the derivatives
-because they roughly double the TEOS-10 arithmetic per cell and layer, and only
-the higher-order pressure gradient needs them.
+because the derivatives roughly double the TEOS-10 arithmetic per cell and
+layer, and not every configuration needs them. A run using the higher-order
+pressure gradient will need them at every time step, and in that case
+`computeSpecVolAndDerivs` takes the place of the `computeSpecVol` call that
+would otherwise be made, so the equation of state is still evaluated only once
+per step. A run using the standard pressure gradient, or one that only needs
+`SpecVol` for `SpecVolDisplaced` or `BruntVaisalaFreqSq`, keeps calling
+`computeSpecVol` and does no extra work. Which method is called is therefore
+decided by the caller, not by the `Eos` class.
+
+There is no displaced counterpart to `computeSpecVolAndDerivs`. The pressure
+gradient needs the derivatives at the in-situ pressure of the layer, whereas
+`computeSpecVolDisp` exists to evaluate the specific volume at the pressure of
+a displaced layer. Nothing about the derivatives prevents an adiabatically
+displaced version: it would take the same `KDisp` argument as
+`computeSpecVolDisp` and evaluate the same coefficients at the displaced
+pressure, with no new polynomial. It is left out here only because no caller
+needs it yet, and it would mean carrying three more model-sized arrays and
+fields.
 
 All four values come from a single pass over the equation of state. For
 `EosType::Teos10Eos` the derivatives are the analytic derivatives of the same

--- a/components/omega/doc/devGuide/IO.md
+++ b/components/omega/doc/devGuide/IO.md
@@ -119,11 +119,21 @@ IO::writeArray(&Array, Size, &FillValue,   FileID, DecompID, VarID, Frame);
 For arrays or scalars that are not distributed, the non-distributed variable
 interface must be used:
 ```c++
-Error Err = IO::readNDVar(&Array, VariableName, FileID, VarID);
+Error Err = IO::readNDVar(&Array, VarType, VariableName, FileID, VarID);
 IO::writeNDVar(&Array, FileID, VarID);
 ```
-with arguments similar to the distributed array calls above. Note that
-when defining dimensions for these fields, the dimensions must be
+with arguments similar to the distributed array calls above. The read
+requires a VarType argument giving the data type of the destination array
+(``IO::IOTypeI4``, ``IOTypeI8``, ``IOTypeR4`` or ``IOTypeR8``). This need
+not be the type the variable has in the file and the values are converted
+on read. Supplying it is required rather than optional: without it the
+underlying SCORPIO call fills the destination using the type stored in the
+file, so reading a double variable into a single-precision array would
+write eight bytes per element into four-byte slots and run off the end of
+the array. Distributed reads get the same information from the
+decomposition, so ``readArray`` needs no equivalent argument.
+
+Note that when defining dimensions for these fields, the dimensions must be
 non-distributed. For scalars, the number of dimensions should be zero.
 Multiple time slices can be also be read/written for non-distributed fields,
 but require two additional arguments. As in the distributed array, the
@@ -131,7 +141,8 @@ Frame (index of the time slice) must be provided. In addition, a vector
 ``std::vector<int> DimLengths`` containing the length of the non-time
 dimensions must be provided:
 ```c++
-Error Err = IO::readNDVar(&Array, VariableName, FileID, VarID, Frame, DimLengths);
+Error Err = IO::readNDVar(&Array, VarType, VariableName, FileID, VarID, Frame,
+                          DimLengths);
 IO::writeNDVar(&Array, FileID, VarID, Frame, DimLengths);
 ```
 Note that the full arrays in this case are written so if any masking or

--- a/components/omega/doc/devGuide/PGrad.md
+++ b/components/omega/doc/devGuide/PGrad.md
@@ -4,15 +4,20 @@
 
 Omega includes a `PressureGrad` class that computes horizontal pressure gradient
 tendencies for the non-Boussinesq momentum equation. The implementation supports a
-centered difference scheme as the default, with a placeholder for future high-order
-methods. The class follows the same factory pattern used by other Omega modules.
+centered difference scheme as the default, with a placeholder for a future
+finite-volume method. The class follows the same factory pattern used by other Omega
+modules.
 
 ## PressureGradType enum
 
 An enumeration of the available pressure gradient schemes is defined in `PGrad.h`:
 
 ```c++
-enum class PressureGradType { Centered, HighOrder1, HighOrder2 };
+enum class PressureGradType {
+   Centered,    ///< existing 2nd-order Montgomery scheme
+   FiniteVolume ///< layer-integrated finite-volume scheme
+   // , <FutureVariant>  ///< e.g. a 6th-order option, added when implemented
+};
 ```
 
 This is used to select which pressure gradient method is applied at runtime.
@@ -130,11 +135,11 @@ KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
                                 const Array2DReal &SpecVol) const;
 ```
 
-### PressureGradHighOrder
+### PressureGradFiniteVolume
 
-This functor is a placeholder for a future high-order pressure gradient implementation
-suitable for ice shelf cavities and complex bathymetry. Currently it performs no
-computation (a no-op).
+This functor is a placeholder for a future finite-volume pressure gradient
+implementation suitable for ice shelf cavities and complex bathymetry. Currently it
+performs no computation (a no-op).
 
 ## Configuration
 
@@ -147,7 +152,8 @@ PressureGrad:
 
 Valid options for `PressureGradType` are:
 - `'centered'` or `'Centered'`: centered difference approximation (default)
-- `'HighOrder1'`: first high-order method (placeholder, future implementation)
+- `'finiteVolume'` or `'FiniteVolume'`: layer-integrated finite-volume method
+  (placeholder, future implementation)
 
 If an unrecognized value is provided, the implementation falls back to the centered
 scheme and logs an informational message.
@@ -167,7 +173,7 @@ The `PressureGrad` class stores the following key data:
 | `TidalPotential` | `Array1DReal` | Tidal potential (placeholder, currently zero) |
 | `SelfAttractionLoading` | `Array1DReal` | Self-attraction and loading term (placeholder, currently zero) |
 | `CenteredPGrad` | `PressureGradCentered` | Centered pressure gradient functor |
-| `HighOrderPGrad` | `PressureGradHighOrder` | High-order pressure gradient functor |
+| `FiniteVolumePGrad` | `PressureGradFiniteVolume` | Finite-volume pressure gradient functor |
 | `PressureGradChoice` | `PressureGradType` | Selected pressure gradient method |
 
 ## Removal

--- a/components/omega/doc/devGuide/PGrad.md
+++ b/components/omega/doc/devGuide/PGrad.md
@@ -155,8 +155,9 @@ Valid options for `PressureGradType` are:
 - `'finiteVolume'` or `'FiniteVolume'`: layer-integrated finite-volume method
   (placeholder, future implementation)
 
-If an unrecognized value is provided, the implementation falls back to the centered
-scheme and logs an informational message.
+An unrecognized value is a fatal error rather than a silent fallback to the
+centered scheme, so that a typo -- or a configuration naming a scheme that no
+longer exists -- cannot produce a run that looks like a passing centered run.
 
 ## Data members
 

--- a/components/omega/doc/devGuide/PGrad.md
+++ b/components/omega/doc/devGuide/PGrad.md
@@ -4,9 +4,9 @@
 
 Omega includes a `PressureGrad` class that computes horizontal pressure gradient
 tendencies for the non-Boussinesq momentum equation. The implementation supports a
-centered difference scheme as the default, with a placeholder for a future
-finite-volume method. The class follows the same factory pattern used by other Omega
-modules.
+centered difference scheme as the default and a layer-integrated finite-volume
+scheme as an option. The class follows the same factory pattern used by other
+Omega modules.
 
 ## PressureGradType enum
 
@@ -71,21 +71,33 @@ to zero.
 To compute pressure gradient tendencies and accumulate them into a tendency array:
 
 ```c++
-PGrad->computePressureGrad(Tend, State, VCoord, EqState, TimeLevel);
+PGrad->computePressureGrad(Tend, PressureMid, PressureInterface, SpecVol,
+                           GeomZInterface, PseudoThick, ConservTemp,
+                           AbsSalinity, EqState);
 ```
 
 where:
 - `Tend` is a 2D array `(NEdgesAll × NVertLayers)` that the pressure gradient
   tendency is accumulated into
-- `State` is the current `OceanState`, from which pseudo-thickness is extracted
-  at the given `TimeLevel`
-- `VCoord` provides pressure, interface height, and geopotential fields
-- `EqState` provides the specific volume field
-- `TimeLevel` selects which time level of the state to use
+- `PressureMid`, `PressureInterface` and `GeomZInterface` come from `VertCoord`
+- `SpecVol` is the specific volume field from `Eos`
+- `PseudoThick` is the pseudo-thickness at the desired time level
+- `ConservTemp` and `AbsSalinity` are the layer-mean tracer fields, used by the
+  finite-volume scheme's vertical reconstruction and ignored by the centered one
+- `EqState` supplies the specific volume derivatives, likewise used only by the
+  finite-volume scheme
 
 The method uses hierarchical Kokkos parallelism: an outer `parallelForOuter` loop
 iterates over edges, and an inner `parallelForInner` loop iterates over vertical
-chunks. The appropriate functor is dispatched based on `PressureGradChoice`.
+chunks. The appropriate functor is dispatched based on `PressureGradChoice`. The
+finite-volume branch additionally runs two kernels ahead of that dispatch: one
+forming the per-cell reconstruction slopes, and the per-edge column scan.
+
+Note that `AuxiliaryState::computeMomVertAux` calls `Eos::computeSpecVolAndDerivs`
+in place of `Eos::computeSpecVol` when the finite-volume scheme is selected. That
+call fills `SpecVol` as well, so it replaces rather than accompanies the simpler
+one, and the branch keeps a centered run from paying for the derivative
+arithmetic.
 
 ## Functors
 
@@ -137,9 +149,107 @@ KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
 
 ### PressureGradFiniteVolume
 
-This functor is a placeholder for a future finite-volume pressure gradient
-implementation suitable for ice shelf cavities and complex bathymetry. Currently it
-performs no computation (a no-op).
+This functor assembles the finite-volume pressure gradient tendency. The whole
+horizontal pressure gradient is the geopotential compared at **fixed pressure**,
+and almost all of the work of forming that comparison happens before the functor
+runs, in the column scan described below. What remains per layer is:
+
+```
+DeltaPress = edge average of the two columns' layer pressure thicknesses
+LayerMean  = DeltaZFixedP(IEdge, K+1) + DeltaZMoment(IEdge, K) / DeltaPress
+Tend(IEdge, K) += EdgeMask(IEdge, K) * (-Gravity / DcEdge * LayerMean - GradGeoPot)
+```
+
+`LayerMean` is the layer average of the fixed-pressure height difference,
+recovered from its value at the layer's bottom interface and the first moment of
+the integrand over the layer. Its signature therefore takes the column scan's two
+output arrays rather than the state the scan consumed:
+
+```c++
+KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
+                                const Array2DReal &PressureInterface,
+                                const Array2DReal &DeltaZFixedP,
+                                const Array2DReal &DeltaZMoment,
+                                const Array1DReal &TidalPotential,
+                                const Array1DReal &SelfAttractionLoading) const;
+```
+
+## The per-edge column scan
+
+`PressureGrad::computeColumnScan` fills `DeltaZFixedP`, the fixed-pressure height
+difference at each edge-layer interface, and `DeltaZMoment`, the first moment of
+the integrand over each layer.
+
+**This cannot live in the functor.** It is a prefix sum down each column with
+edge-dependent coefficients, so it is not expressible as an independent
+per-vertical-chunk operation. It runs as a `parallelForOuter` over edges with a
+`parallelScanInner` down the column, in the same shape as
+`VertCoord::computeGeomZHeight`, and it is the one structural addition the
+finite-volume scheme makes beyond the per-edge, per-chunk pattern the centered
+scheme uses.
+
+The scan is anchored at the **sea floor**. `VertCoord` builds geometric height
+upward from a prescribed bathymetry, so at the bottom interface the cross-edge
+height difference is exact input and vanishes identically for a flat floor, where
+at the surface it would be the small residual of two column-length accumulations.
+There is a second reason: `VertCoord` accumulates a midpoint rule over each
+column's own layers, and on a curved profile two columns with different layer
+partitions give sums that differ at second order in layer thickness. Anchored at
+the surface that discrepancy would enter the height difference directly; anchored
+at the sea floor it never enters, because the scheme integrates its own
+reconstruction rather than accumulating `VertCoord`'s height.
+
+The anchor is computed, not assumed: each column's height at the deepest shared
+interface is shifted to the common pressure by integrating its own reconstruction
+over half the cross-edge pressure difference, and both short integrals vanish
+where the two columns' interface pressures agree.
+
+## Each column's state is looked up by pressure, not by layer index
+
+At each quadrature point of edge layer `K`, the integrand needs the
+reconstruction of whichever of *that column's* layers contains that pressure,
+which under coordinate tilt is generally **not** layer `K`. At a tilt of 50 m/km
+with 64 m layers the two columns' layer `K` are offset by nearly three layer
+thicknesses and do not overlap in pressure at all.
+
+`findLayerForPress` in `PGradRecon.h` performs that lookup. Within the column
+scan the answer advances monotonically with `K`, so passing the previous answer
+as a hint makes it a pair of incremented cursors rather than a search; the result
+does not depend on the hint. A pressure outside the column clamps to the
+outermost valid layer and extrapolates its reconstruction, which is the rule
+where the edge control volume extends past a column's own floor.
+
+**This is the single most important thing not to get wrong, and no answer-level
+test can catch it.** Replacing the lookup with a layer-index lookup passes every
+exactness and accuracy check in the test suite: on a profile linear in pressure
+every layer's mean-preserving reconstruction is that same line, so looking up the
+wrong layer costs nothing. It is pinned instead by direct property tests in
+`PGradTest.cpp`, which assert that the returned layer brackets the pressure, that
+it differs from the edge layer index under tilt, that the answer does not depend
+on the starting hint, and that a pressure outside the column clamps. Those tests
+are not optional.
+
+## Supporting headers
+
+| Header | Contents |
+| ------ | -------- |
+| `PGradRecon.h` | the mean-preserving linear reconstruction of temperature and salinity in pressure, and the per-column pressure lookup |
+| `PGradFiniteVolume.h` | the edge-shared equation-of-state expansion, the matched-pressure integrand, and the Gauss-Legendre rule |
+
+The equation-of-state expansion is **shared across each edge**: the coefficients
+and the expansion state are averaged from the edge's two cells and used for
+*both* columns. That one set multiplies both columns is what the exactness rests
+on -- it is what makes the constant and pressure-derivative terms cancel in the
+matched-pressure difference. Which set is used is an ordinary accuracy question
+and cannot break exactness, because the coefficients end up multiplying a
+quantity that is identically zero on profiles the reconstruction resolves.
+
+Specific volume is never integrated directly and the equation of state is never
+evaluated inside any integral. The four expansion coefficients come from the
+`SpecVol`, `SpecVolDCt`, `SpecVolDSa` and `SpecVolDP` fields `Eos` already
+computes, one evaluation per cell per layer, and the pressure gradient adds none
+of its own -- which the cost check in `PGradTest.cpp` asserts directly, using the
+`Eos::SpecVolEvalCount` counter.
 
 ## Configuration
 
@@ -152,8 +262,16 @@ PressureGrad:
 
 Valid options for `PressureGradType` are:
 - `'centered'` or `'Centered'`: centered difference approximation (default)
-- `'finiteVolume'` or `'FiniteVolume'`: layer-integrated finite-volume method
-  (placeholder, future implementation)
+- `'finiteVolume'` or `'FiniteVolume'`: the layer-integrated finite-volume method
+
+The `FiniteVolume` scheme reads three further keys from the same group, all
+optional: `HorzOrder` (default 2), `VerticalReconstruction` (default `'linear'`)
+and `QuadraturePoints` (default 2). Values reserved for a later phase --
+`HorzOrder: 4` and `VerticalReconstruction: 'ppm'` -- are rejected with an error
+rather than falling back, so that a configuration written for that phase cannot
+quietly run as this one. `QuadraturePoints` is an accuracy setting only: the
+integrand is zero at every point on a resolved profile, so no quadrature rule can
+affect the exactness.
 
 An unrecognized value is a fatal error rather than a silent fallback to the
 centered scheme, so that a typo -- or a configuration naming a scheme that no
@@ -176,6 +294,16 @@ The `PressureGrad` class stores the following key data:
 | `CenteredPGrad` | `PressureGradCentered` | Centered pressure gradient functor |
 | `FiniteVolumePGrad` | `PressureGradFiniteVolume` | Finite-volume pressure gradient functor |
 | `PressureGradChoice` | `PressureGradType` | Selected pressure gradient method |
+| `ReconSlopeCt` | `Array2DReal` | Reconstruction slope of temperature in pressure, per cell and layer |
+| `ReconSlopeSa` | `Array2DReal` | Reconstruction slope of salinity in pressure |
+| `DeltaZIncr` | `Array2DReal` | Per-layer integral of the matched-pressure integrand |
+| `DeltaZMoment` | `Array2DReal` | Its first moment about the layer's top interface |
+| `DeltaZFixedP` | `Array2DReal` | Fixed-pressure height difference at edge-layer interfaces |
+
+The last five are allocated only when the `FiniteVolume` scheme is selected, so a
+centered run pays no memory for them. The reconstruction slopes are computed once
+per cell and layer and reused across each cell's edges; recomputing them per edge
+is what the cost check exists to catch.
 
 ## Removal
 

--- a/components/omega/doc/userGuide/EOS.md
+++ b/components/omega/doc/userGuide/EOS.md
@@ -19,7 +19,7 @@ Eos:
 
 where `DRhoDT` is the thermal expansion coefficient ($\textrm{kg}/(\textrm{m}^3 \cdot ^{\circ}\textrm{C})$), `DRhoDS` is the saline contraction coefficient ($\textrm{kg}/\textrm{m}^3$), and `RhoT0S0` is the reference density at (T,S)=(0,0) (in $\textrm{kg}/\textrm{m}^3$).
 
-In addition to `SpecVol`, the displaced specific volume `SpecVolDisplaced` and `BruntVaisalaFreqSq` are also calculated by the EOS.
+In addition to `SpecVol`, the displaced specific volume `SpecVolDisplaced`, the squared Brunt-Vaisala frequency `BruntVaisalaFreqSq` and the first derivatives of specific volume `SpecVolDCt`, `SpecVolDSa` and `SpecVolDP` are also calculated by the EOS.
 
 ## TEOS-10 Helper Conversions
 
@@ -36,6 +36,16 @@ temperature conversions used by ocean thermodynamics workflows:
 These helper methods are available through the EOS implementation but do not
 replace the standard `computeSpecVol`, `computeSpecVolDisp`, or
 `computeBruntVaisalaFreqSq` calculations.
+
+## First Derivatives of Specific Volume
+
+The `Eos` class can also compute the first derivatives of the specific volume with respect to conservative temperature (in $\textrm{m}^3\textrm{kg}^{-1}\,^{\circ}\textrm{C}^{-1}$), absolute salinity (in $\textrm{m}^3\textrm{g}^{-1}$), and pressure (in $\textrm{m}^3\textrm{kg}^{-1}\textrm{Pa}^{-1}$). These are needed by the higher-order horizontal pressure gradient, which expands the specific volume about a reference state within each layer instead of evaluating the full equation of state at every quadrature point.
+
+There is no user-configurable option associated with the derivatives. They are computed on request by the parts of the model that need them, in the same pass that computes the specific volume, so selecting `teos10` does not make the model slower unless a scheme that uses them is enabled. They are available for all three `EosType` choices: for `teos10` they are the analytic derivatives of the same 75-term polynomial, for `linear` they follow from the configured `DRhoDT` and `DRhoDS` and have no pressure dependence, and for `constant` they are zero.
+
+The derivatives are stored in the `SpecVolDCt`, `SpecVolDSa` and `SpecVolDP` fields of the `Eos` field group and can be requested in a stream's contents just like `SpecVol`.
+
+The thermal expansion and haline contraction coefficients that enter the squared Brunt-Vaisala frequency are computed from these same derivatives.
 
 ## Displaced Specific Volume
 

--- a/components/omega/doc/userGuide/PGrad.md
+++ b/components/omega/doc/userGuide/PGrad.md
@@ -37,8 +37,15 @@ The pressure gradient method is configured in the input YAML file under the
 
 ```yaml
 PressureGrad:
-   PressureGradType: 'centered'
+   PressureGradType: 'Centered'   # Centered | FiniteVolume
+   HorzOrder: 2                   # FiniteVolume only
+   VerticalReconstruction: 'linear'
+   QuadraturePoints: 2
 ```
+
+An unrecognized `PressureGradType` is a fatal error rather than a silent
+fallback to the centered scheme, so that a typo cannot produce a run that looks
+like a passing centered run.
 
 ### Available Methods
 
@@ -46,14 +53,43 @@ PressureGrad:
 - Computes the pressure gradient using a centered finite-difference approximation
   of the Montgomery potential gradient and specific volume correction
 - Suitable for global ocean simulations without ice shelf cavities
-- Default and currently the only fully implemented option
+- The default, and the reference implementation the finite-volume scheme is
+  checked against
 
 **Finite Volume** (`'FiniteVolume'` or `'finiteVolume'`)
-- Placeholder for a layer-integrated, finite-volume pressure gradient method that
-  compares the geopotential of neighboring columns at a common pressure
-- Intended for simulations with ice shelf cavities and steep bathymetry where the
-  centered scheme may be inaccurate
-- Not yet implemented; selecting this option produces zero pressure gradient tendency
+- Compares the geopotential of the two columns sharing an edge at a **common
+  pressure**, rather than at a common layer index
+- Gives a pressure gradient that is zero to machine precision for any resting
+  ocean whose temperature and salinity vary linearly with pressure, at any
+  coordinate tilt, layer thickness or bathymetry
+- Intended for simulations with ice shelf cavities and steep bathymetry, where
+  the centered scheme carries an error that is first order in the coordinate
+  tilt and accumulates downward through the column
+- Second order in the horizontal, using the same two-cell stencil as the
+  centered scheme
+
+### Finite-volume sub-options
+
+These apply only when `PressureGradType` is `FiniteVolume`. All three are
+optional; a configuration written without them gets the values below.
+
+| Option | Default | Meaning |
+| ------ | ------- | ------- |
+| `HorzOrder` | `2` | Width of the edge stencil. `2` is the two-cell stencil. `4`, a wider stencil, is reserved for a later phase and is rejected with an error |
+| `VerticalReconstruction` | `'linear'` | Degree of the mean-preserving reconstruction of temperature and salinity in pressure. `'ppm'` is reserved for a later phase and is rejected with an error |
+| `QuadraturePoints` | `2` | Number of points, 1 to 4, at which the integrand is evaluated within each edge layer |
+
+`QuadraturePoints` is an **accuracy setting only**. The quantity being
+integrated is zero at every point for any profile the reconstruction resolves
+exactly, so no choice of quadrature can affect that exactness; the setting
+trades cost against accuracy elsewhere. Two points is exact for the integrand
+within a sub-interval and is the default. More is worth considering only where
+neighbouring columns' layer interfaces are strongly offset in pressure.
+
+There is no setting that reduces the finite-volume scheme to the centered one.
+The two are separate implementations, which is deliberate: their agreement is
+used as a cross-check on the mesh, vertical coordinate and equation-of-state
+state they both read.
 
 ## Dependencies
 

--- a/components/omega/doc/userGuide/PGrad.md
+++ b/components/omega/doc/userGuide/PGrad.md
@@ -48,9 +48,9 @@ PressureGrad:
 - Suitable for global ocean simulations without ice shelf cavities
 - Default and currently the only fully implemented option
 
-**High-Order** (`'HighOrder1'`)
-- Placeholder for a future high-order pressure gradient method based on volume
-  integral formulations
+**Finite Volume** (`'FiniteVolume'` or `'finiteVolume'`)
+- Placeholder for a layer-integrated, finite-volume pressure gradient method that
+  compares the geopotential of neighboring columns at a common pressure
 - Intended for simulations with ice shelf cavities and steep bathymetry where the
   centered scheme may be inaccurate
 - Not yet implemented; selecting this option produces zero pressure gradient tendency

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -772,6 +772,7 @@ Error readArray(void *Array,                // [out] array to be read
 // All arrays are assumed to be in contiguous storage. Returns an error code so
 // that the calling routine can re-try on failure.
 Error readNDVar(void *Variable,             // [out] array to be read
+                IODataType VarType,         // [in] data type of the array
                 const std::string &VarName, // [in] name of variable to read
                 int FileID,                 // [in] ID of open file to read from
                 int &VarID, // [out] Id assigned to variable for later use
@@ -789,6 +790,13 @@ Error readNDVar(void *Variable,             // [out] array to be read
                    "IO::readArray: Error finding varid for variable {}",
                    VarName);
 
+   // The type-specific PIO read routines are used here rather than the
+   // generic PIOc_get_var/PIOc_get_vara. The generic forms fill the buffer
+   // using the type of the variable as stored in the file, so reading a
+   // double variable into a single-precision array would write eight bytes
+   // per element into four-byte slots and run off the end of the buffer.
+   // Passing the type of the destination array instead lets PIO convert.
+
    if (Frame >= 0) { // time dependent field so must use get_vara
 
       int NDims = DimLengths->size();
@@ -801,8 +809,30 @@ Error readNDVar(void *Variable,             // [out] array to be read
          Count[IDim] = DimLengths->at(IDim - 1);
       }
 
-      PIOErr =
-          PIOc_get_vara(FileID, VarID, Start.data(), Count.data(), Variable);
+      switch (VarType) {
+      case IOTypeI4:
+         PIOErr = PIOc_get_vara_int(FileID, VarID, Start.data(), Count.data(),
+                                    static_cast<int *>(Variable));
+         break;
+      case IOTypeI8:
+         PIOErr =
+             PIOc_get_vara_longlong(FileID, VarID, Start.data(), Count.data(),
+                                    static_cast<long long *>(Variable));
+         break;
+      case IOTypeR4:
+         PIOErr = PIOc_get_vara_float(FileID, VarID, Start.data(), Count.data(),
+                                      static_cast<R4 *>(Variable));
+         break;
+      case IOTypeR8:
+         PIOErr =
+             PIOc_get_vara_double(FileID, VarID, Start.data(), Count.data(),
+                                  static_cast<R8 *>(Variable));
+         break;
+      default:
+         RETURN_ERROR(Err, ErrorCode::Fail,
+                      "IO::readNDVar: Unsupported data type for variable {}",
+                      VarName);
+      }
       if (PIOErr != PIO_NOERR)
          RETURN_ERROR(Err, ErrorCode::Fail,
                       "IO::readNDVar: Error in PIO get_vara for variable {}",
@@ -811,7 +841,27 @@ Error readNDVar(void *Variable,             // [out] array to be read
    } else { // Not a time-dependent field, can use default get_var
 
       // PIO get call to read non-distributed array
-      PIOErr = PIOc_get_var(FileID, VarID, Variable);
+      switch (VarType) {
+      case IOTypeI4:
+         PIOErr = PIOc_get_var_int(FileID, VarID, static_cast<int *>(Variable));
+         break;
+      case IOTypeI8:
+         PIOErr = PIOc_get_var_longlong(FileID, VarID,
+                                        static_cast<long long *>(Variable));
+         break;
+      case IOTypeR4:
+         PIOErr =
+             PIOc_get_var_float(FileID, VarID, static_cast<R4 *>(Variable));
+         break;
+      case IOTypeR8:
+         PIOErr =
+             PIOc_get_var_double(FileID, VarID, static_cast<R8 *>(Variable));
+         break;
+      default:
+         RETURN_ERROR(Err, ErrorCode::Fail,
+                      "IO::readNDVar: Unsupported data type for variable {}",
+                      VarName);
+      }
       if (PIOErr != PIO_NOERR)
          RETURN_ERROR(Err, ErrorCode::Fail,
                       "IO::readNDVar: Error in PIO get_var for variable {}",

--- a/components/omega/src/base/IO.h
+++ b/components/omega/src/base/IO.h
@@ -324,12 +324,16 @@ Error readArray(void *Array,                ///< [out] array to be read
 /// Reads a non-distributed variable. We use a void pointer here to create
 /// a generic interface for all types. Arrays are assumed to be in contiguous
 /// storage so the arrays of any dimension are treated as a 1-d array with
-/// the full local size. The routine returns the variable as well as the id
-/// assigned to the variable should that be needed later. For time-dependent
-/// variables, the optional frame and dimension length information must be
-/// provided. An error code is also returned so that the calling routine can
-/// re-try the read on failure (eg due to name changes).
+/// the full local size. The data type of the destination array must be
+/// supplied; it need not match the type of the variable as stored in the
+/// file and the values are converted on read. The routine returns the
+/// variable as well as the id assigned to the variable should that be needed
+/// later. For time-dependent variables, the optional frame and dimension
+/// length information must be provided. An error code is also returned so
+/// that the calling routine can re-try the read on failure (eg due to name
+/// changes).
 Error readNDVar(void *Variable,             ///< [out] variable to be read
+                IODataType VarType,         ///< [in] data type of variable
                 const std::string &VarName, ///< [in] name of variable to read
                 int FileID,                 ///< [in] ID of open file for read
                 int &VarID,     ///< [out] variable ID in case metadata needed

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -1694,7 +1694,14 @@ Error IOStream::readFieldData(
    // The IO routines require a pointer to a contiguous memory on the host
    // so we first read into a vector. Only one of the vectors below will
    // be used and resized appropriately.
+   // The IO data type is set alongside the buffer so that it always describes
+   // the buffer actually allocated, which need not be the type the variable
+   // has in the file. Distributed reads take this from the decomposition,
+   // but non-distributed reads must be told directly or PIO fills the buffer
+   // using the file's type, overrunning it whenever that type is the wider
+   // of the two.
    void *DataPtr;
+   IO::IODataType MyIOType;
    std::vector<I4> DataI4(1);
    std::vector<I8> DataI8(1);
    std::vector<R4> DataR4(1);
@@ -1703,19 +1710,23 @@ Error IOStream::readFieldData(
    switch (MyType) {
    case ArrayDataType::I4:
       DataI4.resize(LocSize);
-      DataPtr = DataI4.data();
+      DataPtr  = DataI4.data();
+      MyIOType = IO::IOTypeI4;
       break;
    case ArrayDataType::I8:
       DataI8.resize(LocSize);
-      DataPtr = DataI8.data();
+      DataPtr  = DataI8.data();
+      MyIOType = IO::IOTypeI8;
       break;
    case ArrayDataType::R4:
       DataR4.resize(LocSize);
-      DataPtr = DataR4.data();
+      DataPtr  = DataR4.data();
+      MyIOType = IO::IOTypeR4;
       break;
    case ArrayDataType::R8:
       DataR8.resize(LocSize);
-      DataPtr = DataR8.data();
+      DataPtr  = DataR8.data();
+      MyIOType = IO::IOTypeR8;
       break;
    case ArrayDataType::Unknown:
       ABORT_ERROR("IOStream readFieldData: Unknown data array type");
@@ -1728,7 +1739,7 @@ Error IOStream::readFieldData(
       Err =
           IO::readArray(DataPtr, LocSize, FieldName, FileID, DecompID, FieldID);
    } else {
-      Err = IO::readNDVar(DataPtr, FieldName, FileID, FieldID);
+      Err = IO::readNDVar(DataPtr, MyIOType, FieldName, FileID, FieldID);
    }
    // For back compatibility, try to read again with old field name
    if (Err.isFail()) {
@@ -1736,7 +1747,7 @@ Error IOStream::readFieldData(
          Err = IO::readArray(DataPtr, LocSize, OldFieldName, FileID, DecompID,
                              FieldID);
       } else {
-         Err = IO::readNDVar(DataPtr, OldFieldName, FileID, FieldID);
+         Err = IO::readNDVar(DataPtr, MyIOType, OldFieldName, FileID, FieldID);
       }
       if (Err.isFail()) {
          // If the field is optional, a missing variable is not an error. Leave
@@ -2586,8 +2597,8 @@ void IOStream::writeStream(
             int TmpID;
             std::vector<int> TmpDimLengths; // empty dim length for scalar time
             for (int IFrame = 0; IFrame < NFrames; ++IFrame) {
-               Err = IO::readNDVar(&FrameTime, "time", OutFileID, TmpID, IFrame,
-                                   &TmpDimLengths);
+               Err = IO::readNDVar(&FrameTime, IO::IOTypeR8, "time", OutFileID,
+                                   TmpID, IFrame, &TmpDimLengths);
                CHECK_ERROR_ABORT(Err, "Error reading frame time in {}",
                                  OutFileName);
                if (std::abs(ElapsedTimeR8 - FrameTime) < 1.e-5) { // overwrite

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -2,6 +2,7 @@
 #include "Config.h"
 #include "Field.h"
 #include "Logging.h"
+#include "PGrad.h"
 #include "Pacer.h"
 #include "Tendencies.h"
 #include "TimeStepper.h"
@@ -89,9 +90,21 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
    const auto &SurfacePressure = VCoord->SurfacePressure;
    VCoord->computePressure(PseudoThickCell, SurfacePressure);
 
-   // compute specific volume
-   const auto &PressureMid = VCoord->PressureMid;
-   EosInstance->computeSpecVol(ConservTemp, AbsSalinity, PressureMid);
+   // compute specific volume. The FiniteVolume pressure gradient also needs
+   // the specific volume derivatives, which computeSpecVolAndDerivs supplies
+   // from the same single equation-of-state evaluation. It fills SpecVol as
+   // well, so it replaces rather than accompanies computeSpecVol; the branch
+   // is here so that a Centered run does not pay for the derivative
+   // arithmetic. The default PressureGrad instance is queried because the
+   // scheme is a model-wide choice and AuxiliaryState holds no PressureGrad.
+   const auto &PressureMid   = VCoord->PressureMid;
+   const PressureGrad *PGrad = PressureGrad::getDefault();
+   if (PGrad && PGrad->getType() == PressureGradType::FiniteVolume) {
+      EosInstance->computeSpecVolAndDerivs(ConservTemp, AbsSalinity,
+                                           PressureMid);
+   } else {
+      EosInstance->computeSpecVol(ConservTemp, AbsSalinity, PressureMid);
+   }
 
    // compute geometric height
    VCoord->computeGeomZHeight(PseudoThickCell, EosInstance->SpecVol);

--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -282,7 +282,7 @@ void Eos::computeSpecVolAndDerivs(const Array2DReal &ConservTemp,
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocComputeSpecVolLinear.calcSpecVolDerivs(
+                    LocComputeSpecVolLinear.calcSpecVolAndDerivsInChunk(
                         LocSpecVol, LocSpecVolDCt, LocSpecVolDSa, LocSpecVolDP,
                         ICell, KChunk, ConservTemp, AbsSalinity);
                  });
@@ -297,7 +297,7 @@ void Eos::computeSpecVolAndDerivs(const Array2DReal &ConservTemp,
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocComputeSpecVolTeos10.calcSpecVolDerivs(
+                    LocComputeSpecVolTeos10.calcSpecVolAndDerivsInChunk(
                         LocSpecVol, LocSpecVolDCt, LocSpecVolDSa, LocSpecVolDP,
                         ICell, KChunk, ConservTemp, AbsSalinity, Pressure);
                  });
@@ -312,7 +312,7 @@ void Eos::computeSpecVolAndDerivs(const Array2DReal &ConservTemp,
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocComputeSpecVolConstant.calcSpecVolDerivs(
+                    LocComputeSpecVolConstant.calcSpecVolAndDerivsInChunk(
                         LocSpecVol, LocSpecVolDCt, LocSpecVolDSa, LocSpecVolDP,
                         ICell, KChunk, ConservTemp, AbsSalinity);
                  });

--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -134,6 +134,10 @@ void Eos::init() {
 void Eos::computeSpecVol(const Array2DReal &ConservTemp,
                          const Array2DReal &AbsSalinity,
                          const Array2DReal &Pressure) {
+   // count the evaluations this call performs, for the pressure gradient
+   // cost check
+   SpecVolEvalCount += static_cast<I8>(Mesh->NCellsAll) * VCoord->NVertLayers;
+
    OMEGA_SCOPE(LocSpecVol, SpecVol); /// Create a local view for computation
    OMEGA_SCOPE(LocComputeSpecVolLinear,
                ComputeSpecVolLinear); /// Local view for linear EOS computation
@@ -197,6 +201,10 @@ void Eos::computeSpecVol(const Array2DReal &ConservTemp,
 void Eos::computeSpecVolDisp(const Array2DReal &ConservTemp,
                              const Array2DReal &AbsSalinity,
                              const Array2DReal &Pressure, I4 KDisp) {
+   // count the evaluations this call performs, for the pressure gradient
+   // cost check
+   SpecVolEvalCount += static_cast<I8>(Mesh->NCellsAll) * VCoord->NVertLayers;
+
    OMEGA_SCOPE(LocSpecVolDisplaced,
                SpecVolDisplaced); /// Local view for computation
    OMEGA_SCOPE(LocComputeSpecVolLinear,
@@ -258,6 +266,10 @@ void Eos::computeSpecVolDisp(const Array2DReal &ConservTemp,
 void Eos::computeSpecVolAndDerivs(const Array2DReal &ConservTemp,
                                   const Array2DReal &AbsSalinity,
                                   const Array2DReal &Pressure) {
+   // count the evaluations this call performs, for the pressure gradient
+   // cost check
+   SpecVolEvalCount += static_cast<I8>(Mesh->NCellsAll) * VCoord->NVertLayers;
+
    OMEGA_SCOPE(LocSpecVol, SpecVol);       /// Local views for computation
    OMEGA_SCOPE(LocSpecVolDCt, SpecVolDCt); /// Temperature derivative
    OMEGA_SCOPE(LocSpecVolDSa, SpecVolDSa); /// Salinity derivative

--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -48,6 +48,11 @@ Eos::Eos(const std::string &Name, ///< [in] Name for eos object
        Array2DReal("SpecVolDisplaced", Mesh->NCellsSize, VCoord->NVertLayers);
    BruntVaisalaFreqSq = Array2DReal("BruntVaisalaFreqSq", Mesh->NCellsSize,
                                     VCoord->NVertLayersP1);
+   SpecVolDCt =
+       Array2DReal("SpecVolDCt", Mesh->NCellsSize, VCoord->NVertLayers);
+   SpecVolDSa =
+       Array2DReal("SpecVolDSa", Mesh->NCellsSize, VCoord->NVertLayers);
+   SpecVolDP = Array2DReal("SpecVolDP", Mesh->NCellsSize, VCoord->NVertLayers);
 
    defineFields();
 }
@@ -249,6 +254,72 @@ void Eos::computeSpecVolDisp(const Array2DReal &ConservTemp,
    }
 }
 
+/// Compute specific volume and its first derivatives for all cells/layers
+void Eos::computeSpecVolAndDerivs(const Array2DReal &ConservTemp,
+                                  const Array2DReal &AbsSalinity,
+                                  const Array2DReal &Pressure) {
+   OMEGA_SCOPE(LocSpecVol, SpecVol);       /// Local views for computation
+   OMEGA_SCOPE(LocSpecVolDCt, SpecVolDCt); /// Temperature derivative
+   OMEGA_SCOPE(LocSpecVolDSa, SpecVolDSa); /// Salinity derivative
+   OMEGA_SCOPE(LocSpecVolDP, SpecVolDP);   /// Pressure derivative
+   OMEGA_SCOPE(LocComputeSpecVolLinear,
+               ComputeSpecVolLinear); /// Local view for linear EOS computation
+   OMEGA_SCOPE(LocComputeSpecVolTeos10,
+               ComputeSpecVolTeos10); /// Local view for TEOS-10 computation
+   OMEGA_SCOPE(LocComputeSpecVolConstant,
+               ComputeSpecVolConstant); /// Local view for constant computation
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
+   /// Dispatch to the correct EOS calculation
+   if (EosChoice == EosType::LinearEos) {
+      parallelForOuter(
+          "eos-derivs-linear", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocComputeSpecVolLinear.calcSpecVolDerivs(
+                        LocSpecVol, LocSpecVolDCt, LocSpecVolDSa, LocSpecVolDP,
+                        ICell, KChunk, ConservTemp, AbsSalinity);
+                 });
+          });
+   } else if (EosChoice == EosType::Teos10Eos) {
+      parallelForOuter(
+          "eos-derivs-teos10", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocComputeSpecVolTeos10.calcSpecVolDerivs(
+                        LocSpecVol, LocSpecVolDCt, LocSpecVolDSa, LocSpecVolDP,
+                        ICell, KChunk, ConservTemp, AbsSalinity, Pressure);
+                 });
+          });
+   } else if (EosChoice == EosType::ConstantEos) {
+      parallelForOuter(
+          "eos-derivs-constant", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+             const int KMin   = MinLayerCell(ICell);
+             const int KMax   = MaxLayerCell(ICell);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocComputeSpecVolConstant.calcSpecVolDerivs(
+                        LocSpecVol, LocSpecVolDCt, LocSpecVolDSa, LocSpecVolDP,
+                        ICell, KChunk, ConservTemp, AbsSalinity);
+                 });
+          });
+   }
+}
+
 /// Compute squared Brunt-Vaisala frequency for all cells/layers
 void Eos::computeBruntVaisalaFreqSq(const Array2DReal &ConservTemp,
                                     const Array2DReal &AbsSalinity,
@@ -350,10 +421,16 @@ void Eos::defineFields() {
    SpecVolFldName            = "SpecVol";
    SpecVolDisplacedFldName   = "SpecVolDisplaced";
    BruntVaisalaFreqSqFldName = "BruntVaisalaFreqSq";
+   SpecVolDCtFldName         = "SpecVolDCt";
+   SpecVolDSaFldName         = "SpecVolDSa";
+   SpecVolDPFldName          = "SpecVolDP";
    if (Name != "Default") {
       SpecVolFldName.append(Name);
       SpecVolDisplacedFldName.append(Name);
       BruntVaisalaFreqSqFldName.append(Name);
+      SpecVolDCtFldName.append(Name);
+      SpecVolDSaFldName.append(Name);
+      SpecVolDPFldName.append(Name);
    }
 
    /// Create fields for state variables
@@ -386,6 +463,45 @@ void Eos::defineFields() {
                      DimNames // Dimension names
        );
 
+   /// The specific volume derivatives are legitimately negative, so their
+   /// valid range spans the full range of Real rather than starting at zero
+   auto SpecVolDCtField = Field::create(
+       SpecVolDCtFldName, // Field name
+       "Derivative of specific volume with respect to conservative "
+       "temperature",    // Long Name
+       "m3 kg-1 degC-1", // Units
+       // CF-ish Name
+       "sea_water_specific_volume_derivative_wrt_conservative_temperature",
+       std::numeric_limits<Real>::lowest(), // Min valid value
+       std::numeric_limits<Real>::max(),    // Max valid value
+       NDims,                               // Number of dimensions
+       DimNames                             // Dimension names
+   );
+
+   auto SpecVolDSaField = Field::create(
+       SpecVolDSaFldName, // Field name
+       "Derivative of specific volume with respect to absolute "
+       "salinity", // Long Name
+       "m3 g-1",   // Units
+       // CF-ish Name
+       "sea_water_specific_volume_derivative_wrt_absolute_salinity",
+       std::numeric_limits<Real>::lowest(), // Min valid value
+       std::numeric_limits<Real>::max(),    // Max valid value
+       NDims,                               // Number of dimensions
+       DimNames                             // Dimension names
+   );
+
+   auto SpecVolDPField = Field::create(
+       SpecVolDPFldName,                                         // Field name
+       "Derivative of specific volume with respect to pressure", // Long Name
+       "m3 kg-1 Pa-1",                                           // Units
+       "sea_water_specific_volume_derivative_wrt_pressure",      // CF-ish Name
+       std::numeric_limits<Real>::lowest(), // Min valid value
+       std::numeric_limits<Real>::max(),    // Max valid value
+       NDims,                               // Num dimensions
+       DimNames                             // Dimension names
+   );
+
    // Brunt-Vaisala frequency is located at interfaces
    DimNames[1] = "NVertLayersP1";
 
@@ -412,11 +528,17 @@ void Eos::defineFields() {
    EosGroup->addField(SpecVolDisplacedFldName);
    EosGroup->addField(SpecVolFldName);
    EosGroup->addField(BruntVaisalaFreqSqFldName);
+   EosGroup->addField(SpecVolDCtFldName);
+   EosGroup->addField(SpecVolDSaFldName);
+   EosGroup->addField(SpecVolDPFldName);
 
    // Attach Kokkos views to the fields
    SpecVolDisplacedField->attachData<Array2DReal>(SpecVolDisplaced);
    SpecVolField->attachData<Array2DReal>(SpecVol);
    BruntVaisalaFreqSqField->attachData<Array2DReal>(BruntVaisalaFreqSq);
+   SpecVolDCtField->attachData<Array2DReal>(SpecVolDCt);
+   SpecVolDSaField->attachData<Array2DReal>(SpecVolDSa);
+   SpecVolDPField->attachData<Array2DReal>(SpecVolDP);
 
 } // end defineIOFields
 

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -494,10 +494,18 @@ class Teos10Eos {
    /// a single state. P is the relative pressure (gauge pressure in Pa, i.e.
    /// absolute pressure minus the standard atmosphere). The derivatives are
    /// returned per degC, per (g/kg), and per Pa respectively.
-   KOKKOS_FUNCTION void calcSpecVolAndDerivs(const Real Ct, const Real Sa,
-                                             const Real P, Real &SpecVol,
-                                             Real &SpecVolDCt, Real &SpecVolDSa,
-                                             Real &SpecVolDP) const {
+   ///
+   /// This is the point-wise entry point: it takes scalars and returns scalars,
+   /// with no cell, layer or chunk indexing. It is what the unit tests call to
+   /// check the polynomial against GSW-C and against finite differences at
+   /// chosen states, and it is the form to use anywhere a single state needs to
+   /// be evaluated. The array-level path over the mesh instead uses
+   /// calcSpecVolAndDerivsInChunk below, which loops over a vertical chunk and
+   /// reuses the coefficient arrays across the layers of that chunk.
+   KOKKOS_FUNCTION void
+   calcSpecVolAndDerivsAtPoint(const Real Ct, const Real Sa, const Real P,
+                               Real &SpecVol, Real &SpecVolDCt,
+                               Real &SpecVolDSa, Real &SpecVolDP) const {
 
       Real SpecVolPCoeffs[6 * VecLength];
       Real DTtPCoeffs[5 * VecLength];
@@ -525,13 +533,14 @@ class Teos10Eos {
 
    /// Calculate the TEOS-10 specific volume and its three first derivatives
    /// over a vertical chunk of a cell. Pressure is the relative pressure in
-   /// Pa; the derivatives are per degC, per (g/kg), and per Pa.
-   KOKKOS_FUNCTION void
-   calcSpecVolDerivs(Array2DReal SpecVol, Array2DReal SpecVolDCt,
-                     Array2DReal SpecVolDSa, Array2DReal SpecVolDP, I4 ICell,
-                     I4 KChunk, const Array2DReal &ConservTemp,
-                     const Array2DReal &AbsSalinity,
-                     const Array2DReal &Pressure) const {
+   /// Pa; the derivatives are per degC, per (g/kg), and per Pa. This is the
+   /// chunk-wise counterpart of calcSpecVolAndDerivsAtPoint above and is what
+   /// Eos::computeSpecVolAndDerivs calls from the inner parallel loop.
+   KOKKOS_FUNCTION void calcSpecVolAndDerivsInChunk(
+       Array2DReal SpecVol, Array2DReal SpecVolDCt, Array2DReal SpecVolDSa,
+       Array2DReal SpecVolDP, I4 ICell, I4 KChunk,
+       const Array2DReal &ConservTemp, const Array2DReal &AbsSalinity,
+       const Array2DReal &Pressure) const {
 
       Real SpecVolPCoeffs[6 * VecLength];
       Real DTtPCoeffs[5 * VecLength];
@@ -776,11 +785,10 @@ class LinearEos {
    ///    SpecVol = 1 / (RhoT0S0 + DRhodT * Ct + DRhodS * Sa)
    /// the derivatives are -DRhodT * SpecVol^2 and -DRhodS * SpecVol^2, and
    /// the linear EOS has no pressure dependence at all.
-   KOKKOS_FUNCTION void
-   calcSpecVolDerivs(Array2DReal SpecVol, Array2DReal SpecVolDCt,
-                     Array2DReal SpecVolDSa, Array2DReal SpecVolDP, I4 ICell,
-                     I4 KChunk, const Array2DReal &ConservTemp,
-                     const Array2DReal &AbsSalinity) const {
+   KOKKOS_FUNCTION void calcSpecVolAndDerivsInChunk(
+       Array2DReal SpecVol, Array2DReal SpecVolDCt, Array2DReal SpecVolDSa,
+       Array2DReal SpecVolDP, I4 ICell, I4 KChunk,
+       const Array2DReal &ConservTemp, const Array2DReal &AbsSalinity) const {
 
       const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
@@ -830,11 +838,10 @@ class ConstantEos {
    /// Calculate the constant specific volume and its three first derivatives
    /// over a vertical chunk of a cell. The specific volume does not depend on
    /// temperature, salinity or pressure, so all three derivatives vanish.
-   KOKKOS_FUNCTION void
-   calcSpecVolDerivs(Array2DReal SpecVol, Array2DReal SpecVolDCt,
-                     Array2DReal SpecVolDSa, Array2DReal SpecVolDP, I4 ICell,
-                     I4 KChunk, const Array2DReal &ConservTemp,
-                     const Array2DReal &AbsSalinity) const {
+   KOKKOS_FUNCTION void calcSpecVolAndDerivsInChunk(
+       Array2DReal SpecVol, Array2DReal SpecVolDCt, Array2DReal SpecVolDSa,
+       Array2DReal SpecVolDP, I4 ICell, I4 KChunk,
+       const Array2DReal &ConservTemp, const Array2DReal &AbsSalinity) const {
 
       const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -1104,14 +1104,20 @@ class Eos {
    Array2DReal SpecVol;            ///< Specific volume field at level centers
    Array2DReal SpecVolDisplaced;   ///< Displaced specific volume field
    Array2DReal BruntVaisalaFreqSq; ///< Squared Brunt-Vaisala frequency field
+   Array2DReal SpecVolDCt;         ///< d(SpecVol)/d(ConservTemp), per degC
+   Array2DReal SpecVolDSa;         ///< d(SpecVol)/d(AbsSalinity), per (g/kg)
+   Array2DReal SpecVolDP;          ///< d(SpecVol)/d(Pressure), per Pa
 
    std::string SpecVolFldName; ///< Field name for specific volume
    std::string
        SpecVolDisplacedFldName; ///< Field name for displaced specific volume
    std::string BruntVaisalaFreqSqFldName; ///< Field name for squared
                                           ///< Brunt-Vaisala frequency
-   std::string EosGroupName;              ///< EOS group name (for config)
-   std::string Name;                      ///< Name of this EOS instance
+   std::string SpecVolDCtFldName; ///< Field name for temperature derivative
+   std::string SpecVolDSaFldName; ///< Field name for salinity derivative
+   std::string SpecVolDPFldName;  ///< Field name for pressure derivative
+   std::string EosGroupName;      ///< EOS group name (for config)
+   std::string Name;              ///< Name of this EOS instance
 
    /// Compute specific volume for all cells/layers
    void computeSpecVol(const Array2DReal &ConservTemp,
@@ -1122,6 +1128,17 @@ class Eos {
    void computeSpecVolDisp(const Array2DReal &ConservTemp,
                            const Array2DReal &AbsSalinity,
                            const Array2DReal &Pressure, I4 KDisp);
+
+   /// Compute specific volume together with its first derivatives with respect
+   /// to conservative temperature, absolute salinity and pressure, in a single
+   /// pass over the equation of state. Pressure is the relative pressure in Pa
+   /// and the derivatives are returned per degC, per (g/kg) and per Pa. The
+   /// results are stored in the SpecVol, SpecVolDCt, SpecVolDSa and SpecVolDP
+   /// members. Since SpecVol is computed here too, this replaces rather than
+   /// accompanies a call to computeSpecVol.
+   void computeSpecVolAndDerivs(const Array2DReal &ConservTemp,
+                                const Array2DReal &AbsSalinity,
+                                const Array2DReal &Pressure);
 
    /// Compute squared Brunt-Vaisala frequency for all cells/layers
    void computeBruntVaisalaFreqSq(const Array2DReal &ConservTemp,

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -34,6 +34,17 @@ class Teos10Eos {
    /// constructor declaration
    Teos10Eos(const VertCoord *VCoord);
 
+   /// Normalization used by the Roquet et al. 2015 75-term polynomial. The
+   /// polynomial is written in the normalized variables
+   ///    Ss = sqrt((Sa + DeltaS) / SaNorm), Tt = Ct / CtNorm, Pp = P * PNorm
+   /// with P the relative pressure in dbar. These are shared by the specific
+   /// volume and by its derivatives, so that both are evaluated at exactly
+   /// the same normalized state.
+   static constexpr Real SaNorm = 40.0 * SS0 / 35.0; ///< salinity scale (g/kg)
+   static constexpr Real CtNorm = 40.0;   ///< temperature scale (degC)
+   static constexpr Real DeltaS = 24.0;   ///< salinity offset (g/kg)
+   static constexpr Real PNorm  = 1.0e-4; ///< pressure scale (1/dbar)
+
    //   The functor takes the full arrays of specific volume (inout),
    //   the indices ICell and KChunk, and the ocean tracers (conservative)
    //   temperature, (absolute) salinity, and relative pressure (gauge pressure,
@@ -83,11 +94,8 @@ class Teos10Eos {
    KOKKOS_FUNCTION void calcPCoeffs(Real (&SpecVolPCoeffs)[6 * VecLength],
                                     const I4 KVec, const Real Ct,
                                     const Real Sa) const {
-      constexpr Real SaNorm = 40.0 * 35.16504 / 35.0;
-      constexpr Real CtNorm = 40.0;
-      constexpr Real DeltaS = 24.0;
-      Real Ss               = Kokkos::sqrt((Sa + DeltaS) / SaNorm);
-      Real Tt               = Ct / CtNorm;
+      Real Ss = Kokkos::sqrt((Sa + DeltaS) / SaNorm);
+      Real Tt = Ct / CtNorm;
 
       /// Coefficients for the polynomial expansion
       constexpr Real V000 = 1.0769995862e-03;
@@ -207,8 +215,7 @@ class Teos10Eos {
    KOKKOS_FUNCTION Real calcDelta(const Real (&SpecVolPCoeffs)[6 * VecLength],
                                   const I4 KVec, const Real P) const {
 
-      constexpr Real PNorm = 1e-4;
-      Real Pp              = P * PNorm;
+      Real Pp = P * PNorm;
 
       Real Delta = ((((SpecVolPCoeffs[5 + 6 * KVec] * Pp +
                        SpecVolPCoeffs[4 + 6 * KVec]) *
@@ -226,19 +233,336 @@ class Teos10Eos {
 
    /// Calculate reference profile for TEOS-10
    KOKKOS_FUNCTION Real calcRefProfile(Real P) const {
-      constexpr Real PNorm = 1e-4;
-      constexpr Real V00   = -4.4015007269e-05;
-      constexpr Real V01   = 6.9232335784e-06;
-      constexpr Real V02   = -7.5004675975e-07;
-      constexpr Real V03   = 1.7009109288e-08;
-      constexpr Real V04   = -1.6884162004e-08;
-      constexpr Real V05   = 1.9613503930e-09;
-      Real Pp              = P * PNorm;
+      constexpr Real V00 = -4.4015007269e-05;
+      constexpr Real V01 = 6.9232335784e-06;
+      constexpr Real V02 = -7.5004675975e-07;
+      constexpr Real V03 = 1.7009109288e-08;
+      constexpr Real V04 = -1.6884162004e-08;
+      constexpr Real V05 = 1.9613503930e-09;
+      Real Pp            = P * PNorm;
 
       Real V0 =
           (((((V05 * Pp + V04) * Pp + V03) * Pp + V02) * Pp + V01) * Pp + V00) *
           Pp;
       return V0;
+   }
+
+   /// Calculate pressure polynomial coefficients for the derivative of the
+   /// TEOS-10 specific volume with respect to the normalized temperature Tt.
+   ///
+   /// The coefficients are the analytic Tt-derivative of the 75-term
+   /// polynomial in calcPCoeffs above: A(i,j,k) = (j+1) * V(i,j+1,k). They are
+   /// the same values used by Teos10BruntVaisalaFreqSq::calcAlpha, regrouped
+   /// here by power of pressure to match the calcPCoeffs/calcDelta split.
+   /// The Tt-derivative is one degree lower in pressure than the specific
+   /// volume itself, so there are five coefficients rather than six.
+   KOKKOS_FUNCTION void calcPCoeffsDTt(Real (&DTtPCoeffs)[5 * VecLength],
+                                       const I4 KVec, const Real Ss,
+                                       const Real Tt) const {
+
+      constexpr Real A000 = -1.56497346750e-5;
+      constexpr Real A001 = 1.85057654290e-5;
+      constexpr Real A002 = -1.17363867310e-6;
+      constexpr Real A003 = -3.65270065530e-7;
+      constexpr Real A004 = 3.14540999020e-7;
+      constexpr Real A010 = 5.55242129680e-5;
+      constexpr Real A011 = -2.34332137060e-5;
+      constexpr Real A012 = 4.26100574800e-6;
+      constexpr Real A013 = 5.73918103180e-7;
+      constexpr Real A020 = -4.95634777770e-5;
+      constexpr Real A021 = 2.37838968519e-5;
+      constexpr Real A022 = -1.38397620111e-6;
+      constexpr Real A030 = 2.76445290808e-5;
+      constexpr Real A031 = -1.36408749928e-5;
+      constexpr Real A032 = -2.53411666056e-7;
+      constexpr Real A040 = -4.02698077700e-6;
+      constexpr Real A041 = 2.53683834070e-6;
+      constexpr Real A050 = 1.23258565608e-6;
+      constexpr Real A100 = 3.50095997640e-5;
+      constexpr Real A101 = -9.56770881560e-6;
+      constexpr Real A102 = -5.56991545570e-6;
+      constexpr Real A103 = -2.72956962370e-7;
+      constexpr Real A110 = -7.48716846880e-5;
+      constexpr Real A111 = -4.73566167220e-7;
+      constexpr Real A112 = 7.82747741600e-7;
+      constexpr Real A120 = 7.24244384490e-5;
+      constexpr Real A121 = -1.03676320965e-5;
+      constexpr Real A122 = 2.32856664276e-8;
+      constexpr Real A130 = -3.50383492616e-5;
+      constexpr Real A131 = 5.18268711320e-6;
+      constexpr Real A140 = -1.65263794500e-6;
+      constexpr Real A200 = -4.35926785610e-5;
+      constexpr Real A201 = 1.11008347650e-5;
+      constexpr Real A202 = 5.46207488340e-6;
+      constexpr Real A210 = 7.18156455200e-5;
+      constexpr Real A211 = 5.85666925900e-6;
+      constexpr Real A212 = -1.31462208134e-6;
+      constexpr Real A220 = -4.30608991440e-5;
+      constexpr Real A221 = 9.49659182340e-7;
+      constexpr Real A230 = 1.74814722392e-5;
+      constexpr Real A300 = 3.45324618280e-5;
+      constexpr Real A301 = -9.84471178440e-6;
+      constexpr Real A302 = -1.35441856270e-6;
+      constexpr Real A310 = -3.73971683740e-5;
+      constexpr Real A311 = -9.76522784000e-7;
+      constexpr Real A320 = 6.85899736680e-6;
+      constexpr Real A400 = -1.19594097880e-5;
+      constexpr Real A401 = 2.59092252600e-6;
+      constexpr Real A410 = 7.71906784880e-6;
+      constexpr Real A500 = 1.38645945810e-6;
+
+      DTtPCoeffs[4 + 5 * KVec] = A004;
+      DTtPCoeffs[3 + 5 * KVec] = A013 * Tt + A103 * Ss + A003;
+      DTtPCoeffs[2 + 5 * KVec] = ((A032 * Tt + A122 * Ss + A022) * Tt +
+                                  (A212 * Ss + A112) * Ss + A012) *
+                                     Tt +
+                                 ((A302 * Ss + A202) * Ss + A102) * Ss + A002;
+      DTtPCoeffs[1 + 5 * KVec] =
+          (((A041 * Tt + A131 * Ss + A031) * Tt + (A221 * Ss + A121) * Ss +
+            A021) *
+               Tt +
+           ((A311 * Ss + A211) * Ss + A111) * Ss + A011) *
+              Tt +
+          (((A401 * Ss + A301) * Ss + A201) * Ss + A101) * Ss + A001;
+      DTtPCoeffs[0 + 5 * KVec] =
+          ((((A050 * Tt + A140 * Ss + A040) * Tt + (A230 * Ss + A130) * Ss +
+             A030) *
+                Tt +
+            ((A320 * Ss + A220) * Ss + A120) * Ss + A020) *
+               Tt +
+           (((A410 * Ss + A310) * Ss + A210) * Ss + A110) * Ss + A010) *
+              Tt +
+          ((((A500 * Ss + A400) * Ss + A300) * Ss + A200) * Ss + A100) * Ss +
+          A000;
+   }
+
+   /// Calculate pressure polynomial coefficients for the derivative of the
+   /// TEOS-10 specific volume with respect to the normalized salinity Ss.
+   ///
+   /// As above, these are the analytic Ss-derivative of the 75-term
+   /// polynomial: B(i,j,k) = (i+1) * V(i+1,j,k), the same values used by
+   /// Teos10BruntVaisalaFreqSq::calcBeta.
+   KOKKOS_FUNCTION void calcPCoeffsDSs(Real (&DSsPCoeffs)[5 * VecLength],
+                                       const I4 KVec, const Real Ss,
+                                       const Real Tt) const {
+
+      constexpr Real B000 = -3.10389819760e-4;
+      constexpr Real B001 = 2.42624687470e-5;
+      constexpr Real B002 = -5.84844329840e-7;
+      constexpr Real B003 = 3.63101885150e-7;
+      constexpr Real B004 = -1.11471254230e-7;
+      constexpr Real B010 = 3.50095997640e-5;
+      constexpr Real B011 = -9.56770881560e-6;
+      constexpr Real B012 = -5.56991545570e-6;
+      constexpr Real B013 = -2.72956962370e-7;
+      constexpr Real B020 = -3.74358423440e-5;
+      constexpr Real B021 = -2.36783083610e-7;
+      constexpr Real B022 = 3.91373870800e-7;
+      constexpr Real B030 = 2.41414794830e-5;
+      constexpr Real B031 = -3.45587736550e-6;
+      constexpr Real B032 = 7.76188880920e-9;
+      constexpr Real B040 = -8.75958731540e-6;
+      constexpr Real B041 = 1.29567177830e-6;
+      constexpr Real B050 = -3.30527589000e-7;
+      constexpr Real B100 = 1.33856134076e-3;
+      constexpr Real B101 = -6.95849219480e-5;
+      constexpr Real B102 = -9.62445031940e-6;
+      constexpr Real B103 = 3.34926075600e-8;
+      constexpr Real B110 = -8.71853571220e-5;
+      constexpr Real B111 = 2.22016695300e-5;
+      constexpr Real B112 = 1.09241497668e-5;
+      constexpr Real B120 = 7.18156455200e-5;
+      constexpr Real B121 = 5.85666925900e-6;
+      constexpr Real B122 = -1.31462208134e-6;
+      constexpr Real B130 = -2.87072660960e-5;
+      constexpr Real B131 = 6.33106121560e-7;
+      constexpr Real B140 = 8.74073611960e-6;
+      constexpr Real B200 = -2.55143801811e-3;
+      constexpr Real B201 = 1.12412331915e-4;
+      constexpr Real B202 = 1.47789320994e-5;
+      constexpr Real B210 = 1.03597385484e-4;
+      constexpr Real B211 = -2.95341353532e-5;
+      constexpr Real B212 = -4.06325568810e-6;
+      constexpr Real B220 = -5.60957525610e-5;
+      constexpr Real B221 = -1.46478417600e-6;
+      constexpr Real B230 = 6.85899736680e-6;
+      constexpr Real B300 = 2.32344279772e-3;
+      constexpr Real B301 = -6.92888744480e-5;
+      constexpr Real B302 = -7.12478989080e-6;
+      constexpr Real B310 = -4.78376391520e-5;
+      constexpr Real B311 = 1.03636901040e-5;
+      constexpr Real B320 = 1.54381356976e-5;
+      constexpr Real B400 = -1.05461852535e-3;
+      constexpr Real B401 = 1.54637136265e-5;
+      constexpr Real B410 = 6.93229729050e-6;
+      constexpr Real B500 = 1.91594743830e-4;
+
+      DSsPCoeffs[4 + 5 * KVec] = B004;
+      DSsPCoeffs[3 + 5 * KVec] = B013 * Tt + B103 * Ss + B003;
+      DSsPCoeffs[2 + 5 * KVec] = ((B032 * Tt + B122 * Ss + B022) * Tt +
+                                  (B212 * Ss + B112) * Ss + B012) *
+                                     Tt +
+                                 ((B302 * Ss + B202) * Ss + B102) * Ss + B002;
+      DSsPCoeffs[1 + 5 * KVec] =
+          (((B041 * Tt + B131 * Ss + B031) * Tt + (B221 * Ss + B121) * Ss +
+            B021) *
+               Tt +
+           ((B311 * Ss + B211) * Ss + B111) * Ss + B011) *
+              Tt +
+          (((B401 * Ss + B301) * Ss + B201) * Ss + B101) * Ss + B001;
+      DSsPCoeffs[0 + 5 * KVec] =
+          ((((B050 * Tt + B140 * Ss + B040) * Tt + (B230 * Ss + B130) * Ss +
+             B030) *
+                Tt +
+            ((B320 * Ss + B220) * Ss + B120) * Ss + B020) *
+               Tt +
+           (((B410 * Ss + B310) * Ss + B210) * Ss + B110) * Ss + B010) *
+              Tt +
+          ((((B500 * Ss + B400) * Ss + B300) * Ss + B200) * Ss + B100) * Ss +
+          B000;
+   }
+
+   /// Evaluate one of the degree-4 derivative pressure polynomials assembled
+   /// by calcPCoeffsDTt or calcPCoeffsDSs. P is relative pressure in dbar.
+   KOKKOS_FUNCTION Real calcDeltaDeriv(const Real (&DPCoeffs)[5 * VecLength],
+                                       const I4 KVec, const Real P) const {
+
+      Real Pp = P * PNorm;
+
+      Real DDelta =
+          (((DPCoeffs[4 + 5 * KVec] * Pp + DPCoeffs[3 + 5 * KVec]) * Pp +
+            DPCoeffs[2 + 5 * KVec]) *
+               Pp +
+           DPCoeffs[1 + 5 * KVec]) *
+              Pp +
+          DPCoeffs[0 + 5 * KVec];
+
+      return DDelta;
+   }
+
+   /// Evaluate the derivative of the TEOS-10 pressure polynomial with respect
+   /// to pressure, from the coefficients calcPCoeffs has already assembled for
+   /// the specific volume itself. P is relative pressure in dbar and the
+   /// result is per dbar.
+   KOKKOS_FUNCTION Real calcDeltaDP(const Real (&SpecVolPCoeffs)[6 * VecLength],
+                                    const I4 KVec, const Real P) const {
+
+      Real Pp = P * PNorm;
+
+      Real DDelta = (((5.0_Real * SpecVolPCoeffs[5 + 6 * KVec] * Pp +
+                       4.0_Real * SpecVolPCoeffs[4 + 6 * KVec]) *
+                          Pp +
+                      3.0_Real * SpecVolPCoeffs[3 + 6 * KVec]) *
+                         Pp +
+                     2.0_Real * SpecVolPCoeffs[2 + 6 * KVec]) *
+                        Pp +
+                    SpecVolPCoeffs[1 + 6 * KVec];
+
+      return DDelta * PNorm;
+   }
+
+   /// Calculate the derivative of the TEOS-10 reference profile with respect
+   /// to pressure. P is relative pressure in dbar and the result is per dbar.
+   /// The reference profile does not depend on temperature or salinity, so it
+   /// contributes only to the pressure derivative -- but it must not be left
+   /// out of that one.
+   KOKKOS_FUNCTION Real calcRefProfileDP(Real P) const {
+      constexpr Real V00 = -4.4015007269e-05;
+      constexpr Real V01 = 6.9232335784e-06;
+      constexpr Real V02 = -7.5004675975e-07;
+      constexpr Real V03 = 1.7009109288e-08;
+      constexpr Real V04 = -1.6884162004e-08;
+      constexpr Real V05 = 1.9613503930e-09;
+      Real Pp            = P * PNorm;
+
+      Real DV0 =
+          (((((6.0_Real * V05 * Pp + 5.0_Real * V04) * Pp + 4.0_Real * V03) *
+                 Pp +
+             3.0_Real * V02) *
+                Pp +
+            2.0_Real * V01) *
+               Pp +
+           V00);
+
+      return DV0 * PNorm;
+   }
+
+   /// Calculate the TEOS-10 specific volume and its three first derivatives at
+   /// a single state. P is the relative pressure (gauge pressure in Pa, i.e.
+   /// absolute pressure minus the standard atmosphere). The derivatives are
+   /// returned per degC, per (g/kg), and per Pa respectively.
+   KOKKOS_FUNCTION void calcSpecVolAndDerivs(const Real Ct, const Real Sa,
+                                             const Real P, Real &SpecVol,
+                                             Real &SpecVolDCt, Real &SpecVolDSa,
+                                             Real &SpecVolDP) const {
+
+      Real SpecVolPCoeffs[6 * VecLength];
+      Real DTtPCoeffs[5 * VecLength];
+      Real DSsPCoeffs[5 * VecLength];
+
+      const Real Ss  = Kokkos::sqrt((Sa + DeltaS) / SaNorm);
+      const Real Tt  = Ct / CtNorm;
+      const Real Pdb = P * Pa2Db;
+
+      calcPCoeffs(SpecVolPCoeffs, 0, Ct, Sa);
+      calcPCoeffsDTt(DTtPCoeffs, 0, Ss, Tt);
+      calcPCoeffsDSs(DSsPCoeffs, 0, Ss, Tt);
+
+      SpecVol = calcRefProfile(Pdb) + calcDelta(SpecVolPCoeffs, 0, Pdb);
+
+      /// Chain rule from the normalized variables of the polynomial to the
+      /// physical ones: dTt/dCt = 1 / CtNorm, dSs/dSa = 1 / (2 SaNorm Ss),
+      /// and dPdb/dP = Pa2Db.
+      SpecVolDCt = calcDeltaDeriv(DTtPCoeffs, 0, Pdb) / CtNorm;
+      SpecVolDSa =
+          calcDeltaDeriv(DSsPCoeffs, 0, Pdb) * 0.5_Real / (SaNorm * Ss);
+      SpecVolDP =
+          (calcRefProfileDP(Pdb) + calcDeltaDP(SpecVolPCoeffs, 0, Pdb)) * Pa2Db;
+   }
+
+   /// Calculate the TEOS-10 specific volume and its three first derivatives
+   /// over a vertical chunk of a cell. Pressure is the relative pressure in
+   /// Pa; the derivatives are per degC, per (g/kg), and per Pa.
+   KOKKOS_FUNCTION void
+   calcSpecVolDerivs(Array2DReal SpecVol, Array2DReal SpecVolDCt,
+                     Array2DReal SpecVolDSa, Array2DReal SpecVolDP, I4 ICell,
+                     I4 KChunk, const Array2DReal &ConservTemp,
+                     const Array2DReal &AbsSalinity,
+                     const Array2DReal &Pressure) const {
+
+      Real SpecVolPCoeffs[6 * VecLength];
+      Real DTtPCoeffs[5 * VecLength];
+      Real DSsPCoeffs[5 * VecLength];
+
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K     = KStart + KVec;
+         const Real Ct  = ConservTemp(ICell, K);
+         const Real Sa  = AbsSalinity(ICell, K);
+         const Real Ss  = Kokkos::sqrt((Sa + DeltaS) / SaNorm);
+         const Real Tt  = Ct / CtNorm;
+         const Real Pdb = Pressure(ICell, K) * Pa2Db;
+
+         /// Assemble the pressure polynomial coefficients for the specific
+         /// volume and for its temperature and salinity derivatives. All three
+         /// use the same normalized state, so the equation of state is
+         /// evaluated only once per cell and layer.
+         calcPCoeffs(SpecVolPCoeffs, KVec, Ct, Sa);
+         calcPCoeffsDTt(DTtPCoeffs, KVec, Ss, Tt);
+         calcPCoeffsDSs(DSsPCoeffs, KVec, Ss, Tt);
+
+         SpecVol(ICell, K) =
+             calcRefProfile(Pdb) + calcDelta(SpecVolPCoeffs, KVec, Pdb);
+
+         SpecVolDCt(ICell, K) = calcDeltaDeriv(DTtPCoeffs, KVec, Pdb) / CtNorm;
+         SpecVolDSa(ICell, K) =
+             calcDeltaDeriv(DSsPCoeffs, KVec, Pdb) * 0.5_Real / (SaNorm * Ss);
+         SpecVolDP(ICell, K) =
+             (calcRefProfileDP(Pdb) + calcDeltaDP(SpecVolPCoeffs, KVec, Pdb)) *
+             Pa2Db;
+      }
    }
 
    /// Calculate 2nd derivative of Gibbs wrt pot temp at ref P for TEOS-10

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -768,6 +768,33 @@ class LinearEos {
       }
    }
 
+   /// Calculate the linear specific volume and its three first derivatives
+   /// over a vertical chunk of a cell. With
+   ///    SpecVol = 1 / (RhoT0S0 + DRhodT * Ct + DRhodS * Sa)
+   /// the derivatives are -DRhodT * SpecVol^2 and -DRhodS * SpecVol^2, and
+   /// the linear EOS has no pressure dependence at all.
+   KOKKOS_FUNCTION void
+   calcSpecVolDerivs(Array2DReal SpecVol, Array2DReal SpecVolDCt,
+                     Array2DReal SpecVolDSa, Array2DReal SpecVolDP, I4 ICell,
+                     I4 KChunk, const Array2DReal &ConservTemp,
+                     const Array2DReal &AbsSalinity) const {
+
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K = KStart + KVec;
+         const Real Sv =
+             1.0_Real / (RhoT0S0 + (DRhodT * ConservTemp(ICell, K) +
+                                    DRhodS * AbsSalinity(ICell, K)));
+
+         SpecVol(ICell, K)    = Sv;
+         SpecVolDCt(ICell, K) = -DRhodT * Sv * Sv;
+         SpecVolDSa(ICell, K) = -DRhodS * Sv * Sv;
+         SpecVolDP(ICell, K)  = 0.0_Real;
+      }
+   }
+
  private:
    Array1DI4 MinLayerCell;
    Array1DI4 MaxLayerCell;
@@ -794,6 +821,29 @@ class ConstantEos {
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K        = KStart + KVec;
          SpecVol(ICell, K) = 1.0_Real / RhoSw;
+      }
+   }
+
+   /// Calculate the constant specific volume and its three first derivatives
+   /// over a vertical chunk of a cell. The specific volume does not depend on
+   /// temperature, salinity or pressure, so all three derivatives vanish.
+   KOKKOS_FUNCTION void
+   calcSpecVolDerivs(Array2DReal SpecVol, Array2DReal SpecVolDCt,
+                     Array2DReal SpecVolDSa, Array2DReal SpecVolDP, I4 ICell,
+                     I4 KChunk, const Array2DReal &ConservTemp,
+                     const Array2DReal &AbsSalinity) const {
+
+      const I4 KStart = chunkStart(KChunk, MinLayerCell(ICell));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerCell(ICell));
+      (void)ConservTemp;
+      (void)AbsSalinity;
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K           = KStart + KVec;
+         SpecVol(ICell, K)    = 1.0_Real / RhoSw;
+         SpecVolDCt(ICell, K) = 0.0_Real;
+         SpecVolDSa(ICell, K) = 0.0_Real;
+         SpecVolDP(ICell, K)  = 0.0_Real;
       }
    }
 

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -1010,6 +1010,22 @@ class Eos {
    Array2DReal SpecVolDSa;         ///< d(SpecVol)/d(AbsSalinity), per (g/kg)
    Array2DReal SpecVolDP;          ///< d(SpecVol)/d(Pressure), per Pa
 
+   /// Number of specific-volume evaluations performed since the counter was
+   /// last reset, counted as one per cell per active layer per call.
+   ///
+   /// This is instrumentation for the cost check of the finite-volume
+   /// pressure gradient design. That design bounds the number of
+   /// equation-of-state evaluations at approximately one per cell per layer
+   /// per step, independent of the reconstruction order, the stencil width
+   /// and the quadrature; nothing else in the test suite would notice an
+   /// evaluation appearing inside a quadrature loop, since it would change
+   /// run time without changing any answer. Maintaining it costs one host
+   /// addition per call.
+   I8 SpecVolEvalCount = 0;
+
+   /// Reset the specific-volume evaluation counter
+   void resetSpecVolEvalCount() { SpecVolEvalCount = 0; }
+
    std::string SpecVolFldName; ///< Field name for specific volume
    std::string
        SpecVolDisplacedFldName; ///< Field name for displaced specific volume

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -909,6 +909,16 @@ class Teos10BruntVaisalaFreqSq {
    /// TEOS-10 derivative helpers rather than from a second copy of the same
    /// polynomial coefficients. P is relative pressure in dbar and Sp is the
    /// specific volume.
+   ///
+   /// The coefficients are assembled here rather than taken from the
+   /// Eos::SpecVolDCt array because the two are not evaluated at the same
+   /// state: this is called at the interface, with the temperature, salinity
+   /// and pressure averaged from the two adjacent layers, while SpecVolDCt
+   /// holds the derivative at the layer centers. Averaging the layer-center
+   /// derivatives instead would be a different approximation and would change
+   /// answers. The stored derivatives are also filled only when
+   /// computeSpecVolAndDerivs is called, which the Brunt-Vaisala calculation
+   /// cannot assume.
    KOKKOS_FUNCTION Real calcAlpha(Real Sa, Real Ct, Real P, Real Sp) const {
 
       Real DTtPCoeffs[5 * VecLength];
@@ -926,7 +936,9 @@ class Teos10BruntVaisalaFreqSq {
    /// Calculate beta (the haline contraction coefficient) for the squared
    /// Brunt-Vaisala frequency. Beta is minus the salinity derivative of the
    /// specific volume divided by the specific volume. P is relative pressure
-   /// in dbar and Sp is the specific volume.
+   /// in dbar and Sp is the specific volume. As for calcAlpha above, this is
+   /// evaluated at the interface state and so cannot reuse the layer-center
+   /// Eos::SpecVolDSa array.
    KOKKOS_FUNCTION Real calcBeta(Real Sa, Real Ct, Real P, Real Sp) const {
 
       Real DSsPCoeffs[5 * VecLength];

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -251,14 +251,16 @@ class Teos10Eos {
    /// TEOS-10 specific volume with respect to the normalized temperature Tt.
    ///
    /// The coefficients are the analytic Tt-derivative of the 75-term
-   /// polynomial in calcPCoeffs above: A(i,j,k) = (j+1) * V(i,j+1,k). They are
-   /// the same values used by Teos10BruntVaisalaFreqSq::calcAlpha, regrouped
-   /// here by power of pressure to match the calcPCoeffs/calcDelta split.
-   /// The Tt-derivative is one degree lower in pressure than the specific
-   /// volume itself, so there are five coefficients rather than six.
-   KOKKOS_FUNCTION void calcPCoeffsDTt(Real (&DTtPCoeffs)[5 * VecLength],
-                                       const I4 KVec, const Real Ss,
-                                       const Real Tt) const {
+   /// polynomial in calcPCoeffs above: A(i,j,k) = (j+1) * V(i,j+1,k), grouped
+   /// here by power of pressure to match the calcPCoeffs/calcDelta split. The
+   /// Tt-derivative is one degree lower in pressure than the specific volume
+   /// itself, so there are five coefficients rather than six.
+   ///
+   /// This is the only copy of these coefficients: the thermal expansion
+   /// coefficient used by the Brunt-Vaisala frequency is derived from here.
+   KOKKOS_FUNCTION static void calcPCoeffsDTt(Real (&DTtPCoeffs)[5 * VecLength],
+                                              const I4 KVec, const Real Ss,
+                                              const Real Tt) {
 
       constexpr Real A000 = -1.56497346750e-5;
       constexpr Real A001 = 1.85057654290e-5;
@@ -340,11 +342,11 @@ class Teos10Eos {
    /// TEOS-10 specific volume with respect to the normalized salinity Ss.
    ///
    /// As above, these are the analytic Ss-derivative of the 75-term
-   /// polynomial: B(i,j,k) = (i+1) * V(i+1,j,k), the same values used by
-   /// Teos10BruntVaisalaFreqSq::calcBeta.
-   KOKKOS_FUNCTION void calcPCoeffsDSs(Real (&DSsPCoeffs)[5 * VecLength],
-                                       const I4 KVec, const Real Ss,
-                                       const Real Tt) const {
+   /// polynomial: B(i,j,k) = (i+1) * V(i+1,j,k), and this is the only copy of
+   /// them; the haline contraction coefficient is derived from here.
+   KOKKOS_FUNCTION static void calcPCoeffsDSs(Real (&DSsPCoeffs)[5 * VecLength],
+                                              const I4 KVec, const Real Ss,
+                                              const Real Tt) {
 
       constexpr Real B000 = -3.10389819760e-4;
       constexpr Real B001 = 2.42624687470e-5;
@@ -424,8 +426,9 @@ class Teos10Eos {
 
    /// Evaluate one of the degree-4 derivative pressure polynomials assembled
    /// by calcPCoeffsDTt or calcPCoeffsDSs. P is relative pressure in dbar.
-   KOKKOS_FUNCTION Real calcDeltaDeriv(const Real (&DPCoeffs)[5 * VecLength],
-                                       const I4 KVec, const Real P) const {
+   KOKKOS_FUNCTION static Real
+   calcDeltaDeriv(const Real (&DPCoeffs)[5 * VecLength], const I4 KVec,
+                  const Real P) {
 
       Real Pp = P * PNorm;
 
@@ -893,162 +896,42 @@ class Teos10BruntVaisalaFreqSq {
       }
    }
 
-   /// Calculate alpha values for the squared Brunt-Vaisala frequency
+   /// Calculate alpha (the thermal expansion coefficient) for the squared
+   /// Brunt-Vaisala frequency. Alpha is the temperature derivative of the
+   /// specific volume divided by the specific volume, so it is formed from the
+   /// TEOS-10 derivative helpers rather than from a second copy of the same
+   /// polynomial coefficients. P is relative pressure in dbar and Sp is the
+   /// specific volume.
    KOKKOS_FUNCTION Real calcAlpha(Real Sa, Real Ct, Real P, Real Sp) const {
-      constexpr Real Factor = 0.0248826675584615;
-      constexpr Real Offset = 5.971840214030754e-1;
-      constexpr Real PNorm  = 1.0e-4;
-      Real Ss               = Kokkos::sqrt(Factor * Sa + Offset);
-      Real Tt               = 0.025_Real * Ct;
-      Real Pp               = P * PNorm;
 
-      constexpr Real A000 = -1.56497346750e-5;
-      constexpr Real A001 = 1.85057654290e-5;
-      constexpr Real A002 = -1.17363867310e-6;
-      constexpr Real A003 = -3.65270065530e-7;
-      constexpr Real A004 = 3.14540999020e-7;
-      constexpr Real A010 = 5.55242129680e-5;
-      constexpr Real A011 = -2.34332137060e-5;
-      constexpr Real A012 = 4.26100574800e-6;
-      constexpr Real A013 = 5.73918103180e-7;
-      constexpr Real A020 = -4.95634777770e-5;
-      constexpr Real A021 = 2.37838968519e-5;
-      constexpr Real A022 = -1.38397620111e-6;
-      constexpr Real A030 = 2.76445290808e-5;
-      constexpr Real A031 = -1.36408749928e-5;
-      constexpr Real A032 = -2.53411666056e-7;
-      constexpr Real A040 = -4.02698077700e-6;
-      constexpr Real A041 = 2.53683834070e-6;
-      constexpr Real A050 = 1.23258565608e-6;
-      constexpr Real A100 = 3.50095997640e-5;
-      constexpr Real A101 = -9.56770881560e-6;
-      constexpr Real A102 = -5.56991545570e-6;
-      constexpr Real A103 = -2.72956962370e-7;
-      constexpr Real A110 = -7.48716846880e-5;
-      constexpr Real A111 = -4.73566167220e-7;
-      constexpr Real A112 = 7.82747741600e-7;
-      constexpr Real A120 = 7.24244384490e-5;
-      constexpr Real A121 = -1.03676320965e-5;
-      constexpr Real A122 = 2.32856664276e-8;
-      constexpr Real A130 = -3.50383492616e-5;
-      constexpr Real A131 = 5.18268711320e-6;
-      constexpr Real A140 = -1.65263794500e-6;
-      constexpr Real A200 = -4.35926785610e-5;
-      constexpr Real A201 = 1.11008347650e-5;
-      constexpr Real A202 = 5.46207488340e-6;
-      constexpr Real A210 = 7.18156455200e-5;
-      constexpr Real A211 = 5.85666925900e-6;
-      constexpr Real A212 = -1.31462208134e-6;
-      constexpr Real A220 = -4.30608991440e-5;
-      constexpr Real A221 = 9.49659182340e-7;
-      constexpr Real A230 = 1.74814722392e-5;
-      constexpr Real A300 = 3.45324618280e-5;
-      constexpr Real A301 = -9.84471178440e-6;
-      constexpr Real A302 = -1.35441856270e-6;
-      constexpr Real A310 = -3.73971683740e-5;
-      constexpr Real A311 = -9.76522784000e-7;
-      constexpr Real A320 = 6.85899736680e-6;
-      constexpr Real A400 = -1.19594097880e-5;
-      constexpr Real A401 = 2.59092252600e-6;
-      constexpr Real A410 = 7.71906784880e-6;
-      constexpr Real A500 = 1.38645945810e-6;
+      Real DTtPCoeffs[5 * VecLength];
 
-      Real Rval =
-          A000 +
-          Ss * (A100 + Ss * (A200 + Ss * (A300 + Ss * (A400 + A500 * Ss)))) +
-          Tt * (A010 + Ss * (A110 + Ss * (A210 + Ss * (A310 + A410 * Ss))) +
-                Tt * (A020 + Ss * (A120 + Ss * (A220 + A320 * Ss)) +
-                      Tt * (A030 + Ss * (A130 + A230 * Ss) +
-                            Tt * (A040 + A140 * Ss + A050 * Tt)))) +
-          Pp * (A001 + Ss * (A101 + Ss * (A201 + Ss * (A301 + A401 * Ss))) +
-                Tt * (A011 + Ss * (A111 + Ss * (A211 + A311 * Ss)) +
-                      Tt * (A021 + Ss * (A121 + A221 * Ss) +
-                            Tt * (A031 + A131 * Ss + A041 * Tt))) +
-                Pp * (A002 + Ss * (A102 + Ss * (A202 + A302 * Ss)) +
-                      Tt * (A012 + Ss * (A112 + A212 * Ss) +
-                            Tt * (A022 + A122 * Ss + A032 * Tt)) +
-                      Pp * (A003 + A103 * Ss + A013 * Tt + A004 * Pp)));
+      const Real Ss =
+          Kokkos::sqrt((Sa + Teos10Eos::DeltaS) / Teos10Eos::SaNorm);
+      const Real Tt = Ct / Teos10Eos::CtNorm;
 
-      return 0.025_Real * Rval / Sp;
+      Teos10Eos::calcPCoeffsDTt(DTtPCoeffs, 0, Ss, Tt);
+
+      return Teos10Eos::calcDeltaDeriv(DTtPCoeffs, 0, P) /
+             (Teos10Eos::CtNorm * Sp);
    }
 
-   /// Calculate beta values for the squared Brunt-Vaisala frequency
+   /// Calculate beta (the haline contraction coefficient) for the squared
+   /// Brunt-Vaisala frequency. Beta is minus the salinity derivative of the
+   /// specific volume divided by the specific volume. P is relative pressure
+   /// in dbar and Sp is the specific volume.
    KOKKOS_FUNCTION Real calcBeta(Real Sa, Real Ct, Real P, Real Sp) const {
-      constexpr Real Factor = 0.0248826675584615;
-      constexpr Real Offset = 5.971840214030754e-1;
-      constexpr Real PNorm  = 1.0e-4;
-      Real Ss               = Kokkos::sqrt(Factor * Sa + Offset);
-      Real Tt               = 0.025_Real * Ct;
-      Real Pp               = P * PNorm;
 
-      constexpr Real B000 = -3.10389819760e-4;
-      constexpr Real B003 = 3.63101885150e-7;
-      constexpr Real B004 = -1.11471254230e-7;
-      constexpr Real B010 = 3.50095997640e-5;
-      constexpr Real B013 = -2.72956962370e-7;
-      constexpr Real B020 = -3.74358423440e-5;
-      constexpr Real B030 = 2.41414794830e-5;
-      constexpr Real B040 = -8.75958731540e-6;
-      constexpr Real B050 = -3.30527589000e-7;
-      constexpr Real B100 = 1.33856134076e-3;
-      constexpr Real B103 = 3.34926075600e-8;
-      constexpr Real B110 = -8.71853571220e-5;
-      constexpr Real B120 = 7.18156455200e-5;
-      constexpr Real B130 = -2.87072660960e-5;
-      constexpr Real B140 = 8.74073611960e-6;
-      constexpr Real B200 = -2.55143801811e-3;
-      constexpr Real B210 = 1.03597385484e-4;
-      constexpr Real B220 = -5.60957525610e-5;
-      constexpr Real B230 = 6.85899736680e-6;
-      constexpr Real B300 = 2.32344279772e-3;
-      constexpr Real B310 = -4.78376391520e-5;
-      constexpr Real B320 = 1.54381356976e-5;
-      constexpr Real B400 = -1.05461852535e-3;
-      constexpr Real B410 = 6.93229729050e-6;
-      constexpr Real B500 = 1.91594743830e-4;
-      constexpr Real B001 = 2.42624687470e-5;
-      constexpr Real B011 = -9.56770881560e-6;
-      constexpr Real B021 = -2.36783083610e-7;
-      constexpr Real B031 = -3.45587736550e-6;
-      constexpr Real B041 = 1.29567177830e-6;
-      constexpr Real B101 = -6.95849219480e-5;
-      constexpr Real B111 = 2.22016695300e-5;
-      constexpr Real B121 = 5.85666925900e-6;
-      constexpr Real B131 = 6.33106121560e-7;
-      constexpr Real B201 = 1.12412331915e-4;
-      constexpr Real B211 = -2.95341353532e-5;
-      constexpr Real B221 = -1.46478417600e-6;
-      constexpr Real B301 = -6.92888744480e-5;
-      constexpr Real B311 = 1.03636901040e-5;
-      constexpr Real B401 = 1.54637136265e-5;
-      constexpr Real B002 = -5.84844329840e-7;
-      constexpr Real B012 = -5.56991545570e-6;
-      constexpr Real B022 = 3.91373870800e-7;
-      constexpr Real B032 = 7.76188880920e-9;
-      constexpr Real B102 = -9.62445031940e-6;
-      constexpr Real B112 = 1.09241497668e-5;
-      constexpr Real B122 = -1.31462208134e-6;
-      constexpr Real B202 = 1.47789320994e-5;
-      constexpr Real B212 = -4.06325568810e-6;
-      constexpr Real B302 = -7.12478989080e-6;
+      Real DSsPCoeffs[5 * VecLength];
 
-      Real Rval =
-          B000 +
-          Ss * (B100 + Ss * (B200 + Ss * (B300 + Ss * (B400 + B500 * Ss)))) +
-          Tt * (B010 + Ss * (B110 + Ss * (B210 + Ss * (B310 + B410 * Ss))) +
-                Tt * (B020 + Ss * (B120 + Ss * (B220 + B320 * Ss)) +
-                      Tt * (B030 + Ss * (B130 + B230 * Ss) +
-                            Tt * (B040 + B140 * Ss + B050 * Tt)))) +
-          Pp * (B001 + Ss * (B101 + Ss * (B201 + Ss * (B301 + B401 * Ss))) +
-                Tt * (B011 + Ss * (B111 + Ss * (B211 + B311 * Ss)) +
-                      Tt * (B021 + Ss * (B121 + B221 * Ss) +
-                            Tt * (B031 + B131 * Ss + B041 * Tt))) +
-                Pp * (B002 + Ss * (B102 + Ss * (B202 + B302 * Ss)) +
-                      Tt * (B012 + Ss * (B112 + B212 * Ss) +
-                            Tt * (B022 + B122 * Ss + B032 * Tt)) +
-                      Pp * (B003 + B103 * Ss + B013 * Tt + B004 * Pp)));
+      const Real Ss =
+          Kokkos::sqrt((Sa + Teos10Eos::DeltaS) / Teos10Eos::SaNorm);
+      const Real Tt = Ct / Teos10Eos::CtNorm;
 
-      return -0.5_Real * Rval * Factor / (Sp * Ss);
+      Teos10Eos::calcPCoeffsDSs(DSsPCoeffs, 0, Ss, Tt);
+
+      return -0.5_Real * Teos10Eos::calcDeltaDeriv(DSsPCoeffs, 0, P) /
+             (Teos10Eos::SaNorm * Ss * Sp);
    }
 
  private:

--- a/components/omega/src/ocn/PGrad.cpp
+++ b/components/omega/src/ocn/PGrad.cpp
@@ -161,6 +161,29 @@ PressureGrad::PressureGrad(
    FiniteVolumePGrad.HorzOrder        = HorzOrder;
    FiniteVolumePGrad.QuadraturePoints = QuadraturePoints;
 
+   // Additional mesh and coordinate data used by the FiniteVolume column scan
+   CellsOnEdge  = Mesh->CellsOnEdge;
+   DcEdge       = Mesh->DcEdge;
+   EdgeMask     = VCoord->EdgeMask;
+   MinLayerCell = VCoord->MinLayerCell;
+   MaxLayerCell = VCoord->MaxLayerCell;
+   NCellsAll    = Mesh->NCellsAll;
+
+   // Working arrays for the FiniteVolume scheme, allocated only when that
+   // scheme is selected so that a Centered run pays nothing for them
+   if (PressureGradChoice == PressureGradType::FiniteVolume) {
+      ReconSlopeCt =
+          Array2DReal("PGradReconSlopeCt", Mesh->NCellsSize, NVertLayers);
+      ReconSlopeSa =
+          Array2DReal("PGradReconSlopeSa", Mesh->NCellsSize, NVertLayers);
+      DeltaZIncr =
+          Array2DReal("PGradDeltaZIncr", Mesh->NEdgesSize, NVertLayers);
+      DeltaZMoment =
+          Array2DReal("PGradDeltaZMoment", Mesh->NEdgesSize, NVertLayers);
+      DeltaZFixedP =
+          Array2DReal("PGradDeltaZFixedP", Mesh->NEdgesSize, NVertLayersP1);
+   }
+
    // Temporary: initialization of tidal potential and SAL
    TidalPotential = Array1DReal("TidalPotential", Mesh->NCellsSize);
    SelfAttractionLoading =
@@ -213,6 +236,252 @@ PressureGrad *PressureGrad::get(const std::string &Name ///< [in] Name of
 } // end get pressure gradient
 
 //------------------------------------------------------------------------------
+// Compute the mean-preserving reconstruction slopes of temperature and
+// salinity in pressure, once per cell and layer.
+void PressureGrad::computeReconSlopes(
+    const Array2DReal &ConservTemp, ///< [in] layer-mean temperature
+    const Array2DReal &AbsSalinity, ///< [in] layer-mean salinity
+    const Array2DReal &PressureMid  ///< [in] mid-layer pressure
+) const {
+
+   OMEGA_SCOPE(LocReconSlopeCt, ReconSlopeCt);
+   OMEGA_SCOPE(LocReconSlopeSa, ReconSlopeSa);
+   OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
+   OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
+
+   parallelFor(
+       "pgrad-recon-slopes", {NCellsAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 ICell, I4 K) {
+          const I4 KMin = LocMinLayerCell(ICell);
+          const I4 KMax = LocMaxLayerCell(ICell);
+
+          if (K < KMin || K > KMax) {
+             LocReconSlopeCt(ICell, K) = 0.0_Real;
+             LocReconSlopeSa(ICell, K) = 0.0_Real;
+             return;
+          }
+
+          I4 KLo, KHi;
+          linearReconStencil(K, KMin, KMax, KLo, KHi);
+
+          LocReconSlopeCt(ICell, K) = linearReconSlope(
+              ConservTemp(ICell, KLo), ConservTemp(ICell, KHi),
+              PressureMid(ICell, KLo), PressureMid(ICell, KHi));
+          LocReconSlopeSa(ICell, K) = linearReconSlope(
+              AbsSalinity(ICell, KLo), AbsSalinity(ICell, KHi),
+              PressureMid(ICell, KLo), PressureMid(ICell, KHi));
+       });
+
+} // end computeReconSlopes
+
+//------------------------------------------------------------------------------
+// Accumulate the fixed-pressure height difference down each edge's column.
+//
+// The edge control volume is taken as the average of the two columns'
+// interface pressures, which makes its mid-layer pressure and its pressure
+// thickness exactly the edge averages of the two columns' own.
+//
+// The scan runs in two passes. The first evaluates the matched-pressure
+// integrand at the quadrature points of each edge layer and forms two
+// integrals of it over the same points: the increment of the recurrence, and
+// its first moment about the layer's top interface, which the layer mean
+// needs. The second anchors the column and turns the increments into the
+// height difference at every interface.
+//
+// The anchor is at the sea floor. Design section 3.7.4 leaves the end open and
+// prefers this one on conditioning grounds: VertCoord builds geometric height
+// upward from a prescribed bathymetry, so at the bottom interface the height
+// difference is exact input and vanishes identically for a flat floor, where
+// at the surface it is the small residual of two column-length accumulations.
+// The anchor is computed, not assumed -- it is whatever the model's geometric
+// heights and interface pressures imply, evaluated at a common pressure, and
+// it is the deepest instance of the same comparison the recurrence makes at
+// every other interface.
+void PressureGrad::computeColumnScan(
+    const Array2DReal &PressureMid,       ///< [in] mid-layer pressure
+    const Array2DReal &PressureInterface, ///< [in] interface pressure
+    const Array2DReal &GeomZInterface,    ///< [in] interface geometric height
+    const Array2DReal &ConservTemp,       ///< [in] layer-mean temperature
+    const Array2DReal &AbsSalinity,       ///< [in] layer-mean salinity
+    const Eos *EqState                    ///< [in] equation of state
+) const {
+
+   const Array2DReal SpecVol    = EqState->SpecVol;
+   const Array2DReal SpecVolDCt = EqState->SpecVolDCt;
+   const Array2DReal SpecVolDSa = EqState->SpecVolDSa;
+   const Array2DReal SpecVolDP  = EqState->SpecVolDP;
+   const I4 NQuad               = FiniteVolumePGrad.QuadraturePoints;
+   const Real InvGravity        = 1.0_Real / Gravity;
+
+   OMEGA_SCOPE(LocReconSlopeCt, ReconSlopeCt);
+   OMEGA_SCOPE(LocReconSlopeSa, ReconSlopeSa);
+   OMEGA_SCOPE(LocDeltaZIncr, DeltaZIncr);
+   OMEGA_SCOPE(LocDeltaZMoment, DeltaZMoment);
+   OMEGA_SCOPE(LocDeltaZFixedP, DeltaZFixedP);
+   OMEGA_SCOPE(LocCellsOnEdge, CellsOnEdge);
+   OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
+   OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
+   OMEGA_SCOPE(LocMinLayerEdgeBot, MinLayerEdgeBot);
+   OMEGA_SCOPE(LocMaxLayerEdgeTop, MaxLayerEdgeTop);
+
+   // Pass one: the two integrals of the matched-pressure integrand over each
+   // edge layer, from the same quadrature points.
+   parallelFor(
+       "pgrad-fv-integrals", {NEdgesAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 IEdge, I4 K) {
+          LocDeltaZIncr(IEdge, K)   = 0.0_Real;
+          LocDeltaZMoment(IEdge, K) = 0.0_Real;
+
+          const I4 KTop = LocMinLayerEdgeBot(IEdge);
+          const I4 KBot = LocMaxLayerEdgeTop(IEdge);
+          if (K < KTop || K > KBot)
+             return;
+
+          const I4 ICell0 = LocCellsOnEdge(IEdge, 0);
+          const I4 ICell1 = LocCellsOnEdge(IEdge, 1);
+
+          // one shared expansion for this edge layer, multiplying both
+          // columns
+          const PGradEdgeEos EdgeEos = buildEdgeEos(
+              SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP, ConservTemp,
+              AbsSalinity, PressureMid, ICell0, ICell1, K);
+
+          const Real EdgeTop  = 0.5_Real * (PressureInterface(ICell0, K) +
+                                           PressureInterface(ICell1, K));
+          const Real EdgeBot  = 0.5_Real * (PressureInterface(ICell0, K + 1) +
+                                           PressureInterface(ICell1, K + 1));
+          const Real EdgeMid  = 0.5_Real * (EdgeTop + EdgeBot);
+          const Real EdgeHalf = 0.5_Real * (EdgeBot - EdgeTop);
+
+          Real Nodes[MaxPGradQuadPoints];
+          Real Weights[MaxPGradQuadPoints];
+          gaussLegendreRule(NQuad, Nodes, Weights);
+
+          Real Incr   = 0.0_Real;
+          Real Moment = 0.0_Real;
+
+          for (int IQuad = 0; IQuad < NQuad; ++IQuad) {
+
+             const Real Press  = EdgeMid + EdgeHalf * Nodes[IQuad];
+             const Real Weight = EdgeHalf * Weights[IQuad];
+
+             // each column supplies its own temperature and salinity from
+             // whichever of its own layers contains this pressure, which
+             // under tilt is generally not layer K
+             const I4 KFound0 = findLayerForPress(
+                 PressureInterface, ICell0, LocMinLayerCell(ICell0),
+                 LocMaxLayerCell(ICell0), Press, K);
+             const I4 KFound1 = findLayerForPress(
+                 PressureInterface, ICell1, LocMinLayerCell(ICell1),
+                 LocMaxLayerCell(ICell1), Press, K);
+
+             const Real Temp0 = linearReconEval(
+                 ConservTemp(ICell0, KFound0), LocReconSlopeCt(ICell0, KFound0),
+                 PressureMid(ICell0, KFound0), Press);
+             const Real Salt0 = linearReconEval(
+                 AbsSalinity(ICell0, KFound0), LocReconSlopeSa(ICell0, KFound0),
+                 PressureMid(ICell0, KFound0), Press);
+             const Real Temp1 = linearReconEval(
+                 ConservTemp(ICell1, KFound1), LocReconSlopeCt(ICell1, KFound1),
+                 PressureMid(ICell1, KFound1), Press);
+             const Real Salt1 = linearReconEval(
+                 AbsSalinity(ICell1, KFound1), LocReconSlopeSa(ICell1, KFound1),
+                 PressureMid(ICell1, KFound1), Press);
+
+             const Real SpecVolDiff =
+                 matchedPressSpecVolDiff(EdgeEos, Temp0, Salt0, Temp1, Salt1);
+
+             Incr += Weight * SpecVolDiff;
+             Moment += Weight * (Press - EdgeTop) * SpecVolDiff;
+          }
+
+          LocDeltaZIncr(IEdge, K)   = InvGravity * Incr;
+          LocDeltaZMoment(IEdge, K) = InvGravity * Moment;
+       });
+
+   // Pass two: the anchor at the sea floor, then the recurrence upward.
+   parallelForOuter(
+       "pgrad-fv-column-scan", {NEdgesAll},
+       KOKKOS_LAMBDA(I4 IEdge, const TeamMember &Team) {
+          const I4 KTop = LocMinLayerEdgeBot(IEdge);
+          const I4 KBot = LocMaxLayerEdgeTop(IEdge);
+          if (KBot < KTop)
+             return;
+
+          const I4 ICell0 = LocCellsOnEdge(IEdge, 0);
+          const I4 ICell1 = LocCellsOnEdge(IEdge, 1);
+
+          // The anchor sits at the deepest interface the two columns share.
+          // Each column's height there is shifted from its own interface
+          // pressure to the common one by integrating its own reconstruction
+          // over the half of the cross-edge pressure difference that separates
+          // them. Both short integrals vanish where the two columns' interface
+          // pressures agree.
+          const Real AnchorPress =
+              0.5_Real * (PressureInterface(ICell0, KBot + 1) +
+                          PressureInterface(ICell1, KBot + 1));
+
+          const PGradEdgeEos AnchorEos = buildEdgeEos(
+              SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP, ConservTemp,
+              AbsSalinity, PressureMid, ICell0, ICell1, KBot);
+
+          Real Nodes[MaxPGradQuadPoints];
+          Real Weights[MaxPGradQuadPoints];
+          gaussLegendreRule(NQuad, Nodes, Weights);
+
+          Real Anchor = GeomZInterface(ICell1, KBot + 1) -
+                        GeomZInterface(ICell0, KBot + 1);
+
+          for (int ISide = 0; ISide < 2; ++ISide) {
+
+             const I4 ICell  = (ISide == 0) ? ICell0 : ICell1;
+             const Real Sign = (ISide == 0) ? -1.0_Real : 1.0_Real;
+
+             const Real ColPress = PressureInterface(ICell, KBot + 1);
+             const Real Mid      = 0.5_Real * (AnchorPress + ColPress);
+             const Real Half     = 0.5_Real * (ColPress - AnchorPress);
+
+             Real Integral = 0.0_Real;
+             for (int IQuad = 0; IQuad < NQuad; ++IQuad) {
+
+                const Real Press  = Mid + Half * Nodes[IQuad];
+                const Real Weight = Half * Weights[IQuad];
+
+                const I4 KFound = findLayerForPress(
+                    PressureInterface, ICell, LocMinLayerCell(ICell),
+                    LocMaxLayerCell(ICell), Press, KBot);
+
+                const Real Temp = linearReconEval(
+                    ConservTemp(ICell, KFound), LocReconSlopeCt(ICell, KFound),
+                    PressureMid(ICell, KFound), Press);
+                const Real Salt = linearReconEval(
+                    AbsSalinity(ICell, KFound), LocReconSlopeSa(ICell, KFound),
+                    PressureMid(ICell, KFound), Press);
+
+                Integral += Weight * edgeSpecVol(AnchorEos, Temp, Salt, Press);
+             }
+
+             Anchor += Sign * InvGravity * Integral;
+          }
+
+          LocDeltaZFixedP(IEdge, KBot + 1) = Anchor;
+
+          // Accumulate upward, in the same shape as VertCoord's geometric
+          // height. Every quantity here is a horizontal contrast, so no large
+          // quantity is formed and nothing large has to cancel.
+          parallelScanInner(
+              Team, vertRange(KTop, KBot),
+              INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
+                 const I4 KLyr = KBot - K;
+                 Accum += LocDeltaZIncr(IEdge, KLyr);
+                 if (IsFinal)
+                    LocDeltaZFixedP(IEdge, KLyr) = Anchor + Accum;
+              });
+       });
+
+} // end computeColumnScan
+
+//------------------------------------------------------------------------------
 // Compute pressure gradient tendencies and add into Tend array
 void PressureGrad::computePressureGrad(
     Array2DReal &Tend, const Array2DReal &PressureMid,
@@ -248,6 +517,15 @@ void PressureGrad::computePressureGrad(
           });
 
    } else {
+
+      // The per-cell reconstruction slopes are formed once and reused across
+      // each cell's edges; the per-edge work is polynomial arithmetic on them
+      computeReconSlopes(ConservTemp, AbsSalinity, PressureMid);
+
+      // The column scan is a prefix sum with edge-dependent coefficients, so
+      // it cannot live inside the per-vertical-chunk functor below
+      computeColumnScan(PressureMid, PressureInterface, GeomZInterface,
+                        ConservTemp, AbsSalinity, EqState);
 
       // The specific volume derivatives come from Eos, which computes them
       // from the same single equation-of-state evaluation as SpecVol

--- a/components/omega/src/ocn/PGrad.cpp
+++ b/components/omega/src/ocn/PGrad.cpp
@@ -104,8 +104,12 @@ PressureGrad::PressureGrad(
       PressureGradChoice              = PressureGradType::FiniteVolume;
       this->FiniteVolumePGrad.Enabled = true;
    } else {
-      LOG_INFO(
-          "PGrad: Unknown PressureGradType in config, defaulting to centered");
+      // Aborting rather than falling back to the centered scheme: a silent
+      // fallback turns a typo, or a configuration naming a scheme that no
+      // longer exists, into a run that looks like a passing Centered run
+      ABORT_ERROR("PressureGrad: unknown PressureGradType '{}'; valid values "
+                  "are 'Centered' and 'FiniteVolume'",
+                  PGradTypeStr);
    }
 
    // Read the FiniteVolume sub-options. All three are optional so that a

--- a/components/omega/src/ocn/PGrad.cpp
+++ b/components/omega/src/ocn/PGrad.cpp
@@ -163,8 +163,6 @@ PressureGrad::PressureGrad(
 
    // Additional mesh and coordinate data used by the FiniteVolume column scan
    CellsOnEdge  = Mesh->CellsOnEdge;
-   DcEdge       = Mesh->DcEdge;
-   EdgeMask     = VCoord->EdgeMask;
    MinLayerCell = VCoord->MinLayerCell;
    MaxLayerCell = VCoord->MaxLayerCell;
    NCellsAll    = Mesh->NCellsAll;
@@ -527,11 +525,8 @@ void PressureGrad::computePressureGrad(
       computeColumnScan(PressureMid, PressureInterface, GeomZInterface,
                         ConservTemp, AbsSalinity, EqState);
 
-      // The specific volume derivatives come from Eos, which computes them
-      // from the same single equation-of-state evaluation as SpecVol
-      const Array2DReal SpecVolDCt = EqState->SpecVolDCt;
-      const Array2DReal SpecVolDSa = EqState->SpecVolDSa;
-      const Array2DReal SpecVolDP  = EqState->SpecVolDP;
+      OMEGA_SCOPE(LocDeltaZFixedP, DeltaZFixedP);
+      OMEGA_SCOPE(LocDeltaZMoment, DeltaZMoment);
 
       // computes finite-volume geopotential and pressure gradient tendency
       parallelForOuter(
@@ -543,11 +538,10 @@ void PressureGrad::computePressureGrad(
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocFiniteVolumePGrad(
-                        Tend, IEdge, KChunk, PressureMid, PressureInterface,
-                        GeomZInterface, LocTidalPotential,
-                        LocSelfAttractionLoading, SpecVol, ConservTemp,
-                        AbsSalinity, SpecVolDCt, SpecVolDSa, SpecVolDP);
+                    LocFiniteVolumePGrad(Tend, IEdge, KChunk, PressureInterface,
+                                         LocDeltaZFixedP, LocDeltaZMoment,
+                                         LocTidalPotential,
+                                         LocSelfAttractionLoading);
                  });
           });
    }

--- a/components/omega/src/ocn/PGrad.cpp
+++ b/components/omega/src/ocn/PGrad.cpp
@@ -108,6 +108,55 @@ PressureGrad::PressureGrad(
           "PGrad: Unknown PressureGradType in config, defaulting to centered");
    }
 
+   // Read the FiniteVolume sub-options. All three are optional so that a
+   // configuration written before they existed still parses; where a key is
+   // absent the Phase 1 default is used. Phase 2 will add values to these
+   // keys rather than new keys, so a Phase 1 configuration will continue to
+   // work unchanged.
+   I4 HorzOrder = FiniteVolumePGrad.HorzOrder;
+   if (PGradConfig.existsVar("HorzOrder"))
+      Err += PGradConfig.get("HorzOrder", HorzOrder);
+
+   std::string VertReconStr = "linear";
+   if (PGradConfig.existsVar("VerticalReconstruction"))
+      Err += PGradConfig.get("VerticalReconstruction", VertReconStr);
+
+   I4 QuadraturePoints = FiniteVolumePGrad.QuadraturePoints;
+   if (PGradConfig.existsVar("QuadraturePoints"))
+      Err += PGradConfig.get("QuadraturePoints", QuadraturePoints);
+
+   CHECK_ERROR_ABORT(Err, "PressureGrad: error reading PressureGrad options");
+
+   // Validate. Values reserved for Phase 2 are rejected outright rather than
+   // silently falling back to the Phase 1 setting, which would make a Phase 2
+   // run look like a Phase 1 pass.
+   if (HorzOrder != 2)
+      ABORT_ERROR("PressureGrad: HorzOrder {} is not implemented in Phase 1 "
+                  "of the FiniteVolume pressure gradient; only HorzOrder 2 "
+                  "(the two-cell stencil) is available",
+                  HorzOrder);
+
+   if (VertReconStr == "linear" || VertReconStr == "Linear") {
+      FiniteVolumePGrad.VertRecon = PressureGradVertRecon::Linear;
+   } else if (VertReconStr == "ppm" || VertReconStr == "PPM") {
+      ABORT_ERROR("PressureGrad: VerticalReconstruction '{}' is not "
+                  "implemented in Phase 1 of the FiniteVolume pressure "
+                  "gradient; only 'linear' is available",
+                  VertReconStr);
+   } else {
+      ABORT_ERROR("PressureGrad: unknown VerticalReconstruction '{}'; valid "
+                  "values are 'linear' (Phase 1) and 'ppm' (Phase 2)",
+                  VertReconStr);
+   }
+
+   if (QuadraturePoints < 1 || QuadraturePoints > MaxPGradQuadPoints)
+      ABORT_ERROR("PressureGrad: QuadraturePoints {} is out of range; must be "
+                  "between 1 and {}",
+                  QuadraturePoints, MaxPGradQuadPoints);
+
+   FiniteVolumePGrad.HorzOrder        = HorzOrder;
+   FiniteVolumePGrad.QuadraturePoints = QuadraturePoints;
+
    // Temporary: initialization of tidal potential and SAL
    TidalPotential = Array1DReal("TidalPotential", Mesh->NCellsSize);
    SelfAttractionLoading =

--- a/components/omega/src/ocn/PGrad.cpp
+++ b/components/omega/src/ocn/PGrad.cpp
@@ -210,12 +210,12 @@ PressureGrad *PressureGrad::get(const std::string &Name ///< [in] Name of
 
 //------------------------------------------------------------------------------
 // Compute pressure gradient tendencies and add into Tend array
-void PressureGrad::computePressureGrad(Array2DReal &Tend,
-                                       const Array2DReal &PressureMid,
-                                       const Array2DReal &PressureInterface,
-                                       const Array2DReal &SpecVol,
-                                       const Array2DReal &GeomZInterface,
-                                       const Array2DReal &PseudoThick) const {
+void PressureGrad::computePressureGrad(
+    Array2DReal &Tend, const Array2DReal &PressureMid,
+    const Array2DReal &PressureInterface, const Array2DReal &SpecVol,
+    const Array2DReal &GeomZInterface, const Array2DReal &PseudoThick,
+    const Array2DReal &ConservTemp, const Array2DReal &AbsSalinity,
+    const Eos *EqState) const {
 
    OMEGA_SCOPE(LocCenteredPGrad, CenteredPGrad);
    OMEGA_SCOPE(LocFiniteVolumePGrad, FiniteVolumePGrad);
@@ -245,6 +245,12 @@ void PressureGrad::computePressureGrad(Array2DReal &Tend,
 
    } else {
 
+      // The specific volume derivatives come from Eos, which computes them
+      // from the same single equation-of-state evaluation as SpecVol
+      const Array2DReal SpecVolDCt = EqState->SpecVolDCt;
+      const Array2DReal SpecVolDSa = EqState->SpecVolDSa;
+      const Array2DReal SpecVolDP  = EqState->SpecVolDP;
+
       // computes finite-volume geopotential and pressure gradient tendency
       parallelForOuter(
           "pgrad-finitevolume", {NEdgesAll},
@@ -255,10 +261,11 @@ void PressureGrad::computePressureGrad(Array2DReal &Tend,
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocFiniteVolumePGrad(Tend, IEdge, KChunk, PressureMid,
-                                         PressureInterface, GeomZInterface,
-                                         LocTidalPotential,
-                                         LocSelfAttractionLoading, SpecVol);
+                    LocFiniteVolumePGrad(
+                        Tend, IEdge, KChunk, PressureMid, PressureInterface,
+                        GeomZInterface, LocTidalPotential,
+                        LocSelfAttractionLoading, SpecVol, ConservTemp,
+                        AbsSalinity, SpecVolDCt, SpecVolDSa, SpecVolDP);
                  });
           });
    }

--- a/components/omega/src/ocn/PGrad.cpp
+++ b/components/omega/src/ocn/PGrad.cpp
@@ -1,7 +1,7 @@
 //===-- ocn/PGrad.cpp - Pressure Gradient Term -----------------*- C++ -*-===//
 //
 // Implements the PGrad manager and two discretizations: Centered and
-// HighOrder.
+// FiniteVolume.
 //
 //===----------------------------------------------------------------------===//
 
@@ -78,7 +78,7 @@ PressureGrad::PressureGrad(
     Config *Options)         ///< [in] Configuration options
     : MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
       MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop), CenteredPGrad(Mesh, VCoord),
-      HighOrderPGrad(Mesh, VCoord) {
+      FiniteVolumePGrad(Mesh, VCoord) {
 
    // store mesh sizes
    NEdgesAll     = Mesh->NEdgesAll;
@@ -99,9 +99,10 @@ PressureGrad::PressureGrad(
    if (PGradTypeStr == "centered" || PGradTypeStr == "Centered") {
       PressureGradChoice          = PressureGradType::Centered;
       this->CenteredPGrad.Enabled = true;
-   } else if (PGradTypeStr == "HighOrder1") {
-      PressureGradChoice           = PressureGradType::HighOrder1;
-      this->HighOrderPGrad.Enabled = true;
+   } else if (PGradTypeStr == "finiteVolume" ||
+              PGradTypeStr == "FiniteVolume") {
+      PressureGradChoice              = PressureGradType::FiniteVolume;
+      this->FiniteVolumePGrad.Enabled = true;
    } else {
       LOG_INFO(
           "PGrad: Unknown PressureGradType in config, defaulting to centered");
@@ -168,7 +169,7 @@ void PressureGrad::computePressureGrad(Array2DReal &Tend,
                                        const Array2DReal &PseudoThick) const {
 
    OMEGA_SCOPE(LocCenteredPGrad, CenteredPGrad);
-   OMEGA_SCOPE(LocHighOrderPGrad, HighOrderPGrad);
+   OMEGA_SCOPE(LocFiniteVolumePGrad, FiniteVolumePGrad);
    OMEGA_SCOPE(LocMinLayerEdgeBot, MinLayerEdgeBot);
    OMEGA_SCOPE(LocMaxLayerEdgeTop, MaxLayerEdgeTop);
    OMEGA_SCOPE(LocTidalPotential, TidalPotential);
@@ -195,9 +196,9 @@ void PressureGrad::computePressureGrad(Array2DReal &Tend,
 
    } else {
 
-      // computes high-order geopotential and pressure gradient tendency
+      // computes finite-volume geopotential and pressure gradient tendency
       parallelForOuter(
-          "pgrad-highorder", {NEdgesAll},
+          "pgrad-finitevolume", {NEdgesAll},
           KOKKOS_LAMBDA(I4 IEdge, const TeamMember &Team) {
              const int KMin   = LocMinLayerEdgeBot(IEdge);
              const int KMax   = LocMaxLayerEdgeTop(IEdge);
@@ -205,10 +206,10 @@ void PressureGrad::computePressureGrad(Array2DReal &Tend,
 
              parallelForInner(
                  Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocHighOrderPGrad(Tend, IEdge, KChunk, PressureMid,
-                                      PressureInterface, GeomZInterface,
-                                      LocTidalPotential,
-                                      LocSelfAttractionLoading, SpecVol);
+                    LocFiniteVolumePGrad(Tend, IEdge, KChunk, PressureMid,
+                                         PressureInterface, GeomZInterface,
+                                         LocTidalPotential,
+                                         LocSelfAttractionLoading, SpecVol);
                  });
           });
    }
@@ -225,8 +226,8 @@ PressureGradCentered::PressureGradCentered(
       MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
 //------------------------------------------------------------------------------
-// Constructor for high order pressure gradient functor
-PressureGradHighOrder::PressureGradHighOrder(
+// Constructor for finite volume pressure gradient functor
+PressureGradFiniteVolume::PressureGradFiniteVolume(
     const HorzMesh *Mesh,   ///< [in] Horizontal mesh
     const VertCoord *VCoord ///< [in] Vertical coordinate
     )

--- a/components/omega/src/ocn/PGrad.h
+++ b/components/omega/src/ocn/PGrad.h
@@ -25,6 +25,18 @@ enum class PressureGradType {
    // , <FutureVariant>  ///< e.g. a 6th-order option, added when implemented
 };
 
+/// Mean-preserving vertical reconstruction of ConservTemp and AbsSalinity in
+/// pressure used by the FiniteVolume scheme. The degree of the reconstruction
+/// sets the scheme's exact set: linear deviations make the scheme exact for
+/// profiles that vary linearly with pressure.
+enum class PressureGradVertRecon {
+   Linear ///< linear deviations (Phase 1)
+   // , PPM  ///< parabolic (PPM-style) deviations (Phase 2)
+};
+
+/// Largest number of quadrature points supported within an edge layer
+inline constexpr I4 MaxPGradQuadPoints = 4;
+
 // Centered pressure gradient functor
 class PressureGradCentered {
  public:
@@ -97,6 +109,17 @@ class PressureGradFiniteVolume {
  public:
    bool Enabled;
 
+   // Options cached from the PressureGrad config group by the PressureGrad
+   // constructor, which is also where they are validated. Phase 1 implements
+   // HorzOrder 2 and VertRecon Linear only.
+   //
+   // QuadraturePoints is a pure accuracy knob: the matched-pressure integrand
+   // is zero pointwise for any profile the reconstruction resolves exactly, so
+   // no quadrature rule can break the robustness property.
+   I4 HorzOrder                    = 2;
+   PressureGradVertRecon VertRecon = PressureGradVertRecon::Linear;
+   I4 QuadraturePoints             = 2;
+
    // constructor declaration
    PressureGradFiniteVolume(
        const HorzMesh *Mesh,   ///< [in] Horizontal mesh
@@ -159,6 +182,14 @@ class PressureGrad {
 
    // Destructor
    ~PressureGrad();
+
+   // Accessors for the configured scheme and its options
+   PressureGradType getType() const { return PressureGradChoice; }
+   I4 getHorzOrder() const { return FiniteVolumePGrad.HorzOrder; }
+   PressureGradVertRecon getVertRecon() const {
+      return FiniteVolumePGrad.VertRecon;
+   }
+   I4 getQuadraturePoints() const { return FiniteVolumePGrad.QuadraturePoints; }
 
    // Compute pressure gradient tendencies and add into Tend array
    void computePressureGrad(Array2DReal &Tend, const Array2DReal &PressureMid,

--- a/components/omega/src/ocn/PGrad.h
+++ b/components/omega/src/ocn/PGrad.h
@@ -191,6 +191,13 @@ class PressureGrad {
    }
    I4 getQuadraturePoints() const { return FiniteVolumePGrad.QuadraturePoints; }
 
+   // The fixed-pressure height difference at edge-layer interfaces, filled by
+   // the column scan. Exposed so that tests can assert on it directly: it is
+   // zero at every interface for any profile the reconstruction resolves
+   // exactly, and where it is not, a residual growing with depth points at the
+   // recurrence while one flat with depth points at the anchor.
+   const Array2DReal &getDeltaZFixedP() const { return DeltaZFixedP; }
+
    // Compute pressure gradient tendencies and add into Tend array. The
    // FiniteVolume scheme additionally needs the layer-mean conservative
    // temperature and absolute salinity, which it reconstructs in pressure,
@@ -209,6 +216,25 @@ class PressureGrad {
    // Construct a new pressure gradient object
    PressureGrad(const HorzMesh *Mesh, const VertCoord *VCoord, Config *Options);
 
+   // Compute the mean-preserving reconstruction slopes of temperature and
+   // salinity in pressure, once per cell and layer. These are the per-cell
+   // quantities the per-edge work reuses; recomputing them per edge is what
+   // the cost check exists to catch.
+   void computeReconSlopes(const Array2DReal &ConservTemp,
+                           const Array2DReal &AbsSalinity,
+                           const Array2DReal &PressureMid) const;
+
+   // Accumulate the fixed-pressure height difference down each edge's column.
+   // This is a prefix sum with edge-dependent coefficients, so it is not
+   // expressible as an independent per-vertical-chunk operation and cannot
+   // live in the functor; it is the one structural addition Phase 1 makes.
+   void computeColumnScan(const Array2DReal &PressureMid,
+                          const Array2DReal &PressureInterface,
+                          const Array2DReal &GeomZInterface,
+                          const Array2DReal &ConservTemp,
+                          const Array2DReal &AbsSalinity,
+                          const Eos *EqState) const;
+
    // forbid copy and move construction
    PressureGrad(const PressureGrad &) = delete;
    PressureGrad(PressureGrad &&)      = delete;
@@ -219,12 +245,32 @@ class PressureGrad {
    // Mesh-related sizes
    I4 NEdgesAll     = 0;
    I4 NEdgesOwned   = 0;
+   I4 NCellsAll     = 0;
    I4 NVertLayers   = 0;
    I4 NVertLayersP1 = 0;
 
    // Data required for computation (stored copies of VCoord arrays)
    Array1DI4 MinLayerEdgeBot; ///< min vertical layer on each edge
    Array1DI4 MaxLayerEdgeTop; ///< max vertical layer on each edge
+
+   // Additional mesh and coordinate data the FiniteVolume column scan needs
+   Array2DI4 CellsOnEdge;  ///< cells on each edge
+   Array1DReal DcEdge;     ///< distance between cell centers
+   Array2DReal EdgeMask;   ///< land/bathymetry mask on edges
+   Array1DI4 MinLayerCell; ///< shallowest valid layer in each column
+   Array1DI4 MaxLayerCell; ///< deepest valid layer in each column
+
+   // Working arrays for the FiniteVolume scheme. These are allocated only
+   // when that scheme is selected, so a Centered run pays no memory for them.
+   Array2DReal ReconSlopeCt; ///< d(ConservTemp)/dp of the reconstruction
+   Array2DReal ReconSlopeSa; ///< d(AbsSalinity)/dp of the reconstruction
+   Array2DReal DeltaZIncr;   ///< per-layer integral of the matched-pressure
+                             ///< integrand, the increment of the recurrence
+   Array2DReal DeltaZMoment; ///< its first moment about the layer's top
+                             ///< interface, which gives the layer mean
+   Array2DReal
+       DeltaZFixedP; ///< the fixed-pressure height difference at
+                     ///< edge-layer interfaces, (NEdgesSize, NVertLayersP1)
 
    // Temporary: to be moveed to tidal forcing module in future
    Array1DReal TidalPotential; ///< Tidal potential for tidal forcing

--- a/components/omega/src/ocn/PGrad.h
+++ b/components/omega/src/ocn/PGrad.h
@@ -2,8 +2,8 @@
 #define OMEGA_PGRAD_H
 //===-- ocn/PGrad.h - Pressure Gradient -----------------*- C++ -*-===//
 ///
-/// Implements the PressureGrad class which provides a centered and
-/// high-order pressure gradient option and dispatches computations to
+/// Implements the PressureGrad class which provides a centered and a
+/// finite-volume pressure gradient option and dispatches computations to
 /// functor objects. This follows the patterns used in Eos.h/Eos.cpp.
 //
 //===----------------------------------------------------------------------===//
@@ -19,7 +19,11 @@
 
 namespace OMEGA {
 
-enum class PressureGradType { Centered, HighOrder1, HighOrder2 };
+enum class PressureGradType {
+   Centered,    ///< existing 2nd-order Montgomery scheme
+   FiniteVolume ///< layer-integrated finite-volume scheme
+   // , <FutureVariant>  ///< e.g. a 6th-order option, added when implemented
+};
 
 // Centered pressure gradient functor
 class PressureGradCentered {
@@ -88,14 +92,15 @@ class PressureGradCentered {
    Array1DI4 MaxLayerEdgeTop;
 };
 
-// High-order pressure gradient functor (placeholder)
-class PressureGradHighOrder {
+// Finite-volume pressure gradient functor (placeholder)
+class PressureGradFiniteVolume {
  public:
    bool Enabled;
 
    // constructor declaration
-   PressureGradHighOrder(const HorzMesh *Mesh,   ///< [in] Horizontal mesh
-                         const VertCoord *VCoord ///< [in] Vertical coordinate
+   PressureGradFiniteVolume(
+       const HorzMesh *Mesh,   ///< [in] Horizontal mesh
+       const VertCoord *VCoord ///< [in] Vertical coordinate
    );
 
    KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
@@ -106,7 +111,7 @@ class PressureGradHighOrder {
                                    const Array1DReal &SelfAttractionLoading,
                                    const Array2DReal &SpecVol) const {
 
-      // Placeholder: for now, no-op (future high-order implementation)
+      // Placeholder: for now, no-op (future finite-volume implementation)
       const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
 
@@ -190,7 +195,7 @@ class PressureGrad {
 
    // Instances of functors
    PressureGradCentered CenteredPGrad;
-   PressureGradHighOrder HighOrderPGrad;
+   PressureGradFiniteVolume FiniteVolumePGrad;
 
    // Choice from config
    PressureGradType PressureGradChoice = PressureGradType::Centered;

--- a/components/omega/src/ocn/PGrad.h
+++ b/components/omega/src/ocn/PGrad.h
@@ -14,6 +14,8 @@
 #include "HorzMesh.h"
 #include "OceanState.h"
 #include "OmegaKokkos.h"
+#include "PGradFiniteVolume.h"
+#include "PGradRecon.h"
 #include "VertCoord.h"
 #include <memory>
 
@@ -33,9 +35,6 @@ enum class PressureGradVertRecon {
    Linear ///< linear deviations (Phase 1)
    // , PPM  ///< parabolic (PPM-style) deviations (Phase 2)
 };
-
-/// Largest number of quadrature points supported within an edge layer
-inline constexpr I4 MaxPGradQuadPoints = 4;
 
 // Centered pressure gradient functor
 class PressureGradCentered {

--- a/components/omega/src/ocn/PGrad.h
+++ b/components/omega/src/ocn/PGrad.h
@@ -103,7 +103,7 @@ class PressureGradCentered {
    Array1DI4 MaxLayerEdgeTop;
 };
 
-// Finite-volume pressure gradient functor (placeholder)
+// Finite-volume pressure gradient functor
 class PressureGradFiniteVolume {
  public:
    bool Enabled;
@@ -125,22 +125,59 @@ class PressureGradFiniteVolume {
        const VertCoord *VCoord ///< [in] Vertical coordinate
    );
 
-   KOKKOS_FUNCTION void operator()(
-       const Array2DReal &Tend, I4 IEdge, I4 KChunk,
-       const Array2DReal &PressureMid, const Array2DReal &PressureInterface,
-       const Array2DReal &GeomZInterface, const Array1DReal &TidalPotential,
-       const Array1DReal &SelfAttractionLoading, const Array2DReal &SpecVol,
-       const Array2DReal &ConservTemp, const Array2DReal &AbsSalinity,
-       const Array2DReal &SpecVolDCt, const Array2DReal &SpecVolDSa,
-       const Array2DReal &SpecVolDP) const {
+   // Assemble the pressure gradient tendency for one edge and vertical chunk
+   // and append it into Tend, exactly as the centered functor does.
+   //
+   // The whole horizontal pressure gradient is the geopotential compared at
+   // fixed pressure. All the work of forming that comparison happens in the
+   // column scan, which cannot live here because it is a prefix sum down the
+   // column; what remains per layer is to turn the scan's output into a layer
+   // mean and scale it.
+   //
+   // The inputs are therefore the scan's two arrays rather than the state the
+   // scan consumed: the design's illustrative signature in section 4.1.3 lists
+   // the temperature, salinity and specific volume derivative arrays, but with
+   // both integrals formed in the scan over one set of quadrature points --
+   // which section 3.5.1 requires -- the functor reads neither. Passing them
+   // here would mean evaluating the integrand a second time.
+   KOKKOS_FUNCTION void
+   operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
+              const Array2DReal &PressureInterface,
+              const Array2DReal &DeltaZFixedP, const Array2DReal &DeltaZMoment,
+              const Array1DReal &TidalPotential,
+              const Array1DReal &SelfAttractionLoading) const {
 
-      // Placeholder: for now, no-op (future finite-volume implementation)
       const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
       const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
 
+      const I4 ICell0      = CellsOnEdge(IEdge, 0);
+      const I4 ICell1      = CellsOnEdge(IEdge, 1);
+      const Real InvDcEdge = 1.0_Real / DcEdge(IEdge);
+
+      Real GradGeoPot =
+          (TidalPotential(ICell1) - TidalPotential(ICell0)) * InvDcEdge +
+          (SelfAttractionLoading(ICell1) - SelfAttractionLoading(ICell0)) *
+              InvDcEdge;
+
       for (int KVec = 0; KVec < KLen; ++KVec) {
          const I4 K = KStart + KVec;
-         Tend(IEdge, K) += 0.0_Real;
+
+         // the edge control volume's pressure thickness is exactly the edge
+         // average of the two columns' own
+         const Real DeltaPress = 0.5_Real * ((PressureInterface(ICell0, K + 1) -
+                                              PressureInterface(ICell0, K)) +
+                                             (PressureInterface(ICell1, K + 1) -
+                                              PressureInterface(ICell1, K)));
+
+         // The layer mean of the fixed-pressure height difference, from its
+         // value at the layer's bottom interface and the first moment of the
+         // integrand over the layer. Both come from the column scan.
+         Real LayerMean = DeltaZFixedP(IEdge, K + 1);
+         if (DeltaPress > 0.0_Real)
+            LayerMean += DeltaZMoment(IEdge, K) / DeltaPress;
+
+         Tend(IEdge, K) += EdgeMask(IEdge, K) *
+                           (-Gravity * InvDcEdge * LayerMean - GradGeoPot);
       }
    }
 
@@ -255,8 +292,6 @@ class PressureGrad {
 
    // Additional mesh and coordinate data the FiniteVolume column scan needs
    Array2DI4 CellsOnEdge;  ///< cells on each edge
-   Array1DReal DcEdge;     ///< distance between cell centers
-   Array2DReal EdgeMask;   ///< land/bathymetry mask on edges
    Array1DI4 MinLayerCell; ///< shallowest valid layer in each column
    Array1DI4 MaxLayerCell; ///< deepest valid layer in each column
 

--- a/components/omega/src/ocn/PGrad.h
+++ b/components/omega/src/ocn/PGrad.h
@@ -126,13 +126,14 @@ class PressureGradFiniteVolume {
        const VertCoord *VCoord ///< [in] Vertical coordinate
    );
 
-   KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
-                                   const Array2DReal &PressureMid,
-                                   const Array2DReal &PressureInterface,
-                                   const Array2DReal &GeomZInterface,
-                                   const Array1DReal &TidalPotential,
-                                   const Array1DReal &SelfAttractionLoading,
-                                   const Array2DReal &SpecVol) const {
+   KOKKOS_FUNCTION void operator()(
+       const Array2DReal &Tend, I4 IEdge, I4 KChunk,
+       const Array2DReal &PressureMid, const Array2DReal &PressureInterface,
+       const Array2DReal &GeomZInterface, const Array1DReal &TidalPotential,
+       const Array1DReal &SelfAttractionLoading, const Array2DReal &SpecVol,
+       const Array2DReal &ConservTemp, const Array2DReal &AbsSalinity,
+       const Array2DReal &SpecVolDCt, const Array2DReal &SpecVolDSa,
+       const Array2DReal &SpecVolDP) const {
 
       // Placeholder: for now, no-op (future finite-volume implementation)
       const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
@@ -191,12 +192,19 @@ class PressureGrad {
    }
    I4 getQuadraturePoints() const { return FiniteVolumePGrad.QuadraturePoints; }
 
-   // Compute pressure gradient tendencies and add into Tend array
+   // Compute pressure gradient tendencies and add into Tend array. The
+   // FiniteVolume scheme additionally needs the layer-mean conservative
+   // temperature and absolute salinity, which it reconstructs in pressure,
+   // and the specific volume derivatives held by Eos. The Centered scheme
+   // ignores them.
    void computePressureGrad(Array2DReal &Tend, const Array2DReal &PressureMid,
                             const Array2DReal &PressureInterface,
                             const Array2DReal &SpecVol,
                             const Array2DReal &GeomZInterface,
-                            const Array2DReal &PseudoThick) const;
+                            const Array2DReal &PseudoThick,
+                            const Array2DReal &ConservTemp,
+                            const Array2DReal &AbsSalinity,
+                            const Eos *EqState) const;
 
  private:
    // Construct a new pressure gradient object

--- a/components/omega/src/ocn/PGradFiniteVolume.h
+++ b/components/omega/src/ocn/PGradFiniteVolume.h
@@ -42,6 +42,9 @@
 
 namespace OMEGA {
 
+/// Largest number of quadrature points supported within an edge layer
+inline constexpr I4 MaxPGradQuadPoints = 4;
+
 /// The equation-of-state expansion shared by both columns of an edge layer.
 /// One instance multiplies both columns' contributions.
 struct PGradEdgeEos {
@@ -100,6 +103,82 @@ KOKKOS_INLINE_FUNCTION Real edgeSpecVol(
    return Eos.SpecVol0 + Eos.SpecVolDCt * (ConservTemp - Eos.ConservTemp) +
           Eos.SpecVolDSa * (AbsSalinity - Eos.AbsSalinity) +
           Eos.SpecVolDP * (Press - Eos.Press);
+}
+
+/// The matched-pressure difference in specific volume between the two columns
+/// of an edge, evaluated at one pressure with one shared expansion.
+///
+/// This is the central quantity of the scheme. Because both columns use the
+/// same expansion, the SpecVol0 and SpecVolDP terms are identical in the two
+/// and cancel in the difference, leaving a coefficient times the horizontal
+/// contrast in reconstructed temperature and salinity *at matched pressure*.
+/// That contrast is identically zero, pointwise, whenever the two columns'
+/// reconstructions describe the same water -- which is why exactness depends
+/// neither on the values of the coefficients, nor on the quadrature, nor on
+/// the two columns' interfaces lining up.
+///
+/// Compressibility drops out entirely: SpecVolDP does not appear. That is
+/// correct physics rather than an approximation. If temperature and salinity
+/// are horizontally uniform then so is specific volume as a function of
+/// pressure, and a horizontally uniform compressibility exerts no horizontal
+/// pressure gradient.
+KOKKOS_INLINE_FUNCTION Real matchedPressSpecVolDiff(
+    const PGradEdgeEos &Eos, ///< [in] edge-shared expansion
+    const Real ConservTemp0, ///< [in] first column's temperature at p
+    const Real AbsSalinity0, ///< [in] first column's salinity at p
+    const Real ConservTemp1, ///< [in] second column's temperature at p
+    const Real AbsSalinity1  ///< [in] second column's salinity at p
+) {
+   return Eos.SpecVolDCt * (ConservTemp1 - ConservTemp0) +
+          Eos.SpecVolDSa * (AbsSalinity1 - AbsSalinity0);
+}
+
+/// Gauss-Legendre nodes and weights on [-1, 1] for NPoints points, NPoints
+/// running from 1 to MaxPGradQuadPoints.
+///
+/// The number of points is an accuracy setting only. The integrand is zero at
+/// every point for any profile the reconstruction resolves exactly, so no rule
+/// can break the robustness property; the choice trades cost against accuracy
+/// off the exact set with nothing else at stake. Two points is exact for the
+/// Phase 1 integrand within a sub-interval and is the default. More is worth
+/// considering only where the two columns' interfaces are strongly offset,
+/// since the integrand is piecewise linear with breakpoints at the union of
+/// the two columns' interfaces and a fixed rule does not resolve those breaks.
+KOKKOS_INLINE_FUNCTION void
+gaussLegendreRule(const I4 NPoints,                 ///< [in] number of points
+                  Real Nodes[MaxPGradQuadPoints],   ///< [out] nodes on [-1,1]
+                  Real Weights[MaxPGradQuadPoints]) ///< [out] weights
+{
+   switch (NPoints) {
+   case 1:
+      Nodes[0]   = 0.0_Real;
+      Weights[0] = 2.0_Real;
+      break;
+   case 3:
+      Nodes[0]   = -0.77459666924148337704_Real;
+      Nodes[1]   = 0.0_Real;
+      Nodes[2]   = 0.77459666924148337704_Real;
+      Weights[0] = 0.55555555555555555556_Real;
+      Weights[1] = 0.88888888888888888889_Real;
+      Weights[2] = 0.55555555555555555556_Real;
+      break;
+   case 4:
+      Nodes[0]   = -0.86113631159405257522_Real;
+      Nodes[1]   = -0.33998104358485626480_Real;
+      Nodes[2]   = 0.33998104358485626480_Real;
+      Nodes[3]   = 0.86113631159405257522_Real;
+      Weights[0] = 0.34785484513745385737_Real;
+      Weights[1] = 0.65214515486254614263_Real;
+      Weights[2] = 0.65214515486254614263_Real;
+      Weights[3] = 0.34785484513745385737_Real;
+      break;
+   default: // two points, the Phase 1 default
+      Nodes[0]   = -0.57735026918962576451_Real;
+      Nodes[1]   = 0.57735026918962576451_Real;
+      Weights[0] = 1.0_Real;
+      Weights[1] = 1.0_Real;
+      break;
+   }
 }
 
 } // namespace OMEGA

--- a/components/omega/src/ocn/PGradFiniteVolume.h
+++ b/components/omega/src/ocn/PGradFiniteVolume.h
@@ -1,0 +1,108 @@
+#ifndef OMEGA_PGRAD_FINITE_VOLUME_H
+#define OMEGA_PGRAD_FINITE_VOLUME_H
+//===-- ocn/PGradFiniteVolume.h - Finite-Volume PGrad ---------*- C++ -*-===//
+///
+/// The equation-of-state expansion shared across an edge, used by the
+/// FiniteVolume pressure gradient.
+///
+/// Specific volume is never integrated directly. For each cell and layer it is
+/// expanded to first order about a reference state,
+///
+///    alpha(Ct, Sa, p) = alpha0 + alphaCt (Ct - Ct0) + alphaSa (Sa - Sa0)
+///                              + alphaP  (p  - p0)
+///
+/// with the four coefficients coming from a single equation-of-state
+/// evaluation per cell per layer -- the SpecVol, SpecVolDCt, SpecVolDSa and
+/// SpecVolDP fields Eos already computes. Because temperature and salinity are
+/// reconstructed as low-order polynomials in pressure and the expansion is
+/// linear in them, the expanded specific volume is a low-order polynomial in
+/// pressure and every integral the scheme needs is available in closed form.
+/// No equation-of-state evaluation occurs inside any integral, which is what
+/// bounds the cost.
+///
+/// The expansion point and the coefficients are shared across each edge:
+/// averaged from the edge's two cells and used for *both* columns. This is
+/// what the robustness property rests on. Give each column its own expansion
+/// point and the two columns describe the same water with two slightly
+/// different approximations to the same equation of state, their alpha0 and
+/// alphaP terms no longer cancel in the matched-pressure difference, and the
+/// scheme generates spurious flow out of nothing but its own equation-of-state
+/// approximation.
+///
+/// Note what is and is not load-bearing here. That *one* set multiplies both
+/// columns is essential. *Which* set it is -- selected by edge layer, or by
+/// some other rule -- is an ordinary accuracy question and cannot break
+/// exactness, because the coefficients end up multiplying a quantity that is
+/// identically zero on the exact set.
+//
+//===----------------------------------------------------------------------===//
+
+#include "DataTypes.h"
+#include "OmegaKokkos.h"
+
+namespace OMEGA {
+
+/// The equation-of-state expansion shared by both columns of an edge layer.
+/// One instance multiplies both columns' contributions.
+struct PGradEdgeEos {
+   Real SpecVol0;    ///< specific volume at the shared expansion state
+   Real SpecVolDCt;  ///< d(alpha)/d(ConservTemp) at the shared state
+   Real SpecVolDSa;  ///< d(alpha)/d(AbsSalinity) at the shared state
+   Real SpecVolDP;   ///< d(alpha)/d(Pressure) at the shared state
+   Real ConservTemp; ///< shared expansion state, conservative temperature
+   Real AbsSalinity; ///< shared expansion state, absolute salinity
+   Real Press;       ///< shared expansion state, pressure
+};
+
+/// Build the shared expansion for one edge layer by averaging the two
+/// adjacent cells' coefficients and reference states. The pressure of the
+/// shared state is the edge average of the two columns' mid-layer pressures,
+/// which is exactly the mid-layer pressure of the edge control volume when
+/// that volume is taken as the average of the two columns' interface
+/// pressures.
+KOKKOS_INLINE_FUNCTION PGradEdgeEos buildEdgeEos(
+    const Array2DReal &SpecVol,     ///< [in] specific volume
+    const Array2DReal &SpecVolDCt,  ///< [in] d(alpha)/d(ConservTemp)
+    const Array2DReal &SpecVolDSa,  ///< [in] d(alpha)/d(AbsSalinity)
+    const Array2DReal &SpecVolDP,   ///< [in] d(alpha)/d(Pressure)
+    const Array2DReal &ConservTemp, ///< [in] layer-mean temperature
+    const Array2DReal &AbsSalinity, ///< [in] layer-mean salinity
+    const Array2DReal &PressureMid, ///< [in] mid-layer pressure
+    const I4 ICell0,                ///< [in] first cell on the edge
+    const I4 ICell1,                ///< [in] second cell on the edge
+    const I4 K                      ///< [in] edge layer
+) {
+   PGradEdgeEos Eos;
+   Eos.SpecVol0   = 0.5_Real * (SpecVol(ICell0, K) + SpecVol(ICell1, K));
+   Eos.SpecVolDCt = 0.5_Real * (SpecVolDCt(ICell0, K) + SpecVolDCt(ICell1, K));
+   Eos.SpecVolDSa = 0.5_Real * (SpecVolDSa(ICell0, K) + SpecVolDSa(ICell1, K));
+   Eos.SpecVolDP  = 0.5_Real * (SpecVolDP(ICell0, K) + SpecVolDP(ICell1, K));
+   Eos.ConservTemp =
+       0.5_Real * (ConservTemp(ICell0, K) + ConservTemp(ICell1, K));
+   Eos.AbsSalinity =
+       0.5_Real * (AbsSalinity(ICell0, K) + AbsSalinity(ICell1, K));
+   Eos.Press = 0.5_Real * (PressureMid(ICell0, K) + PressureMid(ICell1, K));
+   return Eos;
+}
+
+/// One column's expanded specific volume at a pressure, using the edge-shared
+/// expansion. Needed only where a single column's specific volume is
+/// integrated on its own, which in Phase 1 is only the anchor of the column
+/// scan; the interior of the scheme differences two columns at matched
+/// pressure, where the SpecVol0 and SpecVolDP terms cancel and never have to
+/// be formed.
+KOKKOS_INLINE_FUNCTION Real edgeSpecVol(
+    const PGradEdgeEos &Eos, ///< [in] edge-shared expansion
+    const Real ConservTemp,  ///< [in] this column's temperature at p
+    const Real AbsSalinity,  ///< [in] this column's salinity at p
+    const Real Press         ///< [in] pressure
+) {
+   return Eos.SpecVol0 + Eos.SpecVolDCt * (ConservTemp - Eos.ConservTemp) +
+          Eos.SpecVolDSa * (AbsSalinity - Eos.AbsSalinity) +
+          Eos.SpecVolDP * (Press - Eos.Press);
+}
+
+} // namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif

--- a/components/omega/src/ocn/PGradRecon.h
+++ b/components/omega/src/ocn/PGradRecon.h
@@ -1,0 +1,111 @@
+#ifndef OMEGA_PGRAD_RECON_H
+#define OMEGA_PGRAD_RECON_H
+//===-- ocn/PGradRecon.h - Pressure Gradient Reconstruction ---*- C++ -*-===//
+///
+/// Mean-preserving vertical reconstruction of conservative temperature and
+/// absolute salinity in pressure, used by the FiniteVolume pressure gradient.
+///
+/// Within layer K of a column the prognostic layer mean is supplemented by a
+/// deviation that integrates to zero over the layer,
+///
+///    Theta(p) = Theta_k + Slope_k * (p - PressureMid_k)
+///
+/// Phase 1 uses linear deviations, which makes the pressure gradient exact for
+/// profiles that vary linearly with pressure. There is no limiter: the
+/// reconstruction feeds an integral rather than an advective flux, and a
+/// limiter active on smooth data would break the cancellation the scheme rests
+/// on precisely where the profile is well resolved.
+///
+/// Two properties carry the weight.
+///
+/// Mean-preserving. PressureMid is the exact arithmetic midpoint of the two
+/// interface pressures, so the integral of (p - PressureMid) over the layer is
+/// zero and the deviation cannot move the layer mean. This is also what makes
+/// VertCoord's midpoint rule the exact layer integral of a Phase 1
+/// reconstruction, and hence what spares VertCoord any change.
+///
+/// Exact on a non-uniform grid. For a profile linear in pressure the layer
+/// means lie exactly on the line as a function of mid-layer pressure, because
+/// the mean of a linear function over a layer is its value at the layer's
+/// midpoint. A centered difference of the layer means with respect to
+/// PressureMid therefore recovers the slope exactly, for any distribution of
+/// layer thicknesses. This is why the estimator differences against the actual
+/// mid-layer pressures and not against layer index: a formula that assumed
+/// uniform thickness would pass a uniform-thickness test and fail on Omega's
+/// grid.
+///
+/// The functions here take scalars so that they can be unit tested without a
+/// mesh.
+//
+//===----------------------------------------------------------------------===//
+
+#include "DataTypes.h"
+#include "OmegaKokkos.h"
+
+namespace OMEGA {
+
+/// The two layers the linear slope estimator differences, for layer K of a
+/// column whose valid layers run from KMin to KMax. The difference is centered
+/// in the interior and one-sided in the shallowest and deepest valid layer.
+/// The one-sided branches are not an edge case: the deepest valid layer is a
+/// partial cell, which carries the whole signal where bathymetry steps. Where
+/// a column has a single valid layer both indices are K, which the slope
+/// estimator turns into a zero slope -- a constant being the only
+/// mean-preserving reconstruction available there.
+KOKKOS_INLINE_FUNCTION void
+linearReconStencil(const I4 K,    ///< [in] layer to reconstruct
+                   const I4 KMin, ///< [in] shallowest valid layer
+                   const I4 KMax, ///< [in] deepest valid layer
+                   I4 &KLo,       ///< [out] shallower layer to difference
+                   I4 &KHi        ///< [out] deeper layer to difference
+) {
+   KLo = (K > KMin) ? K - 1 : K;
+   KHi = (K < KMax) ? K + 1 : K;
+}
+
+/// The slope, per Pa, of the mean-preserving linear reconstruction, from the
+/// layer means and mid-layer pressures of the two layers linearReconStencil
+/// selects. Exact for a profile linear in pressure on an arbitrary grid and
+/// second-order accurate otherwise. Returns zero where the two mid-layer
+/// pressures coincide, which happens only when the column has a single valid
+/// layer.
+KOKKOS_INLINE_FUNCTION Real linearReconSlope(
+    const Real ValueLo,    ///< [in] layer mean at KLo
+    const Real ValueHi,    ///< [in] layer mean at KHi
+    const Real PressMidLo, ///< [in] mid-layer pressure at KLo
+    const Real PressMidHi  ///< [in] mid-layer pressure at KHi
+) {
+   const Real DeltaPress = PressMidHi - PressMidLo;
+   return (DeltaPress != 0.0_Real) ? (ValueHi - ValueLo) / DeltaPress
+                                   : 0.0_Real;
+}
+
+/// The deviation of the reconstruction from the layer mean at a pressure.
+/// Integrates to zero over the layer because PressMid is the exact arithmetic
+/// midpoint of the two interface pressures. The pressure need not lie within
+/// the layer: near the sea floor a column's deepest reconstruction is
+/// evaluated slightly below its own floor, where this extrapolates.
+KOKKOS_INLINE_FUNCTION Real linearReconDeviation(
+    const Real Slope,    ///< [in] slope from
+                         ///< linearReconSlope
+    const Real PressMid, ///< [in] mid-layer pressure
+    const Real Press     ///< [in] pressure to evaluate at
+) {
+   return Slope * (Press - PressMid);
+}
+
+/// The reconstruction evaluated at a pressure. Equal to the layer mean at
+/// PressMid, by construction.
+KOKKOS_INLINE_FUNCTION Real linearReconEval(
+    const Real Value,    ///< [in] prognostic layer mean
+    const Real Slope,    ///< [in] slope from linearReconSlope
+    const Real PressMid, ///< [in] mid-layer pressure
+    const Real Press     ///< [in] pressure to evaluate at
+) {
+   return Value + linearReconDeviation(Slope, PressMid, Press);
+}
+
+} // namespace OMEGA
+
+//===----------------------------------------------------------------------===//
+#endif

--- a/components/omega/src/ocn/PGradRecon.h
+++ b/components/omega/src/ocn/PGradRecon.h
@@ -105,6 +105,61 @@ KOKKOS_INLINE_FUNCTION Real linearReconEval(
    return Value + linearReconDeviation(Slope, PressMid, Press);
 }
 
+/// The layer of column ICell whose interfaces bracket the pressure Press,
+/// searched from the hint KHint and clamped to the column's valid range
+/// [KMin, KMax].
+///
+/// This is the lookup that makes the scheme a fixed-pressure comparison rather
+/// than a fixed-layer-index one, and it is the single place where that
+/// distinction lives. At a pressure in edge layer K, each column supplies its
+/// own temperature and salinity from whichever of *its own* layers contains
+/// that pressure, which under tilt is generally not layer K -- at a coordinate
+/// tilt of 50 m/km with 64 m layers the two columns' layer K are offset by
+/// nearly three layer thicknesses and do not overlap in pressure at all.
+/// Looking a column's state up by layer index instead would silently
+/// reintroduce the very error the scheme exists to remove, and would still
+/// pass every exactness and accuracy check available, which is why the
+/// property tests on this function are not optional.
+///
+/// Interface pressures increase downward, so the search walks up while Press
+/// lies above the layer's top interface and down while it lies below the
+/// bottom one. Within the column scan the answer advances monotonically with
+/// K, so passing the previous answer as KHint makes this a pair of incremented
+/// cursors rather than a search; the result does not depend on the hint.
+///
+/// Where Press lies outside the column altogether the outermost valid layer is
+/// returned and its reconstruction is extrapolated. This is the rule at the
+/// top and bottom of the column: the edge control volume's pressure range is
+/// in general neither column's own, so near the sea floor a column's deepest
+/// reconstruction must be evaluated slightly below its own floor. Exactness
+/// survives extrapolation, because on the exact set an extrapolated
+/// reconstruction still reproduces the true profile.
+///
+/// Templated on the array type so that the same code is exercised by the
+/// device kernels and by the host-side property tests that pin it.
+template <class ArrayType>
+KOKKOS_INLINE_FUNCTION I4
+findLayerForPress(const ArrayType &PressInterface, ///< [in] interface pressures
+                  const I4 ICell,                  ///< [in] cell to search
+                  const I4 KMin,    ///< [in] shallowest valid layer
+                  const I4 KMax,    ///< [in] deepest valid layer
+                  const Real Press, ///< [in] pressure to locate
+                  const I4 KHint    ///< [in] starting guess
+) {
+   I4 K = KHint;
+   if (K < KMin)
+      K = KMin;
+   if (K > KMax)
+      K = KMax;
+
+   while (K > KMin && Press < PressInterface(ICell, K))
+      --K;
+   while (K < KMax && Press > PressInterface(ICell, K + 1))
+      ++K;
+
+   return K;
+}
+
 } // namespace OMEGA
 
 //===----------------------------------------------------------------------===//

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -749,9 +749,22 @@ void Tendencies::computeVelocityTendenciesOnly(
       const auto &PressureInterface = VCoord->PressureInterface;
       const auto &SpecVol           = EqState->SpecVol;
       const auto &GeomZInterface    = VCoord->GeomZInterface;
-      PGrad->computePressureGrad(LocNormalVelocityTend, PressureMid,
-                                 PressureInterface, SpecVol, GeomZInterface,
-                                 PseudoThick);
+
+      // The FiniteVolume scheme reconstructs the layer-mean temperature and
+      // salinity in pressure and uses the specific volume derivatives Eos
+      // holds; the Centered scheme ignores both
+      I4 ConservTempIdx;
+      I4 AbsSalinityIdx;
+      Tracers::getIndex(ConservTempIdx, "Temperature");
+      Tracers::getIndex(AbsSalinityIdx, "Salinity");
+      const Array2DReal ConservTemp = Kokkos::subview(
+          TracerArray, ConservTempIdx, Kokkos::ALL, Kokkos::ALL);
+      const Array2DReal AbsSalinity = Kokkos::subview(
+          TracerArray, AbsSalinityIdx, Kokkos::ALL, Kokkos::ALL);
+
+      PGrad->computePressureGrad(
+          LocNormalVelocityTend, PressureMid, PressureInterface, SpecVol,
+          GeomZInterface, PseudoThick, ConservTemp, AbsSalinity, EqState);
       Pacer::stop("Tend:pressureGradTerm", 2);
    }
 

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -385,6 +385,20 @@ add_omega_test(
   "-n;1"
 )
 
+# The pressure gradient exactness gate is run in single precision as well.
+# The finite-volume scheme differences the integrand before integrating it and
+# so forms no large quantities anywhere, which predicts that the cancellation
+# should survive the reduced precision; running PressureGradCentered alongside,
+# which does form and cancel large quantities, is what makes the result
+# interpretable.
+add_omega_test(
+  PGRAD_SINGLE_PRECISION_TEST
+  testPGradSinglePrecision.exe
+  ocn/PGradTest.cpp
+  "-n;1"
+  single_precision
+)
+
 ##################
 # State test
 ##################

--- a/components/omega/test/CMakeLists.txt
+++ b/components/omega/test/CMakeLists.txt
@@ -523,6 +523,14 @@ add_omega_test(
     "-n;8"
 )
 
+add_omega_test(
+    VERTCOORD_SINGLE_PRECISION_TEST
+    testVertCoordSinglePrecision.exe
+    ocn/VertCoordTest.cpp
+    "-n;8"
+    single_precision
+)
+
 ##################
 # Fill Value test
 ##################

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -485,25 +485,32 @@ int main(int argc, char *argv[]) {
       HostArray2DR8 NewR8Vrtx("NewR8Vrtx", NVerticesSize, NVertLayers);
 
       // Read non-distributed variables
-      Err = IO::readNDVar(&NewI4Scalar, "ScalarI4", InFileID, VarIDScalarI4);
+      Err = IO::readNDVar(&NewI4Scalar, IO::IOTypeI4, "ScalarI4", InFileID,
+                          VarIDScalarI4);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read scalar I4 NDVar")
 
-      Err = IO::readNDVar(&NewI8Scalar, "ScalarI8", InFileID, VarIDScalarI8);
+      Err = IO::readNDVar(&NewI8Scalar, IO::IOTypeI8, "ScalarI8", InFileID,
+                          VarIDScalarI8);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read scalar I8 NDVar")
 
-      Err = IO::readNDVar(&NewR4Scalar, "ScalarR4", InFileID, VarIDScalarR4);
+      Err = IO::readNDVar(&NewR4Scalar, IO::IOTypeR4, "ScalarR4", InFileID,
+                          VarIDScalarR4);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read scalar R4 NDVar")
 
-      Err = IO::readNDVar(&NewR8Scalar, "ScalarR8", InFileID, VarIDScalarR8);
+      Err = IO::readNDVar(&NewR8Scalar, IO::IOTypeR8, "ScalarR8", InFileID,
+                          VarIDScalarR8);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read scalar R8 NDVar")
 
-      Err = IO::readNDVar(NewI4Vert.data(), "I4Vert", InFileID, VarIDI4Vert);
+      Err = IO::readNDVar(NewI4Vert.data(), IO::IOTypeI4, "I4Vert", InFileID,
+                          VarIDI4Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read I4 vertical NDVar")
 
-      Err = IO::readNDVar(NewI8Vert.data(), "I8Vert", InFileID, VarIDI8Vert);
+      Err = IO::readNDVar(NewI8Vert.data(), IO::IOTypeI8, "I8Vert", InFileID,
+                          VarIDI8Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read I8 vertical NDVar")
 
-      Err = IO::readNDVar(NewR4Vert.data(), "R4Vert", InFileID, VarIDR4Vert);
+      Err = IO::readNDVar(NewR4Vert.data(), IO::IOTypeR4, "R4Vert", InFileID,
+                          VarIDR4Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R4 vertical NDVar")
 
       // Read non-distributed variables into buffers whose type differs from
@@ -521,18 +528,20 @@ int main(int argc, char *argv[]) {
       std::vector<R4> NewR4FromR8(2 * NVertLayers, GuardR4);
       std::vector<R8> NewR8FromR4(2 * NVertLayers, GuardR8);
 
-      Err = IO::readNDVar(NewR4FromR8.data(), "R8Vert", InFileID, VarIDR8Vert);
+      Err = IO::readNDVar(NewR4FromR8.data(), IO::IOTypeR4, "R8Vert", InFileID,
+                          VarIDR8Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R8 vertical NDVar as R4")
 
-      Err = IO::readNDVar(NewR8FromR4.data(), "R4Vert", InFileID, VarIDR4Vert);
+      Err = IO::readNDVar(NewR8FromR4.data(), IO::IOTypeR8, "R4Vert", InFileID,
+                          VarIDR4Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R4 vertical NDVar as R8")
 
       // Read R8 data as two time slices
-      Err = IO::readNDVar(NewR8Vert.data(), "R8Time", InFileID, VarIDR8Time, 0,
-                          &DimLengths);
+      Err = IO::readNDVar(NewR8Vert.data(), IO::IOTypeR8, "R8Time", InFileID,
+                          VarIDR8Time, 0, &DimLengths);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R8 NDVar time slice 0")
-      Err = IO::readNDVar(NewR8Time.data(), "R8Time", InFileID, VarIDR8Time, 1,
-                          &DimLengths);
+      Err = IO::readNDVar(NewR8Time.data(), IO::IOTypeR8, "R8Time", InFileID,
+                          VarIDR8Time, 1, &DimLengths);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R8 NDVar time slice 1")
 
       // Read distributed arrays

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -271,6 +271,11 @@ int main(int argc, char *argv[]) {
           IO::defineVar(OutFileID, "I8Vert", IO::IOTypeI8, 1, VertDimIDs);
       int VarIDR4Vert =
           IO::defineVar(OutFileID, "R4Vert", IO::IOTypeR4, 1, VertDimIDs);
+      // A double-precision counterpart of R4Vert, used below to check that
+      // a non-distributed variable can be read into a buffer whose type
+      // differs from the type stored in the file
+      int VarIDR8Vert =
+          IO::defineVar(OutFileID, "R8Vert", IO::IOTypeR8, 1, VertDimIDs);
       int VarIDR8Time =
           IO::defineVar(OutFileID, "R8Time", IO::IOTypeR8, 2, TimeDimIDs);
       int VarIDCellI4 =
@@ -328,6 +333,7 @@ int main(int argc, char *argv[]) {
       IO::writeNDVar(RefI4Vert.data(), OutFileID, VarIDI4Vert);
       IO::writeNDVar(RefI8Vert.data(), OutFileID, VarIDI8Vert);
       IO::writeNDVar(RefR4Vert.data(), OutFileID, VarIDR4Vert);
+      IO::writeNDVar(RefR8Vert.data(), OutFileID, VarIDR8Vert);
       // Write R8 arrays as two time slices - the first frame here with
       // the second frame written after re-open
       std::vector<int> DimLengths(1);
@@ -500,6 +506,27 @@ int main(int argc, char *argv[]) {
       Err = IO::readNDVar(NewR4Vert.data(), "R4Vert", InFileID, VarIDR4Vert);
       CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R4 vertical NDVar")
 
+      // Read non-distributed variables into buffers whose type differs from
+      // the type of the variable stored in the file. Mesh and initial state
+      // files are written in double precision, but the arrays they are read
+      // into are single precision in an OMEGA_SINGLE_PRECISION build, so the
+      // read must convert rather than assume the two types match. The buffers
+      // are allocated at twice the length needed and the unused half is set
+      // to a guard value; a read that fills eight bytes per element into a
+      // four-byte buffer then shows up as an overwritten guard instead of as
+      // an out-of-bounds write.
+      const R4 GuardR4 = -1.234e30;
+      const R8 GuardR8 = -1.23456789e30;
+
+      std::vector<R4> NewR4FromR8(2 * NVertLayers, GuardR4);
+      std::vector<R8> NewR8FromR4(2 * NVertLayers, GuardR8);
+
+      Err = IO::readNDVar(NewR4FromR8.data(), "R8Vert", InFileID, VarIDR8Vert);
+      CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R8 vertical NDVar as R4")
+
+      Err = IO::readNDVar(NewR8FromR4.data(), "R4Vert", InFileID, VarIDR4Vert);
+      CHECK_ERROR_ABORT(Err, "IOTest: Failed to read R4 vertical NDVar as R8")
+
       // Read R8 data as two time slices
       Err = IO::readNDVar(NewR8Vert.data(), "R8Time", InFileID, VarIDR8Time, 0,
                           &DimLengths);
@@ -593,6 +620,31 @@ int main(int argc, char *argv[]) {
          ABORT_ERROR("IOTest: read/write vert R8 vector test frame 0 FAIL");
       if (Err5 > 0)
          ABORT_ERROR("IOTest: read/write vert R8 vector test frame 1 FAIL");
+
+      // Check the cross-type reads. The values must be converted from the
+      // type in the file to the type of the destination buffer and nothing
+      // may be written past the end of the data, which the guard values in
+      // the second half of each buffer detect.
+      int ErrR4FromR8 = 0;
+      int ErrR8FromR4 = 0;
+
+      for (int k = 0; k < NVertLayers; ++k) {
+         if (NewR4FromR8[k] != static_cast<R4>(RefR8Vert(k)))
+            ErrR4FromR8++;
+         if (NewR8FromR4[k] != static_cast<R8>(RefR4Vert(k)))
+            ErrR8FromR4++;
+      }
+      for (int k = NVertLayers; k < 2 * NVertLayers; ++k) {
+         if (NewR4FromR8[k] != GuardR4)
+            ErrR4FromR8++;
+         if (NewR8FromR4[k] != GuardR8)
+            ErrR8FromR4++;
+      }
+
+      if (ErrR4FromR8 > 0)
+         ABORT_ERROR("IOTest: read vert R8 variable into R4 buffer FAIL");
+      if (ErrR8FromR4 > 0)
+         ABORT_ERROR("IOTest: read vert R4 variable into R8 buffer FAIL");
 
       Err1 = 0;
       Err2 = 0;

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -54,6 +54,14 @@ const Real LinearBVFExpValue =
 const Real GswBVFExpValue =
     0.02081197958166906; // Expected value from GSW-C library
 
+/// Linear EOS coefficients, matching the Linear subsection of the Eos group in
+/// the test configuration. The expected derivatives follow from
+/// SpecVol = 1 / (RhoT0S0 + DRhodT * Ct + DRhodS * Sa).
+const Real LinearDRhodT      = -0.2;
+const Real LinearDRhodS      = 0.8;
+const Real LinearDCtExpValue = -LinearDRhodT * LinearExpValue * LinearExpValue;
+const Real LinearDSaExpValue = -LinearDRhodS * LinearExpValue * LinearExpValue;
+
 /// Test input values
 const Real Sa = 30.0;           // Absolute Salinity in g/kg
 const Real Ct = 10.0;           // Conservative Temperature in degC
@@ -61,6 +69,48 @@ const Real P  = 1000.0 * Db2Pa; // Pressure in Pa
 
 const I4 KDisp  = 1;     // Displate parcel to K=1 for TEOS-10 eos
 const Real RTol = 1e-10; // Relative tolerance for isApprox checks
+
+/// States spanning the oceanographic range and its corners, used by the
+/// specific volume derivative checks. The fresh end is included because that
+/// is where the normalized salinity is smallest and the salinity derivative
+/// worst conditioned, and the full pressure range because the reference
+/// profile supplies almost all of the pressure derivative.
+constexpr int NSaTest      = 6;
+constexpr int NCtTest      = 6;
+constexpr int NPTest       = 6;
+const Real SaTest[NSaTest] = {0.0, 5.0, 20.0, 30.0, 35.0, 38.5}; // g/kg
+const Real CtTest[NCtTest] = {-2.0, 0.0, 4.0, 10.0, 25.0, 35.0}; // degC
+const Real PTest[NPTest]   = {0.0,    100.0,  1000.0,
+                              4000.0, 8000.0, 10000.0}; // dbar
+
+/// Relative tolerance for the specific volume derivative checks against the
+/// GSW-C library. Omega and GSW-C evaluate the same polynomial in different
+/// arrangements, so a few ulp of disagreement is expected; anything larger
+/// than this means a term has been dropped or mis-scaled.
+const Real DerivRTol = 1e-12;
+
+/// The pressure derivative needs a looser tolerance, and the reason is on the
+/// GSW-C side rather than ours. GSW-C evaluates its v_P from a table of
+/// coefficients that have been pre-multiplied by their pressure exponents and
+/// rounded, so its result departs from the exact derivative of the 75-term
+/// polynomial by about 2e-12 relative at 10000 dbar, growing with pressure.
+/// The Omega implementation differentiates the full-precision coefficients and
+/// agrees with the exact derivative, evaluated in 60-digit arithmetic, to
+/// around 1e-16. This tolerance therefore bounds GSW-C's rounding, not ours;
+/// it is still far tighter than any real mistake would produce, and the
+/// finite-difference check below pins the value independently.
+const Real DerivDPRTol = 1e-10;
+
+/// The temperature derivative passes through zero near the density maximum of
+/// nearly fresh water, where a relative tolerance means nothing. This absolute
+/// floor sits well above the roundoff of the polynomial sum that forms it
+/// (terms of order 1e-5, so roundoff of order 1e-21) and far below any value
+/// of physical interest (order 1e-7).
+const Real DerivDCtATol = 1e-19;
+
+/// Likewise for the thermal expansion coefficient, which is the temperature
+/// derivative divided by the specific volume (order 1e-3).
+const Real AlphaATol = 1e-16;
 
 /// The initialization routine for Eos testing. It calls various
 /// init routines, including the creation of the default decomposition.
@@ -706,6 +756,330 @@ void testBruntVaisalaFreqSqTeos10() {
    return;
 }
 
+/// Test the array-level TEOS-10 specific volume derivatives over the mesh.
+///
+/// The state varies with depth rather than being uniform, so that the check
+/// covers a range of values and exercises the vertical chunking, and the
+/// expected values are obtained layer by layer from GSW-C on the host.
+void testEosTeos10Derivs() {
+   /// Get mesh and coordinate info
+   const auto Mesh     = HorzMesh::getDefault();
+   const auto VCoord   = VertCoord::getDefault();
+   VCoord->NVertLayers = NVertLayers;
+   I4 NCellsSize       = Mesh->NCellsSize;
+   /// Get Eos instance to test
+   Eos *TestEos       = Eos::getInstance();
+   TestEos->EosChoice = EosType::Teos10Eos;
+
+   /// Create the ocean state arrays
+   Array2DReal SArray = Array2DReal("SArray", NCellsSize, NVertLayers);
+   Array2DReal TArray = Array2DReal("TArray", NCellsSize, NVertLayers);
+   Array2DReal PArray = Array2DReal("PArray", NCellsSize, NVertLayers);
+   deepCopy(TestEos->SpecVol, 0.0);
+   deepCopy(TestEos->SpecVolDCt, 0.0);
+   deepCopy(TestEos->SpecVolDSa, 0.0);
+   deepCopy(TestEos->SpecVolDP, 0.0);
+
+   /// A state that gets saltier, colder and deeper with depth, spanning a
+   /// realistic part of the oceanographic range over the column
+   parallelFor(
+       "populateDerivArrays", {Mesh->NCellsAll, NVertLayers},
+       KOKKOS_LAMBDA(I4 ICell, I4 K) {
+          SArray(ICell, K) = Sa + 0.1_Real * K;
+          TArray(ICell, K) = Ct - 0.15_Real * K;
+          PArray(ICell, K) = (100.0_Real + 150.0_Real * K) * Db2Pa;
+       });
+
+   /// Compute specific volume and its derivatives
+   TestEos->computeSpecVolAndDerivs(TArray, SArray, PArray);
+
+   /// Take local handles on the Eos members for the reduction kernels
+   Array2DReal SpecVol    = TestEos->SpecVol;
+   Array2DReal SpecVolDCt = TestEos->SpecVolDCt;
+   Array2DReal SpecVolDSa = TestEos->SpecVolDSa;
+   Array2DReal SpecVolDP  = TestEos->SpecVolDP;
+
+   /// Expected values per layer from GSW-C, computed on the host and copied to
+   /// the device for the comparison
+   HostArray1DReal ExpSpecVolH("ExpSpecVolH", NVertLayers);
+   HostArray1DReal ExpDCtH("ExpDCtH", NVertLayers);
+   HostArray1DReal ExpDSaH("ExpDSaH", NVertLayers);
+   HostArray1DReal ExpDPH("ExpDPH", NVertLayers);
+
+   for (int K = 0; K < NVertLayers; ++K) {
+      const double SaVal = Sa + 0.1 * K;
+      const double CtVal = Ct - 0.15 * K;
+      const double PDb   = 100.0 + 150.0 * K;
+
+      double GswDSa, GswDCt, GswDP;
+      gsw_specvol_first_derivatives(SaVal, CtVal, PDb, &GswDSa, &GswDCt,
+                                    &GswDP);
+
+      ExpSpecVolH(K) = gsw_specvol(SaVal, CtVal, PDb);
+      ExpDCtH(K)     = GswDCt;
+      ExpDSaH(K)     = GswDSa;
+      ExpDPH(K)      = GswDP;
+   }
+
+   auto ExpSpecVol = createDeviceMirrorCopy(ExpSpecVolH);
+   auto ExpDCt     = createDeviceMirrorCopy(ExpDCtH);
+   auto ExpDSa     = createDeviceMirrorCopy(ExpDSaH);
+   auto ExpDP      = createDeviceMirrorCopy(ExpDPH);
+
+   const auto &MinLayerCell = VCoord->MinLayerCell;
+   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+
+   /// Check all active cells and layers against the expected values
+   int NumMismatches = 0;
+   parallelReduceOuter(
+       "CheckSpecVolDerivs-Teos", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (!isApprox(SpecVol(ICell, K), ExpSpecVol(K), DerivRTol) or
+                     !isApprox(SpecVolDCt(ICell, K), ExpDCt(K), DerivRTol,
+                               DerivDCtATol) or
+                     !isApprox(SpecVolDSa(ICell, K), ExpDSa(K), DerivRTol) or
+                     !isApprox(SpecVolDP(ICell, K), ExpDP(K), DerivDPRTol)) {
+                    InnerCount++;
+                 }
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
+       },
+       NumMismatches);
+
+   // If test fails, print bad values and abort
+   if (NumMismatches != 0) {
+      auto SpecVolH    = createHostMirrorCopy(SpecVol);
+      auto SpecVolDCtH = createHostMirrorCopy(SpecVolDCt);
+      auto SpecVolDSaH = createHostMirrorCopy(SpecVolDSa);
+      auto SpecVolDPH  = createHostMirrorCopy(SpecVolDP);
+      for (int I = 0; I < Mesh->NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (!isApprox(SpecVolH(I, K), ExpSpecVolH(K), DerivRTol))
+               LOG_ERROR("EosTest: SpecVol Deriv Bad Value: "
+                         "SpecVol({},{}) = {}; Expected {}",
+                         I, K, SpecVolH(I, K), ExpSpecVolH(K));
+            if (!isApprox(SpecVolDCtH(I, K), ExpDCtH(K), DerivRTol,
+                          DerivDCtATol))
+               LOG_ERROR("EosTest: SpecVolDCt Bad Value: "
+                         "SpecVolDCt({},{}) = {}; Expected {}",
+                         I, K, SpecVolDCtH(I, K), ExpDCtH(K));
+            if (!isApprox(SpecVolDSaH(I, K), ExpDSaH(K), DerivRTol))
+               LOG_ERROR("EosTest: SpecVolDSa Bad Value: "
+                         "SpecVolDSa({},{}) = {}; Expected {}",
+                         I, K, SpecVolDSaH(I, K), ExpDSaH(K));
+            if (!isApprox(SpecVolDPH(I, K), ExpDPH(K), DerivDPRTol))
+               LOG_ERROR("EosTest: SpecVolDP Bad Value: "
+                         "SpecVolDP({},{}) = {}; Expected {}",
+                         I, K, SpecVolDPH(I, K), ExpDPH(K));
+         }
+      }
+      ABORT_ERROR("EosTest: SpecVol Derivs TEOS FAIL with {} bad values",
+                  NumMismatches);
+   }
+
+   /// Check that each derivative is registered as a field in the Eos group
+   /// with the member array attached, so that it can be written to a stream
+   const std::string DerivFldNames[3] = {TestEos->SpecVolDCtFldName,
+                                         TestEos->SpecVolDSaFldName,
+                                         TestEos->SpecVolDPFldName};
+   const Array2DReal DerivArrays[3]   = {SpecVolDCt, SpecVolDSa, SpecVolDP};
+
+   for (int IFld = 0; IFld < 3; ++IFld) {
+      const std::string &FldName = DerivFldNames[IFld];
+
+      if (!Field::exists(FldName)) {
+         ABORT_ERROR("EosTest: SpecVol Derivs field {} does not exist",
+                     FldName);
+      }
+
+      if (!FieldGroup::isFieldInGroup(FldName, TestEos->EosGroupName)) {
+         ABORT_ERROR("EosTest: SpecVol Derivs field {} not in group {}",
+                     FldName, TestEos->EosGroupName);
+      }
+
+      auto DerivField = Field::get(FldName);
+      auto FieldData  = DerivField->getDataArray<Array2DReal>();
+      if (FieldData.data() != DerivArrays[IFld].data()) {
+         ABORT_ERROR("EosTest: SpecVol Derivs field {} does not alias the "
+                     "Eos member array",
+                     FldName);
+      }
+   }
+
+   return;
+}
+
+/// Test the array-level linear EOS specific volume derivatives, which are
+/// known in closed form from the configured linear coefficients
+void testEosLinearDerivs() {
+   /// Get mesh and coordinate info
+   const auto Mesh     = HorzMesh::getDefault();
+   const auto VCoord   = VertCoord::getDefault();
+   VCoord->NVertLayers = NVertLayers;
+   I4 NCellsSize       = Mesh->NCellsSize;
+   /// Get Eos instance to test
+   Eos *TestEos       = Eos::getInstance();
+   TestEos->EosChoice = EosType::LinearEos;
+
+   /// Create and fill ocean state arrays
+   Array2DReal SArray = Array2DReal("SArray", NCellsSize, NVertLayers);
+   Array2DReal TArray = Array2DReal("TArray", NCellsSize, NVertLayers);
+   Array2DReal PArray = Array2DReal("PArray", NCellsSize, NVertLayers);
+   deepCopy(SArray, Sa);
+   deepCopy(TArray, Ct);
+   deepCopy(PArray, P);
+   deepCopy(TestEos->SpecVol, 0.0);
+   deepCopy(TestEos->SpecVolDCt, 0.0);
+   deepCopy(TestEos->SpecVolDSa, 0.0);
+   deepCopy(TestEos->SpecVolDP, 0.0);
+
+   TestEos->computeSpecVolAndDerivs(TArray, SArray, PArray);
+
+   /// Take local handles on the Eos members for the reduction kernels
+   Array2DReal SpecVol    = TestEos->SpecVol;
+   Array2DReal SpecVolDCt = TestEos->SpecVolDCt;
+   Array2DReal SpecVolDSa = TestEos->SpecVolDSa;
+   Array2DReal SpecVolDP  = TestEos->SpecVolDP;
+
+   const auto &MinLayerCell = VCoord->MinLayerCell;
+   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+
+   /// Check all array values against the expected values
+   int NumMismatches = 0;
+   parallelReduceOuter(
+       "CheckSpecVolDerivs-linear", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (!isApprox(SpecVol(ICell, K), LinearExpValue, RTol) or
+                     !isApprox(SpecVolDCt(ICell, K), LinearDCtExpValue, RTol) or
+                     !isApprox(SpecVolDSa(ICell, K), LinearDSaExpValue, RTol) or
+                     SpecVolDP(ICell, K) != 0.0_Real) {
+                    InnerCount++;
+                 }
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
+       },
+       NumMismatches);
+
+   // If test fails, print bad values and abort
+   if (NumMismatches != 0) {
+      auto SpecVolDCtH = createHostMirrorCopy(SpecVolDCt);
+      auto SpecVolDSaH = createHostMirrorCopy(SpecVolDSa);
+      auto SpecVolDPH  = createHostMirrorCopy(SpecVolDP);
+      for (int I = 0; I < Mesh->NCellsAll; ++I) {
+         for (int K = 0; K < NVertLayers; ++K) {
+            if (!isApprox(SpecVolDCtH(I, K), LinearDCtExpValue, RTol))
+               LOG_ERROR("EosTest: SpecVolDCt Linear Bad Value: "
+                         "SpecVolDCt({},{}) = {}; Expected {}",
+                         I, K, SpecVolDCtH(I, K), LinearDCtExpValue);
+            if (!isApprox(SpecVolDSaH(I, K), LinearDSaExpValue, RTol))
+               LOG_ERROR("EosTest: SpecVolDSa Linear Bad Value: "
+                         "SpecVolDSa({},{}) = {}; Expected {}",
+                         I, K, SpecVolDSaH(I, K), LinearDSaExpValue);
+            if (SpecVolDPH(I, K) != 0.0_Real)
+               LOG_ERROR("EosTest: SpecVolDP Linear Bad Value: "
+                         "SpecVolDP({},{}) = {}; Expected 0",
+                         I, K, SpecVolDPH(I, K));
+         }
+      }
+      ABORT_ERROR("EosTest: SpecVol Derivs Linear FAIL with {} bad values",
+                  NumMismatches);
+   }
+
+   return;
+}
+
+/// Test the array-level constant EOS specific volume derivatives, all of which
+/// must be identically zero
+void testEosConstantDerivs() {
+   /// Get mesh and coordinate info
+   const auto Mesh     = HorzMesh::getDefault();
+   const auto VCoord   = VertCoord::getDefault();
+   VCoord->NVertLayers = NVertLayers;
+   I4 NCellsSize       = Mesh->NCellsSize;
+   /// Get Eos instance to test
+   Eos *TestEos       = Eos::getInstance();
+   TestEos->EosChoice = EosType::ConstantEos;
+
+   /// Create and fill ocean state arrays
+   Array2DReal SArray = Array2DReal("SArray", NCellsSize, NVertLayers);
+   Array2DReal TArray = Array2DReal("TArray", NCellsSize, NVertLayers);
+   Array2DReal PArray = Array2DReal("PArray", NCellsSize, NVertLayers);
+   deepCopy(SArray, Sa);
+   deepCopy(TArray, Ct);
+   deepCopy(PArray, P);
+   deepCopy(TestEos->SpecVol, 0.0);
+   deepCopy(TestEos->SpecVolDCt, 0.0);
+   deepCopy(TestEos->SpecVolDSa, 0.0);
+   deepCopy(TestEos->SpecVolDP, 0.0);
+
+   TestEos->computeSpecVolAndDerivs(TArray, SArray, PArray);
+
+   /// Take local handles on the Eos members for the reduction kernels
+   Array2DReal SpecVol    = TestEos->SpecVol;
+   Array2DReal SpecVolDCt = TestEos->SpecVolDCt;
+   Array2DReal SpecVolDSa = TestEos->SpecVolDSa;
+   Array2DReal SpecVolDP  = TestEos->SpecVolDP;
+
+   const auto &MinLayerCell = VCoord->MinLayerCell;
+   const auto &MaxLayerCell = VCoord->MaxLayerCell;
+
+   /// Check all array values against the expected values
+   int NumMismatches = 0;
+   parallelReduceOuter(
+       "CheckSpecVolDerivs-Constant", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team, int &OuterCount) {
+          int NumMismatchesCol;
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRange(KMin, KMax);
+          parallelReduceInner(
+              Team, KRange,
+              INNER_LAMBDA(int KOff, int &InnerCount) {
+                 const int K = KMin + KOff;
+                 if (!isApprox(SpecVol(ICell, K), ConstantExpValue, RTol) or
+                     SpecVolDCt(ICell, K) != 0.0_Real or
+                     SpecVolDSa(ICell, K) != 0.0_Real or
+                     SpecVolDP(ICell, K) != 0.0_Real) {
+                    InnerCount++;
+                 }
+              },
+              NumMismatchesCol);
+
+          Kokkos::single(PerTeam(Team),
+                         [&]() { OuterCount += NumMismatchesCol; });
+       },
+       NumMismatches);
+
+   if (NumMismatches != 0) {
+      ABORT_ERROR("EosTest: SpecVol Derivs Constant FAIL with {} bad values",
+                  NumMismatches);
+   }
+
+   return;
+}
+
 /// Finalize and clean up all test infrastructure
 void finalizeEosTest() {
    Eos::destroyInstance();
@@ -788,6 +1162,249 @@ void checkValueCtFreezing() {
    return;
 }
 
+/// Relative difference between two values, zero when both vanish
+Real relDiff(Real X, Real Y) {
+   const Real Scale = std::max(std::abs(X), std::abs(Y));
+   return Scale > 0.0 ? std::abs(X - Y) / Scale : 0.0;
+}
+
+/// Test the TEOS-10 specific volume derivatives against the GSW-C library over
+/// a range of states.
+///
+/// GSW-C is used here unmodified and through its public API, as an independent
+/// oracle. The Omega implementation does not derive from it: the derivatives
+/// are the analytic derivatives of the Roquet et al. 2015 polynomial that the
+/// Teos10Eos functor already carries.
+void checkValueGswcSpecVolDerivs() {
+
+   Teos10Eos TestEos(VertCoord::getDefault());
+
+   int NumBad     = 0;
+   Real WorstSv   = 0.0;
+   Real WorstDCt  = 0.0;
+   Real WorstDSa  = 0.0;
+   Real WorstDP   = 0.0;
+   int NumChecked = 0;
+
+   for (int ISa = 0; ISa < NSaTest; ++ISa) {
+      for (int ICt = 0; ICt < NCtTest; ++ICt) {
+         for (int IP = 0; IP < NPTest; ++IP) {
+
+            const Real SaVal = SaTest[ISa];
+            const Real CtVal = CtTest[ICt];
+            const Real PDb   = PTest[IP];
+
+            Real SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP;
+            TestEos.calcSpecVolAndDerivs(CtVal, SaVal, PDb * Db2Pa, SpecVol,
+                                         SpecVolDCt, SpecVolDSa, SpecVolDP);
+
+            /// GSW-C takes pressure in dbar and returns the derivatives per
+            /// (g/kg), per degC, and per Pa
+            double GswDSa, GswDCt, GswDP;
+            gsw_specvol_first_derivatives(SaVal, CtVal, PDb, &GswDSa, &GswDCt,
+                                          &GswDP);
+            const double GswSpecVol = gsw_specvol(SaVal, CtVal, PDb);
+
+            WorstSv  = std::max(WorstSv, relDiff(SpecVol, GswSpecVol));
+            WorstDCt = std::max(WorstDCt, relDiff(SpecVolDCt, GswDCt));
+            WorstDSa = std::max(WorstDSa, relDiff(SpecVolDSa, GswDSa));
+            WorstDP  = std::max(WorstDP, relDiff(SpecVolDP, GswDP));
+            ++NumChecked;
+
+            if (!isApprox(SpecVol, GswSpecVol, DerivRTol)) {
+               LOG_ERROR("EosTest: SpecVol Bad Value at Sa={}, Ct={}, "
+                         "P={} dbar: expected {}, got {}",
+                         SaVal, CtVal, PDb, GswSpecVol, SpecVol);
+               ++NumBad;
+            }
+            if (!isApprox(SpecVolDCt, GswDCt, DerivRTol, DerivDCtATol)) {
+               LOG_ERROR("EosTest: SpecVolDCt Bad Value at Sa={}, Ct={}, "
+                         "P={} dbar: expected {}, got {}",
+                         SaVal, CtVal, PDb, GswDCt, SpecVolDCt);
+               ++NumBad;
+            }
+            if (!isApprox(SpecVolDSa, GswDSa, DerivRTol)) {
+               LOG_ERROR("EosTest: SpecVolDSa Bad Value at Sa={}, Ct={}, "
+                         "P={} dbar: expected {}, got {}",
+                         SaVal, CtVal, PDb, GswDSa, SpecVolDSa);
+               ++NumBad;
+            }
+            if (!isApprox(SpecVolDP, GswDP, DerivDPRTol)) {
+               LOG_ERROR("EosTest: SpecVolDP Bad Value at Sa={}, Ct={}, "
+                         "P={} dbar: expected {}, got {}",
+                         SaVal, CtVal, PDb, GswDP, SpecVolDP);
+               ++NumBad;
+            }
+         }
+      }
+   }
+
+   LOG_INFO("EosTest: TEOS-10 derivatives vs GSW-C over {} states, max "
+            "relative difference: SpecVol {}, d/dCt {}, d/dSa {}, d/dP {}",
+            NumChecked, WorstSv, WorstDCt, WorstDSa, WorstDP);
+
+   if (NumBad != 0) {
+      ABORT_ERROR("EosTest: SpecVol derivatives vs GSW-C FAIL with {} bad "
+                  "values",
+                  NumBad);
+   }
+
+   return;
+}
+
+/// Check the specific volume derivatives against centered finite differences of
+/// the Omega specific volume itself.
+///
+/// This overlaps the GSW-C comparison above whenever that library is present
+/// and correct, and that is deliberate: it pins the unit convention of the
+/// Omega interface -- per degC, per (g/kg), and per Pa -- without reference to
+/// GSW. A change that silently made the pressure derivative per dbar instead,
+/// a factor of 1e4, would be caught here as well as there.
+void checkFiniteDiffSpecVolDerivs() {
+
+   Teos10Eos TestEos(VertCoord::getDefault());
+
+   /// Step sizes and tolerance are set by the finite difference itself: large
+   /// enough that the difference of two specific volumes is not lost to
+   /// roundoff, small enough that the truncation error stays below the
+   /// tolerance.
+   const Real DCtStep  = 1.0e-2;  // degC
+   const Real DSaStep  = 1.0e-2;  // g/kg
+   const Real DPStep   = 1.0e5;   // Pa (10 dbar)
+   const Real FDRTol   = 1.0e-5;  // limited by finite difference truncation
+   const Real FDCtATol = 1.0e-14; // finite difference noise floor
+   const Real FDSaATol = 1.0e-14;
+   const Real FDPATol  = 1.0e-20;
+
+   /// Evaluate only the specific volume at a perturbed state
+   auto SpecVolAt = [&TestEos](Real CtVal, Real SaVal, Real PPa) {
+      Real SpecVol, DCt, DSa, DP;
+      TestEos.calcSpecVolAndDerivs(CtVal, SaVal, PPa, SpecVol, DCt, DSa, DP);
+      return SpecVol;
+   };
+
+   int NumBad = 0;
+
+   for (int ISa = 0; ISa < NSaTest; ++ISa) {
+      for (int ICt = 0; ICt < NCtTest; ++ICt) {
+         for (int IP = 0; IP < NPTest; ++IP) {
+
+            const Real SaVal = SaTest[ISa];
+            const Real CtVal = CtTest[ICt];
+            const Real PPa   = PTest[IP] * Db2Pa;
+
+            Real SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP;
+            TestEos.calcSpecVolAndDerivs(CtVal, SaVal, PPa, SpecVol, SpecVolDCt,
+                                         SpecVolDSa, SpecVolDP);
+
+            const Real FDCt = (SpecVolAt(CtVal + DCtStep, SaVal, PPa) -
+                               SpecVolAt(CtVal - DCtStep, SaVal, PPa)) /
+                              (2.0_Real * DCtStep);
+            const Real FDSa = (SpecVolAt(CtVal, SaVal + DSaStep, PPa) -
+                               SpecVolAt(CtVal, SaVal - DSaStep, PPa)) /
+                              (2.0_Real * DSaStep);
+            const Real FDP = (SpecVolAt(CtVal, SaVal, PPa + DPStep) -
+                              SpecVolAt(CtVal, SaVal, PPa - DPStep)) /
+                             (2.0_Real * DPStep);
+
+            if (!isApprox(SpecVolDCt, FDCt, FDRTol, FDCtATol)) {
+               LOG_ERROR("EosTest: SpecVolDCt disagrees with finite difference "
+                         "at Sa={}, Ct={}, P={} dbar: {} vs {}",
+                         SaVal, CtVal, PTest[IP], SpecVolDCt, FDCt);
+               ++NumBad;
+            }
+            if (!isApprox(SpecVolDSa, FDSa, FDRTol, FDSaATol)) {
+               LOG_ERROR("EosTest: SpecVolDSa disagrees with finite difference "
+                         "at Sa={}, Ct={}, P={} dbar: {} vs {}",
+                         SaVal, CtVal, PTest[IP], SpecVolDSa, FDSa);
+               ++NumBad;
+            }
+            if (!isApprox(SpecVolDP, FDP, FDRTol, FDPATol)) {
+               LOG_ERROR("EosTest: SpecVolDP disagrees with finite difference "
+                         "at Sa={}, Ct={}, P={} dbar: {} vs {}",
+                         SaVal, CtVal, PTest[IP], SpecVolDP, FDP);
+               ++NumBad;
+            }
+         }
+      }
+   }
+
+   if (NumBad != 0) {
+      ABORT_ERROR("EosTest: SpecVol derivatives vs finite differences FAIL "
+                  "with {} bad values",
+                  NumBad);
+   }
+
+   return;
+}
+
+/// Test the thermal expansion and haline contraction coefficients used by the
+/// TEOS-10 Brunt-Vaisala frequency against the GSW-C library.
+///
+/// These are the specific volume derivatives divided by the specific volume,
+/// so this covers the same polynomial from the other side. Before this check
+/// existed, calcAlpha and calcBeta were exercised only through the single
+/// hardcoded BruntVaisalaFreqSq value below, which is too loose to catch a
+/// mistake in either of them.
+void checkValueGswcAlphaBeta() {
+
+   Teos10Eos TestEos(VertCoord::getDefault());
+   Teos10BruntVaisalaFreqSq TestBvf(VertCoord::getDefault());
+
+   int NumBad      = 0;
+   Real WorstAlpha = 0.0;
+   Real WorstBeta  = 0.0;
+
+   for (int ISa = 0; ISa < NSaTest; ++ISa) {
+      for (int ICt = 0; ICt < NCtTest; ++ICt) {
+         for (int IP = 0; IP < NPTest; ++IP) {
+
+            const Real SaVal = SaTest[ISa];
+            const Real CtVal = CtTest[ICt];
+            const Real PDb   = PTest[IP];
+
+            Real SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP;
+            TestEos.calcSpecVolAndDerivs(CtVal, SaVal, PDb * Db2Pa, SpecVol,
+                                         SpecVolDCt, SpecVolDSa, SpecVolDP);
+
+            const Real Alpha = TestBvf.calcAlpha(SaVal, CtVal, PDb, SpecVol);
+            const Real Beta  = TestBvf.calcBeta(SaVal, CtVal, PDb, SpecVol);
+
+            double GswSpecVol, GswAlpha, GswBeta;
+            gsw_specvol_alpha_beta(SaVal, CtVal, PDb, &GswSpecVol, &GswAlpha,
+                                   &GswBeta);
+
+            WorstAlpha = std::max(WorstAlpha, relDiff(Alpha, GswAlpha));
+            WorstBeta  = std::max(WorstBeta, relDiff(Beta, GswBeta));
+
+            if (!isApprox(Alpha, GswAlpha, DerivRTol, AlphaATol)) {
+               LOG_ERROR("EosTest: Alpha Bad Value at Sa={}, Ct={}, "
+                         "P={} dbar: expected {}, got {}",
+                         SaVal, CtVal, PDb, GswAlpha, Alpha);
+               ++NumBad;
+            }
+            if (!isApprox(Beta, GswBeta, DerivRTol)) {
+               LOG_ERROR("EosTest: Beta Bad Value at Sa={}, Ct={}, "
+                         "P={} dbar: expected {}, got {}",
+                         SaVal, CtVal, PDb, GswBeta, Beta);
+               ++NumBad;
+            }
+         }
+      }
+   }
+
+   LOG_INFO("EosTest: alpha and beta vs GSW-C, max relative difference: "
+            "alpha {}, beta {}",
+            WorstAlpha, WorstBeta);
+
+   if (NumBad != 0) {
+      ABORT_ERROR("EosTest: alpha and beta vs GSW-C FAIL with {} bad values",
+                  NumBad);
+   }
+
+   return;
+}
+
 /// Test that the Eos CT-from-PT helper matches GSW-C
 void checkValueGswcCtFromPt() {
    Eos *TestEos       = Eos::getInstance();
@@ -822,6 +1439,12 @@ void checkValueGswcPtFromCt() {
 // Single value test:
 // --> test calls the external GSW-C library
 // and compares the specific volume to the published value
+// --> next compares the TEOS-10 specific volume and its three first
+// derivatives against GSW-C over a range of states
+// --> next checks those derivatives against centered finite differences of the
+// Omega specific volume, which pins the unit conventions independently of GSW
+// --> next compares the thermal expansion and haline contraction coefficients
+// against GSW-C over the same range of states
 // Full array tests:
 // --> one tests the value on a Eos with linear option
 // --> next checks the value on a Eos with linear displaced option
@@ -829,8 +1452,10 @@ void checkValueGswcPtFromCt() {
 // calculation
 // --> next checks the value on a Eos with TEOS-10 option
 // --> next checks the value on a Eos with TEOS-10 displaced option
-// --> last checks the value of the TOES-10 squared Brunt Vaisala Freq.
+// --> next checks the value of the TOES-10 squared Brunt Vaisala Freq.
 // calculation
+// --> last checks the specific volume derivatives for each of the three EOS
+// options over the whole mesh
 void eosTest(const std::string &MeshFile = "OmegaMesh.nc") {
    initEosTest(MeshFile);
    const auto &Mesh = HorzMesh::getDefault();
@@ -840,6 +1465,9 @@ void eosTest(const std::string &MeshFile = "OmegaMesh.nc") {
    checkValueCtFreezing();
    checkValueGswcCtFromPt();
    checkValueGswcPtFromCt();
+   checkValueGswcSpecVolDerivs();
+   checkFiniteDiffSpecVolDerivs();
+   checkValueGswcAlphaBeta();
 
    testEosLinear();
    testEosLinearDisplaced();
@@ -848,6 +1476,9 @@ void eosTest(const std::string &MeshFile = "OmegaMesh.nc") {
    testEosTeos10();
    testEosTeos10Displaced();
    testBruntVaisalaFreqSqTeos10();
+   testEosTeos10Derivs();
+   testEosLinearDerivs();
+   testEosConstantDerivs();
 
    finalizeEosTest();
 

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -1195,8 +1195,9 @@ void checkValueGswcSpecVolDerivs() {
             const Real PDb   = PTest[IP];
 
             Real SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP;
-            TestEos.calcSpecVolAndDerivs(CtVal, SaVal, PDb * Db2Pa, SpecVol,
-                                         SpecVolDCt, SpecVolDSa, SpecVolDP);
+            TestEos.calcSpecVolAndDerivsAtPoint(CtVal, SaVal, PDb * Db2Pa,
+                                                SpecVol, SpecVolDCt, SpecVolDSa,
+                                                SpecVolDP);
 
             /// GSW-C takes pressure in dbar and returns the derivatives per
             /// (g/kg), per degC, and per Pa
@@ -1279,7 +1280,8 @@ void checkFiniteDiffSpecVolDerivs() {
    /// Evaluate only the specific volume at a perturbed state
    auto SpecVolAt = [&TestEos](Real CtVal, Real SaVal, Real PPa) {
       Real SpecVol, DCt, DSa, DP;
-      TestEos.calcSpecVolAndDerivs(CtVal, SaVal, PPa, SpecVol, DCt, DSa, DP);
+      TestEos.calcSpecVolAndDerivsAtPoint(CtVal, SaVal, PPa, SpecVol, DCt, DSa,
+                                          DP);
       return SpecVol;
    };
 
@@ -1294,8 +1296,8 @@ void checkFiniteDiffSpecVolDerivs() {
             const Real PPa   = PTest[IP] * Db2Pa;
 
             Real SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP;
-            TestEos.calcSpecVolAndDerivs(CtVal, SaVal, PPa, SpecVol, SpecVolDCt,
-                                         SpecVolDSa, SpecVolDP);
+            TestEos.calcSpecVolAndDerivsAtPoint(
+                CtVal, SaVal, PPa, SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP);
 
             const Real FDCt = (SpecVolAt(CtVal + DCtStep, SaVal, PPa) -
                                SpecVolAt(CtVal - DCtStep, SaVal, PPa)) /
@@ -1364,8 +1366,9 @@ void checkValueGswcAlphaBeta() {
             const Real PDb   = PTest[IP];
 
             Real SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP;
-            TestEos.calcSpecVolAndDerivs(CtVal, SaVal, PDb * Db2Pa, SpecVol,
-                                         SpecVolDCt, SpecVolDSa, SpecVolDP);
+            TestEos.calcSpecVolAndDerivsAtPoint(CtVal, SaVal, PDb * Db2Pa,
+                                                SpecVol, SpecVolDCt, SpecVolDSa,
+                                                SpecVolDP);
 
             const Real Alpha = TestBvf.calcAlpha(SaVal, CtVal, PDb, SpecVol);
             const Real Beta  = TestBvf.calcBeta(SaVal, CtVal, PDb, SpecVol);

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -761,6 +761,15 @@ void testBruntVaisalaFreqSqTeos10() {
 /// The state varies with depth rather than being uniform, so that the check
 /// covers a range of values and exercises the vertical chunking, and the
 /// expected values are obtained layer by layer from GSW-C on the host.
+///
+/// This is a test of the plumbing, not of the polynomial. It runs
+/// Eos::computeSpecVolAndDerivs on the device over the whole mesh and so
+/// covers the dispatch on EosChoice, the chunked vertical loop and its chunk
+/// boundaries, the MinLayerCell/MaxLayerCell masking, the writing of the four
+/// results into the Eos member arrays, and the registration of the derivative
+/// fields in the Eos group. The math itself is covered point by point, over a
+/// much wider range of states, by checkValueGswcSpecVolDerivs below; GSW-C
+/// appears here only as a convenient source of expected values.
 void testEosTeos10Derivs() {
    /// Get mesh and coordinate info
    const auto Mesh     = HorzMesh::getDefault();
@@ -1175,6 +1184,15 @@ Real relDiff(Real X, Real Y) {
 /// oracle. The Omega implementation does not derive from it: the derivatives
 /// are the analytic derivatives of the Roquet et al. 2015 polynomial that the
 /// Teos10Eos functor already carries.
+///
+/// This is the test of the polynomial itself, as opposed to
+/// testEosTeos10Derivs above, which tests the array-level machinery. It calls
+/// the point-wise calcSpecVolAndDerivsAtPoint on the host at every combination
+/// of the salinity, temperature and pressure values in SaTest, CtTest and
+/// PTest, which reach the corners of the oceanographic range -- fresh and
+/// salty, freezing and warm, surface and 10000 dbar -- rather than the single
+/// realistic profile the mesh test uses. A dropped or mis-scaled term shows up
+/// here, and the tolerances are tight enough to say so.
 void checkValueGswcSpecVolDerivs() {
 
    Teos10Eos TestEos(VertCoord::getDefault());

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -24,6 +24,7 @@
 #include "OceanState.h"
 #include "OmegaKokkos.h"
 #include "PGrad.h"
+#include "PGradRecon.h"
 #include "Pacer.h"
 #include "TimeStepper.h"
 #include "Tracers.h"
@@ -92,6 +93,142 @@ void initPGradTest() {
 
    CHECK_ERROR_ABORT(Err, "PGrad: error during initialization");
 }
+
+// Check the mean-preserving linear reconstruction estimator on a single
+// column, without a mesh.
+//
+// Layer means are sampled from a profile that is exactly linear in pressure,
+// so the recovered slope must match the profile's slope to round-off in every
+// layer, including the two that use a one-sided difference. The layer
+// thicknesses are deliberately non-uniform, which is the case this test exists
+// for: a formula that assumed uniform thickness passes the uniform control
+// below and fails here. Both are run, so a failure says which of the two it
+// is.
+//
+// Also asserted are the two properties the scheme leans on: that the
+// reconstruction reproduces the layer mean at mid-layer pressure, and that its
+// deviation integrates to zero over the layer.
+int testReconstruction() {
+
+   int Err = 0;
+
+   const Real Eps = std::numeric_limits<Real>::epsilon();
+   const Real Tol = 16.0_Real;
+
+   // a profile linear in pressure: Theta(p) = Value0 + Slope0 * p
+   const Real Value0 = 12.5_Real;
+   const Real Slope0 = -1.5e-6_Real;
+
+   // deliberately non-uniform thicknesses in Pa, then a uniform control
+   const std::vector<std::vector<Real>> ThicknessSets = {
+       {1.0e5, 3.0e5, 2.0e5, 7.0e5, 1.5e5, 9.0e5, 4.0e5, 2.5e5},
+       {3.0e5, 3.0e5, 3.0e5, 3.0e5, 3.0e5, 3.0e5, 3.0e5, 3.0e5}};
+   const std::vector<std::string> SetNames = {"non-uniform", "uniform"};
+
+   for (int ISet = 0; ISet < ThicknessSets.size(); ++ISet) {
+
+      const std::vector<Real> &DeltaPress = ThicknessSets[ISet];
+      const I4 NLayers                    = DeltaPress.size();
+      const I4 KMin                       = 0;
+      const I4 KMax                       = NLayers - 1;
+
+      // interface pressures accumulated from the surface, mid-layer pressures
+      // as their exact arithmetic midpoint, and layer means sampled from the
+      // profile at mid-layer pressure -- which is the exact layer average of a
+      // linear profile
+      std::vector<Real> PressInterface(NLayers + 1);
+      std::vector<Real> PressMid(NLayers);
+      std::vector<Real> Value(NLayers);
+      PressInterface[0] = 0.0_Real;
+      for (int K = 0; K < NLayers; ++K) {
+         PressInterface[K + 1] = PressInterface[K] + DeltaPress[K];
+         PressMid[K] = 0.5_Real * (PressInterface[K] + PressInterface[K + 1]);
+         Value[K]    = Value0 + Slope0 * PressMid[K];
+      }
+
+      Real MaxSlopeErr = 0.0_Real;
+      Real MaxMeanErr  = 0.0_Real;
+      Real MaxIntegral = 0.0_Real;
+
+      for (int K = 0; K < NLayers; ++K) {
+
+         I4 KLo, KHi;
+         linearReconStencil(K, KMin, KMax, KLo, KHi);
+         const Real Slope = linearReconSlope(Value[KLo], Value[KHi],
+                                             PressMid[KLo], PressMid[KHi]);
+
+         // round-off in the difference is set by the size of the layer means,
+         // divided by the pressure interval differenced over
+         const Real ValueScale =
+             std::max(std::abs(Value[KLo]), std::abs(Value[KHi]));
+         const Real SlopeBound =
+             Eps * ValueScale / std::abs(PressMid[KHi] - PressMid[KLo]);
+         MaxSlopeErr =
+             std::max(MaxSlopeErr, std::abs(Slope - Slope0) / SlopeBound);
+
+         // the reconstruction reproduces the layer mean at mid-layer pressure
+         const Real AtMid =
+             linearReconEval(Value[K], Slope, PressMid[K], PressMid[K]);
+         MaxMeanErr = std::max(MaxMeanErr,
+                               std::abs(AtMid - Value[K]) / (Eps * ValueScale));
+
+         // the deviation integrates to zero over the layer, by two-point
+         // Gauss quadrature, which is exact for a linear integrand
+         const Real HalfWidth = 0.5_Real * DeltaPress[K];
+         const Real Offset    = HalfWidth / std::sqrt(3.0_Real);
+         const Real DevLo =
+             linearReconDeviation(Slope, PressMid[K], PressMid[K] - Offset);
+         const Real DevHi =
+             linearReconDeviation(Slope, PressMid[K], PressMid[K] + Offset);
+         const Real Integral = HalfWidth * (DevLo + DevHi);
+         const Real DevScale = HalfWidth * std::abs(Slope) * HalfWidth;
+         if (DevScale > 0.0_Real)
+            MaxIntegral =
+                std::max(MaxIntegral, std::abs(Integral) / (Eps * DevScale));
+      }
+
+      LOG_INFO("PGradTest: reconstruction on {} layers: slope error {} eps, "
+               "layer-mean error {} eps, layer integral {} eps",
+               SetNames[ISet], MaxSlopeErr, MaxMeanErr, MaxIntegral);
+
+      if (MaxSlopeErr > Tol) {
+         LOG_ERROR("PGradTest: reconstruction slope FAIL on {} layers: {} eps",
+                   SetNames[ISet], MaxSlopeErr);
+         ++Err;
+      }
+      if (MaxMeanErr > Tol) {
+         LOG_ERROR("PGradTest: reconstruction layer mean FAIL on {} layers: "
+                   "{} eps",
+                   SetNames[ISet], MaxMeanErr);
+         ++Err;
+      }
+      if (MaxIntegral > Tol) {
+         LOG_ERROR("PGradTest: reconstruction layer integral FAIL on {} "
+                   "layers: {} eps",
+                   SetNames[ISet], MaxIntegral);
+         ++Err;
+      }
+   }
+
+   // a column with a single valid layer has nothing to difference against, so
+   // a constant is the only mean-preserving reconstruction available
+   I4 KLo, KHi;
+   linearReconStencil(3, 3, 3, KLo, KHi);
+   const Real SingleSlope =
+       linearReconSlope(Value0, Value0, 1.0e5_Real, 1.0e5_Real);
+   if (KLo == 3 && KHi == 3 && SingleSlope == 0.0_Real) {
+      LOG_INFO("PGradTest: reconstruction single-layer column PASS");
+   } else {
+      LOG_ERROR("PGradTest: reconstruction single-layer column FAIL");
+      ++Err;
+   }
+
+   if (Err == 0)
+      LOG_INFO("PGradTest: reconstruction estimator PASS");
+
+   return Err;
+
+} // end testReconstruction
 
 // Build the two-column test state. Every edge joins cells 0 and 1 and is
 // DC apart. Layer interfaces are staggered between the two columns by
@@ -619,6 +756,11 @@ int main(int argc, char *argv[]) {
       // Test the centered identity of design section 3.9 across a sweep of
       // tilts. This resets the two-column state, so it runs after the
       // refinement loop.
+      // Test the reconstruction estimator on its own. It needs no mesh, and
+      // it is the most likely place for the exactness gate to fail, so a
+      // failure here localizes immediately.
+      int ReconErr = testReconstruction();
+
       int IdentityErr = testCenteredIdentity(DefMesh, VCoord, DefState, DefEos);
 
       // Test parsing and dispatch of the PressureGrad configuration options
@@ -632,7 +774,7 @@ int main(int argc, char *argv[]) {
          RetVal = 1;
       }
 
-      RetVal += IdentityErr + ConfigErr;
+      RetVal += ReconErr + IdentityErr + ConfigErr;
 
       // cleanup
       PressureGrad::clear();

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -24,6 +24,7 @@
 #include "OceanState.h"
 #include "OmegaKokkos.h"
 #include "PGrad.h"
+#include "PGradFiniteVolume.h"
 #include "PGradRecon.h"
 #include "Pacer.h"
 #include "TimeStepper.h"
@@ -386,6 +387,209 @@ int testPressureLookup() {
    return Err;
 
 } // end testPressureLookup
+
+// The exact layer average over [PressLo, PressHi] of a profile that is
+// quadratic in pressure, used to initialize layer means the way the exactness
+// gate requires: as the exact layer averages of a prescribed continuous
+// profile, which under tilt come out different in the two columns.
+Real exactLayerAvg(const Real Coeff0,  ///< [in] constant term
+                   const Real Coeff1,  ///< [in] coefficient of p
+                   const Real Coeff2,  ///< [in] coefficient of p squared
+                   const Real PressLo, ///< [in] top interface pressure
+                   const Real PressHi  ///< [in] bottom interface pressure
+) {
+   const Real PressMid   = 0.5_Real * (PressLo + PressHi);
+   const Real DeltaPress = PressHi - PressLo;
+   return Coeff0 + Coeff1 * PressMid +
+          Coeff2 * (PressMid * PressMid + DeltaPress * DeltaPress / 12.0_Real);
+}
+
+// Check the matched-pressure integrand on a fabricated column pair, without a
+// mesh. This exercises the reconstruction, the pressure lookup and the
+// edge-shared expansion together, which is the combination the whole scheme
+// rests on.
+//
+// On a profile linear in pressure the integrand must be zero at *every*
+// quadrature point, not merely in the integral. That is the sharpest available
+// form of the check: it localizes a failure to the layer that caused it, and
+// it is what a per-layer-index sharing rule fails. Both columns' layer means
+// are the exact layer averages of one prescribed continuous profile, so under
+// the offset between the two columns those means genuinely differ -- a
+// configuration built by copying identical means into both columns would not
+// exercise the property at all.
+//
+// A quadratic profile runs as a control. The reconstruction does not resolve
+// it, so the integrand is nonzero there, and the gap between the two cases is
+// what makes the linear result meaningful rather than a statement that
+// everything in the test is zero.
+int testMatchedPressIntegrand() {
+
+   int Err = 0;
+
+   const Real Eps = std::numeric_limits<Real>::epsilon();
+   const Real Tol = 16.0_Real;
+
+   const I4 NLayers = 32;
+   const I4 KMin    = 0;
+   const I4 KMax    = NLayers - 1;
+
+   const Real DeltaP = 1.25e6_Real;
+   const Real Bulge  = 6.0_Real * DeltaP;
+   const Real Pi     = 3.14159265358979323846_Real;
+
+   // representative shared edge coefficients; their values cannot affect the
+   // exact-set result, since they multiply a quantity that is identically zero
+   PGradEdgeEos EdgeEos;
+   EdgeEos.SpecVol0    = 9.7e-4_Real;
+   EdgeEos.SpecVolDCt  = -2.5e-7_Real;
+   EdgeEos.SpecVolDSa  = -7.5e-7_Real;
+   EdgeEos.SpecVolDP   = -4.0e-13_Real;
+   EdgeEos.ConservTemp = 8.0_Real;
+   EdgeEos.AbsSalinity = 34.9_Real;
+   EdgeEos.Press       = 2.0e7_Real;
+
+   // the prescribed continuous profile, linear then quadratic in pressure
+   const Real Temp0 = 12.0_Real, Temp1 = -2.0e-7_Real;
+   const Real Salt0 = 34.5_Real, Salt1 = 2.5e-8_Real;
+
+   Real MaxLinear    = 0.0_Real;
+   Real MaxQuadratic = 0.0_Real;
+
+   for (int ICase = 0; ICase < 2; ++ICase) {
+
+      const bool Curved = (ICase == 1);
+      const Real Temp2  = Curved ? 3.0e-15_Real : 0.0_Real;
+      const Real Salt2  = Curved ? -4.0e-16_Real : 0.0_Real;
+
+      // Column 0 is uniform in pressure; column 1 shares its surface and
+      // bottom pressure but is offset from it by up to three layer
+      // thicknesses in between, as coordinate tilt would make it.
+      HostArray2DReal PressInterface("PressInterface", 2, NLayers + 1);
+      HostArray2DReal PressMid("PressMid", 2, NLayers);
+      HostArray2DReal ConservTemp("ConservTemp", 2, NLayers);
+      HostArray2DReal AbsSalinity("AbsSalinity", 2, NLayers);
+      HostArray2DReal SlopeCt("SlopeCt", 2, NLayers);
+      HostArray2DReal SlopeSa("SlopeSa", 2, NLayers);
+
+      for (int ICell = 0; ICell < 2; ++ICell) {
+         for (int K = 0; K <= NLayers; ++K) {
+            const Real Uniform = K * DeltaP;
+            PressInterface(ICell, K) =
+                (ICell == 1) ? Uniform + Bulge * std::sin(Pi * K / NLayers)
+                             : Uniform;
+         }
+         for (int K = 0; K < NLayers; ++K) {
+            PressMid(ICell, K) = 0.5_Real * (PressInterface(ICell, K) +
+                                             PressInterface(ICell, K + 1));
+            ConservTemp(ICell, K) =
+                exactLayerAvg(Temp0, Temp1, Temp2, PressInterface(ICell, K),
+                              PressInterface(ICell, K + 1));
+            AbsSalinity(ICell, K) =
+                exactLayerAvg(Salt0, Salt1, Salt2, PressInterface(ICell, K),
+                              PressInterface(ICell, K + 1));
+         }
+         for (int K = 0; K < NLayers; ++K) {
+            I4 KLo, KHi;
+            linearReconStencil(K, KMin, KMax, KLo, KHi);
+            SlopeCt(ICell, K) = linearReconSlope(
+                ConservTemp(ICell, KLo), ConservTemp(ICell, KHi),
+                PressMid(ICell, KLo), PressMid(ICell, KHi));
+            SlopeSa(ICell, K) = linearReconSlope(
+                AbsSalinity(ICell, KLo), AbsSalinity(ICell, KHi),
+                PressMid(ICell, KLo), PressMid(ICell, KHi));
+         }
+      }
+
+      Real Nodes[MaxPGradQuadPoints];
+      Real Weights[MaxPGradQuadPoints];
+      const I4 NQuad = 2;
+      gaussLegendreRule(NQuad, Nodes, Weights);
+
+      Real MaxScaled = 0.0_Real;
+      Real MaxAbs    = 0.0_Real;
+
+      for (int K = 0; K < NLayers; ++K) {
+
+         // the edge layer spans the average of the two columns' interfaces
+         const Real EdgeTop =
+             0.5_Real * (PressInterface(0, K) + PressInterface(1, K));
+         const Real EdgeBot =
+             0.5_Real * (PressInterface(0, K + 1) + PressInterface(1, K + 1));
+         const Real EdgeMid  = 0.5_Real * (EdgeTop + EdgeBot);
+         const Real EdgeHalf = 0.5_Real * (EdgeBot - EdgeTop);
+
+         for (int IQuad = 0; IQuad < NQuad; ++IQuad) {
+
+            const Real Press = EdgeMid + EdgeHalf * Nodes[IQuad];
+
+            Real TempAt[2];
+            Real SaltAt[2];
+            for (int ICell = 0; ICell < 2; ++ICell) {
+               // each column's own layer containing this pressure, which
+               // under the offset is generally not layer K
+               const I4 KFound = findLayerForPress(PressInterface, ICell, KMin,
+                                                   KMax, Press, K);
+               TempAt[ICell]   = linearReconEval(ConservTemp(ICell, KFound),
+                                                 SlopeCt(ICell, KFound),
+                                                 PressMid(ICell, KFound), Press);
+               SaltAt[ICell]   = linearReconEval(AbsSalinity(ICell, KFound),
+                                                 SlopeSa(ICell, KFound),
+                                                 PressMid(ICell, KFound), Press);
+            }
+
+            const Real SpecVolDiff = matchedPressSpecVolDiff(
+                EdgeEos, TempAt[0], SaltAt[0], TempAt[1], SaltAt[1]);
+
+            // scale by the size of the terms that had to cancel, not by an
+            // absolute constant
+            const Real Scale = std::abs(EdgeEos.SpecVolDCt * TempAt[0]) +
+                               std::abs(EdgeEos.SpecVolDSa * SaltAt[0]);
+
+            MaxAbs = std::max(MaxAbs, std::abs(SpecVolDiff));
+            MaxScaled =
+                std::max(MaxScaled, std::abs(SpecVolDiff) / (Eps * Scale));
+         }
+      }
+
+      LOG_INFO("PGradTest: matched-pressure integrand, {} profile: max "
+               "|dSpecVol| = {} m3/kg = {} eps of the cancelling terms",
+               Curved ? "quadratic" : "linear", MaxAbs, MaxScaled);
+
+      if (Curved) {
+         MaxQuadratic = MaxScaled;
+      } else {
+         MaxLinear = MaxScaled;
+      }
+   }
+
+   if (MaxLinear <= Tol) {
+      LOG_INFO("PGradTest: matched-pressure integrand PASS: {} eps on a "
+               "profile linear in pressure",
+               MaxLinear);
+   } else {
+      LOG_ERROR("PGradTest: matched-pressure integrand FAIL: {} eps on a "
+                "profile linear in pressure exceeds {} eps",
+                MaxLinear, Tol);
+      ++Err;
+   }
+
+   // the linear result means nothing unless the same machinery gives a large
+   // answer on a profile the reconstruction does not resolve
+   if (MaxQuadratic > 1.0e6_Real) {
+      LOG_INFO("PGradTest: matched-pressure integrand control PASS: the "
+               "quadratic profile gives {} eps",
+               MaxQuadratic);
+   } else {
+      LOG_ERROR("PGradTest: matched-pressure integrand control FAIL: the "
+                "quadratic profile gives only {} eps, so the linear result "
+                "may be trivial",
+                MaxQuadratic);
+      ++Err;
+   }
+
+   return Err;
+
+} // end testMatchedPressIntegrand
 
 // Build the two-column test state. Every edge joins cells 0 and 1 and is
 // DC apart. Layer interfaces are staggered between the two columns by
@@ -923,6 +1127,10 @@ int main(int argc, char *argv[]) {
       // tests are the only protection against that failure mode.
       int LookupErr = testPressureLookup();
 
+      // The matched-pressure integrand must be zero at every quadrature
+      // point on a resolved profile, not merely in the integral.
+      int IntegrandErr = testMatchedPressIntegrand();
+
       int IdentityErr = testCenteredIdentity(DefMesh, VCoord, DefState, DefEos);
 
       // Test parsing and dispatch of the PressureGrad configuration options
@@ -936,7 +1144,7 @@ int main(int argc, char *argv[]) {
          RetVal = 1;
       }
 
-      RetVal += ReconErr + LookupErr + IdentityErr + ConfigErr;
+      RetVal += ReconErr + LookupErr + IntegrandErr + IdentityErr + ConfigErr;
 
       // cleanup
       PressureGrad::clear();

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -230,6 +230,163 @@ int testReconstruction() {
 
 } // end testReconstruction
 
+// Pin the per-column pressure lookup with direct property tests, on a
+// fabricated pair of columns and without a mesh.
+//
+// These tests are not optional, and they are the only thing standing between a
+// correct implementation and a silently wrong one. No answer-level check
+// anywhere in the test plan can distinguish looking a column's state up by
+// pressure from looking it up by layer index: on a profile linear in pressure
+// every layer's mean-preserving reconstruction is that same line, so looking
+// up the wrong layer costs nothing, and on a curved profile the two rules
+// differ by less than a factor of two. An implementation that indexes by layer
+// therefore passes every exactness and accuracy gate specified.
+//
+// Two columns are built sharing a surface and a bottom pressure, with the
+// second column's interfaces bulging away from the first in the middle of the
+// column so that the two are strongly offset there -- the situation coordinate
+// tilt produces. Four properties are asserted:
+//
+//   - the returned layer's interfaces actually bracket the pressure;
+//   - the returned layer differs from the edge layer index by at least two
+//     somewhere, so the lookup is demonstrably not an index lookup;
+//   - the answer does not depend on the starting hint, so the incremented
+//     cursors used in the column scan cannot disagree with a search;
+//   - a pressure outside the column clamps to the outermost valid layer, which
+//     is the rule where the edge control volume extends past a column's own
+//     floor.
+int testPressureLookup() {
+
+   int Err = 0;
+
+   const I4 NLayers = 32;
+   const I4 KMin    = 0;
+   const I4 KMax    = NLayers - 1;
+
+   // Column 0 is uniform in pressure; column 1 has the same surface and
+   // bottom pressure but bulges away from it in between, by up to three layer
+   // thicknesses. The bulge is small enough that column 1's interfaces stay
+   // monotonic.
+   const Real DeltaP = 1.25e6_Real;
+   const Real Bulge  = 6.0_Real * DeltaP;
+
+   const Real Pi = 3.14159265358979323846_Real;
+
+   HostArray2DReal PressInterface("PressInterface", 2, NLayers + 1);
+   for (int K = 0; K <= NLayers; ++K) {
+      const Real Uniform   = K * DeltaP;
+      PressInterface(0, K) = Uniform;
+      PressInterface(1, K) = Uniform + Bulge * std::sin(Pi * K / NLayers);
+   }
+
+   // check that column 1 stayed monotonic, or the test is not testing what it
+   // means to
+   for (int K = 0; K < NLayers; ++K) {
+      if (PressInterface(1, K + 1) <= PressInterface(1, K)) {
+         LOG_ERROR("PGradTest: pressure lookup setup FAIL: column 1 is not "
+                   "monotonic at layer {}",
+                   K);
+         ++Err;
+      }
+   }
+
+   I4 MaxOffset     = 0;
+   int NBracketFail = 0;
+   int NHintFail    = 0;
+
+   for (int K = 0; K < NLayers; ++K) {
+
+      // the edge layer's mid pressure, as the edge average of the two
+      // columns' interface pressures
+      const Real PressTop =
+          0.5_Real * (PressInterface(0, K) + PressInterface(1, K));
+      const Real PressBot =
+          0.5_Real * (PressInterface(0, K + 1) + PressInterface(1, K + 1));
+      const Real Press = 0.5_Real * (PressTop + PressBot);
+
+      for (int ICell = 0; ICell < 2; ++ICell) {
+
+         const I4 KFound =
+             findLayerForPress(PressInterface, ICell, KMin, KMax, Press, K);
+
+         // the interfaces of the returned layer must bracket the pressure,
+         // unless the search clamped at an end of the column
+         const bool Above =
+             (KFound == KMin) && (Press < PressInterface(ICell, KMin));
+         const bool Below =
+             (KFound == KMax) && (Press > PressInterface(ICell, KMax + 1));
+         const bool Brackets = Press >= PressInterface(ICell, KFound) &&
+                               Press <= PressInterface(ICell, KFound + 1);
+         if (!Brackets && !Above && !Below)
+            ++NBracketFail;
+
+         const I4 Offset = std::abs(KFound - K);
+         if (Offset > MaxOffset)
+            MaxOffset = Offset;
+
+         // the answer must not depend on where the search started
+         for (I4 KHint = KMin; KHint <= KMax; ++KHint) {
+            if (findLayerForPress(PressInterface, ICell, KMin, KMax, Press,
+                                  KHint) != KFound)
+               ++NHintFail;
+         }
+      }
+   }
+
+   if (NBracketFail == 0) {
+      LOG_INFO("PGradTest: pressure lookup bracketing PASS");
+   } else {
+      LOG_ERROR("PGradTest: pressure lookup bracketing FAIL: {} pressures not "
+                "bracketed by the returned layer",
+                NBracketFail);
+      ++Err;
+   }
+
+   // Under tilt the layer containing a pressure is generally not the edge
+   // layer index. If this never differed by much, the test configuration
+   // would not be exercising the distinction the lookup exists for.
+   if (MaxOffset >= 2) {
+      LOG_INFO("PGradTest: pressure lookup is not an index lookup PASS: "
+               "returned layer differs from the edge layer by up to {}",
+               MaxOffset);
+   } else {
+      LOG_ERROR("PGradTest: pressure lookup is not an index lookup FAIL: "
+                "returned layer never differs from the edge layer by more "
+                "than {}",
+                MaxOffset);
+      ++Err;
+   }
+
+   if (NHintFail == 0) {
+      LOG_INFO("PGradTest: pressure lookup hint independence PASS");
+   } else {
+      LOG_ERROR("PGradTest: pressure lookup hint independence FAIL: {} "
+                "disagreements between starting hints",
+                NHintFail);
+      ++Err;
+   }
+
+   // Pressures outside the column clamp to the outermost valid layer, whose
+   // reconstruction is then extrapolated
+   const Real AboveTop = PressInterface(0, KMin) - DeltaP;
+   const Real BelowBot = PressInterface(0, KMax + 1) + DeltaP;
+   const I4 KAbove =
+       findLayerForPress(PressInterface, 0, KMin, KMax, AboveTop, KMax);
+   const I4 KBelow =
+       findLayerForPress(PressInterface, 0, KMin, KMax, BelowBot, KMin);
+   if (KAbove == KMin && KBelow == KMax) {
+      LOG_INFO("PGradTest: pressure lookup out-of-column clamping PASS");
+   } else {
+      LOG_ERROR("PGradTest: pressure lookup out-of-column clamping FAIL: got "
+                "{} above the column and {} below it",
+                KAbove, KBelow);
+      ++Err;
+   }
+
+   return Err;
+
+} // end testPressureLookup
+
 // Build the two-column test state. Every edge joins cells 0 and 1 and is
 // DC apart. Layer interfaces are staggered between the two columns by
 // TiltFactor, which tilts them relative to surfaces of constant pressure;
@@ -761,6 +918,11 @@ int main(int argc, char *argv[]) {
       // failure here localizes immediately.
       int ReconErr = testReconstruction();
 
+      // Pin the per-column pressure lookup. No answer-level check anywhere
+      // can distinguish this from a layer-index lookup, so these property
+      // tests are the only protection against that failure mode.
+      int LookupErr = testPressureLookup();
+
       int IdentityErr = testCenteredIdentity(DefMesh, VCoord, DefState, DefEos);
 
       // Test parsing and dispatch of the PressureGrad configuration options
@@ -774,7 +936,7 @@ int main(int argc, char *argv[]) {
          RetVal = 1;
       }
 
-      RetVal += ReconErr + IdentityErr + ConfigErr;
+      RetVal += ReconErr + LookupErr + IdentityErr + ConfigErr;
 
       // cleanup
       PressureGrad::clear();

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -29,6 +29,8 @@
 #include "Tracers.h"
 #include "VertCoord.h"
 #include "mpi.h"
+#include <limits>
+#include <vector>
 
 using namespace OMEGA;
 
@@ -90,6 +92,340 @@ void initPGradTest() {
 
    CHECK_ERROR_ABORT(Err, "PGrad: error during initialization");
 }
+
+// Build the two-column test state. Every edge joins cells 0 and 1 and is
+// DC apart. Layer interfaces are staggered between the two columns by
+// TiltFactor, which tilts them relative to surfaces of constant pressure;
+// TiltFactor = 0.5 gives two identical columns and no tilt. Temperature and
+// salinity vary linearly with geometric height. Pseudo-thickness, specific
+// volume and pressure are iterated to consistency, after which the VertCoord
+// pressure and geometric height fields are filled.
+void setupTwoColumnState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
+                         VertCoord *VCoord, ///< [inout] Vertical coordinate
+                         OceanState *State, ///< [inout] Ocean state
+                         Eos *EqState,      ///< [inout] Equation of state
+                         I4 NVertLayers,    ///< [in] Number of layers
+                         Real DC,           ///< [in] Distance between cells
+                         Real TiltFactor,   ///< [in] Interface tilt, 0.5 = none
+                         Real ZBottom       ///< [in] Depth of the sea floor
+) {
+
+   const I4 NCellsAll = Mesh->NCellsAll;
+   const I4 NEdgesAll = Mesh->NEdgesAll;
+
+   VCoord->NVertLayers   = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayers + 1;
+
+   Array2DReal SpecVolOld("SpecVolOld", Mesh->NCellsSize, NVertLayers);
+   Array1DReal SurfacePressure("SurfacePressure", Mesh->NCellsSize);
+
+   auto &MinLayerCell = VCoord->MinLayerCell;
+   auto &MaxLayerCell = VCoord->MaxLayerCell;
+   parallelFor(
+       {NCellsAll}, KOKKOS_LAMBDA(int i) {
+          MinLayerCell(i) = 0;
+          MaxLayerCell(i) = NVertLayers - 1;
+       });
+
+   auto &MinLayerEdgeBot = VCoord->MinLayerEdgeBot;
+   auto &MaxLayerEdgeTop = VCoord->MaxLayerEdgeTop;
+   parallelFor(
+       {NEdgesAll}, KOKKOS_LAMBDA(int i) {
+          MinLayerEdgeBot(i) = 0;
+          MaxLayerEdgeTop(i) = NVertLayers - 1;
+       });
+
+   auto &CellsOnEdge = Mesh->CellsOnEdge;
+   auto &DcEdge      = Mesh->DcEdge;
+   parallelFor(
+       {NEdgesAll}, KOKKOS_LAMBDA(int i) {
+          CellsOnEdge(i, 0) = 0;
+          CellsOnEdge(i, 1) = 1;
+          DcEdge(i)         = DC;
+       });
+
+   // Fetch reference density from Config
+   const Real Density0 = RhoSw;
+
+   const I4 TimeLevel = 0;
+
+   // get state and tracer arrays
+   Array2DReal PseudoThick = State->getPseudoThickness(TimeLevel);
+   Array2DReal Temp        = Tracers::getByName(TimeLevel, "Temperature");
+   Array2DReal Salinity    = Tracers::getByName(TimeLevel, "Salinity");
+
+   // set Z interface and mid-point locations
+   const Real DZ         = 2.0_Real * (-ZBottom / NVertLayers);
+   auto &BottomGeomDepth = VCoord->BottomGeomDepth;
+   auto &GeomZInterface  = VCoord->GeomZInterface;
+   auto &GeomZMid        = VCoord->GeomZMid;
+   parallelFor(
+       {NCellsAll}, KOKKOS_LAMBDA(int i) {
+          GeomZInterface(i, NVertLayers) = ZBottom;
+          SurfacePressure(i)             = 0.0_Real;
+          BottomGeomDepth(i)             = 0.0_Real;
+          for (int k = NVertLayers - 1; k >= 0; --k) {
+             Real X = (k + i) % 2;
+             Real Dz =
+                 (2.0_Real * TiltFactor - 1.0_Real) * X * DZ +
+                 (1.0_Real - TiltFactor) * DZ; // staggered pseudo-thickness
+             GeomZInterface(i, k) = GeomZInterface(i, k + 1) + Dz;
+             PseudoThick(i, k) =
+                 GeomZInterface(i, k) - GeomZInterface(i, k + 1);
+             GeomZMid(i, k) =
+                 0.5_Real * (GeomZInterface(i, k) + GeomZInterface(i, k + 1));
+             BottomGeomDepth(i) += Dz;
+          }
+       });
+
+   // set simple temperature and salinity profiles
+   auto &SpecVol = EqState->SpecVol;
+   parallelFor(
+       {NCellsAll, NVertLayers}, KOKKOS_LAMBDA(int i, int k) {
+          Real T0 = 30.0;
+          Real TB = 5.0;
+          Real S0 = 30.0;
+          Real SB = 40.0;
+
+          Real Phi0 = (GeomZMid(i, k) - ZBottom) / (-ZBottom);
+          Real PhiB = 1.0_Real - Phi0;
+
+          Temp(i, k)       = T0 * Phi0 + TB * PhiB;
+          Salinity(i, k)   = S0 * Phi0 + SB * PhiB;
+          SpecVol(i, k)    = 1.0_Real / Density0;
+          SpecVolOld(i, k) = SpecVol(i, k);
+       });
+
+   // Iterate to converge PseudoThick, SpecVol, PressureMid
+   auto &PressureMid = VCoord->PressureMid;
+   VCoord->computePressure(PseudoThick, SurfacePressure);
+   for (int Iteration = 0; Iteration < 15; ++Iteration) {
+
+      // compute specific volume from EOS
+      VCoord->computePressure(PseudoThick, SurfacePressure);
+      EqState->computeSpecVol(Temp, Salinity, PressureMid);
+
+      // compute psuedo thickness from specific volume
+      parallelFor(
+          {NCellsAll, NVertLayers}, KOKKOS_LAMBDA(int i, int k) {
+             PseudoThick(i, k) =
+                 1.0_Real / (SpecVol(i, k) * Density0) *
+                 (GeomZInterface(i, k) - GeomZInterface(i, k + 1));
+          });
+
+      // compute difference from previous iteration
+      Real MaxValue = 0.0_Real;
+      parallelReduce(
+          {NCellsAll, NVertLayers},
+          KOKKOS_LAMBDA(int i, int k, Real &max) {
+             Real Diff = Kokkos::abs(SpecVol(i, k) - SpecVolOld(i, k));
+             if (Diff > max)
+                max = Diff;
+          },
+          Kokkos::Max<Real>(MaxValue));
+
+      // check convergence
+      if (MaxValue < 1e-12_Real) {
+         LOG_INFO("converged: max diff = {}", MaxValue);
+         break;
+      } else {
+         parallelFor(
+             {NCellsAll, NVertLayers},
+             KOKKOS_LAMBDA(int i, int k) { SpecVolOld(i, k) = SpecVol(i, k); });
+      }
+   }
+
+   // compute pressure once more with converged PseudoThick
+   VCoord->computePressure(PseudoThick, SurfacePressure);
+
+   // compute z levels
+   VCoord->computeGeomZHeight(PseudoThick, SpecVol);
+
+} // end setupTwoColumnState
+
+// Assert the identity of design section 3.9 (test section 5.5): with the tidal
+// and self-attraction-and-loading potentials zero, PressureGradCentered is
+// exactly
+//
+//    -g / d_e * S_{e,k}
+//    S_{e,k} = 1/2 (dZ_k + dZ_{k+1}) + alphaBar / (2 g) (dq_k + dq_{k+1})
+//
+// where dZ and dq are the cross-edge differences of GeomZInterface and
+// PressureInterface and alphaBar is the edge average of SpecVol. S is the
+// first-order conversion of a height difference taken at fixed layer index
+// into one taken at fixed pressure, so this pins what error the centered
+// scheme makes as well as what it computes.
+//
+// This is a permanent regression test rather than a transitional one. Because
+// the two expressions read the mesh, VertCoord and Eos state through
+// independently written code, their agreement tests the shared upstream state
+// -- edge masks, interface indexing, VertCoord conventions -- and not just the
+// pressure gradient arithmetic. Expect agreement to round-off rather than
+// bit-for-bit: PressureMid may be formed as zBot + h/2 rather than as the mean
+// of the two interface pressures, which is algebraically but not bitwise the
+// same.
+int testCenteredIdentity(HorzMesh *Mesh,    ///< [in] Horizontal mesh
+                         VertCoord *VCoord, ///< [inout] Vertical coordinate
+                         OceanState *State, ///< [inout] Ocean state
+                         Eos *EqState       ///< [inout] Equation of state
+) {
+
+   int Err = 0;
+
+   PressureGrad *DefPGrad = PressureGrad::getDefault();
+   if (!DefPGrad || DefPGrad->getType() != PressureGradType::Centered) {
+      LOG_ERROR("PGradTest: centered identity needs a Centered default");
+      return 1;
+   }
+
+   const I4 NVertLayers = 60;
+   const Real DC        = 30000.0_Real;
+   const Real ZBottom   = -1000.0_Real;
+   const Real Eps       = std::numeric_limits<Real>::epsilon();
+
+   // Round-off in the centered functor is set by the size of the hydrostatic
+   // terms it forms and cancels, so the tolerance is scaled by those rather
+   // than by their differences. Measured at or below half an epsilon; the
+   // factor here is headroom for compiler and precision differences.
+   const Real Tol = 16.0_Real;
+
+   // A sweep of tilts, with 0.5 the untilted case
+   const std::vector<Real> Tilts = {0.5, 0.49, 0.45, 0.4, 0.3, 0.2, 0.1, 0.05};
+
+   Real MaxResid = 0.0_Real;
+   Real MinGuard = std::numeric_limits<Real>::max();
+
+   for (Real TiltFactor : Tilts) {
+
+      setupTwoColumnState(Mesh, VCoord, State, EqState, NVertLayers, DC,
+                          TiltFactor, ZBottom);
+
+      Array2DReal Tend("TendCentered", Mesh->NEdgesSize, NVertLayers);
+      deepCopy(Tend, 0.0_Real);
+
+      Array2DReal PseudoThick = State->getPseudoThickness(0);
+      Array2DReal Temp        = Tracers::getByName(0, "Temperature");
+      Array2DReal Salinity    = Tracers::getByName(0, "Salinity");
+
+      const auto &PressureMid       = VCoord->PressureMid;
+      const auto &PressureInterface = VCoord->PressureInterface;
+      const auto &GeomZInterface    = VCoord->GeomZInterface;
+      const auto &EdgeMask          = VCoord->EdgeMask;
+      const auto &SpecVol           = EqState->SpecVol;
+      const auto &CellsOnEdge       = Mesh->CellsOnEdge;
+      const auto &DcEdge            = Mesh->DcEdge;
+
+      DefPGrad->computePressureGrad(Tend, PressureMid, PressureInterface,
+                                    SpecVol, GeomZInterface, PseudoThick, Temp,
+                                    Salinity, EqState);
+
+      // Residual of the identity, in units of eps times the hydrostatic
+      // scale, and the same measure for a deliberately broken version of the
+      // identity that drops the pressure half of S. The guard is what makes
+      // the check non-vacuous: a mis-derivation must miss by far more than
+      // the tolerance.
+      Real LocResid = 0.0_Real;
+      Real LocGuard = std::numeric_limits<Real>::max();
+      parallelReduce(
+          {Mesh->NEdgesAll, NVertLayers},
+          KOKKOS_LAMBDA(int IEdge, int K, Real &MaxR, Real &MinG) {
+             const I4 ICell0  = CellsOnEdge(IEdge, 0);
+             const I4 ICell1  = CellsOnEdge(IEdge, 1);
+             const Real InvDc = 1.0_Real / DcEdge(IEdge);
+
+             const Real Z0K  = GeomZInterface(ICell0, K);
+             const Real Z1K  = GeomZInterface(ICell1, K);
+             const Real Z0K1 = GeomZInterface(ICell0, K + 1);
+             const Real Z1K1 = GeomZInterface(ICell1, K + 1);
+
+             const Real Q0K  = PressureInterface(ICell0, K);
+             const Real Q1K  = PressureInterface(ICell1, K);
+             const Real Q0K1 = PressureInterface(ICell0, K + 1);
+             const Real Q1K1 = PressureInterface(ICell1, K + 1);
+
+             const Real AlphaBar =
+                 0.5_Real * (SpecVol(ICell0, K) + SpecVol(ICell1, K));
+
+             const Real ShiftZ = 0.5_Real * ((Z1K - Z0K) + (Z1K1 - Z0K1));
+             const Real ShiftQ = AlphaBar / (2.0_Real * Gravity) *
+                                 ((Q1K - Q0K) + (Q1K1 - Q0K1));
+
+             const Real Expected =
+                 EdgeMask(IEdge, K) * (-Gravity * InvDc) * (ShiftZ + ShiftQ);
+             const Real Broken =
+                 EdgeMask(IEdge, K) * (-Gravity * InvDc) * ShiftZ;
+
+             // the hydrostatic terms the centered functor forms and cancels
+             const Real HydroScale =
+                 InvDc * 0.25_Real *
+                 (Gravity * (Kokkos::abs(Z0K) + Kokkos::abs(Z1K) +
+                             Kokkos::abs(Z0K1) + Kokkos::abs(Z1K1)) +
+                  AlphaBar * (Kokkos::abs(Q0K) + Kokkos::abs(Q1K) +
+                              Kokkos::abs(Q0K1) + Kokkos::abs(Q1K1)));
+
+             const Real Resid = Kokkos::abs(Tend(IEdge, K) - Expected);
+             const Real Guard = Kokkos::abs(Tend(IEdge, K) - Broken);
+
+             // masked edges carry no tendency, so neither expression has
+             // anything to say there
+             if (EdgeMask(IEdge, K) > 0.0_Real && HydroScale > 0.0_Real) {
+                const Real Scale = Eps * HydroScale;
+                if (Resid / Scale > MaxR)
+                   MaxR = Resid / Scale;
+                if (Guard / Scale < MinG)
+                   MinG = Guard / Scale;
+             }
+          },
+          Kokkos::Max<Real>(LocResid), Kokkos::Min<Real>(LocGuard));
+
+      LOG_INFO("PGradTest: centered identity at tilt {}: residual {} eps, "
+               "dropped-pressure-term guard {} eps",
+               TiltFactor, LocResid, LocGuard);
+
+      if (LocResid > MaxResid)
+         MaxResid = LocResid;
+      // the untilted case has nothing for the guard to detect
+      if (TiltFactor != 0.5_Real && LocGuard < MinGuard)
+         MinGuard = LocGuard;
+   }
+
+   if (MaxResid <= Tol) {
+      LOG_INFO("PGradTest: centered identity PASS: max residual {} eps",
+               MaxResid);
+   } else {
+      LOG_ERROR("PGradTest: centered identity FAIL: max residual {} eps "
+                "exceeds {} eps",
+                MaxResid, Tol);
+      ++Err;
+   }
+
+   // A mis-derivation that drops the pressure half of S misses by many orders
+   // of magnitude; if it does not, the identity is being satisfied trivially.
+   //
+   // The comparison is against the residual rather than against an absolute
+   // count of epsilons. Both quantities are measured in epsilons of the same
+   // scale, so their ratio is what the check is really about, and it means
+   // the same thing in either precision: an absolute threshold of a thousand
+   // epsilons happens to leave a comfortable margin in double precision and
+   // only a factor of 1.4 in single, which is too near the edge for a check
+   // whose whole purpose is to prove the identity is not vacuous.
+   const Real GuardRatio =
+       (MaxResid > 0.0_Real) ? MinGuard / MaxResid : 0.0_Real;
+   if (GuardRatio > 100.0_Real) {
+      LOG_INFO("PGradTest: centered identity guard PASS: dropping the "
+               "pressure term misses by {} eps, {} times the residual",
+               MinGuard, GuardRatio);
+   } else {
+      LOG_ERROR("PGradTest: centered identity guard FAIL: dropping the "
+                "pressure term changes the answer by only {} eps, {} times "
+                "the residual",
+                MinGuard, GuardRatio);
+      ++Err;
+   }
+
+   return Err;
+
+} // end testCenteredIdentity
 
 // Check that the PressureGrad configuration group is parsed as expected and
 // that a FiniteVolume instance can be created and dispatched to. The
@@ -204,162 +540,38 @@ int main(int argc, char *argv[]) {
 
       // create arrays: Tend on edges, Pressure/Geopotential/SpecVol on cells
       Array2DReal Tend("Tend", DefMesh->NEdgesSize, VCoord->NVertLayers);
-      Array2DReal SpecVolOld("SpecVolOld", DefMesh->NCellsSize,
-                             VCoord->NVertLayers);
-      Array2DReal PressureMidOld("PressureMidOld", DefMesh->NCellsSize,
-                                 VCoord->NVertLayers);
-      Array1DReal SurfacePressure("SurfacePressure", DefMesh->NCellsSize);
 
       I4 NEdgesAll = DefMesh->NEdgesAll;
-      I4 NCellsAll = DefMesh->NCellsAll;
 
       I4 NVertLayers  = 60;
       Real DC         = 30000.0_Real;
+      Real TiltFactor = 0.495_Real;
+      Real ZBottom    = -1000.0_Real;
       I4 NRefinements = 4;
       HostArray1DReal Rmse("Rmse", NRefinements);
       for (int Refinement = 0; Refinement < NRefinements; ++Refinement) {
 
          LOG_INFO("PGradTest: Starting refinement level {}", Refinement);
-         VCoord->NVertLayers   = NVertLayers;
-         VCoord->NVertLayersP1 = NVertLayers + 1;
 
-         auto &MinLayerCell = VCoord->MinLayerCell;
-         auto &MaxLayerCell = VCoord->MaxLayerCell;
-         parallelFor(
-             {NCellsAll}, KOKKOS_LAMBDA(int i) {
-                MinLayerCell(i) = 0;
-                MaxLayerCell(i) = NVertLayers - 1;
-             });
+         setupTwoColumnState(DefMesh, VCoord, DefState, DefEos, NVertLayers, DC,
+                             TiltFactor, ZBottom);
 
-         auto &MinLayerEdgeBot = VCoord->MinLayerEdgeBot;
-         auto &MaxLayerEdgeTop = VCoord->MaxLayerEdgeTop;
-         parallelFor(
-             {NEdgesAll}, KOKKOS_LAMBDA(int i) {
-                MinLayerEdgeBot(i) = 0;
-                MaxLayerEdgeTop(i) = NVertLayers - 1;
-             });
-
-         auto &CellsOnEdge = DefMesh->CellsOnEdge;
-         auto &DcEdge      = DefMesh->DcEdge;
-         parallelFor(
-             {NEdgesAll}, KOKKOS_LAMBDA(int i) {
-                CellsOnEdge(i, 0) = 0;
-                CellsOnEdge(i, 1) = 1;
-                DcEdge(i)         = DC;
-             });
-
-         // Fetch reference desnity from Config
-         Real Density0;
-         Density0 = RhoSw;
-
-         I4 TimeLevel = 0;
-
-         // get state and tracer arrays
-         Array2DReal PseudoThick = DefState->getPseudoThickness(TimeLevel);
-         Array2DReal Temp        = Tracers::getByName(TimeLevel, "Temperature");
-         Array2DReal Salinity    = Tracers::getByName(TimeLevel, "Salinity");
-
-         // set Z interface and mid-point locations
-         Real ZBottom          = -1000.0_Real;
-         Real DZ               = 2.0_Real * (-ZBottom / NVertLayers);
-         auto &BottomGeomDepth = VCoord->BottomGeomDepth;
-         auto &GeomZInterface  = VCoord->GeomZInterface;
-         auto &GeomZMid        = VCoord->GeomZMid;
-         Real TiltFactor       = 0.495_Real;
-         parallelFor(
-             {NCellsAll}, KOKKOS_LAMBDA(int i) {
-                GeomZInterface(i, NVertLayers) = ZBottom;
-                SurfacePressure(i)             = 0.0_Real;
-                BottomGeomDepth(i)             = 0.0_Real;
-                for (int k = NVertLayers - 1; k >= 0; --k) {
-                   Real X  = (k + i) % 2;
-                   Real Dz = (2.0_Real * TiltFactor - 1.0_Real) * X * DZ +
-                             (1.0_Real - TiltFactor) *
-                                 DZ; // staggered pseudo-thickness
-                   GeomZInterface(i, k) = GeomZInterface(i, k + 1) + Dz;
-                   PseudoThick(i, k) =
-                       GeomZInterface(i, k) - GeomZInterface(i, k + 1);
-                   GeomZMid(i, k) = 0.5_Real * (GeomZInterface(i, k) +
-                                                GeomZInterface(i, k + 1));
-                   BottomGeomDepth(i) += Dz;
-                }
-             });
+         Array2DReal PseudoThick = DefState->getPseudoThickness(0);
+         Array2DReal Temp        = Tracers::getByName(0, "Temperature");
+         Array2DReal Salinity    = Tracers::getByName(0, "Salinity");
+         auto &SpecVol           = DefEos->SpecVol;
+         auto &PressureMid       = VCoord->PressureMid;
+         auto &GeomZInterface    = VCoord->GeomZInterface;
 
          LOG_INFO("NVertLayers = {}", NVertLayers);
          LOG_INFO("dC = {}", DC);
          DefState->copyToHost(0);
-         HostArray2DReal PseudoThickH =
-             DefState->getPseudoThicknessH(TimeLevel);
+         HostArray2DReal PseudoThickH = DefState->getPseudoThicknessH(0);
          for (int i = 0; i < 2; ++i) {
             for (int k = 0; k < 2; ++k) {
                LOG_INFO("PseudoThick({}, {}) = {}", i, k, PseudoThickH(i, k));
             }
          }
-
-         // set simple temperature and salinity profiles
-         auto &SpecVol = DefEos->SpecVol;
-         parallelFor(
-             {NCellsAll, NVertLayers}, KOKKOS_LAMBDA(int i, int k) {
-                Real T0 = 30.0;
-                Real TB = 5.0;
-                Real S0 = 30.0;
-                Real SB = 40.0;
-
-                Real Phi0 = (GeomZMid(i, k) - ZBottom) / (-ZBottom);
-                Real PhiB = 1.0_Real - Phi0;
-
-                Temp(i, k)       = T0 * Phi0 + TB * PhiB;
-                Salinity(i, k)   = S0 * Phi0 + SB * PhiB;
-                SpecVol(i, k)    = 1.0_Real / Density0;
-                SpecVolOld(i, k) = SpecVol(i, k);
-             });
-
-         // Iterate to converge PseudoThick, SpecVol, PressureMid
-         auto &PressureMid = VCoord->PressureMid;
-         VCoord->computePressure(PseudoThick, SurfacePressure);
-         deepCopy(PressureMidOld, PressureMid);
-         for (int Iteration = 0; Iteration < 15; ++Iteration) {
-
-            // compute specific volume from EOS
-            VCoord->computePressure(PseudoThick, SurfacePressure);
-            DefEos->computeSpecVol(Temp, Salinity, PressureMid);
-
-            // compute psuedo thickness from specific volume
-            parallelFor(
-                {NCellsAll, NVertLayers}, KOKKOS_LAMBDA(int i, int k) {
-                   PseudoThick(i, k) =
-                       1.0_Real / (SpecVol(i, k) * Density0) *
-                       (GeomZInterface(i, k) - GeomZInterface(i, k + 1));
-                });
-
-            // compute difference from previous iteration
-            Real MaxValue = 0.0_Real;
-            parallelReduce(
-                {NCellsAll, NVertLayers},
-                KOKKOS_LAMBDA(int i, int k, Real &max) {
-                   Real Diff = Kokkos::abs(SpecVol(i, k) - SpecVolOld(i, k));
-                   if (Diff > max)
-                      max = Diff;
-                },
-                Kokkos::Max<Real>(MaxValue));
-
-            // check convergence
-            if (MaxValue < 1e-12_Real) {
-               LOG_INFO("converged: max diff = {}", MaxValue);
-               break;
-            } else {
-               parallelFor(
-                   {NCellsAll, NVertLayers}, KOKKOS_LAMBDA(int i, int k) {
-                      SpecVolOld(i, k) = SpecVol(i, k);
-                   });
-            }
-         }
-
-         // compute pressure once more with converged PseudoThick
-         VCoord->computePressure(PseudoThick, SurfacePressure);
-
-         // compute z levels
-         VCoord->computeGeomZHeight(PseudoThick, SpecVol);
 
          // get PressureGrad instance
          PressureGrad *DefPGrad = PressureGrad::getDefault();
@@ -404,6 +616,11 @@ int main(int argc, char *argv[]) {
 
       } // refinement loop
 
+      // Test the centered identity of design section 3.9 across a sweep of
+      // tilts. This resets the two-column state, so it runs after the
+      // refinement loop.
+      int IdentityErr = testCenteredIdentity(DefMesh, VCoord, DefState, DefEos);
+
       // Test parsing and dispatch of the PressureGrad configuration options
       int ConfigErr = testPGradConfig(DefMesh, VCoord);
 
@@ -415,7 +632,7 @@ int main(int argc, char *argv[]) {
          RetVal = 1;
       }
 
-      RetVal += ConfigErr;
+      RetVal += IdentityErr + ConfigErr;
 
       // cleanup
       PressureGrad::clear();

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -700,7 +700,9 @@ void setupTwoColumnState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
    VCoord->computePressure(PseudoThick, SurfacePressure);
    for (int Iteration = 0; Iteration < 15; ++Iteration) {
 
-      // compute specific volume from EOS
+      // compute specific volume from EOS. This fills SpecVol only, not the
+      // derivatives the FiniteVolume scheme needs; a test running that scheme
+      // on this state must fill them itself.
       VCoord->computePressure(PseudoThick, SurfacePressure);
       EqState->computeSpecVol(Temp, Salinity, PressureMid);
 
@@ -965,6 +967,47 @@ int testColumnScan(HorzMesh *Mesh,    ///< [in] Horizontal mesh
       ++Err;
    }
 
+   // The tendency itself on the same state. Reported alongside the centered
+   // scheme's, which is nonzero and tilt-dependent, so that a pass is a
+   // cancellation against a known nonzero reference rather than a comparison
+   // with zero. The gate here is provisional; the full exactness gate and its
+   // guards follow.
+   Array2DReal TendCentered("TendCentered", Mesh->NEdgesSize, NVertLayers);
+   deepCopy(TendCentered, 0.0_Real);
+   PressureGrad *DefPGrad = PressureGrad::getDefault();
+   DefPGrad->computePressureGrad(TendCentered, VCoord->PressureMid,
+                                 VCoord->PressureInterface, EqState->SpecVol,
+                                 VCoord->GeomZInterface, PseudoThick, Temp,
+                                 Salinity, EqState);
+
+   const auto &EdgeMask = VCoord->EdgeMask;
+   Real MaxFV           = 0.0_Real;
+   Real MaxCentered     = 0.0_Real;
+   parallelReduce(
+       {Mesh->NEdgesAll, NVertLayers},
+       KOKKOS_LAMBDA(int IEdge, int K, Real &MaxF, Real &MaxC) {
+          if (EdgeMask(IEdge, K) <= 0.0_Real)
+             return;
+          const Real F = Kokkos::abs(Tend(IEdge, K));
+          const Real C = Kokkos::abs(TendCentered(IEdge, K));
+          if (F > MaxF)
+             MaxF = F;
+          if (C > MaxC)
+             MaxC = C;
+       },
+       Kokkos::Max<Real>(MaxFV), Kokkos::Max<Real>(MaxCentered));
+
+   LOG_INFO("PGradTest: tendency on the exact set: FiniteVolume max |Tend| = "
+            "{} m/s2, Centered max |Tend| = {} m/s2",
+            MaxFV, MaxCentered);
+
+   // the centered scheme must be nonzero here, or the comparison says nothing
+   if (MaxCentered <= 0.0_Real) {
+      LOG_ERROR("PGradTest: exact-set state FAIL: the centered scheme returns "
+                "zero, so the state does not exercise the property");
+      ++Err;
+   }
+
    PressureGrad::erase("TestColumnScan");
 
    return Err;
@@ -1209,7 +1252,18 @@ int testPGradConfig(const HorzMesh *Mesh,   ///< [in] Horizontal mesh
    }
 
    // Dispatch check: computePressureGrad must take the FiniteVolume branch
-   // and leave a finite tendency everywhere it touches
+   // and produce a tendency of the same order as the centered scheme's on the
+   // same state.
+   //
+   // The specific volume derivatives are computed first. In a run they are
+   // filled by AuxiliaryState, which calls computeSpecVolAndDerivs whenever
+   // the FiniteVolume scheme is selected; here the state was built by a
+   // helper that fills SpecVol alone, so without this the scheme would read
+   // the fill value the fields were attached with. That is worth being
+   // explicit about: checking only for finiteness let this go unnoticed in
+   // double precision, where a fill value of 1e37 propagates through the
+   // arithmetic without overflowing, and it surfaced only in a
+   // single-precision build, where it does.
    OceanState *State       = OceanState::getDefault();
    Eos *EqState            = Eos::getInstance();
    Array2DReal PseudoThick = State->getPseudoThickness(0);
@@ -1220,24 +1274,55 @@ int testPGradConfig(const HorzMesh *Mesh,   ///< [in] Horizontal mesh
    Array2DReal ConservTemp = Tracers::getByName(0, "Temperature");
    Array2DReal AbsSalinity = Tracers::getByName(0, "Salinity");
 
+   EqState->computeSpecVolAndDerivs(ConservTemp, AbsSalinity,
+                                    VCoord->PressureMid);
+
    FVPGrad->computePressureGrad(
        TendFV, VCoord->PressureMid, VCoord->PressureInterface, EqState->SpecVol,
        VCoord->GeomZInterface, PseudoThick, ConservTemp, AbsSalinity, EqState);
 
-   I4 NBad = 0;
+   Array2DReal TendCtr("TendCentered", Mesh->NEdgesSize, VCoord->NVertLayers);
+   deepCopy(TendCtr, 0.0_Real);
+   PressureGrad::getDefault()->computePressureGrad(
+       TendCtr, VCoord->PressureMid, VCoord->PressureInterface,
+       EqState->SpecVol, VCoord->GeomZInterface, PseudoThick, ConservTemp,
+       AbsSalinity, EqState);
+
+   I4 NBad     = 0;
+   Real MaxFV  = 0.0_Real;
+   Real MaxCtr = 0.0_Real;
    parallelReduce(
        {Mesh->NEdgesAll, VCoord->NVertLayers},
-       KOKKOS_LAMBDA(int IEdge, int K, I4 &LSum) {
-          if (!Kokkos::isfinite(TendFV(IEdge, K)))
+       KOKKOS_LAMBDA(int IEdge, int K, I4 &LSum, Real &MaxF, Real &MaxC) {
+          const Real F = Kokkos::abs(TendFV(IEdge, K));
+          const Real C = Kokkos::abs(TendCtr(IEdge, K));
+          if (!Kokkos::isfinite(TendFV(IEdge, K))) {
              ++LSum;
+          } else if (F > MaxF) {
+             MaxF = F;
+          }
+          if (C > MaxC)
+             MaxC = C;
        },
-       Kokkos::Sum<I4>(NBad));
+       Kokkos::Sum<I4>(NBad), Kokkos::Max<Real>(MaxFV),
+       Kokkos::Max<Real>(MaxCtr));
 
-   if (NBad == 0) {
+   // The two schemes agree to second order in the cross-edge pressure
+   // difference, so on any ordinary state they come out the same order of
+   // magnitude. Requiring that as well as finiteness is what keeps this check
+   // from passing on garbage: a fill value would be off by thirty orders.
+   const Real Ratio = (MaxCtr > 0.0_Real) ? MaxFV / MaxCtr : 0.0_Real;
+
+   LOG_INFO("PGradTest: FiniteVolume dispatch: max |Tend| = {} m/s2 against "
+            "Centered {} m/s2, ratio {}",
+            MaxFV, MaxCtr, Ratio);
+
+   if (NBad == 0 && Ratio > 1.0e-3_Real && Ratio < 1.0e3_Real) {
       LOG_INFO("PGradTest: FiniteVolume dispatch PASS");
    } else {
-      LOG_ERROR("PGradTest: FiniteVolume dispatch FAIL: {} non-finite values",
-                NBad);
+      LOG_ERROR("PGradTest: FiniteVolume dispatch FAIL: {} non-finite values, "
+                "ratio to the centered scheme {}",
+                NBad, Ratio);
       ++Err;
    }
 

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -396,14 +396,25 @@ KOKKOS_INLINE_FUNCTION Real exactLayerAvg(
     const Real Coeff0,  ///< [in] constant term
     const Real Coeff1,  ///< [in] coefficient of p
     const Real Coeff2,  ///< [in] coefficient of p squared
+    const Real Coeff3,  ///< [in] coefficient of p cubed
     const Real PressLo, ///< [in] top interface pressure
     const Real PressHi  ///< [in] bottom interface pressure
 ) {
-   const Real PressMid   = 0.5_Real * (PressLo + PressHi);
-   const Real DeltaPress = PressHi - PressLo;
+   const Real PressMid = 0.5_Real * (PressLo + PressHi);
+   const Real HalfSq   = 0.25_Real * (PressHi - PressLo) * (PressHi - PressLo);
    return Coeff0 + Coeff1 * PressMid +
-          Coeff2 * (PressMid * PressMid + DeltaPress * DeltaPress / 12.0_Real);
+          Coeff2 * (PressMid * PressMid + HalfSq / 3.0_Real) +
+          Coeff3 * (PressMid * PressMid * PressMid + PressMid * HalfSq);
 }
+
+// A prescribed continuous profile of temperature and salinity in pressure, up
+// to cubic. Linear is the exact set of the Phase 1 reconstruction; quadratic
+// and cubic lie outside it, where the residual should shrink like the square
+// of the layer thickness.
+struct PGradProfile {
+   Real Temp0, Temp1, Temp2, Temp3;
+   Real Salt0, Salt1, Salt2, Salt3;
+};
 
 // Check the matched-pressure integrand on a fabricated column pair, without a
 // mesh. This exercises the reconstruction, the pressure lookup and the
@@ -480,14 +491,14 @@ int testMatchedPressIntegrand() {
                              : Uniform;
          }
          for (int K = 0; K < NLayers; ++K) {
-            PressMid(ICell, K) = 0.5_Real * (PressInterface(ICell, K) +
+            PressMid(ICell, K)    = 0.5_Real * (PressInterface(ICell, K) +
                                              PressInterface(ICell, K + 1));
-            ConservTemp(ICell, K) =
-                exactLayerAvg(Temp0, Temp1, Temp2, PressInterface(ICell, K),
-                              PressInterface(ICell, K + 1));
-            AbsSalinity(ICell, K) =
-                exactLayerAvg(Salt0, Salt1, Salt2, PressInterface(ICell, K),
-                              PressInterface(ICell, K + 1));
+            ConservTemp(ICell, K) = exactLayerAvg(Temp0, Temp1, Temp2, 0.0_Real,
+                                                  PressInterface(ICell, K),
+                                                  PressInterface(ICell, K + 1));
+            AbsSalinity(ICell, K) = exactLayerAvg(Salt0, Salt1, Salt2, 0.0_Real,
+                                                  PressInterface(ICell, K),
+                                                  PressInterface(ICell, K + 1));
          }
          for (int K = 0; K < NLayers; ++K) {
             I4 KLo, KHi;
@@ -744,33 +755,35 @@ void setupTwoColumnState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
 
 } // end setupTwoColumnState
 
-// Build a two-column state whose vertical profile lies in the scheme's exact
-// set: temperature and salinity vary linearly with pressure, and each column's
-// layer means are the *exact layer averages* of that one continuous profile
-// over that column's own layers.
+// Build a two-column state whose vertical profile is a prescribed continuous
+// function of pressure, with each column's layer means set to the *exact layer
+// averages* of that one profile over that column's own layers.
 //
 // Under the offset between the two columns those averages come out different
-// in the two, and that is the point. A configuration built by copying
-// identical layer means into both columns would not exercise the property at
-// all, because the condition that matters is a property of the reconstructed
-// profiles rather than of the layer means.
+// in the two, and that is the point. A configuration built by copying identical
+// layer means into both columns would not exercise the property at all, because
+// the condition that matters is a property of the reconstructed profiles rather
+// than of the layer means.
 //
-// The two columns share a surface pressure and a bottom pressure and sit on a
-// flat floor; only the distribution of pressure between them differs, which is
-// what an ALE coordinate does. A horizontally uniform surface pressure is
-// required for an exactness gate: where surface pressure varies the state
-// carries a real fixed-pressure height difference at the surface and zero is
-// the wrong expectation.
+// The two columns sit on a flat floor and differ only in how pressure is
+// distributed between their interfaces, which is what an ALE coordinate does.
+// SurfPressDiff offsets the second column's surface pressure, and hence its
+// bottom pressure; the exactness gate must be run with it zero, since where
+// surface pressure varies the state carries a real fixed-pressure height
+// difference and zero is the wrong expectation. It is nonzero only for the
+// anchor guard, which needs the two columns' end pressures to differ.
 //
-// Returns the bottom pressure so tests can scale their tolerances by the
-// hydrostatic terms.
-Real setupExactSetState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
-                        VertCoord *VCoord, ///< [inout] Vertical coordinate
-                        OceanState *State, ///< [inout] Ocean state
-                        Eos *EqState,      ///< [inout] Equation of state
-                        I4 NVertLayers,    ///< [in] Number of layers
-                        Real DC,           ///< [in] Distance between cells
-                        Real Offset        ///< [in] interface offset, in layers
+// Returns the pressure at the bottom of the columns, so tests can scale their
+// tolerances by the hydrostatic terms.
+Real setupProfileState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
+                       VertCoord *VCoord, ///< [inout] Vertical coordinate
+                       OceanState *State, ///< [inout] Ocean state
+                       Eos *EqState,      ///< [inout] Equation of state
+                       I4 NVertLayers,    ///< [in] Number of layers
+                       Real DC,           ///< [in] Distance between cells
+                       Real BulgePress,   ///< [in] interface offset, in Pa
+                       PGradProfile Prof, ///< [in] prescribed profile
+                       Real SurfPressDiff ///< [in] surface pressure contrast
 ) {
 
    const I4 NCellsAll = Mesh->NCellsAll;
@@ -779,14 +792,9 @@ Real setupExactSetState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
    VCoord->NVertLayers   = NVertLayers;
    VCoord->NVertLayersP1 = NVertLayers + 1;
 
-   // the prescribed continuous profile, linear in pressure
    const Real PressBot = 4.0e7_Real;
-   const Real Temp0 = 12.0_Real, Temp1 = -2.0e-7_Real;
-   const Real Salt0 = 34.0_Real, Salt1 = 2.5e-8_Real;
-   const Real Pi = 3.14159265358979323846_Real;
-
-   const Real DeltaP = PressBot / NVertLayers;
-   const Real Bulge  = Offset * DeltaP;
+   const Real Pi       = 3.14159265358979323846_Real;
+   const Real DeltaP   = PressBot / NVertLayers;
 
    auto &MinLayerCell = VCoord->MinLayerCell;
    auto &MaxLayerCell = VCoord->MaxLayerCell;
@@ -818,24 +826,26 @@ Real setupExactSetState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
    Array2DReal Temp        = Tracers::getByName(0, "Temperature");
    Array2DReal Salinity    = Tracers::getByName(0, "Salinity");
 
-   // Column 0 is uniform in pressure; column 1 bulges away from it by up to
-   // Offset layer thicknesses in the interior while sharing both end
-   // pressures. Pseudo-thickness and pressure thickness are proportional, so
-   // setting one sets the other.
+   // Column 0 is uniform in pressure; column 1 bulges away from it in the
+   // interior while spanning the same pressure range. Pseudo-thickness and
+   // pressure thickness are proportional, so setting one sets the other. The
+   // bulge stays below PressBot/pi, which keeps column 1's interfaces
+   // monotonic.
    auto &BottomGeomDepth = VCoord->BottomGeomDepth;
    parallelFor(
        {NCellsAll}, KOKKOS_LAMBDA(int i) {
-          SurfacePressure(i) = 0.0_Real;
-          // a flat floor: the anchor's height difference is then exact input
-          // and vanishes identically
+          SurfacePressure(i) = (i == 1) ? SurfPressDiff : 0.0_Real;
+          // a flat floor: at the sea-floor anchor the height difference is
+          // then exact input and vanishes identically
           BottomGeomDepth(i) = 4000.0_Real;
           for (int k = 0; k < NVertLayers; ++k) {
              const Real Shape = (i == 1) ? 1.0_Real : 0.0_Real;
              const Real PTop =
-                 k * DeltaP + Shape * Bulge * Kokkos::sin(Pi * k / NVertLayers);
+                 k * DeltaP +
+                 Shape * BulgePress * Kokkos::sin(Pi * k / NVertLayers);
              const Real PBot =
                  (k + 1) * DeltaP +
-                 Shape * Bulge * Kokkos::sin(Pi * (k + 1) / NVertLayers);
+                 Shape * BulgePress * Kokkos::sin(Pi * (k + 1) / NVertLayers);
              PseudoThick(i, k) = (PBot - PTop) / (Gravity * RhoSw);
           }
        });
@@ -848,12 +858,12 @@ Real setupExactSetState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
    const auto &PressureInterface = VCoord->PressureInterface;
    parallelFor(
        {NCellsAll, NVertLayers}, KOKKOS_LAMBDA(int i, int k) {
-          Temp(i, k) =
-              exactLayerAvg(Temp0, Temp1, 0.0_Real, PressureInterface(i, k),
-                            PressureInterface(i, k + 1));
-          Salinity(i, k) =
-              exactLayerAvg(Salt0, Salt1, 0.0_Real, PressureInterface(i, k),
-                            PressureInterface(i, k + 1));
+          Temp(i, k)     = exactLayerAvg(Prof.Temp0, Prof.Temp1, Prof.Temp2,
+                                         Prof.Temp3, PressureInterface(i, k),
+                                         PressureInterface(i, k + 1));
+          Salinity(i, k) = exactLayerAvg(Prof.Salt0, Prof.Salt1, Prof.Salt2,
+                                         Prof.Salt3, PressureInterface(i, k),
+                                         PressureInterface(i, k + 1));
        });
 
    // specific volume and its derivatives, from one equation-of-state pass
@@ -863,44 +873,227 @@ Real setupExactSetState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
 
    return PressBot;
 
-} // end setupExactSetState
+} // end setupProfileState
 
-// Assert that the column scan returns a zero fixed-pressure height difference
-// at *every* interface, not merely in the layer mean, for a profile the
-// reconstruction resolves exactly.
+// Which of the scheme's three rules the reference assembly below applies.
+// Turning one off is how the guards of design section 5.2 are made to fire.
+struct PGradGuardRules {
+   bool SharedExpansion = true; ///< one EOS expansion per edge layer, shared
+                                ///< by both columns, rather than one per cell
+   bool PressureLookup = true;  ///< each column's state from the layer
+                                ///< containing the pressure, not from layer K
+   bool ShiftedAnchor = true;   ///< the anchor shifted to a common pressure,
+                                ///< rather than the raw height difference
+};
+
+// Assemble the column scan and the tendency on the host for the single edge
+// joining cells 0 and 1, out of the same helper functions the kernel uses, with
+// each of the scheme's rules switchable.
 //
-// The shape of a failure is diagnostic and is reported: a residual growing
-// with depth points at the recurrence, while one flat with depth points at the
-// anchor. Here the two columns share a bottom pressure and a flat floor, so
-// the anchor is identically zero by construction and any residual at all is
-// the recurrence's.
-int testColumnScan(HorzMesh *Mesh,    ///< [in] Horizontal mesh
-                   VertCoord *VCoord, ///< [inout] Vertical coordinate
-                   OceanState *State, ///< [inout] Ocean state
-                   Eos *EqState       ///< [inout] Equation of state
+// With all three rules on this must reproduce the kernel to round-off, and that
+// is checked before any guard is trusted. A guard that cannot fire is worse
+// than no guard, because it looks like protection.
+void referenceScan(const HostArray2DReal &PressInterface, ///< [in]
+                   const HostArray2DReal &PressMid,       ///< [in]
+                   const HostArray2DReal &Temp,           ///< [in]
+                   const HostArray2DReal &Salt,           ///< [in]
+                   const HostArray2DReal &SpecVol,        ///< [in]
+                   const HostArray2DReal &SpecVolDCt,     ///< [in]
+                   const HostArray2DReal &SpecVolDSa,     ///< [in]
+                   const HostArray2DReal &SpecVolDP,      ///< [in]
+                   const HostArray2DReal &GeomZ,          ///< [in]
+                   const I4 NLayers,                      ///< [in]
+                   const Real Dc,                         ///< [in]
+                   const I4 NQuad,                        ///< [in]
+                   const PGradGuardRules &Rules,          ///< [in]
+                   std::vector<Real> &DeltaZ,             ///< [out] NLayers+1
+                   std::vector<Real> &Tend                ///< [out] NLayers
 ) {
 
-   int Err = 0;
+   const I4 KMin = 0;
+   const I4 KMax = NLayers - 1;
 
-   const I4 NVertLayers = 32;
-   const Real DC        = 4000.0_Real;
-   const Real Offset    = 3.0_Real;
-   const Real Eps       = std::numeric_limits<Real>::epsilon();
+   DeltaZ.assign(NLayers + 1, 0.0_Real);
+   Tend.assign(NLayers, 0.0_Real);
 
-   const Real PressBot = setupExactSetState(Mesh, VCoord, State, EqState,
-                                            NVertLayers, DC, Offset);
+   // the per-cell reconstruction slopes
+   std::vector<std::vector<Real>> SlopeCt(2, std::vector<Real>(NLayers));
+   std::vector<std::vector<Real>> SlopeSa(2, std::vector<Real>(NLayers));
+   for (int ICell = 0; ICell < 2; ++ICell) {
+      for (int K = 0; K < NLayers; ++K) {
+         I4 KLo, KHi;
+         linearReconStencil(K, KMin, KMax, KLo, KHi);
+         SlopeCt[ICell][K] =
+             linearReconSlope(Temp(ICell, KLo), Temp(ICell, KHi),
+                              PressMid(ICell, KLo), PressMid(ICell, KHi));
+         SlopeSa[ICell][K] =
+             linearReconSlope(Salt(ICell, KLo), Salt(ICell, KHi),
+                              PressMid(ICell, KLo), PressMid(ICell, KHi));
+      }
+   }
 
-   // A FiniteVolume instance, created after the state so that its working
-   // arrays are sized for this number of layers
+   Real Nodes[MaxPGradQuadPoints];
+   Real Weights[MaxPGradQuadPoints];
+   gaussLegendreRule(NQuad, Nodes, Weights);
+
+   const Real InvGravity = 1.0_Real / Gravity;
+
+   // one expansion per cell, used when the shared-expansion rule is off
+   auto cellEos = [&](int ICell, int K) {
+      PGradEdgeEos Eos;
+      Eos.SpecVol0    = SpecVol(ICell, K);
+      Eos.SpecVolDCt  = SpecVolDCt(ICell, K);
+      Eos.SpecVolDSa  = SpecVolDSa(ICell, K);
+      Eos.SpecVolDP   = SpecVolDP(ICell, K);
+      Eos.ConservTemp = Temp(ICell, K);
+      Eos.AbsSalinity = Salt(ICell, K);
+      Eos.Press       = PressMid(ICell, K);
+      return Eos;
+   };
+
+   auto lookup = [&](int ICell, Real Press, I4 K) {
+      return Rules.PressureLookup ? findLayerForPress(PressInterface, ICell,
+                                                      KMin, KMax, Press, K)
+                                  : K;
+   };
+
+   std::vector<Real> Incr(NLayers, 0.0_Real);
+   std::vector<Real> Moment(NLayers, 0.0_Real);
+
+   for (int K = 0; K < NLayers; ++K) {
+
+      const PGradEdgeEos EdgeEos =
+          buildEdgeEos(SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP, Temp, Salt,
+                       PressMid, 0, 1, K);
+
+      const Real EdgeTop =
+          0.5_Real * (PressInterface(0, K) + PressInterface(1, K));
+      const Real EdgeBot =
+          0.5_Real * (PressInterface(0, K + 1) + PressInterface(1, K + 1));
+      const Real EdgeMid  = 0.5_Real * (EdgeTop + EdgeBot);
+      const Real EdgeHalf = 0.5_Real * (EdgeBot - EdgeTop);
+
+      for (int IQuad = 0; IQuad < NQuad; ++IQuad) {
+         const Real Press  = EdgeMid + EdgeHalf * Nodes[IQuad];
+         const Real Weight = EdgeHalf * Weights[IQuad];
+
+         const I4 KF0 = lookup(0, Press, K);
+         const I4 KF1 = lookup(1, Press, K);
+
+         const Real T0 = linearReconEval(Temp(0, KF0), SlopeCt[0][KF0],
+                                         PressMid(0, KF0), Press);
+         const Real S0 = linearReconEval(Salt(0, KF0), SlopeSa[0][KF0],
+                                         PressMid(0, KF0), Press);
+         const Real T1 = linearReconEval(Temp(1, KF1), SlopeCt[1][KF1],
+                                         PressMid(1, KF1), Press);
+         const Real S1 = linearReconEval(Salt(1, KF1), SlopeSa[1][KF1],
+                                         PressMid(1, KF1), Press);
+
+         Real Diff;
+         if (Rules.SharedExpansion) {
+            Diff = matchedPressSpecVolDiff(EdgeEos, T0, S0, T1, S1);
+         } else {
+            // two expansion points mean the SpecVol0 and SpecVolDP terms no
+            // longer cancel, and the full specific volume must be formed for
+            // each column separately
+            Diff = edgeSpecVol(cellEos(1, KF1), T1, S1, Press) -
+                   edgeSpecVol(cellEos(0, KF0), T0, S0, Press);
+         }
+
+         Incr[K] += Weight * Diff;
+         Moment[K] += Weight * (Press - EdgeTop) * Diff;
+      }
+      Incr[K] *= InvGravity;
+      Moment[K] *= InvGravity;
+   }
+
+   // the anchor, at the sea floor
+   Real Anchor = GeomZ(1, KMax + 1) - GeomZ(0, KMax + 1);
+   if (Rules.ShiftedAnchor) {
+      const Real AnchorPress = 0.5_Real * (PressInterface(0, KMax + 1) +
+                                           PressInterface(1, KMax + 1));
+      const PGradEdgeEos AnchorEos =
+          buildEdgeEos(SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP, Temp, Salt,
+                       PressMid, 0, 1, KMax);
+      for (int ISide = 0; ISide < 2; ++ISide) {
+         const int ICell     = ISide;
+         const Real Sign     = (ISide == 0) ? -1.0_Real : 1.0_Real;
+         const Real ColPress = PressInterface(ICell, KMax + 1);
+         const Real Mid      = 0.5_Real * (AnchorPress + ColPress);
+         const Real Half     = 0.5_Real * (ColPress - AnchorPress);
+         Real Integral       = 0.0_Real;
+         for (int IQuad = 0; IQuad < NQuad; ++IQuad) {
+            const Real Press  = Mid + Half * Nodes[IQuad];
+            const Real Weight = Half * Weights[IQuad];
+            const I4 KF       = lookup(ICell, Press, KMax);
+            const Real T = linearReconEval(Temp(ICell, KF), SlopeCt[ICell][KF],
+                                           PressMid(ICell, KF), Press);
+            const Real S = linearReconEval(Salt(ICell, KF), SlopeSa[ICell][KF],
+                                           PressMid(ICell, KF), Press);
+            Integral += Weight * edgeSpecVol(AnchorEos, T, S, Press);
+         }
+         Anchor += Sign * InvGravity * Integral;
+      }
+   }
+
+   DeltaZ[KMax + 1] = Anchor;
+   for (int K = KMax; K >= KMin; --K)
+      DeltaZ[K] = DeltaZ[K + 1] + Incr[K];
+
+   for (int K = 0; K < NLayers; ++K) {
+      const Real DeltaPress =
+          0.5_Real * ((PressInterface(0, K + 1) - PressInterface(0, K)) +
+                      (PressInterface(1, K + 1) - PressInterface(1, K)));
+      const Real LayerMean = DeltaZ[K + 1] + Moment[K] / DeltaPress;
+      Tend[K]              = -Gravity / Dc * LayerMean;
+   }
+
+} // end referenceScan
+
+// Copy the state the reference assembly needs to the host.
+struct PGradHostState {
+   HostArray2DReal PressInterface, PressMid, Temp, Salt;
+   HostArray2DReal SpecVol, SpecVolDCt, SpecVolDSa, SpecVolDP, GeomZ;
+};
+
+PGradHostState copyStateToHost(VertCoord *VCoord, Eos *EqState) {
+   PGradHostState H;
+   H.PressInterface = createHostMirrorCopy(VCoord->PressureInterface);
+   H.PressMid       = createHostMirrorCopy(VCoord->PressureMid);
+   H.Temp       = createHostMirrorCopy(Tracers::getByName(0, "Temperature"));
+   H.Salt       = createHostMirrorCopy(Tracers::getByName(0, "Salinity"));
+   H.SpecVol    = createHostMirrorCopy(EqState->SpecVol);
+   H.SpecVolDCt = createHostMirrorCopy(EqState->SpecVolDCt);
+   H.SpecVolDSa = createHostMirrorCopy(EqState->SpecVolDSa);
+   H.SpecVolDP  = createHostMirrorCopy(EqState->SpecVolDP);
+   H.GeomZ      = createHostMirrorCopy(VCoord->GeomZInterface);
+   return H;
+}
+
+// Run the FiniteVolume scheme on the current state and return the largest
+// tendency magnitude, along with its root-mean-square over the active edges
+// and layers and the largest fixed-pressure height difference the column scan
+// produced.
+//
+// The exactness gate uses the maximum, since it asserts a zero at every edge
+// and layer. The convergence rates use the RMS: a maximum is set by whichever
+// layer happens to be worst, and that layer moves under refinement, which
+// makes the measured rate noisy and non-monotone. RMS is also the norm the
+// design's measured rates were taken in, so the two are comparable.
+Real runFiniteVolume(HorzMesh *Mesh, VertCoord *VCoord, OceanState *State,
+                     Eos *EqState, I4 NVertLayers, Real &MaxDeltaZ,
+                     Real &MaxDeltaZUpper, Real &MaxDeltaZLower,
+                     Real &RmsTend) {
+
    Config *Options = Config::getOmegaConfig();
    Config PGradConfig("PressureGrad");
    Options->get(PGradConfig);
    PGradConfig.set("PressureGradType", std::string("FiniteVolume"));
    PressureGrad *FVPGrad =
-       PressureGrad::create("TestColumnScan", Mesh, VCoord, Options);
+       PressureGrad::create("TestFV", Mesh, VCoord, Options);
    PGradConfig.set("PressureGradType", std::string("Centered"));
 
-   Array2DReal Tend("TendColumnScan", Mesh->NEdgesSize, NVertLayers);
+   Array2DReal Tend("TendFV", Mesh->NEdgesSize, NVertLayers);
    deepCopy(Tend, 0.0_Real);
 
    Array2DReal PseudoThick = State->getPseudoThickness(0);
@@ -911,13 +1104,126 @@ int testColumnScan(HorzMesh *Mesh,    ///< [in] Horizontal mesh
        Tend, VCoord->PressureMid, VCoord->PressureInterface, EqState->SpecVol,
        VCoord->GeomZInterface, PseudoThick, Temp, Salinity, EqState);
 
-   // Scale by the size of the terms that had to cancel: the hydrostatic
-   // contribution of the temperature and salinity structure over the column.
+   const auto &EdgeMask = VCoord->EdgeMask;
+   Real MaxTend         = 0.0_Real;
+   Real SumSq           = 0.0_Real;
+   I4 NActive           = 0;
+   parallelReduce(
+       {Mesh->NEdgesAll, NVertLayers},
+       KOKKOS_LAMBDA(int IEdge, int K, Real &MaxV, Real &LSum, I4 &LCount) {
+          if (EdgeMask(IEdge, K) <= 0.0_Real)
+             return;
+          const Real V = Kokkos::abs(Tend(IEdge, K));
+          if (V > MaxV)
+             MaxV = V;
+          LSum += V * V;
+          ++LCount;
+       },
+       Kokkos::Max<Real>(MaxTend), Kokkos::Sum<Real>(SumSq),
+       Kokkos::Sum<I4>(NActive));
+
+   RmsTend = (NActive > 0) ? std::sqrt(SumSq / NActive) : 0.0_Real;
+
+   const auto &DeltaZFixedP = FVPGrad->getDeltaZFixedP();
+   MaxDeltaZ                = 0.0_Real;
+   MaxDeltaZUpper           = 0.0_Real;
+   MaxDeltaZLower           = 0.0_Real;
+   parallelReduce(
+       {Mesh->NEdgesAll, NVertLayers + 1},
+       KOKKOS_LAMBDA(int IEdge, int K, Real &MaxA, Real &MaxU, Real &MaxL) {
+          const Real V = Kokkos::abs(DeltaZFixedP(IEdge, K));
+          if (V > MaxA)
+             MaxA = V;
+          if (K <= NVertLayers / 2 && V > MaxU)
+             MaxU = V;
+          if (K > NVertLayers / 2 && V > MaxL)
+             MaxL = V;
+       },
+       Kokkos::Max<Real>(MaxDeltaZ), Kokkos::Max<Real>(MaxDeltaZUpper),
+       Kokkos::Max<Real>(MaxDeltaZLower));
+
+   PressureGrad::erase("TestFV");
+
+   return MaxTend;
+
+} // end runFiniteVolume
+
+// Run PressureGradCentered on the current state and return the largest
+// tendency magnitude.
+Real runCentered(HorzMesh *Mesh, VertCoord *VCoord, OceanState *State,
+                 Eos *EqState, I4 NVertLayers) {
+
+   Array2DReal Tend("TendCentered", Mesh->NEdgesSize, NVertLayers);
+   deepCopy(Tend, 0.0_Real);
+
+   Array2DReal PseudoThick = State->getPseudoThickness(0);
+   Array2DReal Temp        = Tracers::getByName(0, "Temperature");
+   Array2DReal Salinity    = Tracers::getByName(0, "Salinity");
+
+   PressureGrad::getDefault()->computePressureGrad(
+       Tend, VCoord->PressureMid, VCoord->PressureInterface, EqState->SpecVol,
+       VCoord->GeomZInterface, PseudoThick, Temp, Salinity, EqState);
+
+   const auto &EdgeMask = VCoord->EdgeMask;
+   Real MaxTend         = 0.0_Real;
+   parallelReduce(
+       {Mesh->NEdgesAll, NVertLayers},
+       KOKKOS_LAMBDA(int IEdge, int K, Real &MaxV) {
+          if (EdgeMask(IEdge, K) <= 0.0_Real)
+             return;
+          const Real V = Kokkos::abs(Tend(IEdge, K));
+          if (V > MaxV)
+             MaxV = V;
+       },
+       Kokkos::Max<Real>(MaxTend));
+
+   return MaxTend;
+
+} // end runCentered
+
+// The gating test of design section 5.2: exactness on the exact set, the
+// convergence of the residual off it, and the guards.
+int testExactnessAndGuards(HorzMesh *Mesh,    ///< [in] Horizontal mesh
+                           VertCoord *VCoord, ///< [inout] Vertical coordinate
+                           OceanState *State, ///< [inout] Ocean state
+                           Eos *EqState       ///< [inout] Equation of state
+) {
+
+   int Err = 0;
+
+   const Real Eps   = std::numeric_limits<Real>::epsilon();
+   const Real DC    = 4000.0_Real;
+   const Real Bulge = 7.5e6_Real;
+   const I4 NLayers = 32;
+   const I4 NQuad   = 2;
+
+   // linear in pressure: the exact set of the Phase 1 reconstruction
+   const PGradProfile Linear = {12.0_Real, -2.0e-7_Real, 0.0_Real, 0.0_Real,
+                                34.0_Real, 2.5e-8_Real,  0.0_Real, 0.0_Real};
+   // quadratic and cubic: outside it
+   const PGradProfile Quadratic = {12.0_Real,     -2.0e-7_Real, 3.0e-15_Real,
+                                   0.0_Real,      34.0_Real,    2.5e-8_Real,
+                                   -4.0e-16_Real, 0.0_Real};
+   const PGradProfile Cubic     = {12.0_Real,     -2.0e-7_Real, 3.0e-15_Real,
+                                   -5.0e-23_Real, 34.0_Real,    2.5e-8_Real,
+                                   -4.0e-16_Real, 8.0e-24_Real};
+
+   //
+   // Group one: the exact set. The tendency must be zero to machine precision
+   // at every edge and layer, for any tilt, thickness or bathymetry.
+   //
+   const Real PressBot = setupProfileState(
+       Mesh, VCoord, State, EqState, NLayers, DC, Bulge, Linear, 0.0_Real);
+
+   // the size of the terms that had to cancel: the hydrostatic contribution of
+   // the temperature and salinity structure over the column
    const auto &SpecVolDCt = EqState->SpecVolDCt;
    const auto &SpecVolDSa = EqState->SpecVolDSa;
+   Array2DReal Temp       = Tracers::getByName(0, "Temperature");
+   Array2DReal Salinity   = Tracers::getByName(0, "Salinity");
    Real CancelScale       = 0.0_Real;
    parallelReduce(
-       {2, NVertLayers},
+       {2, NLayers},
        KOKKOS_LAMBDA(int i, int k, Real &MaxV) {
           const Real V = (Kokkos::abs(SpecVolDCt(i, k) * Temp(i, k)) +
                           Kokkos::abs(SpecVolDSa(i, k) * Salinity(i, k))) *
@@ -927,92 +1233,287 @@ int testColumnScan(HorzMesh *Mesh,    ///< [in] Horizontal mesh
        },
        Kokkos::Max<Real>(CancelScale));
 
-   const auto &DeltaZFixedP = FVPGrad->getDeltaZFixedP();
+   Real MaxDeltaZ, MaxUpper, MaxLower, RmsFV;
+   const Real MaxFV = runFiniteVolume(Mesh, VCoord, State, EqState, NLayers,
+                                      MaxDeltaZ, MaxUpper, MaxLower, RmsFV);
+   const Real MaxCentered = runCentered(Mesh, VCoord, State, EqState, NLayers);
 
-   Real MaxTop = 0.0_Real;
-   Real MaxBot = 0.0_Real;
-   Real MaxAll = 0.0_Real;
-   parallelReduce(
-       {Mesh->NEdgesAll, NVertLayers + 1},
-       KOKKOS_LAMBDA(int IEdge, int K, Real &MaxA, Real &MaxT, Real &MaxB) {
-          const Real V = Kokkos::abs(DeltaZFixedP(IEdge, K));
-          if (V > MaxA)
-             MaxA = V;
-          // the shallower and deeper halves of the column, to show whether a
-          // residual grows with depth
-          if (K <= NVertLayers / 2 && V > MaxT)
-             MaxT = V;
-          if (K > NVertLayers / 2 && V > MaxB)
-             MaxB = V;
-       },
-       Kokkos::Max<Real>(MaxAll), Kokkos::Max<Real>(MaxTop),
-       Kokkos::Max<Real>(MaxBot));
+   // The tendency scale is the height scale divided by the cell spacing and
+   // multiplied by gravity, so that the gate tracks Real's epsilon and the
+   // size of the hydrostatic terms rather than a physical tolerance.
+   const Real HeightScale = CancelScale;
+   const Real TendScale   = Gravity * CancelScale / DC;
 
-   const Real Scaled = MaxAll / (Eps * CancelScale);
+   const Real ScaledDeltaZ = MaxDeltaZ / (Eps * HeightScale);
+   const Real ScaledTend   = MaxFV / (Eps * TendScale);
 
-   LOG_INFO("PGradTest: column scan on the exact set: max |DeltaZFixedP| = {} "
-            "m ({} eps of the cancelling terms, which are {} m); upper column "
-            "{} m, lower column {} m",
-            MaxAll, Scaled, CancelScale, MaxTop, MaxBot);
+   LOG_INFO("PGradTest: exact set: FiniteVolume max |Tend| = {} m/s2 ({} eps), "
+            "Centered max |Tend| = {} m/s2, ratio {}",
+            MaxFV, ScaledTend, MaxCentered, MaxFV / MaxCentered);
+   LOG_INFO("PGradTest: exact set: max |DeltaZFixedP| = {} m ({} eps); upper "
+            "column {} m, lower column {} m -- the residual grows away from "
+            "the sea-floor anchor",
+            MaxDeltaZ, ScaledDeltaZ, MaxUpper, MaxLower);
 
-   // Provisional gate. The residual is expected to be a few eps of the
-   // cancelling terms: the integrand is zero pointwise to about one eps and
-   // the recurrence accumulates that over the column.
-   const Real Tol = 100.0_Real;
-   if (Scaled <= Tol) {
-      LOG_INFO("PGradTest: column scan PASS: {} eps", Scaled);
+   // Gates set from the measured values: 0.027 eps for both, so four eps
+   // leaves well over a hundredfold margin while still catching drift.
+   const Real ExactTol = 4.0_Real;
+   if (ScaledTend <= ExactTol && ScaledDeltaZ <= ExactTol) {
+      LOG_INFO("PGradTest: exactness gate PASS");
    } else {
-      LOG_ERROR("PGradTest: column scan FAIL: {} eps exceeds {} eps", Scaled,
-                Tol);
+      LOG_ERROR("PGradTest: exactness gate FAIL: tendency {} eps, height "
+                "difference {} eps, against {} eps",
+                ScaledTend, ScaledDeltaZ, ExactTol);
       ++Err;
    }
 
-   // The tendency itself on the same state. Reported alongside the centered
-   // scheme's, which is nonzero and tilt-dependent, so that a pass is a
-   // cancellation against a known nonzero reference rather than a comparison
-   // with zero. The gate here is provisional; the full exactness gate and its
-   // guards follow.
-   Array2DReal TendCentered("TendCentered", Mesh->NEdgesSize, NVertLayers);
-   deepCopy(TendCentered, 0.0_Real);
-   PressureGrad *DefPGrad = PressureGrad::getDefault();
-   DefPGrad->computePressureGrad(TendCentered, VCoord->PressureMid,
-                                 VCoord->PressureInterface, EqState->SpecVol,
-                                 VCoord->GeomZInterface, PseudoThick, Temp,
-                                 Salinity, EqState);
-
-   const auto &EdgeMask = VCoord->EdgeMask;
-   Real MaxFV           = 0.0_Real;
-   Real MaxCentered     = 0.0_Real;
-   parallelReduce(
-       {Mesh->NEdgesAll, NVertLayers},
-       KOKKOS_LAMBDA(int IEdge, int K, Real &MaxF, Real &MaxC) {
-          if (EdgeMask(IEdge, K) <= 0.0_Real)
-             return;
-          const Real F = Kokkos::abs(Tend(IEdge, K));
-          const Real C = Kokkos::abs(TendCentered(IEdge, K));
-          if (F > MaxF)
-             MaxF = F;
-          if (C > MaxC)
-             MaxC = C;
-       },
-       Kokkos::Max<Real>(MaxFV), Kokkos::Max<Real>(MaxCentered));
-
-   LOG_INFO("PGradTest: tendency on the exact set: FiniteVolume max |Tend| = "
-            "{} m/s2, Centered max |Tend| = {} m/s2",
-            MaxFV, MaxCentered);
-
-   // the centered scheme must be nonzero here, or the comparison says nothing
-   if (MaxCentered <= 0.0_Real) {
-      LOG_ERROR("PGradTest: exact-set state FAIL: the centered scheme returns "
-                "zero, so the state does not exercise the property");
+   // Guard (a), tilt sensitivity. This is the only guard that can fire on a
+   // configuration where every other check passes: a bug that zeroed the tilt
+   // response would satisfy all of them perfectly.
+   Real PrevCentered  = 0.0_Real;
+   bool CenteredGrows = true;
+   for (int ITilt = 1; ITilt <= 3; ++ITilt) {
+      setupProfileState(Mesh, VCoord, State, EqState, NLayers, DC,
+                        Bulge * ITilt / 3.0_Real, Linear, 0.0_Real);
+      const Real C = runCentered(Mesh, VCoord, State, EqState, NLayers);
+      if (C <= PrevCentered)
+         CenteredGrows = false;
+      PrevCentered = C;
+   }
+   if (CenteredGrows && MaxCentered > 0.0_Real && MaxFV < MaxCentered) {
+      LOG_INFO("PGradTest: guard (a) tilt sensitivity PASS: Centered grows "
+               "with tilt and the two schemes differ");
+   } else {
+      LOG_ERROR("PGradTest: guard (a) tilt sensitivity FAIL");
       ++Err;
    }
 
-   PressureGrad::erase("TestColumnScan");
+   //
+   // The guards below need an assembly whose rules can be switched, so they
+   // run against a host reference built from the same helper functions. It is
+   // only trustworthy if it reproduces the kernel first.
+   //
+   setupProfileState(Mesh, VCoord, State, EqState, NLayers, DC, Bulge, Linear,
+                     0.0_Real);
+   Real KernelDeltaZ, KernelUpper, KernelLower, KernelRms;
+   const Real KernelTend =
+       runFiniteVolume(Mesh, VCoord, State, EqState, NLayers, KernelDeltaZ,
+                       KernelUpper, KernelLower, KernelRms);
+
+   PGradHostState H = copyStateToHost(VCoord, EqState);
+   std::vector<Real> RefDeltaZ, RefTend;
+   PGradGuardRules Rules;
+   referenceScan(H.PressInterface, H.PressMid, H.Temp, H.Salt, H.SpecVol,
+                 H.SpecVolDCt, H.SpecVolDSa, H.SpecVolDP, H.GeomZ, NLayers, DC,
+                 NQuad, Rules, RefDeltaZ, RefTend);
+
+   Real RefMax = 0.0_Real;
+   for (int K = 0; K < NLayers; ++K)
+      RefMax = std::max(RefMax, std::abs(RefTend[K]));
+
+   if (std::abs(RefMax - KernelTend) <= 8.0_Real * Eps * TendScale) {
+      LOG_INFO("PGradTest: guard harness fidelity on the exact set PASS: "
+               "reference {} m/s2 against kernel {} m/s2",
+               RefMax, KernelTend);
+   } else {
+      LOG_ERROR("PGradTest: guard harness fidelity on the exact set FAIL: "
+                "reference {} m/s2 against kernel {} m/s2; the guards below "
+                "say nothing",
+                RefMax, KernelTend);
+      ++Err;
+   }
+
+   // Agreeing at 1e-18 on the exact set says little, since a harness that
+   // computed nothing at all would also agree. The check that has content is
+   // on a curved profile, where both sides are large.
+   setupProfileState(Mesh, VCoord, State, EqState, NLayers, DC, Bulge,
+                     Quadratic, 0.0_Real);
+   Real CurvedDeltaZ, CurvedUpper, CurvedLower, CurvedRms;
+   const Real CurvedKernel =
+       runFiniteVolume(Mesh, VCoord, State, EqState, NLayers, CurvedDeltaZ,
+                       CurvedUpper, CurvedLower, CurvedRms);
+
+   PGradHostState HC = copyStateToHost(VCoord, EqState);
+   std::vector<Real> CurvedRefDeltaZ, CurvedRefTend;
+   Rules = PGradGuardRules();
+   referenceScan(HC.PressInterface, HC.PressMid, HC.Temp, HC.Salt, HC.SpecVol,
+                 HC.SpecVolDCt, HC.SpecVolDSa, HC.SpecVolDP, HC.GeomZ, NLayers,
+                 DC, NQuad, Rules, CurvedRefDeltaZ, CurvedRefTend);
+   Real CurvedRefMax = 0.0_Real;
+   for (int K = 0; K < NLayers; ++K)
+      CurvedRefMax = std::max(CurvedRefMax, std::abs(CurvedRefTend[K]));
+
+   const Real CurvedRelDiff =
+       (CurvedKernel > 0.0_Real)
+           ? std::abs(CurvedRefMax - CurvedKernel) / CurvedKernel
+           : 1.0_Real;
+   LOG_INFO("PGradTest: guard harness fidelity on a curved profile: reference "
+            "{} m/s2 against kernel {} m/s2, relative difference {}",
+            CurvedRefMax, CurvedKernel, CurvedRelDiff);
+   if (CurvedRelDiff <= 1.0e-10_Real) {
+      LOG_INFO("PGradTest: guard harness fidelity on a curved profile PASS");
+   } else {
+      LOG_ERROR("PGradTest: guard harness fidelity on a curved profile FAIL: "
+                "the reference assembly does not reproduce the kernel, so the "
+                "guards below say nothing");
+      ++Err;
+   }
+
+   // back to the exact-set state for the guards
+   setupProfileState(Mesh, VCoord, State, EqState, NLayers, DC, Bulge, Linear,
+                     0.0_Real);
+   H = copyStateToHost(VCoord, EqState);
+
+   // Guard (b), a cell-local expansion point in place of the edge-shared one.
+   // Two expansion points mean the SpecVol0 and SpecVolDP terms no longer
+   // cancel, so this must fire.
+   Rules                 = PGradGuardRules();
+   Rules.SharedExpansion = false;
+   referenceScan(H.PressInterface, H.PressMid, H.Temp, H.Salt, H.SpecVol,
+                 H.SpecVolDCt, H.SpecVolDSa, H.SpecVolDP, H.GeomZ, NLayers, DC,
+                 NQuad, Rules, RefDeltaZ, RefTend);
+   Real GuardB = 0.0_Real;
+   for (int K = 0; K < NLayers; ++K)
+      GuardB = std::max(GuardB, std::abs(RefTend[K]));
+
+   LOG_INFO("PGradTest: guard (b) cell-local expansion point gives {} m/s2, "
+            "against {} m/s2 with the shared point",
+            GuardB, RefMax);
+   if (GuardB > 1.0e4_Real * Eps * TendScale) {
+      LOG_INFO("PGradTest: guard (b) PASS: the edge-shared expansion point is "
+               "load-bearing");
+   } else {
+      LOG_ERROR("PGradTest: guard (b) FAIL: replacing the shared expansion "
+                "point with a cell-local one changed nothing, so the sharing "
+                "is not being exercised");
+      ++Err;
+   }
+
+   // Guard (c), each column's state taken from its own layer K rather than
+   // from the layer containing the pressure. This *cannot* fire on the exact
+   // set: the profile is a single line in pressure, so every layer's
+   // reconstruction is that same line and looking up the wrong layer costs
+   // nothing. The check here records that, because the alternative -- writing
+   // it as a guard that must fire -- would be asserting something false, and
+   // because it is the reason the property tests on the lookup exist at all.
+   Rules                = PGradGuardRules();
+   Rules.PressureLookup = false;
+   referenceScan(H.PressInterface, H.PressMid, H.Temp, H.Salt, H.SpecVol,
+                 H.SpecVolDCt, H.SpecVolDSa, H.SpecVolDP, H.GeomZ, NLayers, DC,
+                 NQuad, Rules, RefDeltaZ, RefTend);
+   Real GuardC = 0.0_Real;
+   for (int K = 0; K < NLayers; ++K)
+      GuardC = std::max(GuardC, std::abs(RefTend[K]));
+
+   LOG_INFO("PGradTest: guard (c) layer-index lookup gives {} m/s2, against {} "
+            "m/s2 with the pressure lookup -- this guard cannot fire on the "
+            "exact set, which is why the lookup is pinned by property tests",
+            GuardC, RefMax);
+   if (GuardC <= ExactTol * Eps * TendScale) {
+      LOG_INFO("PGradTest: guard (c) behaves as documented: no answer-level "
+               "check can distinguish the two lookups here");
+   } else {
+      LOG_INFO("PGradTest: guard (c) unexpectedly fired at {} m/s2; an "
+               "answer-level check on the lookup may now be available",
+               GuardC);
+   }
+
+   // Guard (d), the anchor taken as the raw height difference, dropping the
+   // short integrals that shift it to a common pressure. It fires only where
+   // the two columns' end pressures differ, and it is flat with depth, which
+   // is what distinguishes it from guard (b).
+   setupProfileState(Mesh, VCoord, State, EqState, NLayers, DC, Bulge, Linear,
+                     2.0e4_Real);
+   PGradHostState HD = copyStateToHost(VCoord, EqState);
+
+   std::vector<Real> DZCorrect, TendCorrect, DZBroken, TendBroken;
+   Rules = PGradGuardRules();
+   referenceScan(HD.PressInterface, HD.PressMid, HD.Temp, HD.Salt, HD.SpecVol,
+                 HD.SpecVolDCt, HD.SpecVolDSa, HD.SpecVolDP, HD.GeomZ, NLayers,
+                 DC, NQuad, Rules, DZCorrect, TendCorrect);
+   Rules               = PGradGuardRules();
+   Rules.ShiftedAnchor = false;
+   referenceScan(HD.PressInterface, HD.PressMid, HD.Temp, HD.Salt, HD.SpecVol,
+                 HD.SpecVolDCt, HD.SpecVolDSa, HD.SpecVolDP, HD.GeomZ, NLayers,
+                 DC, NQuad, Rules, DZBroken, TendBroken);
+
+   Real GuardD    = 0.0_Real;
+   Real OffsetMin = std::numeric_limits<Real>::max();
+   Real OffsetMax = 0.0_Real;
+   for (int K = 0; K <= NLayers; ++K) {
+      const Real Offset = std::abs(DZBroken[K] - DZCorrect[K]);
+      OffsetMin         = std::min(OffsetMin, Offset);
+      OffsetMax         = std::max(OffsetMax, Offset);
+   }
+   for (int K = 0; K < NLayers; ++K)
+      GuardD = std::max(GuardD, std::abs(TendBroken[K] - TendCorrect[K]));
+
+   LOG_INFO("PGradTest: guard (d) unshifted anchor changes the tendency by {} "
+            "m/s2; the offset in the height difference runs from {} m to {} m "
+            "over the column",
+            GuardD, OffsetMin, OffsetMax);
+   const bool Fires = GuardD > 1.0e4_Real * Eps * TendScale;
+   const bool Flat  = OffsetMax > 0.0_Real &&
+                     (OffsetMax - OffsetMin) <= 1.0e-6_Real * OffsetMax;
+   if (Fires && Flat) {
+      LOG_INFO("PGradTest: guard (d) PASS: the anchor shift is load-bearing "
+               "and its omission is flat with depth");
+   } else {
+      LOG_ERROR("PGradTest: guard (d) FAIL: fires {}, flat with depth {}",
+                Fires, Flat);
+      ++Err;
+   }
+
+   //
+   // Group two: profiles the reconstruction does not resolve. The residual
+   // must shrink like the square of the layer thickness under vertical
+   // refinement at fixed tilt, matching the design's table. A residual that
+   // does not shrink at that rate means one of the scheme's conditions has
+   // been broken; it is a bug to find, not a tolerance to widen.
+   //
+   const PGradProfile Profiles[2] = {Quadratic, Cubic};
+   const char *ProfileNames[2]    = {"quadratic", "cubic"};
+
+   for (int IProf = 0; IProf < 2; ++IProf) {
+      Real PrevErr   = 0.0_Real;
+      Real WorstRate = 1.0e30_Real;
+      // 15, 30, 60 layers: a refinement factor of two, staying within the
+      // vertical dimension the mesh file provides
+      const I4 RefLayers[3] = {15, 30, 60};
+      for (int IRef = 0; IRef < 3; ++IRef) {
+         const I4 NRef = RefLayers[IRef];
+         setupProfileState(Mesh, VCoord, State, EqState, NRef, DC, Bulge,
+                           Profiles[IProf], 0.0_Real);
+         Real DZ, Up, Low, Rms;
+         const Real MaxE = runFiniteVolume(Mesh, VCoord, State, EqState, NRef,
+                                           DZ, Up, Low, Rms);
+         if (IRef > 0 && Rms > 0.0_Real) {
+            const Real Rate = std::log2(PrevErr / Rms);
+            WorstRate       = std::min(WorstRate, Rate);
+            LOG_INFO("PGradTest: {} profile, {} layers: RMS |Tend| = {} m/s2 "
+                     "(max {}), rate {}",
+                     ProfileNames[IProf], NRef, Rms, MaxE, Rate);
+         } else {
+            LOG_INFO("PGradTest: {} profile, {} layers: RMS |Tend| = {} m/s2 "
+                     "(max {})",
+                     ProfileNames[IProf], NRef, Rms, MaxE);
+         }
+         PrevErr = Rms;
+      }
+      if (WorstRate >= 1.7_Real) {
+         LOG_INFO("PGradTest: {} profile convergence PASS: worst rate {}",
+                  ProfileNames[IProf], WorstRate);
+      } else {
+         LOG_ERROR("PGradTest: {} profile convergence FAIL: worst rate {} is "
+                   "below the second order the design predicts",
+                   ProfileNames[IProf], WorstRate);
+         ++Err;
+      }
+   }
 
    return Err;
 
-} // end testColumnScan
+} // end testExactnessAndGuards
 
 // Assert the identity of design section 3.9 (test section 5.5): with the tidal
 // and self-attraction-and-loading potentials zero, PressureGradCentered is
@@ -1446,9 +1947,9 @@ int main(int argc, char *argv[]) {
       // point on a resolved profile, not merely in the integral.
       int IntegrandErr = testMatchedPressIntegrand();
 
-      // The column scan must return a zero fixed-pressure height difference
-      // at every interface on the exact set, not merely in the layer mean.
-      int ScanErr = testColumnScan(DefMesh, VCoord, DefState, DefEos);
+      // The gating test: exactness on the exact set, the convergence of the
+      // residual off it, and the guards.
+      int ScanErr = testExactnessAndGuards(DefMesh, VCoord, DefState, DefEos);
 
       int IdentityErr = testCenteredIdentity(DefMesh, VCoord, DefState, DefEos);
 

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -464,8 +464,10 @@ int testMatchedPressIntegrand() {
    const Real Temp0 = 12.0_Real, Temp1 = -2.0e-7_Real;
    const Real Salt0 = 34.5_Real, Salt1 = 2.5e-8_Real;
 
-   Real MaxLinear    = 0.0_Real;
-   Real MaxQuadratic = 0.0_Real;
+   Real MaxLinear       = 0.0_Real;
+   Real MaxQuadratic    = 0.0_Real;
+   Real MaxAbsLinear    = 0.0_Real;
+   Real MaxAbsQuadratic = 0.0_Real;
 
    for (int ICase = 0; ICase < 2; ++ICase) {
 
@@ -568,9 +570,11 @@ int testMatchedPressIntegrand() {
                Curved ? "quadratic" : "linear", MaxAbs, MaxScaled);
 
       if (Curved) {
-         MaxQuadratic = MaxScaled;
+         MaxQuadratic    = MaxScaled;
+         MaxAbsQuadratic = MaxAbs;
       } else {
-         MaxLinear = MaxScaled;
+         MaxLinear    = MaxScaled;
+         MaxAbsLinear = MaxAbs;
       }
    }
 
@@ -585,17 +589,23 @@ int testMatchedPressIntegrand() {
       ++Err;
    }
 
-   // the linear result means nothing unless the same machinery gives a large
-   // answer on a profile the reconstruction does not resolve
-   if (MaxQuadratic > 1.0e6_Real) {
+   // The linear result means nothing unless the same machinery gives a large
+   // answer on a profile the reconstruction does not resolve. The comparison
+   // is a ratio of the two absolute values rather than a count of epsilons,
+   // so that it means the same thing in a single-precision build, where the
+   // linear result rises with the round-off floor while the quadratic one, a
+   // truncation error, does not.
+   const Real ControlRatio =
+       (MaxAbsLinear > 0.0_Real) ? MaxAbsQuadratic / MaxAbsLinear : 0.0_Real;
+   if (ControlRatio > 100.0_Real) {
       LOG_INFO("PGradTest: matched-pressure integrand control PASS: the "
-               "quadratic profile gives {} eps",
-               MaxQuadratic);
+               "quadratic profile is {} times the linear one ({} eps)",
+               ControlRatio, MaxQuadratic);
    } else {
       LOG_ERROR("PGradTest: matched-pressure integrand control FAIL: the "
-                "quadratic profile gives only {} eps, so the linear result "
-                "may be trivial",
-                MaxQuadratic);
+                "quadratic profile is only {} times the linear one, so the "
+                "linear result may be trivial",
+                ControlRatio);
       ++Err;
    }
 
@@ -1247,17 +1257,23 @@ int testExactnessAndGuards(HorzMesh *Mesh,    ///< [in] Horizontal mesh
    const Real ScaledDeltaZ = MaxDeltaZ / (Eps * HeightScale);
    const Real ScaledTend   = MaxFV / (Eps * TendScale);
 
-   LOG_INFO("PGradTest: exact set: FiniteVolume max |Tend| = {} m/s2 ({} eps), "
-            "Centered max |Tend| = {} m/s2, ratio {}",
-            MaxFV, ScaledTend, MaxCentered, MaxFV / MaxCentered);
+   LOG_INFO("PGradTest: exact set ({} precision): FiniteVolume max |Tend| = "
+            "{} m/s2 ({} eps), Centered max |Tend| = {} m/s2, ratio {}",
+            (Eps < 1.0e-10_Real) ? "double" : "single", MaxFV, ScaledTend,
+            MaxCentered, MaxFV / MaxCentered);
    LOG_INFO("PGradTest: exact set: max |DeltaZFixedP| = {} m ({} eps); upper "
             "column {} m, lower column {} m -- the residual grows away from "
             "the sea-floor anchor",
             MaxDeltaZ, ScaledDeltaZ, MaxUpper, MaxLower);
 
-   // Gates set from the measured values: 0.027 eps for both, so four eps
-   // leaves well over a hundredfold margin while still catching drift.
-   const Real ExactTol = 4.0_Real;
+   // Gates set from the measured values: 0.027 eps for both in double
+   // precision, so four eps leaves well over a hundredfold margin while still
+   // catching drift. A single-precision build has fewer guard digits in the
+   // accumulation down the column, so the same measurement in epsilons is
+   // expected to be somewhat larger; the gate is loosened to match rather
+   // than being turned into a different kind of claim.
+   const bool DoublePrec = Eps < 1.0e-10_Real;
+   const Real ExactTol   = DoublePrec ? 4.0_Real : 16.0_Real;
    if (ScaledTend <= ExactTol && ScaledDeltaZ <= ExactTol) {
       LOG_INFO("PGradTest: exactness gate PASS");
    } else {
@@ -1286,6 +1302,23 @@ int testExactnessAndGuards(HorzMesh *Mesh,    ///< [in] Horizontal mesh
    } else {
       LOG_ERROR("PGradTest: guard (a) tilt sensitivity FAIL");
       ++Err;
+   }
+
+   // Everything from here on measures a truncation error rather than a
+   // cancellation, and a single-precision build cannot resolve it: the
+   // round-off floor of the tendency there is about 3e-8 m/s2, which swamps
+   // the quadratic profile's residual at 60 layers and leaves only a factor
+   // of ten between guard (b)'s signal and the noise. The exactness gate
+   // above is the check design section 5.2 asks to be run in both
+   // precisions, since it is the one that tests whether the scheme forms
+   // large quantities; the rest is a statement about the discretization and
+   // is precision-independent, so measuring it once in double precision is
+   // enough.
+   if (!DoublePrec) {
+      LOG_INFO("PGradTest: single precision: skipping the convergence rates "
+               "and guards (b) to (d), which measure truncation errors below "
+               "this build's round-off floor");
+      return Err;
    }
 
    //
@@ -1844,6 +1877,13 @@ int main(int argc, char *argv[]) {
 
    {
       initPGradTest();
+
+      // Flush every message rather than only those at warn and above. Omega's
+      // default buffers info messages, so a run that aborts loses the whole
+      // record of what it had measured, which is the case that most needs it.
+      // This test is small enough that the cost does not matter.
+      spdlog::flush_on(spdlog::level::info);
+
       // Initialize default PressureGrad
       PressureGrad::init();
 
@@ -1956,12 +1996,34 @@ int main(int argc, char *argv[]) {
       // Test parsing and dispatch of the PressureGrad configuration options
       int ConfigErr = testPGradConfig(DefMesh, VCoord);
 
-      // Test for second order convergence
-      // resolution (dC) increases in refimenent loop
-      if (Rmse(0) < Rmse(NRefinements - 1) / pow(4.0_Real, NRefinements - 1)) {
-         RetVal = 0;
+      // Test for second order convergence of the centered scheme under
+      // refinement; resolution (dC) increases in the refinement loop.
+      //
+      // Double precision only. This measures PressureGradCentered's
+      // truncation error, and a single-precision build cannot resolve it at
+      // the finest resolution: the centered scheme forms and cancels
+      // Montgomery potentials of order 1e4 m2 s-2, so dividing by a 30 km cell
+      // spacing leaves a round-off floor near 4e-8 m s-2. The finest
+      // resolution sits below that, measuring round-off rather than
+      // truncation -- 4.9e-8 in single precision against 7.1e-9 in double on
+      // the same state -- so the convergence relation cannot hold there. That
+      // is a property of the scheme being measured, not a defect: it is the
+      // arithmetic the finite-volume scheme avoids by differencing the
+      // integrand before integrating it.
+      const bool DoublePrecision =
+          std::numeric_limits<Real>::epsilon() < 1.0e-10_Real;
+
+      RetVal = 0;
+      if (DoublePrecision) {
+         if (Rmse(0) >=
+             Rmse(NRefinements - 1) / pow(4.0_Real, NRefinements - 1))
+            RetVal = 1;
       } else {
-         RetVal = 1;
+         LOG_INFO("PGradTest: single precision: skipping the centered "
+                  "refinement convergence check; its finest resolution gives "
+                  "{}, which is the round-off floor of a scheme that cancels "
+                  "large quantities rather than its truncation error",
+                  Rmse(0));
       }
 
       RetVal += ReconErr + LookupErr + IntegrandErr + IdentityErr + ConfigErr;

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -1191,6 +1191,123 @@ Real runCentered(HorzMesh *Mesh, VertCoord *VCoord, OceanState *State,
 
 } // end runCentered
 
+// The cost check of design section 5.6.
+//
+// The design bounds the number of equation-of-state evaluations at about one
+// per cell per layer per step, independent of the reconstruction order, the
+// stencil width and the quadrature. Nothing else in the test suite would
+// notice a violation: an evaluation inside the quadrature loop would change
+// run time without changing any answer, so every accuracy gate would still
+// pass.
+//
+// The check is sharper than the requirement. The pressure gradient performs
+// *no* equation-of-state evaluations at all -- the one per cell per layer that
+// the requirement allows is paid once by AuxiliaryState, before the tendency
+// is computed, and the scheme works from the specific volume and its
+// derivatives that call leaves behind. So the count across a call to
+// computePressureGrad must be exactly zero, at every setting of
+// QuadraturePoints.
+//
+// This is a counter comparison rather than a timing measurement, so it is
+// deterministic and suitable for continuous integration.
+int testEosCost(HorzMesh *Mesh,    ///< [in] Horizontal mesh
+                VertCoord *VCoord, ///< [inout] Vertical coordinate
+                OceanState *State, ///< [inout] Ocean state
+                Eos *EqState       ///< [inout] Equation of state
+) {
+
+   int Err = 0;
+
+   const I4 NLayers          = 32;
+   const Real DC             = 4000.0_Real;
+   const Real Bulge          = 7.5e6_Real;
+   const PGradProfile Linear = {12.0_Real, -2.0e-7_Real, 0.0_Real, 0.0_Real,
+                                34.0_Real, 2.5e-8_Real,  0.0_Real, 0.0_Real};
+
+   setupProfileState(Mesh, VCoord, State, EqState, NLayers, DC, Bulge, Linear,
+                     0.0_Real);
+
+   Array2DReal PseudoThick = State->getPseudoThickness(0);
+   Array2DReal Temp        = Tracers::getByName(0, "Temperature");
+   Array2DReal Salinity    = Tracers::getByName(0, "Salinity");
+
+   Config *Options = Config::getOmegaConfig();
+   Config PGradConfig("PressureGrad");
+   Options->get(PGradConfig);
+
+   // The quadrature is where an equation-of-state call would most naturally
+   // creep in, so it is the setting that matters most here.
+   const I4 QuadSweep[4] = {1, 2, 3, 4};
+   I8 FirstCount         = -1;
+
+   for (int IQuad = 0; IQuad < 4; ++IQuad) {
+
+      PGradConfig.set("PressureGradType", std::string("FiniteVolume"));
+      PGradConfig.set("QuadraturePoints", QuadSweep[IQuad]);
+      PressureGrad *FVPGrad =
+          PressureGrad::create("TestCost", Mesh, VCoord, Options);
+      PGradConfig.set("PressureGradType", std::string("Centered"));
+
+      Array2DReal Tend("TendCost", Mesh->NEdgesSize, NLayers);
+      deepCopy(Tend, 0.0_Real);
+
+      EqState->resetSpecVolEvalCount();
+      FVPGrad->computePressureGrad(Tend, VCoord->PressureMid,
+                                   VCoord->PressureInterface, EqState->SpecVol,
+                                   VCoord->GeomZInterface, PseudoThick, Temp,
+                                   Salinity, EqState);
+      const I8 Count = EqState->SpecVolEvalCount;
+
+      LOG_INFO("PGradTest: cost check: QuadraturePoints {} gives {} "
+               "equation-of-state evaluations in the pressure gradient",
+               QuadSweep[IQuad], Count);
+
+      if (Count != 0) {
+         LOG_ERROR("PGradTest: cost check FAIL: the pressure gradient "
+                   "performed {} equation-of-state evaluations at "
+                   "QuadraturePoints {}; it must perform none",
+                   Count, QuadSweep[IQuad]);
+         ++Err;
+      }
+      if (FirstCount >= 0 && Count != FirstCount) {
+         LOG_ERROR("PGradTest: cost check FAIL: the evaluation count changed "
+                   "with QuadraturePoints, from {} to {}",
+                   FirstCount, Count);
+         ++Err;
+      }
+      FirstCount = Count;
+
+      PressureGrad::erase("TestCost");
+   }
+
+   // restore the configured default
+   PGradConfig.set("QuadraturePoints", 2);
+
+   // The evaluation the requirement does allow is paid once per cell per
+   // layer by the auxiliary state, which is where it belongs. Confirm the
+   // counter sees it, so that a count of zero above cannot come from the
+   // instrumentation being broken.
+   EqState->resetSpecVolEvalCount();
+   EqState->computeSpecVolAndDerivs(Temp, Salinity, VCoord->PressureMid);
+   const I8 OneCall  = EqState->SpecVolEvalCount;
+   const I8 Expected = static_cast<I8>(Mesh->NCellsAll) * VCoord->NVertLayers;
+
+   if (OneCall == Expected) {
+      LOG_INFO("PGradTest: cost check PASS: the pressure gradient performs no "
+               "equation-of-state evaluations, and one call to "
+               "computeSpecVolAndDerivs performs {}, one per cell per layer",
+               OneCall);
+   } else {
+      LOG_ERROR("PGradTest: cost check FAIL: the counter is not working; one "
+                "call gave {} evaluations against {} expected",
+                OneCall, Expected);
+      ++Err;
+   }
+
+   return Err;
+
+} // end testEosCost
+
 // The gating test of design section 5.2: exactness on the exact set, the
 // convergence of the residual off it, and the guards.
 int testExactnessAndGuards(HorzMesh *Mesh,    ///< [in] Horizontal mesh
@@ -1970,9 +2087,6 @@ int main(int argc, char *argv[]) {
 
       } // refinement loop
 
-      // Test the centered identity of design section 3.9 across a sweep of
-      // tilts. This resets the two-column state, so it runs after the
-      // refinement loop.
       // Test the reconstruction estimator on its own. It needs no mesh, and
       // it is the most likely place for the exactness gate to fail, so a
       // failure here localizes immediately.
@@ -1991,6 +2105,12 @@ int main(int argc, char *argv[]) {
       // residual off it, and the guards.
       int ScanErr = testExactnessAndGuards(DefMesh, VCoord, DefState, DefEos);
 
+      // The bounded equation-of-state cost, which no accuracy gate would
+      // notice being violated.
+      int CostErr = testEosCost(DefMesh, VCoord, DefState, DefEos);
+
+      // The centered identity of design section 3.9 across a sweep of tilts.
+      // This resets the two-column state, so it runs after the others.
       int IdentityErr = testCenteredIdentity(DefMesh, VCoord, DefState, DefEos);
 
       // Test parsing and dispatch of the PressureGrad configuration options
@@ -2026,7 +2146,14 @@ int main(int argc, char *argv[]) {
                   Rmse(0));
       }
 
-      RetVal += ReconErr + LookupErr + IntegrandErr + IdentityErr + ConfigErr;
+      RetVal += ReconErr + LookupErr + IntegrandErr + ScanErr + CostErr +
+                IdentityErr + ConfigErr;
+
+      // Flush before teardown. Omega logs at info level but only flushes at
+      // warn and above, so a run that aborts during cleanup loses every
+      // measurement it made -- which is exactly the case that most needs the
+      // record.
+      spdlog::default_logger()->flush();
 
       // cleanup
       PressureGrad::clear();

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -392,11 +392,12 @@ int testPressureLookup() {
 // quadratic in pressure, used to initialize layer means the way the exactness
 // gate requires: as the exact layer averages of a prescribed continuous
 // profile, which under tilt come out different in the two columns.
-Real exactLayerAvg(const Real Coeff0,  ///< [in] constant term
-                   const Real Coeff1,  ///< [in] coefficient of p
-                   const Real Coeff2,  ///< [in] coefficient of p squared
-                   const Real PressLo, ///< [in] top interface pressure
-                   const Real PressHi  ///< [in] bottom interface pressure
+KOKKOS_INLINE_FUNCTION Real exactLayerAvg(
+    const Real Coeff0,  ///< [in] constant term
+    const Real Coeff1,  ///< [in] coefficient of p
+    const Real Coeff2,  ///< [in] coefficient of p squared
+    const Real PressLo, ///< [in] top interface pressure
+    const Real PressHi  ///< [in] bottom interface pressure
 ) {
    const Real PressMid   = 0.5_Real * (PressLo + PressHi);
    const Real DeltaPress = PressHi - PressLo;
@@ -740,6 +741,235 @@ void setupTwoColumnState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
    VCoord->computeGeomZHeight(PseudoThick, SpecVol);
 
 } // end setupTwoColumnState
+
+// Build a two-column state whose vertical profile lies in the scheme's exact
+// set: temperature and salinity vary linearly with pressure, and each column's
+// layer means are the *exact layer averages* of that one continuous profile
+// over that column's own layers.
+//
+// Under the offset between the two columns those averages come out different
+// in the two, and that is the point. A configuration built by copying
+// identical layer means into both columns would not exercise the property at
+// all, because the condition that matters is a property of the reconstructed
+// profiles rather than of the layer means.
+//
+// The two columns share a surface pressure and a bottom pressure and sit on a
+// flat floor; only the distribution of pressure between them differs, which is
+// what an ALE coordinate does. A horizontally uniform surface pressure is
+// required for an exactness gate: where surface pressure varies the state
+// carries a real fixed-pressure height difference at the surface and zero is
+// the wrong expectation.
+//
+// Returns the bottom pressure so tests can scale their tolerances by the
+// hydrostatic terms.
+Real setupExactSetState(HorzMesh *Mesh,    ///< [in] Horizontal mesh
+                        VertCoord *VCoord, ///< [inout] Vertical coordinate
+                        OceanState *State, ///< [inout] Ocean state
+                        Eos *EqState,      ///< [inout] Equation of state
+                        I4 NVertLayers,    ///< [in] Number of layers
+                        Real DC,           ///< [in] Distance between cells
+                        Real Offset        ///< [in] interface offset, in layers
+) {
+
+   const I4 NCellsAll = Mesh->NCellsAll;
+   const I4 NEdgesAll = Mesh->NEdgesAll;
+
+   VCoord->NVertLayers   = NVertLayers;
+   VCoord->NVertLayersP1 = NVertLayers + 1;
+
+   // the prescribed continuous profile, linear in pressure
+   const Real PressBot = 4.0e7_Real;
+   const Real Temp0 = 12.0_Real, Temp1 = -2.0e-7_Real;
+   const Real Salt0 = 34.0_Real, Salt1 = 2.5e-8_Real;
+   const Real Pi = 3.14159265358979323846_Real;
+
+   const Real DeltaP = PressBot / NVertLayers;
+   const Real Bulge  = Offset * DeltaP;
+
+   auto &MinLayerCell = VCoord->MinLayerCell;
+   auto &MaxLayerCell = VCoord->MaxLayerCell;
+   parallelFor(
+       {NCellsAll}, KOKKOS_LAMBDA(int i) {
+          MinLayerCell(i) = 0;
+          MaxLayerCell(i) = NVertLayers - 1;
+       });
+
+   auto &MinLayerEdgeBot = VCoord->MinLayerEdgeBot;
+   auto &MaxLayerEdgeTop = VCoord->MaxLayerEdgeTop;
+   parallelFor(
+       {NEdgesAll}, KOKKOS_LAMBDA(int i) {
+          MinLayerEdgeBot(i) = 0;
+          MaxLayerEdgeTop(i) = NVertLayers - 1;
+       });
+
+   auto &CellsOnEdge = Mesh->CellsOnEdge;
+   auto &DcEdge      = Mesh->DcEdge;
+   parallelFor(
+       {NEdgesAll}, KOKKOS_LAMBDA(int i) {
+          CellsOnEdge(i, 0) = 0;
+          CellsOnEdge(i, 1) = 1;
+          DcEdge(i)         = DC;
+       });
+
+   Array1DReal SurfacePressure("SurfacePressure", Mesh->NCellsSize);
+   Array2DReal PseudoThick = State->getPseudoThickness(0);
+   Array2DReal Temp        = Tracers::getByName(0, "Temperature");
+   Array2DReal Salinity    = Tracers::getByName(0, "Salinity");
+
+   // Column 0 is uniform in pressure; column 1 bulges away from it by up to
+   // Offset layer thicknesses in the interior while sharing both end
+   // pressures. Pseudo-thickness and pressure thickness are proportional, so
+   // setting one sets the other.
+   auto &BottomGeomDepth = VCoord->BottomGeomDepth;
+   parallelFor(
+       {NCellsAll}, KOKKOS_LAMBDA(int i) {
+          SurfacePressure(i) = 0.0_Real;
+          // a flat floor: the anchor's height difference is then exact input
+          // and vanishes identically
+          BottomGeomDepth(i) = 4000.0_Real;
+          for (int k = 0; k < NVertLayers; ++k) {
+             const Real Shape = (i == 1) ? 1.0_Real : 0.0_Real;
+             const Real PTop =
+                 k * DeltaP + Shape * Bulge * Kokkos::sin(Pi * k / NVertLayers);
+             const Real PBot =
+                 (k + 1) * DeltaP +
+                 Shape * Bulge * Kokkos::sin(Pi * (k + 1) / NVertLayers);
+             PseudoThick(i, k) = (PBot - PTop) / (Gravity * RhoSw);
+          }
+       });
+
+   // pressure from the pseudo-thickness the model will actually use
+   VCoord->computePressure(PseudoThick, SurfacePressure);
+
+   // layer means as the exact layer averages of the prescribed profile, taken
+   // over the model's own interface pressures so the two are consistent
+   const auto &PressureInterface = VCoord->PressureInterface;
+   parallelFor(
+       {NCellsAll, NVertLayers}, KOKKOS_LAMBDA(int i, int k) {
+          Temp(i, k) =
+              exactLayerAvg(Temp0, Temp1, 0.0_Real, PressureInterface(i, k),
+                            PressureInterface(i, k + 1));
+          Salinity(i, k) =
+              exactLayerAvg(Salt0, Salt1, 0.0_Real, PressureInterface(i, k),
+                            PressureInterface(i, k + 1));
+       });
+
+   // specific volume and its derivatives, from one equation-of-state pass
+   EqState->computeSpecVolAndDerivs(Temp, Salinity, VCoord->PressureMid);
+
+   VCoord->computeGeomZHeight(PseudoThick, EqState->SpecVol);
+
+   return PressBot;
+
+} // end setupExactSetState
+
+// Assert that the column scan returns a zero fixed-pressure height difference
+// at *every* interface, not merely in the layer mean, for a profile the
+// reconstruction resolves exactly.
+//
+// The shape of a failure is diagnostic and is reported: a residual growing
+// with depth points at the recurrence, while one flat with depth points at the
+// anchor. Here the two columns share a bottom pressure and a flat floor, so
+// the anchor is identically zero by construction and any residual at all is
+// the recurrence's.
+int testColumnScan(HorzMesh *Mesh,    ///< [in] Horizontal mesh
+                   VertCoord *VCoord, ///< [inout] Vertical coordinate
+                   OceanState *State, ///< [inout] Ocean state
+                   Eos *EqState       ///< [inout] Equation of state
+) {
+
+   int Err = 0;
+
+   const I4 NVertLayers = 32;
+   const Real DC        = 4000.0_Real;
+   const Real Offset    = 3.0_Real;
+   const Real Eps       = std::numeric_limits<Real>::epsilon();
+
+   const Real PressBot = setupExactSetState(Mesh, VCoord, State, EqState,
+                                            NVertLayers, DC, Offset);
+
+   // A FiniteVolume instance, created after the state so that its working
+   // arrays are sized for this number of layers
+   Config *Options = Config::getOmegaConfig();
+   Config PGradConfig("PressureGrad");
+   Options->get(PGradConfig);
+   PGradConfig.set("PressureGradType", std::string("FiniteVolume"));
+   PressureGrad *FVPGrad =
+       PressureGrad::create("TestColumnScan", Mesh, VCoord, Options);
+   PGradConfig.set("PressureGradType", std::string("Centered"));
+
+   Array2DReal Tend("TendColumnScan", Mesh->NEdgesSize, NVertLayers);
+   deepCopy(Tend, 0.0_Real);
+
+   Array2DReal PseudoThick = State->getPseudoThickness(0);
+   Array2DReal Temp        = Tracers::getByName(0, "Temperature");
+   Array2DReal Salinity    = Tracers::getByName(0, "Salinity");
+
+   FVPGrad->computePressureGrad(
+       Tend, VCoord->PressureMid, VCoord->PressureInterface, EqState->SpecVol,
+       VCoord->GeomZInterface, PseudoThick, Temp, Salinity, EqState);
+
+   // Scale by the size of the terms that had to cancel: the hydrostatic
+   // contribution of the temperature and salinity structure over the column.
+   const auto &SpecVolDCt = EqState->SpecVolDCt;
+   const auto &SpecVolDSa = EqState->SpecVolDSa;
+   Real CancelScale       = 0.0_Real;
+   parallelReduce(
+       {2, NVertLayers},
+       KOKKOS_LAMBDA(int i, int k, Real &MaxV) {
+          const Real V = (Kokkos::abs(SpecVolDCt(i, k) * Temp(i, k)) +
+                          Kokkos::abs(SpecVolDSa(i, k) * Salinity(i, k))) *
+                         PressBot / Gravity;
+          if (V > MaxV)
+             MaxV = V;
+       },
+       Kokkos::Max<Real>(CancelScale));
+
+   const auto &DeltaZFixedP = FVPGrad->getDeltaZFixedP();
+
+   Real MaxTop = 0.0_Real;
+   Real MaxBot = 0.0_Real;
+   Real MaxAll = 0.0_Real;
+   parallelReduce(
+       {Mesh->NEdgesAll, NVertLayers + 1},
+       KOKKOS_LAMBDA(int IEdge, int K, Real &MaxA, Real &MaxT, Real &MaxB) {
+          const Real V = Kokkos::abs(DeltaZFixedP(IEdge, K));
+          if (V > MaxA)
+             MaxA = V;
+          // the shallower and deeper halves of the column, to show whether a
+          // residual grows with depth
+          if (K <= NVertLayers / 2 && V > MaxT)
+             MaxT = V;
+          if (K > NVertLayers / 2 && V > MaxB)
+             MaxB = V;
+       },
+       Kokkos::Max<Real>(MaxAll), Kokkos::Max<Real>(MaxTop),
+       Kokkos::Max<Real>(MaxBot));
+
+   const Real Scaled = MaxAll / (Eps * CancelScale);
+
+   LOG_INFO("PGradTest: column scan on the exact set: max |DeltaZFixedP| = {} "
+            "m ({} eps of the cancelling terms, which are {} m); upper column "
+            "{} m, lower column {} m",
+            MaxAll, Scaled, CancelScale, MaxTop, MaxBot);
+
+   // Provisional gate. The residual is expected to be a few eps of the
+   // cancelling terms: the integrand is zero pointwise to about one eps and
+   // the recurrence accumulates that over the column.
+   const Real Tol = 100.0_Real;
+   if (Scaled <= Tol) {
+      LOG_INFO("PGradTest: column scan PASS: {} eps", Scaled);
+   } else {
+      LOG_ERROR("PGradTest: column scan FAIL: {} eps exceeds {} eps", Scaled,
+                Tol);
+      ++Err;
+   }
+
+   PressureGrad::erase("TestColumnScan");
+
+   return Err;
+
+} // end testColumnScan
 
 // Assert the identity of design section 3.9 (test section 5.5): with the tidal
 // and self-attraction-and-loading potentials zero, PressureGradCentered is
@@ -1130,6 +1360,10 @@ int main(int argc, char *argv[]) {
       // The matched-pressure integrand must be zero at every quadrature
       // point on a resolved profile, not merely in the integral.
       int IntegrandErr = testMatchedPressIntegrand();
+
+      // The column scan must return a zero fixed-pressure height difference
+      // at every interface on the exact set, not merely in the layer mean.
+      int ScanErr = testColumnScan(DefMesh, VCoord, DefState, DefEos);
 
       int IdentityErr = testCenteredIdentity(DefMesh, VCoord, DefState, DefEos);
 

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -153,9 +153,12 @@ int testPGradConfig(const HorzMesh *Mesh,   ///< [in] Horizontal mesh
                       VCoord->NVertLayers);
    deepCopy(TendFV, 0.0_Real);
 
-   FVPGrad->computePressureGrad(TendFV, VCoord->PressureMid,
-                                VCoord->PressureInterface, EqState->SpecVol,
-                                VCoord->GeomZInterface, PseudoThick);
+   Array2DReal ConservTemp = Tracers::getByName(0, "Temperature");
+   Array2DReal AbsSalinity = Tracers::getByName(0, "Salinity");
+
+   FVPGrad->computePressureGrad(
+       TendFV, VCoord->PressureMid, VCoord->PressureInterface, EqState->SpecVol,
+       VCoord->GeomZInterface, PseudoThick, ConservTemp, AbsSalinity, EqState);
 
    I4 NBad = 0;
    parallelReduce(
@@ -369,7 +372,8 @@ int main(int argc, char *argv[]) {
 
          const auto &PressureInterface = VCoord->PressureInterface;
          DefPGrad->computePressureGrad(Tend, PressureMid, PressureInterface,
-                                       SpecVol, GeomZInterface, PseudoThick);
+                                       SpecVol, GeomZInterface, PseudoThick,
+                                       Temp, Salinity, DefEos);
 
          // compute errors
          Real MaxValue = 0.0_Real;

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -91,6 +91,96 @@ void initPGradTest() {
    CHECK_ERROR_ABORT(Err, "PGrad: error during initialization");
 }
 
+// Check that the PressureGrad configuration group is parsed as expected and
+// that a FiniteVolume instance can be created and dispatched to. The
+// FiniteVolume sub-options are read from the same group as PressureGradType
+// and default to the Phase 1 values when a key is absent.
+int testPGradConfig(const HorzMesh *Mesh,   ///< [in] Horizontal mesh
+                    const VertCoord *VCoord ///< [in] Vertical coordinate
+) {
+
+   int Err = 0;
+
+   // The default instance is built from the PressureGrad group in the
+   // config, which selects the centered scheme
+   PressureGrad *DefPGrad = PressureGrad::getDefault();
+
+   if (DefPGrad->getType() == PressureGradType::Centered) {
+      LOG_INFO("PGradTest: default PressureGradType parse PASS");
+   } else {
+      LOG_ERROR("PGradTest: default PressureGradType parse FAIL");
+      ++Err;
+   }
+
+   // The Phase 1 sub-option values, whether read from the config or taken
+   // from the defaults
+   if (DefPGrad->getHorzOrder() == 2 &&
+       DefPGrad->getVertRecon() == PressureGradVertRecon::Linear &&
+       DefPGrad->getQuadraturePoints() >= 1) {
+      LOG_INFO("PGradTest: FiniteVolume sub-option parse PASS");
+   } else {
+      LOG_ERROR("PGradTest: FiniteVolume sub-option parse FAIL: HorzOrder={} "
+                "QuadraturePoints={}",
+                DefPGrad->getHorzOrder(), DefPGrad->getQuadraturePoints());
+      ++Err;
+   }
+
+   // Create a second instance that selects the FiniteVolume scheme. The
+   // sub-config shares its node with the parent, so resetting the type here
+   // is what the new instance sees. Note the explicit std::string: a string
+   // literal would select the boolean overload of Config::set.
+   Config *Options = Config::getOmegaConfig();
+   Config PGradConfig("PressureGrad");
+   Err += (Options->get(PGradConfig).isFail() ? 1 : 0);
+   PGradConfig.set("PressureGradType", std::string("FiniteVolume"));
+
+   PressureGrad *FVPGrad =
+       PressureGrad::create("TestFiniteVolume", Mesh, VCoord, Options);
+
+   if (FVPGrad && FVPGrad->getType() == PressureGradType::FiniteVolume) {
+      LOG_INFO("PGradTest: FiniteVolume PressureGradType parse PASS");
+   } else {
+      LOG_ERROR("PGradTest: FiniteVolume PressureGradType parse FAIL");
+      ++Err;
+   }
+
+   // Dispatch check: computePressureGrad must take the FiniteVolume branch
+   // and leave a finite tendency everywhere it touches
+   OceanState *State       = OceanState::getDefault();
+   Eos *EqState            = Eos::getInstance();
+   Array2DReal PseudoThick = State->getPseudoThickness(0);
+   Array2DReal TendFV("TendFiniteVolume", Mesh->NEdgesSize,
+                      VCoord->NVertLayers);
+   deepCopy(TendFV, 0.0_Real);
+
+   FVPGrad->computePressureGrad(TendFV, VCoord->PressureMid,
+                                VCoord->PressureInterface, EqState->SpecVol,
+                                VCoord->GeomZInterface, PseudoThick);
+
+   I4 NBad = 0;
+   parallelReduce(
+       {Mesh->NEdgesAll, VCoord->NVertLayers},
+       KOKKOS_LAMBDA(int IEdge, int K, I4 &LSum) {
+          if (!Kokkos::isfinite(TendFV(IEdge, K)))
+             ++LSum;
+       },
+       Kokkos::Sum<I4>(NBad));
+
+   if (NBad == 0) {
+      LOG_INFO("PGradTest: FiniteVolume dispatch PASS");
+   } else {
+      LOG_ERROR("PGradTest: FiniteVolume dispatch FAIL: {} non-finite values",
+                NBad);
+      ++Err;
+   }
+
+   PGradConfig.set("PressureGradType", std::string("Centered"));
+   PressureGrad::erase("TestFiniteVolume");
+
+   return Err;
+
+} // end testPGradConfig
+
 int main(int argc, char *argv[]) {
    int RetVal = 0;
 
@@ -310,6 +400,9 @@ int main(int argc, char *argv[]) {
 
       } // refinement loop
 
+      // Test parsing and dispatch of the PressureGrad configuration options
+      int ConfigErr = testPGradConfig(DefMesh, VCoord);
+
       // Test for second order convergence
       // resolution (dC) increases in refimenent loop
       if (Rmse(0) < Rmse(NRefinements - 1) / pow(4.0_Real, NRefinements - 1)) {
@@ -317,6 +410,8 @@ int main(int argc, char *argv[]) {
       } else {
          RetVal = 1;
       }
+
+      RetVal += ConfigErr;
 
       // cleanup
       PressureGrad::clear();

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -1102,6 +1102,11 @@ Real runFiniteVolume(HorzMesh *Mesh, VertCoord *VCoord, OceanState *State,
    PressureGrad *FVPGrad =
        PressureGrad::create("TestFV", Mesh, VCoord, Options);
    PGradConfig.set("PressureGradType", std::string("Centered"));
+   // create returns null if an instance of this name already exists, and
+   // dereferencing that gives a segmentation fault rather than a message
+   CHECK_ERROR_ABORT(
+       Error(FVPGrad ? ErrorCode::Success : ErrorCode::Fail, ""),
+       "PGradTest: could not create the TestFV pressure gradient");
 
    Array2DReal Tend("TendFV", Mesh->NEdgesSize, NVertLayers);
    deepCopy(Tend, 0.0_Real);
@@ -1247,6 +1252,9 @@ int testEosCost(HorzMesh *Mesh,    ///< [in] Horizontal mesh
       PressureGrad *FVPGrad =
           PressureGrad::create("TestCost", Mesh, VCoord, Options);
       PGradConfig.set("PressureGradType", std::string("Centered"));
+      CHECK_ERROR_ABORT(
+          Error(FVPGrad ? ErrorCode::Success : ErrorCode::Fail, ""),
+          "PGradTest: could not create the TestCost pressure gradient");
 
       Array2DReal Tend("TendCost", Mesh->NEdgesSize, NLayers);
       deepCopy(Tend, 0.0_Real);
@@ -1894,6 +1902,9 @@ int testPGradConfig(const HorzMesh *Mesh,   ///< [in] Horizontal mesh
 
    PressureGrad *FVPGrad =
        PressureGrad::create("TestFiniteVolume", Mesh, VCoord, Options);
+   CHECK_ERROR_ABORT(
+       Error(FVPGrad ? ErrorCode::Success : ErrorCode::Fail, ""),
+       "PGradTest: could not create the TestFiniteVolume pressure gradient");
 
    if (FVPGrad && FVPGrad->getType() == PressureGradType::FiniteVolume) {
       LOG_INFO("PGradTest: FiniteVolume PressureGradType parse PASS");
@@ -1958,22 +1969,27 @@ int testPGradConfig(const HorzMesh *Mesh,   ///< [in] Horizontal mesh
        Kokkos::Sum<I4>(NBad), Kokkos::Max<Real>(MaxFV),
        Kokkos::Max<Real>(MaxCtr));
 
-   // The two schemes agree to second order in the cross-edge pressure
-   // difference, so on any ordinary state they come out the same order of
-   // magnitude. Requiring that as well as finiteness is what keeps this check
-   // from passing on garbage: a fill value would be off by thirty orders.
+   // What can be asserted here is one-sided. The finite-volume tendency may
+   // legitimately be very much *smaller* than the centered one -- that is the
+   // whole point of the scheme, and this state has a profile close to linear
+   // in pressure, so it is -- but it cannot be very much larger, since the two
+   // agree to second order in the cross-edge pressure difference. An upper
+   // bound plus a nonzero lower bound is therefore the honest check: it
+   // catches a fill value, which is off by thirty orders, and it catches a
+   // dispatch that quietly did nothing, without forbidding the scheme from
+   // working.
    const Real Ratio = (MaxCtr > 0.0_Real) ? MaxFV / MaxCtr : 0.0_Real;
 
    LOG_INFO("PGradTest: FiniteVolume dispatch: max |Tend| = {} m/s2 against "
             "Centered {} m/s2, ratio {}",
             MaxFV, MaxCtr, Ratio);
 
-   if (NBad == 0 && Ratio > 1.0e-3_Real && Ratio < 1.0e3_Real) {
+   if (NBad == 0 && MaxFV > 0.0_Real && Ratio < 1.0e3_Real) {
       LOG_INFO("PGradTest: FiniteVolume dispatch PASS");
    } else {
       LOG_ERROR("PGradTest: FiniteVolume dispatch FAIL: {} non-finite values, "
-                "ratio to the centered scheme {}",
-                NBad, Ratio);
+                "max |Tend| {} m/s2, ratio to the centered scheme {}",
+                NBad, MaxFV, Ratio);
       ++Err;
    }
 

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -20,6 +20,7 @@
 #include "IOStream.h"
 #include "Logging.h"
 #include "MachEnv.h"
+#include "OceanTestCommon.h"
 #include "OmegaKokkos.h"
 #include "Pacer.h"
 #include "TimeMgr.h"
@@ -108,6 +109,19 @@ int main(int argc, char *argv[]) {
       I4 VertexDegree   = DefMesh->VertexDegree;
       I4 NVertLayers    = DefVertCoord->NVertLayers;
 
+      // Tolerances for the comparisons below. In double precision these
+      // reproduce the fixed 1e-10 absolute tolerance this test has always
+      // used. Single precision cannot hold that: the expected values reach a
+      // few thousand once cell and layer indices accumulate down a column, and
+      // several of them (the sea surface height, the target thicknesses) are
+      // arrived at by cancelling contributions from every layer, so the error
+      // is set by the magnitude of the whole column rather than by the size of
+      // the result. Hence a relative tolerance with an absolute floor. Both
+      // stay far below the smallest separation any of these checks has to
+      // resolve, which is the 0.5 between a layer midpoint and its interface.
+      const Real RTol = sizeof(Real) == 4 ? 1.0e-4_Real : 0.0_Real;
+      const Real ATol = sizeof(Real) == 4 ? 1.0e-2_Real : 1.0e-10_Real;
+
       // Rest bottom depth successful read
       R8 MaxBathy = -1e10;
       R8 MinBathy = 1e10;
@@ -167,15 +181,13 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             // Interface pressure at layer K should be K+1
             Real Expected = K + 1;
-            Real Diff     = std::abs(PressInterfH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(PressInterfH(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
             // Mid pressures at layer K should be K+1.5
             Expected = K + 1.5;
-            Diff     = std::abs(PressMidH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
-               Err += Err + 1;
+            if (!isApprox(PressMidH(ICell, K), Expected, RTol, ATol)) {
+               Err += 1;
             }
          }
       }
@@ -212,8 +224,7 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// Interface pressure should be (K+1)*K/2 + the cell number
             Real Expected = ((K + 1.0_Real) * K) / 2.0_Real + ICell;
-            Real Diff     = std::abs(PressInterfH2(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(PressInterfH2(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
          }
@@ -264,21 +275,18 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// Z value at interface K should be -K
             Real Expected = -K;
-            Real Diff     = std::abs(GeomZInterfH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(GeomZInterfH(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
             /// Z value at mid point of layer K should be -(K + .5)
             Expected = -K - 0.5;
-            Diff     = std::abs(GeomZMidH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(GeomZMidH(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
          }
          /// SshCell should equal ZInterface at the top of the active column
          Real Expected = -DefVertCoord->MinLayerCellH(ICell);
-         Real Diff     = std::abs(SshCellH(ICell) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(SshCellH(ICell), Expected, RTol, ATol)) {
             Err += 1;
          }
       }
@@ -317,8 +325,7 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// Z value at interface should be -(K+1)*K/2
             Real Expected = -((K + 1.0_Real) * K) / 2.0_Real;
-            Real Diff     = std::abs(ZInterfH2(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(ZInterfH2(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
          }
@@ -326,8 +333,7 @@ int main(int argc, char *argv[]) {
          /// which is -((MinLayer+1)*MinLayer)/2
          I4 MinK       = DefVertCoord->MinLayerCellH(ICell);
          Real Expected = -((MinK + 1.0_Real) * MinK) / 2.0_Real;
-         Real Diff     = std::abs(SshCellH2(ICell) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(SshCellH2(ICell), Expected, RTol, ATol)) {
             Err += 1;
          }
       }
@@ -372,8 +378,7 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// Geopotential should be cell number + layer number
             Real Expected = ICell + K;
-            Real Diff     = std::abs(GeopotentialMidH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(GeopotentialMidH(ICell, K), Expected, RTol, ATol)) {
                Err += 1;
             }
          }
@@ -416,8 +421,8 @@ int main(int argc, char *argv[]) {
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// target thickness should be 2
             Real Expected = 2.0;
-            Real Diff = std::abs(PseudoThicknessTargetH(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(PseudoThicknessTargetH(ICell, K), Expected, RTol,
+                          ATol)) {
                Err += 1;
             }
          }
@@ -472,8 +477,8 @@ int main(int argc, char *argv[]) {
                /// target thickness is 1 in all other layer
                Expected = 1.0;
             }
-            Real Diff = std::abs(PseudoThicknessTargetH2(ICell, K) - Expected);
-            if (Diff > 1e-10) {
+            if (!isApprox(PseudoThicknessTargetH2(ICell, K), Expected, RTol,
+                          ATol)) {
                LOG_INFO("PseudoThicknessTargetH({},{}) = {}, {}", ICell, K,
                         PseudoThicknessTargetH2(ICell, K), Expected);
                Err += 1;
@@ -524,27 +529,27 @@ int main(int argc, char *argv[]) {
          I4 CellID1 = DefDecomp->CellIDH(DefMesh->CellsOnEdgeH(IEdge, 0));
          I4 CellID2 = DefDecomp->CellIDH(DefMesh->CellsOnEdgeH(IEdge, 1));
          /// MinLayerEdgeTop is the min of the min cell values on edge
-         Expected  = std::min(-2 * CellID1, -2 * CellID2);
-         Real Diff = std::abs(DefVertCoord->MinLayerEdgeTopH(IEdge) - Expected);
-         if (Diff > 1e-10) {
+         Expected = std::min(-2 * CellID1, -2 * CellID2);
+         if (!isApprox(DefVertCoord->MinLayerEdgeTopH(IEdge), Expected, RTol,
+                       ATol)) {
             Err += 1;
          }
          /// MinLayerEdgeBot is the max of the min cell values on edge
          Expected = std::max(-2 * CellID1, -2 * CellID2);
-         Diff     = std::abs(DefVertCoord->MinLayerEdgeBotH(IEdge) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MinLayerEdgeBotH(IEdge), Expected, RTol,
+                       ATol)) {
             Err += 1;
          }
          /// MaxLayerEdgeTop is the min of the max cell values on edge
          Expected = std::min(2 * CellID1, 2 * CellID2);
-         Diff     = std::abs(DefVertCoord->MaxLayerEdgeTopH(IEdge) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MaxLayerEdgeTopH(IEdge), Expected, RTol,
+                       ATol)) {
             Err += 1;
          }
          /// MaxLayerEdgeBot is the max of the max cell values on edge
          Expected = std::max(2 * CellID1, 2 * CellID2);
-         Diff     = std::abs(DefVertCoord->MaxLayerEdgeBotH(IEdge) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MaxLayerEdgeBotH(IEdge), Expected, RTol,
+                       ATol)) {
             Err += 1;
          }
       }
@@ -590,9 +595,8 @@ int main(int argc, char *argv[]) {
          for (int I = 0; I < VertexDegree; I++) {
             Expected = std::min(Expected, -2 * CellIDs[I]);
          }
-         Real Diff =
-             std::abs(DefVertCoord->MinLayerVertexTopH(IVertex) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MinLayerVertexTopH(IVertex), Expected,
+                       RTol, ATol)) {
             Err += 1;
          }
 
@@ -601,8 +605,8 @@ int main(int argc, char *argv[]) {
          for (int I = 0; I < VertexDegree; I++) {
             Expected = std::max(Expected, -2 * CellIDs[I]);
          }
-         Diff = std::abs(DefVertCoord->MinLayerVertexBotH(IVertex) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MinLayerVertexBotH(IVertex), Expected,
+                       RTol, ATol)) {
             Err += 1;
          }
 
@@ -611,8 +615,8 @@ int main(int argc, char *argv[]) {
          for (int I = 0; I < VertexDegree; I++) {
             Expected = std::min(Expected, 2 * CellIDs[I]);
          }
-         Diff = std::abs(DefVertCoord->MaxLayerVertexTopH(IVertex) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MaxLayerVertexTopH(IVertex), Expected,
+                       RTol, ATol)) {
             Err += 1;
          }
 
@@ -621,8 +625,8 @@ int main(int argc, char *argv[]) {
          for (int I = 0; I < VertexDegree; I++) {
             Expected = std::max(Expected, 2 * CellIDs[I]);
          }
-         Diff = std::abs(DefVertCoord->MaxLayerVertexBotH(IVertex) - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(DefVertCoord->MaxLayerVertexBotH(IVertex), Expected,
+                       RTol, ATol)) {
             Err += 1;
          }
       }
@@ -675,8 +679,7 @@ int main(int argc, char *argv[]) {
             Sum += DefVertCoord->CellMaskH(ICell, K);
          }
 
-         Real Diff = std::abs(Sum - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(Sum, Expected, RTol, ATol)) {
             Err += 1;
          }
       }
@@ -697,8 +700,7 @@ int main(int argc, char *argv[]) {
          for (int K = 0; K < NVertLayers; ++K) {
             Sum += DefVertCoord->EdgeMaskH(IEdge, K);
          }
-         Real Diff = std::abs(Sum - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(Sum, Expected, RTol, ATol)) {
             Err += 1;
          }
       }
@@ -711,8 +713,7 @@ int main(int argc, char *argv[]) {
          for (int K = 0; K < NVertLayers; ++K) {
             Sum += DefVertCoord->VertexMaskH(IVertex, K);
          }
-         Real Diff = std::abs(Sum - Expected);
-         if (Diff > 1e-10) {
+         if (!isApprox(Sum, Expected, RTol, ATol)) {
             Err += 1;
          }
       }


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

In phase 1, we add the 2nd order version of the finite-volume pressure gradient.  The finite-volume implementation improves on the centered implementation in that it is "consistent" to machine precision for a certain class of solutions.  The 2nd-order implementation is designed to produce machine-zero horizontal pressure gradient for CT and SA fields that are linear functions of pressure even for tilted layers.

Phase 2 (not in this PR) will add a 4th-order implementation that guarantees consistency with more variation of CT and SA with pressure, and will produce less spurious flow in tilted coordinates with thin layers (like sigma and p-star squashed by ice shelves) that is desirable for longer-term work.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Documentation:
  * [ ] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
  * [ ] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [ ] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* Linting
  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.
* [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
* [ ] New tests:
  * [ ] CTest unit tests for new features have been added per the approved design.
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
* Stealth Features
  * [ ] If any stealth features are included in the PR, please confirm that they have been documented.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


