### PR TITLE
Fix a bug in field registration of `ProvPseudoThickness`

### DIFF
--- a/components/omega/src/ocn/auxiliaryVars/PseudoThicknessAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/PseudoThicknessAuxVars.cpp
@@ -63,6 +63,8 @@ void PseudoThicknessAuxVars::registerFields(const std::string &AuxGroupName,
        DimNames                          // dimension names
    );
 
+   DimNames[0] = "NCells" + DimSuffix;
+
    // Provisional Thickness
    auto ProvPseudoThicknessField = Field::create(
        ProvPseudoThickness.label(),              // field name


### PR DESCRIPTION
This bug fix PR resolves an out-of-bounds read when writing the `AuxiliaryState` group.

- Registered `ProvPseudoThickness` on cells instead of edges
- Fixes an out-of-bounds read when writing the `AuxiliaryState` group, which segfaults on GPU builds

This PR fixes the issue #501 .

* Linting
  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests