### PR TITLE
Add MPI_Barrier before MPI_Finalize

### DIFF
--- a/components/omega/src/drivers/standalone/OceanDriver.cpp
+++ b/components/omega/src/drivers/standalone/OceanDriver.cpp
@@ -64,6 +64,7 @@ int main(int argc, char **argv) {
    Pacer::finalize();
 
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (ErrAll >= 256)

--- a/components/omega/test/analysis/AnalysisOperatorTest.cpp
+++ b/components/omega/test/analysis/AnalysisOperatorTest.cpp
@@ -1050,6 +1050,7 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return Err;

--- a/components/omega/test/analysis/AnalysisSystemTest.cpp
+++ b/components/omega/test/analysis/AnalysisSystemTest.cpp
@@ -822,6 +822,7 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return ErrCode;

--- a/components/omega/test/base/BroadcastTest.cpp
+++ b/components/omega/test/base/BroadcastTest.cpp
@@ -215,6 +215,7 @@ int main(int argc, char *argv[]) {
    LOG_INFO("------ Broadcast Unit Tests Successful ------");
 
    // MPI_Status status;
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return 0; // if we made it here, return a success code

--- a/components/omega/test/base/DataTypesTest.cpp
+++ b/components/omega/test/base/DataTypesTest.cpp
@@ -957,6 +957,7 @@ int main(int argc, char *argv[]) {
    LOG_INFO("------ DataTypes Unit Tests Successful ------");
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return 0; // if we made it here, return successfully

--- a/components/omega/test/base/DecompTest.cpp
+++ b/components/omega/test/base/DecompTest.cpp
@@ -166,6 +166,7 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    // if we made it to the end, return success

--- a/components/omega/test/base/HaloTest.cpp
+++ b/components/omega/test/base/HaloTest.cpp
@@ -569,6 +569,7 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (TotErr >= 256)

--- a/components/omega/test/base/IOTest.cpp
+++ b/components/omega/test/base/IOTest.cpp
@@ -793,6 +793,7 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return RetVal;

--- a/components/omega/test/base/MachEnvTest.cpp
+++ b/components/omega/test/base/MachEnvTest.cpp
@@ -355,6 +355,7 @@ int main(int argc, char *argv[]) {
    LOG_INFO("------ MachEnv Unit Tests Successful ------");
 
    // MPI_Status status;
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return 0; // if we made it here, we were successful

--- a/components/omega/test/base/ReductionsTest.cpp
+++ b/components/omega/test/base/ReductionsTest.cpp
@@ -1668,6 +1668,7 @@ int main(int argc, char *argv[]) {
    // clean up
    MachEnv::removeAll();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return 0; // if we made it here, return success

--- a/components/omega/test/base/TriDiagSolversTest.cpp
+++ b/components/omega/test/base/TriDiagSolversTest.cpp
@@ -605,6 +605,7 @@ int main(int argc, char *argv[]) {
    }
 
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)

--- a/components/omega/test/drivers/StandaloneDriverTest.cpp
+++ b/components/omega/test/drivers/StandaloneDriverTest.cpp
@@ -76,6 +76,7 @@ int main(int argc, char *argv[]) {
    Pacer::finalize();
 
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (ErrAll >= 256)

--- a/components/omega/test/infra/ConfigTest.cpp
+++ b/components/omega/test/infra/ConfigTest.cpp
@@ -700,6 +700,7 @@ int main(int argc, char *argv[]) {
 
    // Finalize environments
    Pacer::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return 0; // successful completion

--- a/components/omega/test/infra/DimensionTest.cpp
+++ b/components/omega/test/infra/DimensionTest.cpp
@@ -271,6 +271,7 @@ int main(int argc, char **argv) {
    Decomp::clear();
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    // End of testing

--- a/components/omega/test/infra/ErrorTest.cpp
+++ b/components/omega/test/infra/ErrorTest.cpp
@@ -165,6 +165,7 @@ int main(int argc, char **argv) {
 
    // If code reaches here, the critical error test has failed so return a
    // success code
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
    return 0;
 }

--- a/components/omega/test/infra/FieldTest.cpp
+++ b/components/omega/test/infra/FieldTest.cpp
@@ -890,6 +890,7 @@ int main(int argc, char **argv) {
    Decomp::clear();
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    // End of testing

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -335,6 +335,7 @@ int main(int argc, char **argv) {
    Decomp::clear();
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    CHECK_ERROR_ABORT(Err, "IOStream Unit Tests: FAIL");

--- a/components/omega/test/infra/IOStreamTest.cpp
+++ b/components/omega/test/infra/IOStreamTest.cpp
@@ -335,11 +335,12 @@ int main(int argc, char **argv) {
    Decomp::clear();
    Pacer::finalize();
    Kokkos::finalize();
-   MPI_Barrier(MPI_COMM_WORLD);
-   MPI_Finalize();
 
    CHECK_ERROR_ABORT(Err, "IOStream Unit Tests: FAIL");
    LOG_INFO("------ IOStream Unit Tests successful ------");
+
+   MPI_Barrier(MPI_COMM_WORLD);
+   MPI_Finalize();
 
    // End of testing
    return 0;

--- a/components/omega/test/infra/LoggingTest.cpp
+++ b/components/omega/test/infra/LoggingTest.cpp
@@ -280,6 +280,7 @@ int main(int argc, char **argv) {
    }
 
    // Finalize environments
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return RetVal;

--- a/components/omega/test/infra/OmegaKokkosFlatParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosFlatParTest.cpp
@@ -528,6 +528,7 @@ int main(int argc, char **argv) {
 
    CHECK_ERROR_ABORT(Err, "Kokkos Wrappers Unit Tests FAIL");
 
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return 0;

--- a/components/omega/test/infra/OmegaKokkosHiParTest.cpp
+++ b/components/omega/test/infra/OmegaKokkosHiParTest.cpp
@@ -893,6 +893,7 @@ int main(int argc, char **argv) {
 
    CHECK_ERROR_ABORT(Err, "Kokkos Wrappers Unit Tests FAIL");
 
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return 0;

--- a/components/omega/test/infra/TimeIntervalParseExtendedFormatsTest.cpp
+++ b/components/omega/test/infra/TimeIntervalParseExtendedFormatsTest.cpp
@@ -87,6 +87,7 @@ int main(int argc, char **argv) {
    // If we made it here, the tests were successful
    LOG_INFO("----- TimeIntervalParseExtendedFormatsTest Successful -----");
 
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
    return 0;
 }

--- a/components/omega/test/infra/TimeIntervalParseTest.cpp
+++ b/components/omega/test/infra/TimeIntervalParseTest.cpp
@@ -119,6 +119,7 @@ int main(int argc, char **argv) {
    // If we made it here, we are successful
    LOG_INFO("----- TimeIntervalParseTest Successful -----");
 
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
    return 0;
 }

--- a/components/omega/test/infra/TimeMgrTest.cpp
+++ b/components/omega/test/infra/TimeMgrTest.cpp
@@ -3482,6 +3482,7 @@ int main(int argc, char *argv[]) {
    // if it made it here, all tests successful
    LOG_INFO("----- TimeMgr Unit Tests Successful -----");
 
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
    return 0;
 

--- a/components/omega/test/ocn/AuxiliaryStateTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryStateTest.cpp
@@ -376,6 +376,7 @@ int main(int argc, char *argv[]) {
 
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)

--- a/components/omega/test/ocn/AuxiliaryVarsTest.cpp
+++ b/components/omega/test/ocn/AuxiliaryVarsTest.cpp
@@ -805,6 +805,7 @@ int main(int argc, char *argv[]) {
 
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -868,6 +868,7 @@ int main(int argc, char *argv[]) {
 
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    // If we made it here, test is successful

--- a/components/omega/test/ocn/FillValueTest.cpp
+++ b/components/omega/test/ocn/FillValueTest.cpp
@@ -459,6 +459,7 @@ int main(int argc, char *argv[]) {
    Pacer::finalize();
    Kokkos::finalize();
    int RetVal = ErrAll.isFail() ? 1 : 0;
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return RetVal;

--- a/components/omega/test/ocn/ForcingTest.cpp
+++ b/components/omega/test/ocn/ForcingTest.cpp
@@ -382,6 +382,7 @@ int main(int argc, char *argv[]) {
 
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return RetErr;

--- a/components/omega/test/ocn/HorzMeshTest.cpp
+++ b/components/omega/test/ocn/HorzMeshTest.cpp
@@ -676,6 +676,7 @@ int main(int argc, char *argv[]) {
 
    // Success if we made it here
    LOG_INFO("------ Horz Mesh unit tests successful ------");
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    // Return success if we made it here

--- a/components/omega/test/ocn/HorzOperatorsTest.cpp
+++ b/components/omega/test/ocn/HorzOperatorsTest.cpp
@@ -1085,6 +1085,7 @@ int main(int argc, char *argv[]) {
    Kokkos::finalize();
    if (RetVal == 0)
       LOG_INFO("------ Horz Operators unit tests successful ------");
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)

--- a/components/omega/test/ocn/PGradTest.cpp
+++ b/components/omega/test/ocn/PGradTest.cpp
@@ -335,6 +335,7 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)

--- a/components/omega/test/ocn/SfcCouplingTest.cpp
+++ b/components/omega/test/ocn/SfcCouplingTest.cpp
@@ -580,6 +580,7 @@ int main(int argc, char *argv[]) {
 
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)

--- a/components/omega/test/ocn/StateTest.cpp
+++ b/components/omega/test/ocn/StateTest.cpp
@@ -471,6 +471,7 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)

--- a/components/omega/test/ocn/StateValidationTest.cpp
+++ b/components/omega/test/ocn/StateValidationTest.cpp
@@ -411,6 +411,7 @@ int main(int argc, char *argv[]) {
 
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)

--- a/components/omega/test/ocn/TendenciesTest.cpp
+++ b/components/omega/test/ocn/TendenciesTest.cpp
@@ -391,6 +391,7 @@ int main(int argc, char *argv[]) {
 
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -1477,6 +1477,7 @@ int main(int argc, char *argv[]) {
 
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    return RetErr;

--- a/components/omega/test/ocn/TracersTest.cpp
+++ b/components/omega/test/ocn/TracersTest.cpp
@@ -470,6 +470,7 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)

--- a/components/omega/test/ocn/VertAdvTest.cpp
+++ b/components/omega/test/ocn/VertAdvTest.cpp
@@ -448,6 +448,7 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    CHECK_ERROR_ABORT(ErrAll, "VertAdv unit tests FAIL");

--- a/components/omega/test/ocn/VertAdvTest.cpp
+++ b/components/omega/test/ocn/VertAdvTest.cpp
@@ -448,10 +448,11 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
-   MPI_Barrier(MPI_COMM_WORLD);
-   MPI_Finalize();
 
    CHECK_ERROR_ABORT(ErrAll, "VertAdv unit tests FAIL");
+
+   MPI_Barrier(MPI_COMM_WORLD);
+   MPI_Finalize();
 
    return 0;
 }

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -738,6 +738,7 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    CHECK_ERROR_ABORT(ErrAll, "VertCoord unit tests FAIL");

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -738,10 +738,11 @@ int main(int argc, char *argv[]) {
    }
    Pacer::finalize();
    Kokkos::finalize();
-   MPI_Barrier(MPI_COMM_WORLD);
-   MPI_Finalize();
 
    CHECK_ERROR_ABORT(ErrAll, "VertCoord unit tests FAIL");
+
+   MPI_Barrier(MPI_COMM_WORLD);
+   MPI_Finalize();
 
    return 0;
 

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -1085,6 +1085,7 @@ int main(int argc, char *argv[]) {
 
    LOG_INFO("------ Vertical Mixing Unit Tests Successful ------");
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    // if we made it here, it is successful

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -518,6 +518,7 @@ int main(int argc, char *argv[]) {
 
    Pacer::finalize();
    Kokkos::finalize();
+   MPI_Barrier(MPI_COMM_WORLD);
    MPI_Finalize();
 
    if (RetVal >= 256)


### PR DESCRIPTION
This PR add an `MPI_Barrier` before `MPI_Finalize` in every Omega unit test and in the standalone driver. Fixes #514. While #514 only affects two unit tests, the failure is intermittent and not fully understood, and it seems harmless to do this before every call to `MPI_Finalize`.
<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

* [x] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


