### PR TITLE
Limit implicit vertical mixing to owned cells and edges

### DIFF
--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -442,7 +442,10 @@ void VertMix::applyVelVertMixImplicit(
     int VelTimeLevel                ///< [in] Time level
 ) {
 
-   OMEGA_SCOPE(LocNEdgesAll, Mesh->NEdgesAll);
+   // Only owned edges are solved here. Halo edges are refreshed by the
+   // halo exchange that immediately follows the implicit vertical mixing
+   // in the time steppers.
+   OMEGA_SCOPE(LocNEdgesOwned, Mesh->NEdgesOwned);
    OMEGA_SCOPE(LocVelVertMixSetup, VelVertMixSetup);
    OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
    OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
@@ -471,13 +474,13 @@ void VertMix::applyVelVertMixImplicit(
       const int NVertLayers  = VCoord->NVertLayers;
       const int LocVecLength = VecLength;
       auto LConfig =
-          TriDiagSolver::makeLaunchConfig(Mesh->NEdgesAll, NVertLayers);
+          TriDiagSolver::makeLaunchConfig(Mesh->NEdgesOwned, NVertLayers);
 
       parallelForOuter(
           LConfig, KOKKOS_LAMBDA(int, const TeamMember &Team) {
              const int IStart = Team.league_rank() * LocVecLength;
              const int ILen   = Kokkos::max(
-                 0, Kokkos::min(LocVecLength, LocNEdgesAll - IStart));
+                 0, Kokkos::min(LocVecLength, LocNEdgesOwned - IStart));
 
              TriDiagDiffScratch Scratch(Team, NVertLayers);
 
@@ -486,7 +489,7 @@ void VertMix::applyVelVertMixImplicit(
                 for (int IVec = 0; IVec < LocVecLength; ++IVec) {
                    const int IEdge = IStart + IVec;
 
-                   if (IEdge >= LocNEdgesAll) {
+                   if (IEdge >= LocNEdgesOwned) {
                       // Fill values
                       Scratch.G(K, IVec) = 0._Real;
                       Scratch.H(K, IVec) = 1._Real;
@@ -548,7 +551,10 @@ void VertMix::applyTracerVertMixImplicit(
     int VelTimeLevel                ///< [in] Time level
 ) {
 
-   OMEGA_SCOPE(LocNCellsAll, Mesh->NCellsAll);
+   // Only owned cells are solved here. Halo cells are refreshed by the
+   // halo exchange that immediately follows the implicit vertical mixing
+   // in the time steppers.
+   OMEGA_SCOPE(LocNCellsOwned, Mesh->NCellsOwned);
    OMEGA_SCOPE(LocTracerVertMixSetup, TracerVertMixSetup);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
@@ -573,7 +579,7 @@ void VertMix::applyTracerVertMixImplicit(
 
       const int NVertLayers = VCoord->NVertLayers;
       auto LConfig =
-          TriDiagSolver::makeLaunchConfig(Mesh->NCellsAll, NVertLayers);
+          TriDiagSolver::makeLaunchConfig(Mesh->NCellsOwned, NVertLayers);
       const int LocVecLength = VecLength;
 
       for (int L = 0; L < NTracers; ++L) {
@@ -581,7 +587,7 @@ void VertMix::applyTracerVertMixImplicit(
              LConfig, KOKKOS_LAMBDA(int, const TeamMember &Team) {
                 const int IStart = Team.league_rank() * LocVecLength;
                 const int ILen   = Kokkos::max(
-                    0, Kokkos::min(LocVecLength, LocNCellsAll - IStart));
+                    0, Kokkos::min(LocVecLength, LocNCellsOwned - IStart));
 
                 TriDiagDiffScratch Scratch(Team, NVertLayers);
 
@@ -590,7 +596,7 @@ void VertMix::applyTracerVertMixImplicit(
                    for (int IVec = 0; IVec < LocVecLength; ++IVec) {
                       const int ICell = IStart + IVec;
 
-                      if (ICell >= LocNCellsAll) {
+                      if (ICell >= LocNCellsOwned) {
                          // Fill values
                          Scratch.G(K, IVec) = 0._Real;
                          Scratch.H(K, IVec) = 1._Real;

--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -472,14 +472,6 @@ class VertMix {
    /// Initialize VertMix from config and mesh
    static void init();
 
-   void applyVelVertMixImplicit(OceanState *State,
-                                const AuxiliaryState *AuxState,
-                                int ThickTimeLevel, int VelTimeLevel);
-   void applyTracerVertMixImplicit(OceanState *State,
-                                   const AuxiliaryState *AuxState,
-                                   Array3DReal &TracerArray, int NTracers,
-                                   int ThickTimeLevel, int VelTimeLevel);
-
    /// Apply implicit vertical mixing to velocities and tracers
    void VertMixImplicit(OceanState *State, AuxiliaryState *AuxState,
                         Array3DReal &TracerArray, int NTracers, int TimeLevel);
@@ -505,6 +497,17 @@ class VertMix {
 
    // Define fields and metadata
    void defineFields();
+
+   /// Apply implicit vertical mixing to velocities
+   void applyVelVertMixImplicit(OceanState *State,
+                                const AuxiliaryState *AuxState,
+                                int ThickTimeLevel, int VelTimeLevel);
+
+   /// Apply implicit vertical mixing to tracers
+   void applyTracerVertMixImplicit(OceanState *State,
+                                   const AuxiliaryState *AuxState,
+                                   Array3DReal &TracerArray, int NTracers,
+                                   int ThickTimeLevel, int VelTimeLevel);
 
 }; // End class VertMix
 


### PR DESCRIPTION
This PR changes the horizontal loop ranges for implicit vertical mixing from all local cells and edges (`NCellsAll`; `NEdgesAll`) to owned cells and edges (`NCellsOwned`; `NEdgesOwned`). This avoids unnecessary computations in halo regions, since halo exchanges are performed immediately after implicit vertical mixing. A small improvement in computational efficiency is expected for implicit vertical mixing, especially when running with a larger number of GPUs or  CPU cores.

Checklist
* Linting
  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
