### PR TITLE
Check for null pointers in `init` and `create` and add missing init calls in tests

### DIFF
--- a/components/omega/doc/devGuide/Tendencies.md
+++ b/components/omega/doc/devGuide/Tendencies.md
@@ -26,15 +26,21 @@ tendency terms, which each store constant mesh information as private member var
 ## Creation of non-default tendencies
 
 A non-default tendency group can be created with or without custom tendencies.
-Without custom tendencies, it is created from a string `Name`, horizontal mesh `Mesh`, vertical coordinate `VCoord`, number of tracers `NTracers`, and a configuration `Options`:
+Without custom tendencies, it is created from a string `Name`, horizontal mesh `Mesh`,
+vertical coordinate `VCoord`, vertical advection `VAdv`, pressure gradient `PGrad`,
+equation of state `EqState`, vertical mixing `VMix`, number of tracers `NTracers`,
+time step `TimeStep`, and a configuration `Options`:
 ```c++
-OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, VCoord, NTracers, Options);
+OMEGA::Tendencies* NewTendencies = OMEGA::Tendencies::create(
+    Name, Mesh, VCoord, VAdv, PGrad, EqState, VMix, NTracers, TimeStep, Options);
 ```
 For convenience, this returns a pointer to the newly created instance.
 To allow the user to provide custom tendencies, the `create` function can take two additional arguments
 `CustomThicknessTend` and `CustomVelocityTend`
 ```c++
-OMEGA::Tendencies*  NewTendencies = OMEGA::Tendencies::create(Name, Mesh, VCoord, NTracers, Options, CustomThicknessTend, CustomVelocityTend);
+OMEGA::Tendencies* NewTendencies = OMEGA::Tendencies::create(
+    Name, Mesh, VCoord, VAdv, PGrad, EqState, VMix, NTracers, TimeStep, Options,
+    CustomThicknessTend, CustomVelocityTend);
 ```
 The two custom tendency arguments need to be callable objects that take a Kokkos array `Tend`, ocean state `State`,
 auxiliary state `AuxState`, two integers: `ThickTimeLevel` and `VelTimeLevel`, and time instant `Time`.

--- a/components/omega/src/analysis/Analysis.cpp
+++ b/components/omega/src/analysis/Analysis.cpp
@@ -64,12 +64,18 @@ void Analysis::init() {
    registerAllBaseAnalysisOperators();
 
    // Retrieve default instances of required components
-   auto DefEnv         = MachEnv::getDefault();
-   auto Mesh           = HorzMesh::getDefault();
-   auto VCoord         = VertCoord::getDefault();
+   auto DefEnv = MachEnv::getDefault();
+   OMEGA_REQUIRE(DefEnv, "Null default MachEnv pointer in Analysis::init");
+   auto Mesh = HorzMesh::getDefault();
+   OMEGA_REQUIRE(Mesh, "Null default HorzMesh pointer in Analysis::init");
+   auto VCoord = VertCoord::getDefault();
+   OMEGA_REQUIRE(VCoord, "Null default VertCoord pointer in Analysis::init");
    auto DefTimeStepper = TimeStepper::getDefault();
+   OMEGA_REQUIRE(DefTimeStepper,
+                 "Null default TimeStepper pointer in Analysis::init");
    Clock *OmegaClock   = DefTimeStepper->getClock();
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in Analysis::init");
 
    // Create the default Analysis instance
    Analysis::DefAnalysis =
@@ -86,6 +92,16 @@ void Analysis::init() {
 Analysis *Analysis::create(const std::string &Name, const MachEnv *Env,
                            const HorzMesh *Mesh, const VertCoord *VCoord,
                            Clock *ModelClock, Config *Options) {
+
+   OMEGA_REQUIRE(Env, "Null MachEnv pointer in Analysis::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(
+       Mesh, "Null HorzMesh pointer in Analysis::create with Name = {}", Name);
+   OMEGA_REQUIRE(VCoord,
+                 "Null VertCoord pointer in Analysis::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(ModelClock,
+                 "Null Clock pointer in Analysis::create with Name = {}", Name);
 
    // Check for duplicate names
    if (AllAnalysisObjects.find(Name) != AllAnalysisObjects.end()) {

--- a/components/omega/src/analysis/AnalysisOperator.cpp
+++ b/components/omega/src/analysis/AnalysisOperator.cpp
@@ -36,6 +36,12 @@ AnalysisOperator::AnalysisOperator(const std::string &OperatorType) {
 void AnalysisOperator::initialize(const MachEnv *Env, const HorzMesh *InMesh,
                                   const VertCoord *InVCoord, Config Options) {
 
+   OMEGA_REQUIRE(Env, "Null MachEnv pointer in AnalysisOperator::initialize");
+   OMEGA_REQUIRE(InMesh,
+                 "Null HorzMesh pointer in AnalysisOperator::initialize");
+   OMEGA_REQUIRE(InVCoord,
+                 "Null VertCoord pointer in AnalysisOperator::initialize");
+
    // Store pointers needed during compute()
    Mesh   = InMesh;
    VCoord = InVCoord;

--- a/components/omega/src/base/Decomp.cpp
+++ b/components/omega/src/base/Decomp.cpp
@@ -408,6 +408,7 @@ void Decomp::init(const std::string &InMeshFileName) {
 
    // Retrieve options from Config
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in Decomp::init");
 
    Config DecompConfig("Decomp");
    Err = OmegaConfig->get(DecompConfig);
@@ -443,6 +444,7 @@ void Decomp::init(const std::string &InMeshFileName) {
 
    // Retrieve the default machine environment
    MachEnv *DefEnv = MachEnv::getDefault();
+   OMEGA_REQUIRE(DefEnv, "Null default MachEnv pointer in Decomp::init");
 
    // Use one partition per MPI task as the default
    I4 NParts = DefEnv->getNumTasks();
@@ -778,6 +780,9 @@ Decomp *Decomp::create(
 ) {
 
    bool TimerFlag = Pacer::start("Decomp create", 1);
+   OMEGA_REQUIRE(Env, "Null MachEnv pointer in Decomp::create with Name = {}",
+                 Name);
+
    // Check to see if a decomposition of the same name already exists and
    // if so, exit with an error
    if (AllDecomps.find(Name) != AllDecomps.end()) {

--- a/components/omega/src/base/Halo.cpp
+++ b/components/omega/src/base/Halo.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Halo.h"
+#include "Error.h"
 #include "mpi.h"
 #include <algorithm>
 #include <iterator>
@@ -134,8 +135,10 @@ int Halo::init() {
 
    I4 IErr{0}; // error code
 
-   MachEnv *DefEnv   = MachEnv::getDefault();
+   MachEnv *DefEnv = MachEnv::getDefault();
+   OMEGA_REQUIRE(DefEnv, "Null default MachEnv pointer in Halo::init");
    Decomp *DefDecomp = Decomp::getDefault();
+   OMEGA_REQUIRE(DefDecomp, "Null default Decomp pointer in Halo::init");
 
    Halo::DefaultHalo = create("Default", DefEnv, DefDecomp);
 
@@ -204,6 +207,11 @@ Halo::Halo(const std::string &Name, const MachEnv *InEnv,
 /// map
 Halo *Halo::create(const std::string &Name, const MachEnv *Env,
                    const Decomp *Decomp) {
+   OMEGA_REQUIRE(Env, "Null MachEnv pointer in Halo::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(Decomp, "Null Decomp pointer in Halo::create with Name = {}",
+                 Name);
+
    // Check to see if a halo of the same name already exists and
    // if so, exit with an error
    if (AllHalos.find(Name) != AllHalos.end()) {

--- a/components/omega/src/base/IO.cpp
+++ b/components/omega/src/base/IO.cpp
@@ -133,6 +133,7 @@ void init(const MPI_Comm &InComm // [in] MPI communicator to use
 
    Error Err;
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in IO::init");
 
    // Read IO subconfiguration
    Config IOConfig("IO");

--- a/components/omega/src/infra/IOStream.cpp
+++ b/components/omega/src/infra/IOStream.cpp
@@ -45,8 +45,11 @@ void IOStream::init(Clock *&ModelClock //< [inout] Omega model clock
 
    Error Err;
 
+   OMEGA_REQUIRE(ModelClock, "Null ModelClock pointer in IOStream::init");
+
    // Retrieve the model configuration and get the streams sub-config
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in IOStream::init");
    Config StreamsCfgAll("IOStreams");
    Err = OmegaConfig->get(StreamsCfgAll);
    CHECK_ERROR_ABORT(
@@ -388,6 +391,10 @@ void IOStream::create(const std::string &StreamName, //< [in] name of stream
 ) {
 
    Error Err; // internal error code
+
+   OMEGA_REQUIRE(ModelClock,
+                 "Null ModelClock pointer in IOStream::create with Name = {}",
+                 StreamName);
 
    // Check whether the stream already exists
    if (AllStreams.find(StreamName) != AllStreams.end())

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -329,6 +329,19 @@ AuxiliaryState *AuxiliaryState::create(const std::string &Name,
                                        VertCoord *VCoord, VertAdv *VAdv,
                                        const int NTracers,
                                        TimeInterval TimeStep) {
+   OMEGA_REQUIRE(
+       Mesh, "Null HorzMesh pointer in AuxiliaryState::create with Name = {}",
+       Name);
+   OMEGA_REQUIRE(MeshHalo,
+                 "Null Halo pointer in AuxiliaryState::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(
+       VCoord,
+       "Null VertCoord pointer in AuxiliaryState::create with Name = {}", Name);
+   OMEGA_REQUIRE(
+       VAdv, "Null VertAdv pointer in AuxiliaryState::create with Name = {}",
+       Name);
+
    if (AllAuxStates.find(Name) != AllAuxStates.end()) {
       LOG_ERROR("Attempted to create a new AuxiliaryState with name {} but it "
                 "already exists",
@@ -346,11 +359,20 @@ AuxiliaryState *AuxiliaryState::create(const std::string &Name,
 // Create the default auxiliary state. Assumes that HorzMesh, VertCoord,
 // VertAdv, and Halo have been initialized.
 void AuxiliaryState::init() {
-   const HorzMesh *DefMesh           = HorzMesh::getDefault();
-   Halo *DefHalo                     = Halo::getDefault();
-   VertCoord *DefVCoord              = VertCoord::getDefault();
-   VertAdv *DefVAdv                  = VertAdv::getDefault();
+   const HorzMesh *DefMesh = HorzMesh::getDefault();
+   OMEGA_REQUIRE(DefMesh,
+                 "Null default HorzMesh pointer in AuxiliaryState::init");
+   Halo *DefHalo = Halo::getDefault();
+   OMEGA_REQUIRE(DefHalo, "Null default Halo pointer in AuxiliaryState::init");
+   VertCoord *DefVCoord = VertCoord::getDefault();
+   OMEGA_REQUIRE(DefVCoord,
+                 "Null default VertCoord pointer in AuxiliaryState::init");
+   VertAdv *DefVAdv = VertAdv::getDefault();
+   OMEGA_REQUIRE(DefVAdv,
+                 "Null default VertAdv pointer in AuxiliaryState::init");
    const TimeStepper *DefTimeStepper = TimeStepper::getDefault();
+   OMEGA_REQUIRE(DefTimeStepper,
+                 "Null default TimeStepper pointer in AuxiliaryState::init");
 
    int NTracers          = Tracers::getNumTracers();
    TimeInterval TimeStep = DefTimeStepper->getTimeStep();
@@ -359,6 +381,8 @@ void AuxiliaryState::init() {
        "Default", DefMesh, DefHalo, DefVCoord, DefVAdv, NTracers, TimeStep);
 
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig,
+                 "Null OmegaConfig pointer in AuxiliaryState::init");
    DefaultAuxState->readConfigOptions(OmegaConfig);
 }
 

--- a/components/omega/src/ocn/CustomTendencyTerms.cpp
+++ b/components/omega/src/ocn/CustomTendencyTerms.cpp
@@ -22,6 +22,8 @@ void ManufacturedSolution::init() {
 
    // Get ManufacturedSolConfig group
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig,
+                 "Null OmegaConfig pointer in ManufacturedSolution::init");
    Config ManufacturedSolConfig("ManufacturedSolution");
    Err += OmegaConfig->get(ManufacturedSolConfig);
    CHECK_ERROR_ABORT(

--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -9,6 +9,7 @@
 
 #include "Eos.h"
 #include "DataTypes.h"
+#include "Error.h"
 #include "HorzMesh.h"
 
 namespace OMEGA {
@@ -73,9 +74,13 @@ void Eos::destroyInstance() {
 /// for either a Linear or TEOS-10 equation.
 void Eos::init() {
 
+   HorzMesh *DefMesh = HorzMesh::getDefault();
+   OMEGA_REQUIRE(DefMesh, "Null default HorzMesh pointer in Eos::init");
+   VertCoord *DefVCoord = VertCoord::getDefault();
+   OMEGA_REQUIRE(DefVCoord, "Null default VertCoord pointer in Eos::init");
+
    if (!Instance) {
-      Instance =
-          new Eos("Default", HorzMesh::getDefault(), VertCoord::getDefault());
+      Instance = new Eos("Default", DefMesh, DefVCoord);
    }
 
    Error Err; // error code
@@ -85,6 +90,7 @@ void Eos::init() {
 
    /// Get EosConfig group from Omega config
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in Eos::init");
    Config EosConfig("Eos");
    Err += OmegaConfig->get(EosConfig);
    CHECK_ERROR_ABORT(Err, "Eos::init: Eos group not found in Config");

--- a/components/omega/src/ocn/Forcing.cpp
+++ b/components/omega/src/ocn/Forcing.cpp
@@ -10,6 +10,7 @@
 //===--------------------------------------------------------------===//
 
 #include "Forcing.h"
+#include "Error.h"
 #include "Field.h"
 #include "IOStream.h"
 #include "Logging.h"
@@ -45,6 +46,11 @@ void Forcing::unregisterFields() const { SfcStressForcing.unregisterFields(); }
 // Create and register a non-default forcing instance.
 Forcing *Forcing::create(const std::string &Name, const HorzMesh *Mesh,
                          Halo *MeshHalo) {
+   OMEGA_REQUIRE(
+       Mesh, "Null HorzMesh pointer in Forcing::create with Name = {}", Name);
+   OMEGA_REQUIRE(MeshHalo,
+                 "Null Halo pointer in Forcing::create with Name = {}", Name);
+
    if (AllForcing.find(Name) != AllForcing.end()) {
       LOG_ERROR("Attempted to create new Forcing with name {} but it already "
                 "exists",
@@ -68,7 +74,9 @@ void Forcing::init() {
    FieldGroup::create("Forcing");
 
    const HorzMesh *DefMesh = HorzMesh::getDefault();
-   Halo *DefHalo           = Halo::getDefault();
+   OMEGA_REQUIRE(DefMesh, "Null default HorzMesh pointer in Forcing::init");
+   Halo *DefHalo = Halo::getDefault();
+   OMEGA_REQUIRE(DefHalo, "Null default Halo pointer in Forcing::init");
 
    DefaultForcing = Forcing::create("Default", DefMesh, DefHalo);
 
@@ -79,6 +87,7 @@ void Forcing::init() {
    DefaultForcing->registerFields(DefMesh->MeshName);
 
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in Forcing::init");
    DefaultForcing->readConfigOptions(OmegaConfig);
    // for now, forcing fields are read at start-up only.
    // to be extended to include switch from standalone to coupled.

--- a/components/omega/src/ocn/HorzMesh.cpp
+++ b/components/omega/src/ocn/HorzMesh.cpp
@@ -33,8 +33,11 @@ std::map<std::string, std::unique_ptr<HorzMesh>> HorzMesh::AllHorzMeshes;
 void HorzMesh::init(const Clock *ModelClock //< [in] Model clock for IO alarms
 ) {
 
+   OMEGA_REQUIRE(ModelClock, "Null ModelClock pointer in HorzMesh::init");
+
    // Retrieve the default decomposition
    Decomp *DefDecomp = Decomp::getDefault();
+   OMEGA_REQUIRE(DefDecomp, "Null default Decomp pointer in HorzMesh::init");
 
    // Create the default mesh and set pointer to it
    HorzMesh::DefaultHorzMesh = create("Default", DefDecomp, ModelClock);
@@ -218,6 +221,13 @@ HorzMesh *HorzMesh::create(const std::string &Name, //< [in] Name for new mesh
                            Decomp *MeshDecomp,      //< [in] Decomp for new mesh
                            const Clock *ModelClock  //< [in] Model clock for IO
 ) {
+   OMEGA_REQUIRE(MeshDecomp,
+                 "Null Decomp pointer in HorzMesh::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(ModelClock,
+                 "Null ModelClock pointer in HorzMesh::create with Name = {}",
+                 Name);
+
    // Check to see if a mesh of the same name already exists and
    // if so, exit with an error
    if (AllHorzMeshes.find(Name) != AllHorzMeshes.end())

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -64,10 +64,9 @@ static bool PrintAllRanks = false;
 bool printTimingAllRanks() { return Timing::PrintAllRanks; }
 
 // Read timing configuration and set Pacer options
-static void readTimingConfig() {
+static void readTimingConfig(Config *OmegaConfig) {
    Error Err;
 
-   Config *OmegaConfig = Config::getOmegaConfig();
    Config TimingConfig("Timing");
    Err += OmegaConfig->get(TimingConfig);
    CHECK_ERROR_ABORT(Err, "Timing: Timing group not found in Config");
@@ -104,6 +103,7 @@ int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
    // Init the default machine environment based on input MPI communicator
    MachEnv::init(Comm);
    MachEnv *DefEnv = MachEnv::getDefault();
+   OMEGA_REQUIRE(DefEnv, "Null default MachEnv pointer in ocnInit");
 
    // Initialize Omega logging
    initLogging(DefEnv);
@@ -112,8 +112,9 @@ int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
    Config("Omega");
    Config::readAll("omega.yml");
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in ocnInit");
 
-   readTimingConfig();
+   readTimingConfig(OmegaConfig);
 
    // initialize remaining Omega modules
    Err = initOmegaModules(Comm);
@@ -179,13 +180,15 @@ int ocnInit1(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
    I4 Err = 0; // return error code
 
    MachEnv *DefEnv = MachEnv::getDefault();
+   OMEGA_REQUIRE(DefEnv, "Null default MachEnv pointer in ocnInit1");
 
    // Read config file into Config object
    Config("Omega");
    Config::readAll(ConfigFile);
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in ocnInit1");
 
-   readTimingConfig();
+   readTimingConfig(OmegaConfig);
 
    // initialize remaining Omega modules
    Err = initOmegaModules(Comm, TimeParams, CouplingParams);

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -37,9 +37,15 @@ int OceanState::init() {
    // Retrieve the default decomposition and mesh
    Decomp *DefDecomp     = Decomp::getDefault();
    HorzMesh *DefHorzMesh = HorzMesh::getDefault();
-   Halo *DefHalo         = Halo::getDefault();
+   OMEGA_REQUIRE(DefHorzMesh,
+                 "Null default HorzMesh pointer in OceanState::init");
+   Halo *DefHalo = Halo::getDefault();
+   OMEGA_REQUIRE(DefHalo, "Null default Halo pointer in OceanState::init");
 
-   int NVertLayers = VertCoord::getDefault()->NVertLayers;
+   VertCoord *DefVCoord = VertCoord::getDefault();
+   OMEGA_REQUIRE(DefVCoord,
+                 "Null default VertCoord pointer in OceanState::init");
+   int NVertLayers = DefVCoord->NVertLayers;
 
    auto *DefTimeStepper = TimeStepper::getDefault();
    if (!DefTimeStepper) {
@@ -139,6 +145,13 @@ OceanState::create(const std::string &Name, //< [in] Name for new state
                    const int NVertLayers,   //< [in] number of vertical layers
                    const int NTimeLevels    //< [in] number of time levels
 ) {
+
+   OMEGA_REQUIRE(Mesh,
+                 "Null HorzMesh pointer in OceanState::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(MeshHalo,
+                 "Null Halo pointer in OceanState::create with Name = {}",
+                 Name);
 
    // Check to see if a state of the same name already exists and
    // if so, exit with an error

--- a/components/omega/src/ocn/PGrad.cpp
+++ b/components/omega/src/ocn/PGrad.cpp
@@ -24,11 +24,16 @@ std::map<std::string, std::unique_ptr<PressureGrad>> PressureGrad::AllPGrads;
 void PressureGrad::init() {
 
    // Retrieve default mesh and vertical coordinate
-   HorzMesh *DefMesh    = HorzMesh::getDefault();
+   HorzMesh *DefMesh = HorzMesh::getDefault();
+   OMEGA_REQUIRE(DefMesh,
+                 "Null default HorzMesh pointer in PressureGrad::init");
    VertCoord *DefVCoord = VertCoord::getDefault();
+   OMEGA_REQUIRE(DefVCoord,
+                 "Null default VertCoord pointer in PressureGrad::init");
 
    // Retrieve omega config
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in PressureGrad::init");
 
    // Create the default PressureGrad and set pointer to it
    PressureGrad::DefaultPGrad =
@@ -43,6 +48,16 @@ PressureGrad::create(const std::string &Name, /// [in] Name for PressureGrad
                      const HorzMesh *Mesh,    ///< [in] Horizontal mesh
                      const VertCoord *VCoord, ///< [in] Vertical coordinate
                      Config *Options) {       ///< [in] Configuration options
+
+   OMEGA_REQUIRE(Mesh,
+                 "Null HorzMesh pointer in PressureGrad::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(
+       VCoord, "Null VertCoord pointer in PressureGrad::create with Name = {}",
+       Name);
+   OMEGA_REQUIRE(Options,
+                 "Null Config pointer in PressureGrad::create with Name = {}",
+                 Name);
 
    // Check to see if a PressureGrad of the same name already exists and
    // if so, exit with an error

--- a/components/omega/src/ocn/SfcCoupling.cpp
+++ b/components/omega/src/ocn/SfcCoupling.cpp
@@ -1,5 +1,6 @@
 #include "SfcCoupling.h"
 #include "Eos.h"
+#include "Error.h"
 #include "GlobalConstants.h"
 #include "Logging.h"
 #include "OceanState.h"
@@ -21,7 +22,11 @@ int SfcCoupling::init(const CouplingInitParams &CouplingInitParams) {
 
    // Retrieve the default horizontal mesh and timestepper
    HorzMesh *DefHorzMesh = HorzMesh::getDefault();
-   auto *DefTimeStepper  = TimeStepper::getDefault();
+   OMEGA_REQUIRE(DefHorzMesh,
+                 "Null default HorzMesh pointer in SfcCoupling::init");
+   auto *DefTimeStepper = TimeStepper::getDefault();
+   OMEGA_REQUIRE(DefTimeStepper,
+                 "Null default TimeStepper pointer in SfcCoupling::init");
 
    TimeInterval OcnTimeStep = DefTimeStepper->getTimeStep();
    TimeInterval CplTimeStep = CouplingInitParams.CouplingTimeStep;
@@ -91,6 +96,13 @@ SfcCoupling *SfcCoupling::create(
     const int NExportFields, const std::map<std::string, int> &ImportIdxMap,
     const std::map<std::string, int> &ExportIdxMap, TimeStepper *Stepper,
     const TimeInterval &CouplingTimeStep, const CouplingLayout &Layout) {
+
+   OMEGA_REQUIRE(Mesh,
+                 "Null HorzMesh pointer in SfcCoupling::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(
+       Stepper,
+       "Null TimeStepper pointer in SfcCoupling::create with Name = {}", Name);
 
    // Check to see if a surface coupling of the same name already exists
    if (AllSfcCoupling.find(Name) != AllSfcCoupling.end()) {

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -484,19 +484,39 @@ Tendencies::Tendencies(const std::string &Name_, ///< [in] Name for tendencies
 
 } // end constructor
 
-Tendencies::Tendencies(const std::string &Name_, ///< [in] Name for tendencies
-                       const HorzMesh *Mesh,     ///< [in] Horizontal mesh
-                       VertCoord *VCoord,        ///< [in] Vertical coordinate
-                       VertAdv *VAdv,            ///< [in] Vertical advection
-                       PressureGrad *PGrad,      ///< [in] Pressure gradient
-                       Eos *EqState,             ///< [in] Equation of state
-                       VertMix *VMix,            ///< [in] Vertical mixing
-                       int NTracersIn,           ///< [in] Number of tracers
-                       TimeInterval TimeStepIn,  ///< [in] Time step
-                       Config *Options)          ///< [in] Configuration options
-    : Tendencies(Name_, Mesh, VCoord, VAdv, PGrad, EqState, VMix, NTracersIn,
-                 TimeStepIn, Options, CustomTendencyType{},
-                 CustomTendencyType{}) {}
+// Create a non-default group of tendencies
+Tendencies *Tendencies::create(const std::string &Name,
+                               const HorzMesh *Mesh, ///< [in] Horizontal mesh
+                               VertCoord *VCoord, ///< [in] Vertical coordinate
+                               VertAdv *VAdv,     ///< [in] Vertical advection
+                               PressureGrad *PGrad, ///< [in] Pressure gradient
+                               Eos *EqState,        ///< [in] Equation of state
+                               VertMix *VMix,       ///< [in] Vertical mixing
+                               int NTracersIn,      ///< [in] Number of tracers
+                               TimeInterval TimeStep, ///< [in] Time step
+                               Config *Options, ///< [in] Configuration options
+                               CustomTendencyType CustomThicknessTend,
+                               CustomTendencyType CustomVelocityTend) {
+
+   // Check to see if tendencies of the same name already exist and
+   // if so, exit with an error
+   if (AllTendencies.find(Name) != AllTendencies.end()) {
+      LOG_ERROR("Attempted to create Tendencies with name {} but Tendencies of "
+                "that name already exists",
+                Name);
+      return nullptr;
+   }
+
+   // create new tendencies on the heap and put it in a map of
+   // unique_ptrs, which will manage its lifetime
+   auto *NewTendencies = new Tendencies(
+       Name, Mesh, VCoord, VAdv, PGrad, EqState, VMix, NTracersIn, TimeStep,
+       Options, CustomThicknessTend, CustomVelocityTend);
+
+   AllTendencies.emplace(Name, NewTendencies);
+
+   return get(Name);
+}
 
 //------------------------------------------------------------------------------
 // Compute tendencies for the pseudo-thickness equation

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -34,18 +34,32 @@ std::map<std::string, std::unique_ptr<Tendencies>> Tendencies::AllTendencies;
 void Tendencies::init() {
    Error Err; // error code
 
-   HorzMesh *DefHorzMesh       = HorzMesh::getDefault();
-   VertCoord *DefVertCoord     = VertCoord::getDefault();
-   VertAdv *DefVertAdv         = VertAdv::getDefault();
+   HorzMesh *DefHorzMesh = HorzMesh::getDefault();
+   OMEGA_REQUIRE(DefHorzMesh,
+                 "Null default HorzMesh pointer in Tendencies::init");
+   VertCoord *DefVertCoord = VertCoord::getDefault();
+   OMEGA_REQUIRE(DefVertCoord,
+                 "Null default VertCoord pointer in Tendencies::init");
+   VertAdv *DefVertAdv = VertAdv::getDefault();
+   OMEGA_REQUIRE(DefVertAdv,
+                 "Null default VertAdv pointer in Tendencies::init");
    TimeStepper *DefTimeStepper = TimeStepper::getDefault();
-   Eos *DefEos                 = Eos::getInstance();
-   PressureGrad *DefPGrad      = PressureGrad::getDefault();
-   VertMix *DefVertMix         = VertMix::getInstance();
+   OMEGA_REQUIRE(DefTimeStepper,
+                 "Null default TimeStepper pointer in Tendencies::init");
+   Eos *DefEos = Eos::getInstance();
+   OMEGA_REQUIRE(DefEos, "Null default Eos pointer in Tendencies::init");
+   PressureGrad *DefPGrad = PressureGrad::getDefault();
+   OMEGA_REQUIRE(DefPGrad,
+                 "Null default PressureGrad pointer in Tendencies::init");
+   VertMix *DefVertMix = VertMix::getInstance();
+   OMEGA_REQUIRE(DefVertMix,
+                 "Null default VertMix pointer in Tendencies::init");
 
    I4 NTracers = Tracers::getNumTracers();
 
    // Get TendConfig group
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in Tendencies::init");
    Config TendConfig("Tendencies");
    Err += OmegaConfig->get(TendConfig);
    CHECK_ERROR_ABORT(Err, "Tendencies: Tendencies group not found in Config");
@@ -497,6 +511,25 @@ Tendencies *Tendencies::create(const std::string &Name,
                                Config *Options, ///< [in] Configuration options
                                CustomTendencyType CustomThicknessTend,
                                CustomTendencyType CustomVelocityTend) {
+
+   OMEGA_REQUIRE(Mesh,
+                 "Null HorzMesh pointer in Tendencies::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(VCoord,
+                 "Null VCoord pointer in Tendencies::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(
+       VAdv, "Null VertAdv pointer in Tendencies::create with Name = {}", Name);
+   OMEGA_REQUIRE(
+       PGrad, "Null PressureGrad pointer in Tendencies::create with Name = {}",
+       Name);
+   OMEGA_REQUIRE(EqState,
+                 "Null Eos pointer in Tendencies::create with Name = {}", Name);
+   OMEGA_REQUIRE(
+       VMix, "Null VertMix pointer in Tendencies::create with Name = {}", Name);
+   OMEGA_REQUIRE(Options,
+                 "Null Config pointer in Tendencies::create with Name = {}",
+                 Name);
 
    // Check to see if tendencies of the same name already exist and
    // if so, exit with an error

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -119,26 +119,19 @@ class Tendencies {
                                     TimeInstant Time);
 
    // Create a non-default group of tendencies
-   template <class... ArgTypes>
-   static Tendencies *create(const std::string &Name, ArgTypes &&...Args) {
-      // Check to see if tendencies of the same name already exist and
-      // if so, exit with an error
-      if (AllTendencies.find(Name) != AllTendencies.end()) {
-         LOG_ERROR(
-             "Attempted to create Tendencies with name {} but Tendencies of "
-             "that name already exists",
-             Name);
-         return nullptr;
-      }
-
-      // create new tendencies on the heap and put it in a map of
-      // unique_ptrs, which will manage its lifetime
-      auto *NewTendencies =
-          new Tendencies(Name, std::forward<ArgTypes>(Args)...);
-      AllTendencies.emplace(Name, NewTendencies);
-
-      return get(Name);
-   }
+   static Tendencies *
+   create(const std::string &Name, ///< [in] Name for tendencies
+          const HorzMesh *Mesh,    ///< [in] Horizontal mesh
+          VertCoord *VCoord,       ///< [in] Vertical coordinate
+          VertAdv *VAdv,           ///< [in] Vertical advection
+          PressureGrad *PGrad,     ///< [in] Pressure gradient
+          Eos *EqState,            ///< [in] Equation of state
+          VertMix *VMix,           ///< [in] Vertical mixing
+          int NTracersIn,          ///< [in] Number of tracers
+          TimeInterval TimeStep,   ///< [in] Time step
+          Config *Options,         ///< [in] Configuration options
+          CustomTendencyType CustomThicknessTend = CustomTendencyType{},
+          CustomTendencyType CustomVelocityTend  = CustomTendencyType{});
 
    // Destructor
    ~Tendencies();
@@ -181,18 +174,6 @@ class Tendencies {
               Config *Options,         ///< [in] Configuration options
               CustomTendencyType InCustomThicknessTend,
               CustomTendencyType InCustomVelocityTend);
-
-   Tendencies(const std::string &Name, ///< [in] Name for tendencies
-              const HorzMesh *Mesh,    ///< [in] Horizontal mesh
-              VertCoord *VCoord,       ///< [in] Vertical coordinate
-              VertAdv *VAdv,           ///< [in] Vertical advection
-              PressureGrad *PGrad,     ///< [in] Pressure gradient
-              Eos *EqState,            ///< [in] Equation of state
-              VertMix *VMix,           ///< [in] Vertical mixing
-              int NTracersIn,          ///< [in] Number of tracers
-              TimeInterval TimeStep,   ///< [in] Time step
-              Config *Options          ///< [in] Configuration options
-   );
 
    void defineFields();
 

--- a/components/omega/src/ocn/Tracers.cpp
+++ b/components/omega/src/ocn/Tracers.cpp
@@ -43,8 +43,11 @@ void Tracers::init() {
    Error Err; // error code
 
    // Retrieve mesh cell/edge/vertex totals from Decomp
-   HorzMesh *DefHorzMesh   = HorzMesh::getDefault();
+   HorzMesh *DefHorzMesh = HorzMesh::getDefault();
+   OMEGA_REQUIRE(DefHorzMesh, "Null default HorzMesh pointer in Tracers::init");
    VertCoord *DefVertCoord = VertCoord::getDefault();
+   OMEGA_REQUIRE(DefVertCoord,
+                 "Null default VertCoord pointer in Tracers::init");
 
    NCellsOwned = DefHorzMesh->NCellsOwned;
    NCellsAll   = DefHorzMesh->NCellsAll;
@@ -52,6 +55,7 @@ void Tracers::init() {
    NVertLayers = DefVertCoord->NVertLayers;
 
    MeshHalo = Halo::getDefault();
+   OMEGA_REQUIRE(MeshHalo, "Null default Halo pointer in Tracers::init");
 
    auto *DefTimeStepper = TimeStepper::getDefault();
    if (!DefTimeStepper) {
@@ -67,6 +71,7 @@ void Tracers::init() {
 
    // load Tracers configs
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in Tracers::init");
    Config TracersConfig("Tracers");
    Err += OmegaConfig->get(TracersConfig);
    CHECK_ERROR_ABORT(Err, "Tracers: Tracers group not found in Config");

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "VertAdv.h"
+#include "Error.h"
 #include "Field.h"
 #include "Tracers.h"
 
@@ -25,10 +26,13 @@ std::map<std::string, std::unique_ptr<VertAdv>> VertAdv::AllVertAdvs;
 // HorzMesh, VertCoord, and Tracers
 void VertAdv::init() {
 
-   auto Mesh   = HorzMesh::getDefault();
+   auto Mesh = HorzMesh::getDefault();
+   OMEGA_REQUIRE(Mesh, "Null default HorzMesh pointer in VertAdv::init");
    auto VCoord = VertCoord::getDefault();
+   OMEGA_REQUIRE(VCoord, "Null default VertCoord pointer in VertAdv::init");
 
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in VertAdv::init");
 
    VertAdv::DefaultVertAdv = create("Default", Mesh, VCoord, OmegaConfig);
 
@@ -95,6 +99,14 @@ VertAdv *VertAdv::create(const std::string &Name, //< [in] name for new VertAdv
                          const VertCoord *VCoord, //< [in] associated VertCoord
                          Config *Options          //< [in] configuration options
 ) {
+   OMEGA_REQUIRE(
+       Mesh, "Null HorzMesh pointer in VertAdv::create with Name = {}", Name);
+   OMEGA_REQUIRE(VCoord,
+                 "Null VertCoord pointer in VertAdv::create with Name = {}",
+                 Name);
+   OMEGA_REQUIRE(Options,
+                 "Null Config pointer in VertAdv::create with Name = {}", Name);
+
    // Check to see if a VertAdv of the same name already exists and, if so,
    // exit with an error
    if (AllVertAdvs.find(Name) != AllVertAdvs.end()) {

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -9,6 +9,7 @@
 
 #include "VertCoord.h"
 #include "Dimension.h"
+#include "Error.h"
 #include "Field.h"
 #include "GlobalConstants.h"
 #include "IO.h"
@@ -38,10 +39,13 @@ void VertCoord::init(
 ) {
 
    Decomp *DefDecomp = Decomp::getDefault();
+   OMEGA_REQUIRE(DefDecomp, "Null default Decomp pointer in VertCoord::init");
 
    Halo *DefHalo = Halo::getDefault();
+   OMEGA_REQUIRE(DefHalo, "Null default Halo pointer in VertCoord::init");
 
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in VertCoord::init");
 
    VertCoord::DefaultVertCoord = create("Default", DefDecomp, DefHalo,
                                         OmegaConfig, ReadStream, InNVertLayers);
@@ -196,6 +200,14 @@ VertCoord *VertCoord::create(
     const bool ReadStream,   // [in] optional logical to read stream
     const int InNVertLayers  // [in] optional int to set vertical dim
 ) {
+   OMEGA_REQUIRE(
+       Decomp, "Null Decomp pointer in VertCoord::create with Name = {}", Name);
+   OMEGA_REQUIRE(MeshHalo,
+                 "Null Halo pointer in VertCoord::create with Name = {}", Name);
+   OMEGA_REQUIRE(Options,
+                 "Null Config pointer in VertCoord::create with Name = {}",
+                 Name);
+
    // Check to see if a VertCoord of the same name already exists and, if so,
    // exit with an error
    if (AllVertCoords.find(Name) != AllVertCoords.end()) {

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -13,6 +13,7 @@
 #include "VertMix.h"
 #include "DataTypes.h"
 #include "Eos.h"
+#include "Error.h"
 #include "GlobalConstants.h"
 #include "HorzMesh.h"
 #include "HorzOperators.h"
@@ -100,9 +101,13 @@ void VertMix::destroyInstance() {
 /// missing.
 void VertMix::init() {
 
+   HorzMesh *DefMesh = HorzMesh::getDefault();
+   OMEGA_REQUIRE(DefMesh, "Null default HorzMesh pointer in VertMix::init");
+   VertCoord *DefVCoord = VertCoord::getDefault();
+   OMEGA_REQUIRE(DefVCoord, "Null default VertCoord pointer in VertMix::init");
+
    if (!Instance) {
-      Instance = new VertMix("Default", HorzMesh::getDefault(),
-                             VertCoord::getDefault());
+      Instance = new VertMix("Default", DefMesh, DefVCoord);
    }
 
    Error Err; // error code
@@ -112,6 +117,7 @@ void VertMix::init() {
 
    /// Get VertMixConfig group from Omega config
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in VertMix::init");
    Config VertMixConfig("VertMix");
    Err += OmegaConfig->get(VertMixConfig);
    CHECK_ERROR_ABORT(Err, "VertMix::init: VertMix group not found in Config");

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -127,6 +127,23 @@ TimeStepper *TimeStepper::create(
     Halo *InMeshHalo                ///< [in] ptr to halos
 ) {
 
+   OMEGA_REQUIRE(
+       InTend, "Null Tendencies pointer in TimeStepper::create with Name = {}",
+       InName);
+   OMEGA_REQUIRE(
+       InAuxState,
+       "Null AuxiliaryState pointer in TimeStepper::create with Name = {}",
+       InName);
+   OMEGA_REQUIRE(InMesh,
+                 "Null HorzMesh pointer in TimeStepper::create with Name = {}",
+                 InName);
+   OMEGA_REQUIRE(InVCoord,
+                 "Null VertCoord pointer in TimeStepper::create with Name = {}",
+                 InName);
+   OMEGA_REQUIRE(InMeshHalo,
+                 "Null Halo pointer in TimeStepper::create with Name = {}",
+                 InName);
+
    // Start by calling the two-phase create function
    TimeStepper *NewTimeStepper =
        create(InName, InType, InTimeStep, InStartTime, InStopTime);
@@ -248,6 +265,7 @@ void TimeStepper::init1() {
 
    // Retrieve TimeStepper options from Config if available
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in TimeStepper::init1");
    Config TimeIntConfig("TimeIntegration");
    Err = OmegaConfig->get(TimeIntConfig);
    CHECK_ERROR_ABORT(Err, "TimeIntegration group not found in Config");
@@ -335,6 +353,7 @@ void TimeStepper::init1(const TimeInitParams &TimeParams) {
 
    // TimeStepper and TimeStep are always read from the Config
    Config *OmegaConfig = Config::getOmegaConfig();
+   OMEGA_REQUIRE(OmegaConfig, "Null OmegaConfig pointer in TimeStepper::init1");
    Config TimeIntConfig("TimeIntegration");
    Err = OmegaConfig->get(TimeIntConfig);
    CHECK_ERROR_ABORT(Err, "TimeIntegration group not found in Config");
@@ -363,12 +382,24 @@ void TimeStepper::init1(const TimeInitParams &TimeParams) {
 // Finish initialization of the default time stepper (phase 2)
 void TimeStepper::init2() {
 
+   OMEGA_REQUIRE(DefaultTimeStepper,
+                 "Null default TimeStepper pointer in TimeStepper::init2");
+
    // Get default pointers
-   HorzMesh *DefMesh        = HorzMesh::getDefault();
-   VertCoord *DefVCoord     = VertCoord::getDefault();
-   Halo *DefHalo            = Halo::getDefault();
-   Tendencies *DefTend      = Tendencies::getDefault();
+   HorzMesh *DefMesh = HorzMesh::getDefault();
+   OMEGA_REQUIRE(DefMesh,
+                 "Null default HorzMesh pointer in TimeStepper::init2");
+   VertCoord *DefVCoord = VertCoord::getDefault();
+   OMEGA_REQUIRE(DefVCoord,
+                 "Null default VertCoord pointer in TimeStepper::init2");
+   Halo *DefHalo = Halo::getDefault();
+   OMEGA_REQUIRE(DefHalo, "Null default Halo pointer in TimeStepper::init2");
+   Tendencies *DefTend = Tendencies::getDefault();
+   OMEGA_REQUIRE(DefTend,
+                 "Null default Tendencies pointer in TimeStepper::init2");
    AuxiliaryState *AuxState = AuxiliaryState::getDefault();
+   OMEGA_REQUIRE(AuxState,
+                 "Null default AuxiliaryState pointer in TimeStepper::init2");
 
    // Attach data pointers
    DefaultTimeStepper->attachData(DefTend, AuxState, DefMesh, DefVCoord,

--- a/components/omega/test/analysis/AnalysisOperatorTest.cpp
+++ b/components/omega/test/analysis/AnalysisOperatorTest.cpp
@@ -16,6 +16,7 @@
 #include "IOStream.h"
 #include "Logging.h"
 #include "TimeStepper.h"
+#include "VertAdv.h"
 #include "VertCoord.h"
 #include "VertMix.h"
 
@@ -942,6 +943,9 @@ void initAnalysisTest() {
 
    // Initialize the default vertical coordinate
    VertCoord::init();
+
+   // Initialize VertAdv
+   VertAdv::init();
 
    // Initialize tracers
    Tracers::init();

--- a/components/omega/test/analysis/AnalysisSystemTest.cpp
+++ b/components/omega/test/analysis/AnalysisSystemTest.cpp
@@ -691,6 +691,9 @@ void initAnalysisSystemTest() {
    // Initialize the default vertical coordinate
    VertCoord::init();
 
+   // Initialize VertAdv
+   VertAdv::init();
+
    // Initialize tracers
    Tracers::init();
 
@@ -711,9 +714,6 @@ void initAnalysisSystemTest() {
 
    // Initialize tendencies
    Tendencies::init();
-
-   // Initialize vertical advection
-   VertAdv::init();
 
    // Second step of time stepper initialization
    TimeStepper::init2();

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -32,6 +32,7 @@
 #include "TimeMgr.h"
 #include "TimeStepper.h"
 #include "Tracers.h"
+#include "VertAdv.h"
 #include "VertCoord.h"
 #include "VertMix.h"
 #include "mpi.h"
@@ -136,6 +137,9 @@ void initIOStreamTest(Clock *&ModelClock // Model clock
 
    // Initialize the vertical coordinate
    VertCoord::init();
+
+   // Initialize VertAdv
+   VertAdv::init();
 
    // Initialize State
    TmpErr = OceanState::init();
@@ -322,6 +326,7 @@ int main(int argc, char **argv) {
    OceanState::clear();
    AuxiliaryState::clear();
    Forcing::clear();
+   VertAdv::clear();
    HorzMesh::clear();
    VertCoord::clear();
    Field::clear();

--- a/components/omega/test/ocn/FillValueTest.cpp
+++ b/components/omega/test/ocn/FillValueTest.cpp
@@ -42,6 +42,7 @@
 #include "TimeMgr.h"
 #include "TimeStepper.h"
 #include "Tracers.h"
+#include "VertAdv.h"
 #include "VertCoord.h"
 #include "VertMix.h"
 #include "mpi.h"
@@ -129,6 +130,7 @@ void initFillValueTest() {
 
    HorzMesh::init(ModelClock);
    VertCoord::init();
+   VertAdv::init();
    Tracers::init();
    AuxiliaryState::init();
    PressureGrad::init();
@@ -445,6 +447,7 @@ int main(int argc, char *argv[]) {
       Tracers::clear();
       IOStream::finalize();
       TimeStepper::clear();
+      VertAdv::clear();
       HorzMesh::clear();
       VertCoord::clear();
       Field::clear();

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -29,6 +29,7 @@
 #include "Pacer.h"
 #include "Tendencies.h"
 #include "TimeStepper.h"
+#include "VertAdv.h"
 #include "VertCoord.h"
 #include "VertMix.h"
 #include "mpi.h"
@@ -88,6 +89,9 @@ void initStateTest() {
 
    // Initialize the vertical coordinate
    VertCoord::init();
+
+   // Initialize VertAdv
+   VertAdv::init();
 
    // Initialize tracers
    Tracers::init();
@@ -452,6 +456,7 @@ int main(int argc, char *argv[]) {
       VertMix::destroyInstance();
       Tendencies::clear();
       TimeStepper::clear();
+      VertAdv::clear();
       HorzMesh::clear();
       VertCoord::clear();
       Halo::clear();


### PR DESCRIPTION
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

This PR
- Add null checks for input pointers in `init` and `create` methods for most of  Omega modules
- Add missing calls to `VertAdv::init` in a couple of tests
- Slightly refactors `Tendencies::create` to enable adding such checks 

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation:
  * [x] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

* [x] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


