### PR TITLE
Add an `e3sm_omega_developer` CIME test suite

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -123,6 +123,7 @@
 
   <comp_archive_spec compname="omega" compclass="ocn" exclude_testing="true">
     <rest_file_extension>r</rest_file_extension>
+    <hist_file_extension>unset</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>

--- a/cime_config/config_files.xml
+++ b/cime_config/config_files.xml
@@ -359,6 +359,7 @@
       <value component="scream"   >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testmods_dirs</value>
       <value component="eamxx"    >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testmods_dirs</value>
       <value component="mpaso"    >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
+      <value component="omega"    >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
       <value component="mpassi"   >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testmods_dirs</value>
       <value component="ww3"      >$COMP_ROOT_DIR_WAV/cime_config/testdefs/testmods_dirs</value>
       <value component="mali"      >$COMP_ROOT_DIR_GLC/cime_config/testdefs/testmods_dirs</value>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2555,6 +2555,7 @@
         <command name="load">subversion/1.14.0-e4smcy3</command>
         <command name="load">perl/5.32.0-bsnc6lt</command>
         <command name="load">cmake/3.24.2-whgdv7y</command>
+        <command name="load">python/3.11.7-iexc6vq</command>
       </modules>
       <modules compiler="intel-classic">
         <command name="load">intel/20.0.4-kodw73g</command>

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -1148,10 +1148,12 @@ _TESTS = {
         "time"  : "0:30:00",
         "share" : True,
         "tests" : (
+            "SMS_Vmct.T62_oQU240.COMEGA-IAF",
             "ERS_Vmct.T62_oQU240.COMEGA-IAF",
-            "PEM_Vmct.T62_oQU240.COMEGA-IAF",
+            #"PEM_Vmct.T62_oQU240.COMEGA-IAF",
+            "SMS_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",
             "ERS_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",
-            "PEM_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",
+            #"PEM_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",
             )
     },
 }

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -1146,11 +1146,10 @@ _TESTS = {
     },
     "e3sm_omega_developer" : {
         "time"  : "0:30:00",
-        "share" : True,
         "tests" : (
             "SMS_Vmct.T62_oQU240.COMEGA-IAF",
             "ERS_Vmct.T62_oQU240.COMEGA-IAF",
-            #"PEM_Vmct.T62_oQU240.COMEGA-IAF",
+            "PEM_Vmct.T62_oQU240.COMEGA-IAF",
             "SMS_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",
             "ERS_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",
             #"PEM_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -1144,4 +1144,14 @@ _TESTS = {
             "ERS.ne30pg2_f09_oEC60to30v3.SSP245_ZATM_BGC",
             )
     },
+    "e3sm_omega_developer" : {
+        "time"  : "0:30:00",
+        "share" : True,
+        "tests" : (
+            "ERS_Vmct.T62_oQU240.COMEGA-IAF",
+            "PEM_Vmct.T62_oQU240.COMEGA-IAF",
+            "ERS_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",
+            "PEM_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",
+            )
+    },
 }

--- a/components/omega/cime_config/config_compsets.xml
+++ b/components/omega/cime_config/config_compsets.xml
@@ -16,8 +16,8 @@
   </compset>
 
   <compset>
-    <alias>COMEGA-JRA1p4</alias>
-    <lname>2000_DATM%JRA-1p4-2018_SLND_DICE%SSMI_OMEGA%DATMFORCED_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
+    <alias>COMEGA-JRA1p5</alias>
+    <lname>2000_DATM%JRA-1p5_SLND_DICE%SSMI_OMEGA%DATMFORCED_DROF%JRA-1p5_SGLC_SWAV</lname>
     <support_level>Experimental, under development</support_level>
   </compset>
 

--- a/components/omega/cime_config/testdefs/testmods_dirs/omega/jra_1958/shell_commands
+++ b/components/omega/cime_config/testdefs/testmods_dirs/omega/jra_1958/shell_commands
@@ -1,0 +1,4 @@
+./xmlchange DATM_CLMNCEP_YR_START=1958
+./xmlchange DATM_CLMNCEP_YR_END=1958
+./xmlchange DROF_STRM_YR_START=1958
+./xmlchange DROF_STRM_YR_END=1958


### PR DESCRIPTION
This PR adds a `e3sm_omega_developer` test suite, comprised of `SMS` and `ERS` test for Omega. As part adding this test suite, some modifications to the existing compsets were addded:
- Updated to newest JRA data source (`JRA1p5`). 
- Added an Omega testmod, to limit data download to 1958. 
- Add a missing entry in Omega's archive configuration. 

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Documentation:
  * [ ] Design document has been generated and [added to the docs](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/design)
  * [ ] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [ ] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* Linting
  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass
  - [x] e3sm_omega_developer Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass
  - [x] e3sm_omega_developer Pass

  **frontier, craygnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass
  - [x] e3sm_omega_developer Pass

  **frontier, craygnu-mphipcc, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass
  - [ ] e3sm_omega_developer Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass
  - [ ] e3sm_omega_developer Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass
  - [ ] e3sm_omega_developer Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.
* [ ] Performance related PRs: Please include a relevant PACE experiment link documenting performance before and after.
* [ ] New tests:
  * [ ] CTest unit tests for new features have been added per the approved design.
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)
* Stealth Features
  * [ ] If any stealth features are included in the PR, please confirm that they have been documented.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


