### PR TITLE
Add the split-explicit time stepper

### DIFF
--- a/components/omega/configs/Default.yml
+++ b/components/omega/configs/Default.yml
@@ -8,6 +8,12 @@ Omega:
     CalendarType: No Leap
     TimeStepper: Forward-Backward
     TimeStep: 0000_00:10:00
+    ModeSplitShare:
+      BtrTimeStepper: Predictor-Corrector
+      BtrTimeStep: 0000_00:00:20
+      NTimeStepIteration: 2
+      NBclCoriolisIteration: 2
+      ReinitSplitVelocity: false
     StartTime: 0001-01-01_00:00:00
     StopTime: 0001-01-01_02:00:00
     RunDuration: none

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -30,6 +30,7 @@ AuxiliaryState::AuxiliaryState(const std::string &Name, const HorzMesh *Mesh,
       VelocityDel2Aux(stripDefault(Name), Mesh, VCoord),
       SurfTracerRestAux(stripDefault(Name), Mesh, NTracers),
       TracerAux(stripDefault(Name), Mesh, VCoord, NTracers),
+      TransportAux(stripDefault(Name), Mesh, VCoord),
       TimeStep(TimeStep) {
 
    GroupName = "AuxiliaryState";
@@ -46,6 +47,7 @@ AuxiliaryState::AuxiliaryState(const std::string &Name, const HorzMesh *Mesh,
    VelocityDel2Aux.registerFields(GroupName, AuxMeshName);
    SurfTracerRestAux.registerFields(GroupName, AuxMeshName);
    TracerAux.registerFields(GroupName, AuxMeshName);
+   TransportAux.registerFields(GroupName, AuxMeshName);
 }
 
 // Destructor. Unregisters the fields with IOStreams and destroys this auxiliary
@@ -57,6 +59,7 @@ AuxiliaryState::~AuxiliaryState() {
    VelocityDel2Aux.unregisterFields();
    SurfTracerRestAux.unregisterFields();
    TracerAux.unregisterFields();
+   TransportAux.unregisterFields();
 
    FieldGroup::destroy(GroupName);
 }

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -436,32 +436,18 @@ void AuxiliaryState::computePseudoThicknessTracerAux(
    parallelForOuter(
        "edgeThicknessTracerAux", {Mesh->NEdgesAll},
        KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-          const int KMin   = MinLayerEdgeBot(IEdge);
-          const int KMax   = MaxLayerEdgeTop(IEdge);
-          const int KRange = vertRangeChunked(KMin, KMax);
-
-          parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 LocPseudoThicknessAux.computeVarsOnEdge(
-                     IEdge, KChunk, PseudoThickCell, NormalVelEdge);
-              });
+          LocPseudoThicknessAux.computeVarsOnEdge(Team, IEdge, PseudoThickCell,
+                                                  NormalVelEdge);
        });
    Pacer::stop("AuxState:edgeThicknessTracerAux", 2);
 
    Pacer::start("AuxState:cellThicknessAux", 2);
    parallelForOuter(
-       "cellThicknessAux", {Mesh->NCellsAll},
+       "cellThicknessAux",
+       LaunchConfig({Mesh->NCellsAll}, TeamScratch<Real>(VCoord->NVertLayers)),
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRangeChunked(KMin, KMax);
-
-          parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 LocPseudoThicknessAux.computeVarsOnCells(
-                     ICell, KChunk, PseudoThickCell, NormalVelEdge,
-                     ProjDtSeconds);
-              });
+          LocPseudoThicknessAux.computeVarsOnCells(
+              Team, ICell, PseudoThickCell, NormalVelEdge, ProjDtSeconds);
        });
    Pacer::stop("AuxState:cellThicknessAux", 2);
 
@@ -471,15 +457,8 @@ void AuxiliaryState::computePseudoThicknessTracerAux(
    parallelForOuter(
        "cellTracerAux", {NTracers, Mesh->NCellsAll},
        KOKKOS_LAMBDA(int LTracer, int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRangeChunked(KMin, KMax);
-
-          parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 LocTracerAux.computeVarsOnCells(
-                     LTracer, ICell, KChunk, MeanPseudoThickEdge, TracerArray);
-              });
+          LocTracerAux.computeVarsOnCells(Team, LTracer, ICell,
+                                          MeanPseudoThickEdge, TracerArray);
        });
    Pacer::stop("AuxState:cellTracerAux", 2);
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -180,15 +180,7 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
 
    Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
    Array2DReal NormalVelEdge   = State->getNormalVelocity(VelTimeLevel);
-   computeMomAux(State, TracerArray, ThickTimeLevel, NormalVelEdge, ProjDt);
-}
 
-void AuxiliaryState::computeMomAux(const OceanState *State,
-                                   const Array3DReal &TracerArray,
-                                   int ThickTimeLevel,
-                                   const Array2DReal &NormalVelEdge,
-                                   const TimeInterval ProjDt) const {
-   Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
    OMEGA_SCOPE(LocKineticAux, KineticAux);
    OMEGA_SCOPE(LocPseudoThicknessAux, PseudoThicknessAux);
    OMEGA_SCOPE(LocVorticityAux, VorticityAux);

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -299,6 +299,8 @@ void AuxiliaryState::computeTracerAux(const OceanState *State,
    OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
    OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
+   R8 TimeStepSeconds;
+   TimeStep.get(TimeStepSeconds, TimeUnits::Seconds);
    R8 ProjDtSeconds;
    ProjDt.get(ProjDtSeconds, TimeUnits::Seconds);
 
@@ -330,10 +332,22 @@ void AuxiliaryState::computeTracerAux(const OceanState *State,
 
    computeTransportVelocity(State, VelTimeLevel);
 
+   const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
+
+   Pacer::start("AuxState:cellThicknessAux", 2);
+   parallelForOuter(
+       "cellThicknessAux",
+       LaunchConfig({Mesh->NCellsAll}, TeamScratch<Real>(VCoord->NVertLayers)),
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          LocPseudoThicknessAux.computeVarsOnCells(Team, ICell, PseudoThickCell,
+                                                   NormalTransportVelocity,
+                                                   TimeStepSeconds);
+       });
+   Pacer::stop("AuxState:cellThicknessAux", 2);
+
    Pacer::start("AuxState:computeVerticalPseudoVelocity", 2);
 
-   const auto &FluxPseudoThickEdge     = PseudoThicknessAux.FluxPseudoThickEdge;
-   const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
+   const auto &FluxPseudoThickEdge = PseudoThicknessAux.FluxPseudoThickEdge;
    VAdv->computeVerticalTransportPseudoVelocity(NormalTransportVelocity,
                                                 FluxPseudoThickEdge,
                                                 PseudoThickCell, ProjDtSeconds);
@@ -367,33 +381,34 @@ void AuxiliaryState::computeAll(const OceanState *State,
 
    computeMomAux(State, TracerArray, ThickTimeLevel, VelTimeLevel, ProjDt);
 
-   Pacer::start("AuxState:cellAuxState3", 2);
-   parallelForOuter(
-       "cellAuxState3",
-       LaunchConfig({Mesh->NCellsAll}, TeamScratch<Real>(VCoord->NVertLayers)),
-       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          LocPseudoThicknessAux.computeVarsOnCells(
-              Team, ICell, PseudoThickCell, NormalVelEdge, TimeStepSeconds);
-       });
-   Pacer::stop("AuxState:cellAuxState3", 2);
-
    const auto &MeanPseudoThickEdge = PseudoThicknessAux.MeanPseudoThickEdge;
 
-   Pacer::start("AuxState:cellAuxState4", 2);
+   Pacer::start("AuxState:cellTracerAux", 2);
    parallelForOuter(
-       "cellAuxState4",
+       "tracerCellAux",
        LaunchConfig({NTracers, Mesh->NCellsAll},
                     TeamScratch<Real>(VCoord->NVertLayers)),
        KOKKOS_LAMBDA(int LTracer, int ICell, const TeamMember &Team) {
           LocTracerAux.computeVarsOnCells(Team, LTracer, ICell,
                                           MeanPseudoThickEdge, TracerArray);
        });
-   Pacer::stop("AuxState:cellAuxState4", 2);
+   Pacer::stop("AuxState:cellTracerAux", 2);
 
    computeTransportVelocity(State, VelTimeLevel);
 
    const auto &FluxPseudoThickEdge     = PseudoThicknessAux.FluxPseudoThickEdge;
    const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
+
+   Pacer::start("AuxState:cellThickAux", 2);
+   parallelForOuter(
+       "thickCellAux",
+       LaunchConfig({Mesh->NCellsAll}, TeamScratch<Real>(VCoord->NVertLayers)),
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          LocPseudoThicknessAux.computeVarsOnCells(Team, ICell, PseudoThickCell,
+                                                   NormalTransportVelocity,
+                                                   TimeStepSeconds);
+       });
+   Pacer::stop("AuxState:cellThickAux", 2);
 
    VAdv->computeVerticalTransportPseudoVelocity(NormalTransportVelocity,
                                                 FluxPseudoThickEdge,
@@ -443,16 +458,6 @@ void AuxiliaryState::computePseudoThicknessTracerAux(
        });
    Pacer::stop("AuxState:edgeThicknessTracerAux", 2);
 
-   Pacer::start("AuxState:cellThicknessAux", 2);
-   parallelForOuter(
-       "cellThicknessAux",
-       LaunchConfig({Mesh->NCellsAll}, TeamScratch<Real>(VCoord->NVertLayers)),
-       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          LocPseudoThicknessAux.computeVarsOnCells(
-              Team, ICell, PseudoThickCell, NormalVelEdge, TimeStepSeconds);
-       });
-   Pacer::stop("AuxState:cellThicknessAux", 2);
-
    const auto &MeanPseudoThickEdge = PseudoThicknessAux.MeanPseudoThickEdge;
 
    Pacer::start("AuxState:cellTracerAux", 2);
@@ -468,10 +473,22 @@ void AuxiliaryState::computePseudoThicknessTracerAux(
 
    computeTransportVelocity(State, VelTimeLevel, TransportVelocityAdd);
 
+   const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
+
+   Pacer::start("AuxState:cellThicknessAux", 2);
+   parallelForOuter(
+       "cellThicknessAux",
+       LaunchConfig({Mesh->NCellsAll}, TeamScratch<Real>(VCoord->NVertLayers)),
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          LocPseudoThicknessAux.computeVarsOnCells(Team, ICell, PseudoThickCell,
+                                                   NormalTransportVelocity,
+                                                   TimeStepSeconds);
+       });
+   Pacer::stop("AuxState:cellThicknessAux", 2);
+
    Pacer::start("AuxState:computeVerticalPseudoVelocity", 2);
 
-   const auto &FluxPseudoThickEdge     = PseudoThicknessAux.FluxPseudoThickEdge;
-   const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
+   const auto &FluxPseudoThickEdge = PseudoThicknessAux.FluxPseudoThickEdge;
    VAdv->computeVerticalTransportPseudoVelocity(NormalTransportVelocity,
                                                 FluxPseudoThickEdge,
                                                 PseudoThickCell, ProjDtSeconds);

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -141,11 +141,15 @@ void AuxiliaryState::computePseudoThicknessAux(
        });
    Pacer::stop("AuxState:computePseudoThickAux", 2);
 
+   computeTransportVelocity(State, VelTimeLevel);
+
    Pacer::start("AuxState:computeVerticalPseudoVelocity", 2);
 
-   const auto &FluxPseudoThickEdge = PseudoThicknessAux.FluxPseudoThickEdge;
-   VAdv->computeVerticalPseudoVelocity(NormalVelEdge, FluxPseudoThickEdge,
-                                       PseudoThickCell, ProjDtSeconds);
+   const auto &FluxPseudoThickEdge     = PseudoThicknessAux.FluxPseudoThickEdge;
+   const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
+   VAdv->computeVerticalPseudoVelocity(NormalTransportVelocity,
+                                       FluxPseudoThickEdge, PseudoThickCell,
+                                       ProjDtSeconds);
 
    Pacer::stop("AuxState:computeVerticalPseudoVelocity", 2);
 }
@@ -305,11 +309,15 @@ void AuxiliaryState::computeTracerAux(const OceanState *State,
        });
    Pacer::stop("Tend:computeTracerAuxCell", 2);
 
+   computeTransportVelocity(State, VelTimeLevel);
+
    Pacer::start("AuxState:computeVerticalPseudoVelocity", 2);
 
-   const auto &FluxPseudoThickEdge = PseudoThicknessAux.FluxPseudoThickEdge;
-   VAdv->computeVerticalPseudoVelocity(NormalVelEdge, FluxPseudoThickEdge,
-                                       PseudoThickCell, ProjDtSeconds);
+   const auto &FluxPseudoThickEdge     = PseudoThicknessAux.FluxPseudoThickEdge;
+   const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
+   VAdv->computeVerticalPseudoVelocity(NormalTransportVelocity,
+                                       FluxPseudoThickEdge, PseudoThickCell,
+                                       ProjDtSeconds);
 
    Pacer::stop("AuxState:computeVerticalPseudoVelocity", 2);
 }
@@ -360,6 +368,8 @@ void AuxiliaryState::computeAll(const OceanState *State,
                                           MeanPseudoThickEdge, TracerArray);
        });
    Pacer::stop("AuxState:cellAuxState4", 2);
+
+   computeTransportVelocity(State, VelTimeLevel);
 
    Pacer::stop("AuxState:computeAll", 1);
 }

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -94,8 +94,6 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
    const auto &PressureMid = VCoord->PressureMid;
    EosInstance->computeSpecVol(ConservTemp, AbsSalinity, PressureMid);
    EosInstance->computeDepthIntegratedSpecificVolume(PseudoThickCell);
-   VCoord->computeTotalGeometricThickness(
-       EosInstance->DepthIntegSpecificVolume);
 
    // compute geometric height
    VCoord->computeGeomZHeight(PseudoThickCell, EosInstance->SpecVol);

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -410,7 +410,8 @@ void AuxiliaryState::computeAll(const OceanState *State,
 
 void AuxiliaryState::computePseudoThicknessTracerAux(
     const OceanState *State, const Array3DReal &TracerArray, int ThickTimeLevel,
-    int VelTimeLevel, const TimeInterval ProjDt) const {
+    int VelTimeLevel, const TimeInterval ProjDt,
+    const Array2DReal &TransportVelocityAdd) const {
 
    Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
    Array2DReal NormalVelEdge   = State->getNormalVelocity(VelTimeLevel);

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -104,6 +104,38 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
    Pacer::stop("AuxState:computeMomVertAux", 2);
 }
 
+// Compute the auxiliary variables needed for pseudo-thickness equation
+void AuxiliaryState::computePseudoThicknessAux(
+    const OceanState *State, const Array3DReal &TracerArray, int ThickTimeLevel,
+    int VelTimeLevel, const TimeInterval ProjDt) const {
+
+   Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
+   Array2DReal NormalVelEdge   = State->getNormalVelocity(VelTimeLevel);
+   OMEGA_SCOPE(LocPseudoThicknessAux, PseudoThicknessAux);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   R8 ProjDtSeconds;
+   ProjDt.get(ProjDtSeconds, TimeUnits::Seconds);
+
+   Pacer::start("AuxState:computePseudoThickAux", 2);
+   parallelForOuter(
+       "computePseudoThickAux", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          LocPseudoThicknessAux.computeVarsOnEdge(Team, IEdge, PseudoThickCell,
+                                                  NormalVelEdge);
+       });
+   Pacer::stop("AuxState:computePseudoThickAux", 2);
+
+   Pacer::start("AuxState:computeVerticalPseudoVelocity", 2);
+
+   const auto &FluxPseudoThickEdge = PseudoThicknessAux.FluxPseudoThickEdge;
+   VAdv->computeVerticalPseudoVelocity(NormalVelEdge, FluxPseudoThickEdge,
+                                       PseudoThickCell, ProjDtSeconds);
+
+   Pacer::stop("AuxState:computeVerticalPseudoVelocity", 2);
+}
+
 // Compute the auxiliary variables needed for momentum equation
 void AuxiliaryState::computeMomAux(const OceanState *State,
                                    const Array3DReal &TracerArray,

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -93,10 +93,11 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
    // compute specific volume
    const auto &PressureMid = VCoord->PressureMid;
    EosInstance->computeSpecVol(ConservTemp, AbsSalinity, PressureMid);
-   EosInstance->computeDepthMeanSpecificVolume(PseudoThickCell);
 
    // compute geometric height
    VCoord->computeGeomZHeight(PseudoThickCell, EosInstance->SpecVol);
+
+   EosInstance->computeDepthMeanSpecificVolume(PseudoThickCell);
 
    // compute target thickness
    VCoord->computeTargetThickness();

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -93,7 +93,7 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
    // compute specific volume
    const auto &PressureMid = VCoord->PressureMid;
    EosInstance->computeSpecVol(ConservTemp, AbsSalinity, PressureMid);
-   EosInstance->computeDepthIntegratedSpecificVolume(PseudoThickCell);
+   EosInstance->computeDepthMeanSpecificVolume(PseudoThickCell);
 
    // compute geometric height
    VCoord->computeGeomZHeight(PseudoThickCell, EosInstance->SpecVol);

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -30,8 +30,7 @@ AuxiliaryState::AuxiliaryState(const std::string &Name, const HorzMesh *Mesh,
       VelocityDel2Aux(stripDefault(Name), Mesh, VCoord),
       SurfTracerRestAux(stripDefault(Name), Mesh, NTracers),
       TracerAux(stripDefault(Name), Mesh, VCoord, NTracers),
-      TransportAux(stripDefault(Name), Mesh, VCoord),
-      TimeStep(TimeStep) {
+      TransportAux(stripDefault(Name), Mesh, VCoord), TimeStep(TimeStep) {
 
    GroupName = "AuxiliaryState";
    if (Name != "Default") {
@@ -105,6 +104,18 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
    VCoord->computeTargetThickness();
 
    Pacer::stop("AuxState:computeMomVertAux", 2);
+}
+
+// Compute transport velocity for pseudo-thickness and tracers
+void AuxiliaryState::computeTransportVelocity(const OceanState *State,
+                                              int VelTimeLevel) const {
+   Pacer::start("AuxState:computeTransportVelocity", 2);
+
+   Array2DReal NormalVel = State->getNormalVelocity(VelTimeLevel);
+
+   deep_copy(TransportAux.NormalTransportVelocity, NormalVel);
+
+   Pacer::stop("AuxState:computeTransportVelocity", 2);
 }
 
 // Compute the auxiliary variables needed for pseudo-thickness equation

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -483,6 +483,18 @@ void AuxiliaryState::computePseudoThicknessTracerAux(
        });
    Pacer::stop("AuxState:cellTracerAux", 2);
 
+   computeTransportVelocity(State, VelTimeLevel, TransportVelocityAdd);
+
+   Pacer::start("AuxState:computeVerticalPseudoVelocity", 2);
+
+   const auto &FluxPseudoThickEdge     = PseudoThicknessAux.FluxPseudoThickEdge;
+   const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
+   VAdv->computeVerticalTransportPseudoVelocity(NormalTransportVelocity,
+                                                FluxPseudoThickEdge,
+                                                PseudoThickCell, ProjDtSeconds);
+
+   Pacer::stop("AuxState:computeVerticalPseudoVelocity", 2);
+
    Pacer::stop("AuxState:computePseudoThicknessTracerAux", 1);
 }
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -107,13 +107,32 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
 }
 
 // Compute transport velocity for pseudo-thickness and tracers
-void AuxiliaryState::computeTransportVelocity(const OceanState *State,
-                                              int VelTimeLevel) const {
+void AuxiliaryState::computeTransportVelocity(
+    const OceanState *State, int VelTimeLevel,
+    const Array2DReal &TransportVelocityAdd) const {
    Pacer::start("AuxState:computeTransportVelocity", 2);
 
-   Array2DReal NormalVel = State->getNormalVelocity(VelTimeLevel);
+   Array2DReal NormalVelocity          = State->getNormalVelocity(VelTimeLevel);
+   const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
 
-   deep_copy(TransportAux.NormalTransportVelocity, NormalVel);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   parallelForOuter(
+       "computeTransportVelocity", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin = MinLayerEdgeBot(IEdge);
+          const int KMax = MaxLayerEdgeTop(IEdge);
+
+          parallelForInner(
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
+                 NormalTransportVelocity(IEdge, K) = NormalVelocity(IEdge, K);
+                 if (TransportVelocityAdd.data()) {
+                    NormalTransportVelocity(IEdge, K) +=
+                        TransportVelocityAdd(IEdge, K);
+                 }
+              });
+       });
 
    Pacer::stop("AuxState:computeTransportVelocity", 2);
 }

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -425,6 +425,8 @@ void AuxiliaryState::computePseudoThicknessTracerAux(
    OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
    OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
+   R8 TimeStepSeconds;
+   TimeStep.get(TimeStepSeconds, TimeUnits::Seconds);
    R8 ProjDtSeconds;
    ProjDt.get(ProjDtSeconds, TimeUnits::Seconds);
 
@@ -447,7 +449,7 @@ void AuxiliaryState::computePseudoThicknessTracerAux(
        LaunchConfig({Mesh->NCellsAll}, TeamScratch<Real>(VCoord->NVertLayers)),
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
           LocPseudoThicknessAux.computeVarsOnCells(
-              Team, ICell, PseudoThickCell, NormalVelEdge, ProjDtSeconds);
+              Team, ICell, PseudoThickCell, NormalVelEdge, TimeStepSeconds);
        });
    Pacer::stop("AuxState:cellThicknessAux", 2);
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -323,8 +323,8 @@ void AuxiliaryState::computeTracerAux(const OceanState *State,
        LaunchConfig({NTracers, Mesh->NCellsAll},
                     TeamScratch<Real>(VCoord->NVertLayers)),
        KOKKOS_LAMBDA(int LTracer, int ICell, const TeamMember &Team) {
-          TracerAux.computeVarsOnCells(Team, LTracer, ICell,
-                                       MeanPseudoThickEdge, TracerArray);
+          LocTracerAux.computeVarsOnCells(Team, LTracer, ICell,
+                                          MeanPseudoThickEdge, TracerArray);
        });
    Pacer::stop("Tend:computeTracerAuxCell", 2);
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -66,8 +66,7 @@ AuxiliaryState::~AuxiliaryState() {
 // Compute auxiliary variables for vertical dynamics
 void AuxiliaryState::computeMomVertAux(const OceanState *State,
                                        const Array3DReal &TracerArray,
-                                       int ThickTimeLevel,
-                                       int VelTimeLevel) const {
+                                       int ThickTimeLevel) const {
 
    Pacer::start("AuxState:computeMomVertAux", 2);
 
@@ -75,8 +74,6 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
 
    // get pseudo-thickness
    Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
-   // get normal velocity
-   Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
 
    // get temperature and salinity
    I4 ConservTempIdx;
@@ -96,6 +93,9 @@ void AuxiliaryState::computeMomVertAux(const OceanState *State,
    // compute specific volume
    const auto &PressureMid = VCoord->PressureMid;
    EosInstance->computeSpecVol(ConservTemp, AbsSalinity, PressureMid);
+   EosInstance->computeDepthIntegratedSpecificVolume(PseudoThickCell);
+   VCoord->computeTotalGeometricThickness(
+       EosInstance->DepthIntegSpecificVolume);
 
    // compute geometric height
    VCoord->computeGeomZHeight(PseudoThickCell, EosInstance->SpecVol);
@@ -178,9 +178,18 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
                                    const Array3DReal &TracerArray,
                                    int ThickTimeLevel, int VelTimeLevel,
                                    const TimeInterval ProjDt) const {
+
    Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
    Array2DReal NormalVelEdge   = State->getNormalVelocity(VelTimeLevel);
+   computeMomAux(State, TracerArray, ThickTimeLevel, NormalVelEdge, ProjDt);
+}
 
+void AuxiliaryState::computeMomAux(const OceanState *State,
+                                   const Array3DReal &TracerArray,
+                                   int ThickTimeLevel,
+                                   const Array2DReal &NormalVelEdge,
+                                   const TimeInterval ProjDt) const {
+   Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
    OMEGA_SCOPE(LocKineticAux, KineticAux);
    OMEGA_SCOPE(LocPseudoThicknessAux, PseudoThicknessAux);
    OMEGA_SCOPE(LocVorticityAux, VorticityAux);
@@ -206,7 +215,7 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
 
    Pacer::start("AuxState:computeMomAux", 1);
 
-   computeMomVertAux(State, TracerArray, ThickTimeLevel, VelTimeLevel);
+   computeMomVertAux(State, TracerArray, ThickTimeLevel);
 
    Pacer::start("AuxState:vertexAuxState1", 2);
    parallelForOuter(
@@ -406,6 +415,91 @@ void AuxiliaryState::computeAll(const OceanState *State,
                                 const Array3DReal &TracerArray, int TimeLevel,
                                 const TimeInterval ProjDt) const {
    computeAll(State, TracerArray, TimeLevel, TimeLevel, ProjDt);
+}
+
+void AuxiliaryState::computePseudoThicknessTracerAux(
+    const OceanState *State, const Array3DReal &TracerArray, int ThickTimeLevel,
+    int VelTimeLevel) const {
+
+   Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
+   computePseudoThicknessTracerAux(State, TracerArray, ThickTimeLevel,
+                                   NormalVelEdge, TimeStep);
+}
+
+void AuxiliaryState::computePseudoThicknessTracerAux(
+    const OceanState *State, const Array3DReal &TracerArray, int ThickTimeLevel,
+    const Array2DReal &NormalVelEdge, const TimeInterval ProjDt) const {
+
+   Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
+
+   const int NTracers = TracerArray.extent_int(0);
+
+   OMEGA_SCOPE(LocPseudoThicknessAux, PseudoThicknessAux);
+   OMEGA_SCOPE(LocTracerAux, TracerAux);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   R8 ProjDtSeconds;
+   ProjDt.get(ProjDtSeconds, TimeUnits::Seconds);
+
+   Pacer::start("AuxState:computePseudoThicknessTracerAux", 1);
+
+   computeMomVertAux(State, TracerArray, ThickTimeLevel);
+
+   Pacer::start("AuxState:edgeThicknessTracerAux", 2);
+   parallelForOuter(
+       "edgeThicknessTracerAux", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocPseudoThicknessAux.computeVarsOnEdge(
+                     IEdge, KChunk, PseudoThickCell, NormalVelEdge);
+              });
+       });
+   Pacer::stop("AuxState:edgeThicknessTracerAux", 2);
+
+   Pacer::start("AuxState:cellThicknessAux", 2);
+   parallelForOuter(
+       "cellThicknessAux", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocPseudoThicknessAux.computeVarsOnCells(
+                     ICell, KChunk, PseudoThickCell, NormalVelEdge,
+                     ProjDtSeconds);
+              });
+       });
+   Pacer::stop("AuxState:cellThicknessAux", 2);
+
+   const auto &MeanPseudoThickEdge = PseudoThicknessAux.MeanPseudoThickEdge;
+
+   Pacer::start("AuxState:cellTracerAux", 2);
+   parallelForOuter(
+       "cellTracerAux", {NTracers, Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int LTracer, int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocTracerAux.computeVarsOnCells(
+                     LTracer, ICell, KChunk, MeanPseudoThickEdge, TracerArray);
+              });
+       });
+   Pacer::stop("AuxState:cellTracerAux", 2);
+
+   Pacer::stop("AuxState:computePseudoThicknessTracerAux", 1);
 }
 
 // Create a non-default auxiliary state

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -410,18 +410,10 @@ void AuxiliaryState::computeAll(const OceanState *State,
 
 void AuxiliaryState::computePseudoThicknessTracerAux(
     const OceanState *State, const Array3DReal &TracerArray, int ThickTimeLevel,
-    int VelTimeLevel) const {
-
-   Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
-   computePseudoThicknessTracerAux(State, TracerArray, ThickTimeLevel,
-                                   NormalVelEdge, TimeStep);
-}
-
-void AuxiliaryState::computePseudoThicknessTracerAux(
-    const OceanState *State, const Array3DReal &TracerArray, int ThickTimeLevel,
-    const Array2DReal &NormalVelEdge, const TimeInterval ProjDt) const {
+    int VelTimeLevel, const TimeInterval ProjDt) const {
 
    Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
+   Array2DReal NormalVelEdge   = State->getNormalVelocity(VelTimeLevel);
 
    const int NTracers = TracerArray.extent_int(0);
 

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -147,9 +147,9 @@ void AuxiliaryState::computePseudoThicknessAux(
 
    const auto &FluxPseudoThickEdge     = PseudoThicknessAux.FluxPseudoThickEdge;
    const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
-   VAdv->computeVerticalPseudoVelocity(NormalTransportVelocity,
-                                       FluxPseudoThickEdge, PseudoThickCell,
-                                       ProjDtSeconds);
+   VAdv->computeVerticalTransportPseudoVelocity(NormalTransportVelocity,
+                                                FluxPseudoThickEdge,
+                                                PseudoThickCell, ProjDtSeconds);
 
    Pacer::stop("AuxState:computeVerticalPseudoVelocity", 2);
 }
@@ -315,9 +315,9 @@ void AuxiliaryState::computeTracerAux(const OceanState *State,
 
    const auto &FluxPseudoThickEdge     = PseudoThicknessAux.FluxPseudoThickEdge;
    const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
-   VAdv->computeVerticalPseudoVelocity(NormalTransportVelocity,
-                                       FluxPseudoThickEdge, PseudoThickCell,
-                                       ProjDtSeconds);
+   VAdv->computeVerticalTransportPseudoVelocity(NormalTransportVelocity,
+                                                FluxPseudoThickEdge,
+                                                PseudoThickCell, ProjDtSeconds);
 
    Pacer::stop("AuxState:computeVerticalPseudoVelocity", 2);
 }
@@ -341,6 +341,8 @@ void AuxiliaryState::computeAll(const OceanState *State,
 
    R8 TimeStepSeconds;
    TimeStep.get(TimeStepSeconds, TimeUnits::Seconds);
+   R8 ProjDtSeconds;
+   ProjDt.get(ProjDtSeconds, TimeUnits::Seconds);
 
    Pacer::start("AuxState:computeAll", 1);
 
@@ -370,6 +372,13 @@ void AuxiliaryState::computeAll(const OceanState *State,
    Pacer::stop("AuxState:cellAuxState4", 2);
 
    computeTransportVelocity(State, VelTimeLevel);
+
+   const auto &FluxPseudoThickEdge     = PseudoThicknessAux.FluxPseudoThickEdge;
+   const auto &NormalTransportVelocity = TransportAux.NormalTransportVelocity;
+
+   VAdv->computeVerticalTransportPseudoVelocity(NormalTransportVelocity,
+                                                FluxPseudoThickEdge,
+                                                PseudoThickCell, ProjDtSeconds);
 
    Pacer::stop("AuxState:computeAll", 1);
 }

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -455,7 +455,9 @@ void AuxiliaryState::computePseudoThicknessTracerAux(
 
    Pacer::start("AuxState:cellTracerAux", 2);
    parallelForOuter(
-       "cellTracerAux", {NTracers, Mesh->NCellsAll},
+       "cellTracerAux",
+       LaunchConfig({NTracers, Mesh->NCellsAll},
+                    TeamScratch<Real>(VCoord->NVertLayers)),
        KOKKOS_LAMBDA(int LTracer, int ICell, const TeamMember &Team) {
           LocTracerAux.computeVarsOnCells(Team, LTracer, ICell,
                                           MeanPseudoThickEdge, TracerArray);

--- a/components/omega/src/ocn/AuxiliaryState.cpp
+++ b/components/omega/src/ocn/AuxiliaryState.cpp
@@ -249,6 +249,57 @@ void AuxiliaryState::computeMomAux(const OceanState *State,
    Pacer::stop("AuxState:computeMomAux", 1);
 }
 
+// Compute the auxiliary variables needed for tracer equation
+void AuxiliaryState::computeTracerAux(const OceanState *State,
+                                      const Array3DReal &TracerArray,
+                                      int ThickTimeLevel, int VelTimeLevel,
+                                      const TimeInterval ProjDt) const {
+
+   OMEGA_SCOPE(LocPseudoThicknessAux, PseudoThicknessAux);
+   OMEGA_SCOPE(LocTracerAux, TracerAux);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   R8 ProjDtSeconds;
+   ProjDt.get(ProjDtSeconds, TimeUnits::Seconds);
+
+   Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
+   Array2DReal NormalVelEdge   = State->getNormalVelocity(VelTimeLevel);
+
+   Pacer::start("AuxState:computePseudoThickAux", 2);
+   parallelForOuter(
+       "computePseudoThickAux", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          LocPseudoThicknessAux.computeVarsOnEdge(Team, IEdge, PseudoThickCell,
+                                                  NormalVelEdge);
+       });
+   Pacer::stop("AuxState:computePseudoThickAux", 2);
+
+   const int NTracers              = Tracers::getNumTracers();
+   const auto &MeanPseudoThickEdge = PseudoThicknessAux.MeanPseudoThickEdge;
+
+   Pacer::start("Tend:computeTracerAuxCell", 2);
+   parallelForOuter(
+       "computeTracerAuxCell",
+       LaunchConfig({NTracers, Mesh->NCellsAll},
+                    TeamScratch<Real>(VCoord->NVertLayers)),
+       KOKKOS_LAMBDA(int LTracer, int ICell, const TeamMember &Team) {
+          TracerAux.computeVarsOnCells(Team, LTracer, ICell,
+                                       MeanPseudoThickEdge, TracerArray);
+       });
+   Pacer::stop("Tend:computeTracerAuxCell", 2);
+
+   Pacer::start("AuxState:computeVerticalPseudoVelocity", 2);
+
+   const auto &FluxPseudoThickEdge = PseudoThicknessAux.FluxPseudoThickEdge;
+   VAdv->computeVerticalPseudoVelocity(NormalVelEdge, FluxPseudoThickEdge,
+                                       PseudoThickCell, ProjDtSeconds);
+
+   Pacer::stop("AuxState:computeVerticalPseudoVelocity", 2);
+}
+
 // Compute the auxiliary variables
 void AuxiliaryState::computeAll(const OceanState *State,
                                 const Array3DReal &TracerArray,

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -88,8 +88,9 @@ class AuxiliaryState {
                           int VelTimeLevel) const;
 
    // Compute transport velocity for pseudo-thickness and tracers
-   void computeTransportVelocity(const OceanState *State,
-                                 int VelTimeLevel) const;
+   void computeTransportVelocity(
+       const OceanState *State, int VelTimeLevel,
+       const Array2DReal &TransportVelocityAdd = Array2DReal()) const;
 
    // Compute all auxiliary variables needed for momentum equation
    void computeMomAux(const OceanState *State, const Array3DReal &TracerArray,

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -14,6 +14,7 @@
 #include "auxiliaryVars/PseudoThicknessAuxVars.h"
 #include "auxiliaryVars/SurfTracerRestAuxVars.h"
 #include "auxiliaryVars/TracerAuxVars.h"
+#include "auxiliaryVars/TransportAuxVars.h"
 #include "auxiliaryVars/VelocityDel2AuxVars.h"
 #include "auxiliaryVars/VorticityAuxVars.h"
 
@@ -42,6 +43,7 @@ class AuxiliaryState {
    VorticityAuxVars VorticityAux;
    VelocityDel2AuxVars VelocityDel2Aux;
    SurfTracerRestAuxVars SurfTracerRestAux;
+   TransportAuxVars TransportAux;
 
    ~AuxiliaryState();
 

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -90,6 +90,11 @@ class AuxiliaryState {
                       int ThickTimeLevel, int VelTimeLevel,
                       const TimeInterval ProjDt) const;
 
+   // Compute all auxiliary variables needed for tracer equation
+   void computeTracerAux(const OceanState *State,
+                         const Array3DReal &TracerArray, int ThickTimeLevel,
+                         int VelTimeLevel, const TimeInterval ProjDt) const;
+
    /// Compute all auxiliary variables based on an ocean state at a given time
    /// level
    void computeAll(const OceanState *State, const Array3DReal &TracerArray,

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -87,6 +87,10 @@ class AuxiliaryState {
                           const Array3DReal &TracerArray, int ThickTimeLevel,
                           int VelTimeLevel) const;
 
+   // Compute transport velocity for pseudo-thickness and tracers
+   void computeTransportVelocity(const OceanState *State,
+                                 int VelTimeLevel) const;
+
    // Compute all auxiliary variables needed for momentum equation
    void computeMomAux(const OceanState *State, const Array3DReal &TracerArray,
                       int ThickTimeLevel, int VelTimeLevel,

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -111,10 +111,10 @@ class AuxiliaryState {
                    int TimeLevel, const TimeInterval ProjDt) const;
 
    /// Compute auxiliary variables needed for thickness and tracer tendencies.
-   void computePseudoThicknessTracerAux(const OceanState *State,
-                                        const Array3DReal &TracerArray,
-                                        int ThickTimeLevel, int VelTimeLevel,
-                                        const TimeInterval ProjDt) const;
+   void computePseudoThicknessTracerAux(
+       const OceanState *State, const Array3DReal &TracerArray,
+       int ThickTimeLevel, int VelTimeLevel, const TimeInterval ProjDt,
+       const Array2DReal &TransportVelocityAdd = Array2DReal()) const;
 
  private:
    AuxiliaryState(const std::string &Name, const HorzMesh *Mesh, Halo *MeshHalo,

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -74,6 +74,12 @@ class AuxiliaryState {
    /// Exchange halo
    I4 exchangeHalo();
 
+   // Compute all auxiliary variables needed for pseudo-thickness equation
+   void computePseudoThicknessAux(const OceanState *State,
+                                  const Array3DReal &TracerArray,
+                                  int ThickTimeLevel, int VelTimeLevel,
+                                  const TimeInterval ProjDt) const;
+
    // Compute auxiliary variables for vertical dynamics
    void computeMomVertAux(const OceanState *State,
                           const Array3DReal &TracerArray, int ThickTimeLevel,

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -113,12 +113,7 @@ class AuxiliaryState {
    /// Compute auxiliary variables needed for thickness and tracer tendencies.
    void computePseudoThicknessTracerAux(const OceanState *State,
                                         const Array3DReal &TracerArray,
-                                        int ThickTimeLevel,
-                                        int VelTimeLevel) const;
-   void computePseudoThicknessTracerAux(const OceanState *State,
-                                        const Array3DReal &TracerArray,
-                                        int ThickTimeLevel,
-                                        const Array2DReal &NormalVelEdge,
+                                        int ThickTimeLevel, int VelTimeLevel,
                                         const TimeInterval ProjDt) const;
 
  private:

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -96,9 +96,6 @@ class AuxiliaryState {
    void computeMomAux(const OceanState *State, const Array3DReal &TracerArray,
                       int ThickTimeLevel, int VelTimeLevel,
                       const TimeInterval ProjDt) const;
-   void computeMomAux(const OceanState *State, const Array3DReal &TracerArray,
-                      int ThickTimeLevel, const Array2DReal &NormalVelEdge,
-                      const TimeInterval ProjDt) const;
 
    // Compute all auxiliary variables needed for tracer equation
    void computeTracerAux(const OceanState *State,

--- a/components/omega/src/ocn/AuxiliaryState.h
+++ b/components/omega/src/ocn/AuxiliaryState.h
@@ -84,8 +84,8 @@ class AuxiliaryState {
 
    // Compute auxiliary variables for vertical dynamics
    void computeMomVertAux(const OceanState *State,
-                          const Array3DReal &TracerArray, int ThickTimeLevel,
-                          int VelTimeLevel) const;
+                          const Array3DReal &TracerArray,
+                          int ThickTimeLevel) const;
 
    // Compute transport velocity for pseudo-thickness and tracers
    void computeTransportVelocity(
@@ -95,6 +95,9 @@ class AuxiliaryState {
    // Compute all auxiliary variables needed for momentum equation
    void computeMomAux(const OceanState *State, const Array3DReal &TracerArray,
                       int ThickTimeLevel, int VelTimeLevel,
+                      const TimeInterval ProjDt) const;
+   void computeMomAux(const OceanState *State, const Array3DReal &TracerArray,
+                      int ThickTimeLevel, const Array2DReal &NormalVelEdge,
                       const TimeInterval ProjDt) const;
 
    // Compute all auxiliary variables needed for tracer equation
@@ -109,6 +112,17 @@ class AuxiliaryState {
                    const TimeInterval ProjDt) const;
    void computeAll(const OceanState *State, const Array3DReal &TracerArray,
                    int TimeLevel, const TimeInterval ProjDt) const;
+
+   /// Compute auxiliary variables needed for thickness and tracer tendencies.
+   void computePseudoThicknessTracerAux(const OceanState *State,
+                                        const Array3DReal &TracerArray,
+                                        int ThickTimeLevel,
+                                        int VelTimeLevel) const;
+   void computePseudoThicknessTracerAux(const OceanState *State,
+                                        const Array3DReal &TracerArray,
+                                        int ThickTimeLevel,
+                                        const Array2DReal &NormalVelEdge,
+                                        const TimeInterval ProjDt) const;
 
  private:
    AuxiliaryState(const std::string &Name, const HorzMesh *Mesh, Halo *MeshHalo,

--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -54,8 +54,6 @@ Eos::Eos(const std::string &Name, ///< [in] Name for eos object
    SpecVolDSa =
        Array2DReal("SpecVolDSa", Mesh->NCellsSize, VCoord->NVertLayers);
    SpecVolDP = Array2DReal("SpecVolDP", Mesh->NCellsSize, VCoord->NVertLayers);
-   DepthIntegSpecificVolume =
-       Array1DReal("DepthIntegSpecificVolume", Mesh->NCellsSize);
    DepthMeanSpecificVolume =
        Array1DReal("DepthMeanSpecificVolume", Mesh->NCellsSize);
 
@@ -179,11 +177,10 @@ void Eos::computeSpecVol(const Array2DReal &ConservTemp,
    }
 }
 
-/// Compute depth-integrated specific volume for all cells
-void Eos::computeDepthIntegratedSpecificVolume(
+/// Compute depth-mean specific volume for all cells
+void Eos::computeDepthMeanSpecificVolume(
     const Array2DReal &PseudoThickness // [in] pseudo thickness
 ) {
-   OMEGA_SCOPE(LocDepthIntegSpecificVolume, DepthIntegSpecificVolume);
    OMEGA_SCOPE(LocDepthMeanSpecificVolume, DepthMeanSpecificVolume);
    OMEGA_SCOPE(LocSpecVol, SpecVol);
    OMEGA_SCOPE(LocTotalPseudoThickness, VCoord->TotalPseudoThickness);
@@ -191,7 +188,7 @@ void Eos::computeDepthIntegratedSpecificVolume(
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
 
    parallelForOuter(
-       "computeDepthIntegratedSpecificVolume", {Mesh->NCellsAll},
+       "computeDepthMeanSpecificVolume", {Mesh->NCellsAll},
        KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
           const int KMin = MinLayerCell(ICell);
           const int KMax = MaxLayerCell(ICell);
@@ -206,7 +203,6 @@ void Eos::computeDepthIntegratedSpecificVolume(
 
           Kokkos::single(
               PerTeam(Team), INNER_LAMBDA() {
-                 LocDepthIntegSpecificVolume(ICell) = DepthIntegSpecVol;
                  const Real ColumnThickness = LocTotalPseudoThickness(ICell);
                  LocDepthMeanSpecificVolume(ICell) =
                      DepthIntegSpecVol / ColumnThickness;
@@ -395,7 +391,6 @@ void Eos::defineFields() {
    SpecVolDCtFldName         = "SpecVolDCt";
    SpecVolDSaFldName         = "SpecVolDSa";
    SpecVolDPFldName          = "SpecVolDP";
-   DepthIntegSpecVolFldName  = "DepthIntegSpecificVolume";
    DepthMeanSpecVolFldName   = "DepthMeanSpecificVolume";
    if (Name != "Default") {
       SpecVolFldName.append(Name);
@@ -404,7 +399,6 @@ void Eos::defineFields() {
       SpecVolDCtFldName.append(Name);
       SpecVolDSaFldName.append(Name);
       SpecVolDPFldName.append(Name);
-      DepthIntegSpecVolFldName.append(Name);
       DepthMeanSpecVolFldName.append(Name);
    }
 
@@ -495,16 +489,6 @@ void Eos::defineFields() {
    NDims = 1;
    DimNames.resize(NDims);
    DimNames[0] = "NCells";
-   auto DepthIntegSpecificVolumeField =
-       Field::create(DepthIntegSpecVolFldName,           // Field name
-                     "Depth-integrated specific volume", // Long Name
-                     "m4 kg-1",                          // Units
-                     "",                                 // CF-ish Name
-                     0.0,                                // Min valid value
-                     std::numeric_limits<Real>::max(),   // Max valid value
-                     NDims,                              // Number of dimensions
-                     DimNames                            // Dimension names
-       );
    auto DepthMeanSpecificVolumeField =
        Field::create(DepthMeanSpecVolFldName,          // Field name
                      "Depth-mean specific volume",     // Long Name
@@ -530,7 +514,6 @@ void Eos::defineFields() {
    EosGroup->addField(SpecVolDCtFldName);
    EosGroup->addField(SpecVolDSaFldName);
    EosGroup->addField(SpecVolDPFldName);
-   EosGroup->addField(DepthIntegSpecVolFldName);
    EosGroup->addField(DepthMeanSpecVolFldName);
 
    // Attach Kokkos views to the fields
@@ -540,8 +523,6 @@ void Eos::defineFields() {
    SpecVolDCtField->attachData<Array2DReal>(SpecVolDCt);
    SpecVolDSaField->attachData<Array2DReal>(SpecVolDSa);
    SpecVolDPField->attachData<Array2DReal>(SpecVolDP);
-   DepthIntegSpecificVolumeField->attachData<Array1DReal>(
-       DepthIntegSpecificVolume);
    DepthMeanSpecificVolumeField->attachData<Array1DReal>(
        DepthMeanSpecificVolume);
 

--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -54,6 +54,10 @@ Eos::Eos(const std::string &Name, ///< [in] Name for eos object
    SpecVolDSa =
        Array2DReal("SpecVolDSa", Mesh->NCellsSize, VCoord->NVertLayers);
    SpecVolDP = Array2DReal("SpecVolDP", Mesh->NCellsSize, VCoord->NVertLayers);
+   DepthIntegSpecificVolume =
+       Array1DReal("DepthIntegSpecificVolume", Mesh->NCellsSize);
+   DepthMeanSpecificVolume =
+       Array1DReal("DepthMeanSpecificVolume", Mesh->NCellsSize);
 
    defineFields();
 }
@@ -173,6 +177,41 @@ void Eos::computeSpecVol(const Array2DReal &ConservTemp,
                                        AbsSalinity);
           });
    }
+}
+
+/// Compute depth-integrated specific volume for all cells
+void Eos::computeDepthIntegratedSpecificVolume(
+    const Array2DReal &PseudoThickness // [in] pseudo thickness
+) {
+   OMEGA_SCOPE(LocDepthIntegSpecificVolume, DepthIntegSpecificVolume);
+   OMEGA_SCOPE(LocDepthMeanSpecificVolume, DepthMeanSpecificVolume);
+   OMEGA_SCOPE(LocSpecVol, SpecVol);
+   OMEGA_SCOPE(LocTotalPseudoThickness, VCoord->TotalPseudoThickness);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
+   parallelForOuter(
+       "computeDepthIntegratedSpecificVolume", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+          const int KMin = MinLayerCell(ICell);
+          const int KMax = MaxLayerCell(ICell);
+
+          Real DepthIntegSpecVol = 0._Real;
+          parallelReduceInner(
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(const int K, Real &Accum) {
+                 Accum += LocSpecVol(ICell, K) * PseudoThickness(ICell, K);
+              },
+              DepthIntegSpecVol);
+
+          Kokkos::single(
+              PerTeam(Team), INNER_LAMBDA() {
+                 LocDepthIntegSpecificVolume(ICell) = DepthIntegSpecVol;
+                 const Real ColumnThickness = LocTotalPseudoThickness(ICell);
+                 LocDepthMeanSpecificVolume(ICell) =
+                     DepthIntegSpecVol / ColumnThickness;
+              });
+       });
 }
 
 /// Compute displaced specific volume (for vertical displacement)
@@ -356,6 +395,8 @@ void Eos::defineFields() {
    SpecVolDCtFldName         = "SpecVolDCt";
    SpecVolDSaFldName         = "SpecVolDSa";
    SpecVolDPFldName          = "SpecVolDP";
+   DepthIntegSpecVolFldName  = "DepthIntegSpecificVolume";
+   DepthMeanSpecVolFldName   = "DepthMeanSpecificVolume";
    if (Name != "Default") {
       SpecVolFldName.append(Name);
       SpecVolDisplacedFldName.append(Name);
@@ -363,6 +404,8 @@ void Eos::defineFields() {
       SpecVolDCtFldName.append(Name);
       SpecVolDSaFldName.append(Name);
       SpecVolDPFldName.append(Name);
+      DepthIntegSpecVolFldName.append(Name);
+      DepthMeanSpecVolFldName.append(Name);
    }
 
    /// Create fields for state variables
@@ -449,6 +492,30 @@ void Eos::defineFields() {
                      DimNames                          // Dimension names
        );
 
+   NDims = 1;
+   DimNames.resize(NDims);
+   DimNames[0] = "NCells";
+   auto DepthIntegSpecificVolumeField =
+       Field::create(DepthIntegSpecVolFldName,           // Field name
+                     "Depth-integrated specific volume", // Long Name
+                     "m4 kg-1",                          // Units
+                     "",                                 // CF-ish Name
+                     0.0,                                // Min valid value
+                     std::numeric_limits<Real>::max(),   // Max valid value
+                     NDims,                              // Number of dimensions
+                     DimNames                            // Dimension names
+       );
+   auto DepthMeanSpecificVolumeField =
+       Field::create(DepthMeanSpecVolFldName,          // Field name
+                     "Depth-mean specific volume",     // Long Name
+                     "m3 kg-1",                        // Units
+                     "",                               // CF-ish Name
+                     0.0,                              // Min valid value
+                     std::numeric_limits<Real>::max(), // Max valid value
+                     NDims,                            // Number of dimensions
+                     DimNames                          // Dimension names
+       );
+
    // Create a field group for the eos-specific state fields
    EosGroupName = "Eos";
    if (Name != "Default") {
@@ -463,6 +530,8 @@ void Eos::defineFields() {
    EosGroup->addField(SpecVolDCtFldName);
    EosGroup->addField(SpecVolDSaFldName);
    EosGroup->addField(SpecVolDPFldName);
+   EosGroup->addField(DepthIntegSpecVolFldName);
+   EosGroup->addField(DepthMeanSpecVolFldName);
 
    // Attach Kokkos views to the fields
    SpecVolDisplacedField->attachData<Array2DReal>(SpecVolDisplaced);
@@ -471,6 +540,10 @@ void Eos::defineFields() {
    SpecVolDCtField->attachData<Array2DReal>(SpecVolDCt);
    SpecVolDSaField->attachData<Array2DReal>(SpecVolDSa);
    SpecVolDPField->attachData<Array2DReal>(SpecVolDP);
+   DepthIntegSpecificVolumeField->attachData<Array1DReal>(
+       DepthIntegSpecificVolume);
+   DepthMeanSpecificVolumeField->attachData<Array1DReal>(
+       DepthMeanSpecificVolume);
 
 } // end defineIOFields
 

--- a/components/omega/src/ocn/Eos.cpp
+++ b/components/omega/src/ocn/Eos.cpp
@@ -182,31 +182,27 @@ void Eos::computeDepthMeanSpecificVolume(
     const Array2DReal &PseudoThickness // [in] pseudo thickness
 ) {
    OMEGA_SCOPE(LocDepthMeanSpecificVolume, DepthMeanSpecificVolume);
-   OMEGA_SCOPE(LocSpecVol, SpecVol);
-   OMEGA_SCOPE(LocTotalPseudoThickness, VCoord->TotalPseudoThickness);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+   OMEGA_SCOPE(GeomZInterface, VCoord->GeomZInterface);
+   OMEGA_SCOPE(PressureInterface, VCoord->PressureInterface);
 
-   parallelForOuter(
+   parallelFor(
        "computeDepthMeanSpecificVolume", {Mesh->NCellsAll},
-       KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+       KOKKOS_LAMBDA(I4 ICell) {
           const int KMin = MinLayerCell(ICell);
           const int KMax = MaxLayerCell(ICell);
 
-          Real DepthIntegSpecVol = 0._Real;
-          parallelReduceInner(
-              Team, Range{KMin, KMax},
-              INNER_LAMBDA(const int K, Real &Accum) {
-                 Accum += LocSpecVol(ICell, K) * PseudoThickness(ICell, K);
-              },
-              DepthIntegSpecVol);
+          const Real DepthIntegSpecVol =
+              (GeomZInterface(ICell, KMin) - GeomZInterface(ICell, KMax + 1)) /
+              RhoSw;
 
-          Kokkos::single(
-              PerTeam(Team), INNER_LAMBDA() {
-                 const Real ColumnThickness = LocTotalPseudoThickness(ICell);
-                 LocDepthMeanSpecificVolume(ICell) =
-                     DepthIntegSpecVol / ColumnThickness;
-              });
+          const Real ColumnThickness = (PressureInterface(ICell, KMax + 1) -
+                                        PressureInterface(ICell, KMin)) /
+                                       (Gravity * RhoSw);
+
+          LocDepthMeanSpecificVolume(ICell) =
+              DepthIntegSpecVol / ColumnThickness;
        });
 }
 

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -982,8 +982,7 @@ class Eos {
    Array2DReal SpecVolDCt;         ///< d(SpecVol)/d(ConservTemp), per degC
    Array2DReal SpecVolDSa;         ///< d(SpecVol)/d(AbsSalinity), per (g/kg)
    Array2DReal SpecVolDP;          ///< d(SpecVol)/d(Pressure), per Pa
-   Array1DReal DepthIntegSpecificVolume; ///< Depth-integrated specific volume
-   Array1DReal DepthMeanSpecificVolume;  ///< Depth-mean specific volume
+   Array1DReal DepthMeanSpecificVolume; ///< Depth-mean specific volume
 
    std::string SpecVolFldName; ///< Field name for specific volume
    std::string
@@ -993,12 +992,10 @@ class Eos {
    std::string SpecVolDCtFldName; ///< Field name for temperature derivative
    std::string SpecVolDSaFldName; ///< Field name for salinity derivative
    std::string SpecVolDPFldName;  ///< Field name for pressure derivative
-   std::string DepthIntegSpecVolFldName; ///< Field name for depth-integrated
-                                         ///< specific volume
-   std::string DepthMeanSpecVolFldName;  ///< Field name for depth-mean
-                                         ///< specific volume
-   std::string EosGroupName;             ///< EOS group name (for config)
-   std::string Name;                     ///< Name of this EOS instance
+   std::string DepthMeanSpecVolFldName; ///< Field name for depth-mean
+                                        ///< specific volume
+   std::string EosGroupName;            ///< EOS group name (for config)
+   std::string Name;                    ///< Name of this EOS instance
 
    /// Compute specific volume for all cells/layers
    void computeSpecVol(const Array2DReal &ConservTemp,
@@ -1006,7 +1003,7 @@ class Eos {
                        const Array2DReal &Pressure);
 
    /// Compute depth-integrated specific volume for all cells
-   void computeDepthIntegratedSpecificVolume(
+   void computeDepthMeanSpecificVolume(
        const Array2DReal &PseudoThickness ///< [in] pseudo thickness
    );
 

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -993,12 +993,12 @@ class Eos {
    std::string SpecVolDCtFldName; ///< Field name for temperature derivative
    std::string SpecVolDSaFldName; ///< Field name for salinity derivative
    std::string SpecVolDPFldName;  ///< Field name for pressure derivative
-   std::string DepthIntegSpecVolFldName;  ///< Field name for depth-integrated
-                                          ///< specific volume
-   std::string DepthMeanSpecVolFldName;   ///< Field name for depth-mean
-                                          ///< specific volume
-   std::string EosGroupName;              ///< EOS group name (for config)
-   std::string Name;                      ///< Name of this EOS instance
+   std::string DepthIntegSpecVolFldName; ///< Field name for depth-integrated
+                                         ///< specific volume
+   std::string DepthMeanSpecVolFldName;  ///< Field name for depth-mean
+                                         ///< specific volume
+   std::string EosGroupName;             ///< EOS group name (for config)
+   std::string Name;                     ///< Name of this EOS instance
 
    /// Compute specific volume for all cells/layers
    void computeSpecVol(const Array2DReal &ConservTemp,

--- a/components/omega/src/ocn/Eos.h
+++ b/components/omega/src/ocn/Eos.h
@@ -982,6 +982,8 @@ class Eos {
    Array2DReal SpecVolDCt;         ///< d(SpecVol)/d(ConservTemp), per degC
    Array2DReal SpecVolDSa;         ///< d(SpecVol)/d(AbsSalinity), per (g/kg)
    Array2DReal SpecVolDP;          ///< d(SpecVol)/d(Pressure), per Pa
+   Array1DReal DepthIntegSpecificVolume; ///< Depth-integrated specific volume
+   Array1DReal DepthMeanSpecificVolume;  ///< Depth-mean specific volume
 
    std::string SpecVolFldName; ///< Field name for specific volume
    std::string
@@ -991,13 +993,22 @@ class Eos {
    std::string SpecVolDCtFldName; ///< Field name for temperature derivative
    std::string SpecVolDSaFldName; ///< Field name for salinity derivative
    std::string SpecVolDPFldName;  ///< Field name for pressure derivative
-   std::string EosGroupName;      ///< EOS group name (for config)
-   std::string Name;              ///< Name of this EOS instance
+   std::string DepthIntegSpecVolFldName;  ///< Field name for depth-integrated
+                                          ///< specific volume
+   std::string DepthMeanSpecVolFldName;   ///< Field name for depth-mean
+                                          ///< specific volume
+   std::string EosGroupName;              ///< EOS group name (for config)
+   std::string Name;                      ///< Name of this EOS instance
 
    /// Compute specific volume for all cells/layers
    void computeSpecVol(const Array2DReal &ConservTemp,
                        const Array2DReal &AbsSalinity,
                        const Array2DReal &Pressure);
+
+   /// Compute depth-integrated specific volume for all cells
+   void computeDepthIntegratedSpecificVolume(
+       const Array2DReal &PseudoThickness ///< [in] pseudo thickness
+   );
 
    /// Compute displaced specific volume (for vertical displacement)
    void computeSpecVolDisp(const Array2DReal &ConservTemp,

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -110,19 +110,8 @@ static void initStateForTimeStepper(
    // Both split-explicit variants need their velocity split established
    // before the first step.
    TimeStepper *DefStepper = TimeStepper::getDefault();
-   if (!DefStepper->isSplit())
-      return;
-
-   OceanState *DefState  = OceanState::getDefault();
-   const I4 CurTimeLevel = 0;
-
+   OceanState *DefState    = OceanState::getDefault();
    DefStepper->initializeStateFromInput(DefState, ReadRestart);
-
-   // The velocity split is computed over all edges, so halo edges whose
-   // neighboring cells lie outside the halo must be refreshed from their
-   // owners before the newly split arrays are copied to the host
-   DefState->exchangeHalo(CurTimeLevel);
-   DefState->copyToHost(CurTimeLevel);
 }
 
 int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -109,10 +109,8 @@ static void initStateForTimeStepper(
 ) {
    // Both split-explicit variants need their velocity split established
    // before the first step.
-   TimeStepper *DefStepper           = TimeStepper::getDefault();
-   const TimeStepperType StepperType = DefStepper->getType();
-   if (StepperType != TimeStepperType::SplitExplicitRK2 &&
-       StepperType != TimeStepperType::UnsplitRK2)
+   TimeStepper *DefStepper = TimeStepper::getDefault();
+   if (!DefStepper->isSplit())
       return;
 
    OceanState *DefState  = OceanState::getDefault();

--- a/components/omega/src/ocn/OceanInit.cpp
+++ b/components/omega/src/ocn/OceanInit.cpp
@@ -95,6 +95,38 @@ static void readTimingConfig(Config *OmegaConfig) {
    CHECK_ERROR_ABORT(Err, "Timing: PrintAllRanks not found in TimingConfig");
 }
 
+// Records whether the coupled init read the state from a restart file. Set in
+// ocnInit1, where the start type is known, and used in ocnInit2, which is where
+// the state is far enough along for initStateForTimeStepper
+static bool CoupledReadRestart = false;
+
+// Perform any time-stepper specific state initialization that can only be done
+// once the input has been read and the halos have been exchanged. For the
+// split-explicit stepper this separates the input velocity into its barotropic
+// and baroclinic parts. Must be called after initUpdateHaloAndHostArrays.
+static void initStateForTimeStepper(
+    bool ReadRestart ///< [in] true if restart input initialized the state
+) {
+   // Both split-explicit variants need their velocity split established
+   // before the first step.
+   TimeStepper *DefStepper           = TimeStepper::getDefault();
+   const TimeStepperType StepperType = DefStepper->getType();
+   if (StepperType != TimeStepperType::SplitExplicitRK2 &&
+       StepperType != TimeStepperType::UnsplitRK2)
+      return;
+
+   OceanState *DefState  = OceanState::getDefault();
+   const I4 CurTimeLevel = 0;
+
+   DefStepper->initializeStateFromInput(DefState, ReadRestart);
+
+   // The velocity split is computed over all edges, so halo edges whose
+   // neighboring cells lie outside the halo must be refreshed from their
+   // owners before the newly split arrays are copied to the host
+   DefState->exchangeHalo(CurTimeLevel);
+   DefState->copyToHost(CurTimeLevel);
+}
+
 int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
 ) {
 
@@ -157,13 +189,17 @@ int ocnInit(MPI_Comm Comm ///< [in] ocean MPI communicator
 
    // If reading from restart, reset the current time to the input time
    SimTimeStr = std::any_cast<std::string>(ReqMeta["SimulationTime"]);
-   if (SimTimeStr != " ") {
+   const bool ReadRestart = SimTimeStr != " ";
+   if (ReadRestart) {
       TimeInstant NewCurrentTime(SimTimeStr);
       ModelClock->setCurrentTime(NewCurrentTime);
    }
 
    // Update Halo/Host arrays with new state, auxiliary state, and tracer fields
    Err = initUpdateHaloAndHostArrays();
+
+   // Finish any time-stepper specific state initialization
+   initStateForTimeStepper(ReadRestart);
 
    return Err;
 } // end ocnInit
@@ -206,6 +242,7 @@ int ocnInit1(MPI_Comm Comm,                 ///< [in] ocean MPI communicator
    }
 
    Metadata ReqMeta;
+   CoupledReadRestart = StartType != StartType::StartUp;
    if (StartType == StartType::StartUp) {
       // read from initial state if this is starting a new simulation
       Error IOError = IOStream::read("InitialState", ModelClock, ReqMeta);
@@ -256,7 +293,12 @@ int ocnInit2(const Real *CplToOcnData, Real *OcnToCplData) {
    DefCoupling->importFromCoupler();
    DefCoupling->applyImportFields(Forcing::getDefault());
 
-   return initUpdateHaloAndHostArrays();
+   int Err = initUpdateHaloAndHostArrays();
+
+   // Finish any time-stepper specific state initialization
+   initStateForTimeStepper(CoupledReadRestart);
+
+   return Err;
 } // end ocnInit2
 
 // Call init routines for remaining Omega modules
@@ -362,6 +404,7 @@ int initUpdateHaloAndHostArrays() {
    if (Err != 0) {
       ABORT_ERROR("Error updating tracer halo");
    }
+
    Tracers::copyToHost(CurTimeLevel);
 
    return Err;

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -63,9 +63,7 @@ int OceanState::init() {
 
    // Only the mode-split time steppers carry the split velocity and barotropic
    // pressure fields; every other stepper leaves them unallocated.
-   const TimeStepperType StepperType = DefTimeStepper->getType();
-   const bool UseModeSplit = StepperType == TimeStepperType::SplitExplicitRK2 ||
-                             StepperType == TimeStepperType::UnsplitRK2;
+   const bool UseModeSplit = DefTimeStepper->isSplit();
 
    // Create the default state and set pointer to it
    OceanState::DefaultOceanState = create(

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -103,17 +103,30 @@ OceanState::OceanState(
    // Allocate state host arrays
    PseudoThicknessH.resize(NTimeLevels);
    NormalVelocityH.resize(NTimeLevels);
+   NormalBaroclinicVelocityH.resize(NTimeLevels);
+   NormalBarotropicVelocityH.resize(NTimeLevels);
+   BarotropicPressureAnomalyH.resize(NTimeLevels);
 
    for (int I = 0; I < NTimeLevels; I++) {
       PseudoThicknessH[I] = HostArray2DReal(
           "PseudoThickness" + std::to_string(I), NCellsSize, NVertLayers);
       NormalVelocityH[I] = HostArray2DReal("NormalVelocity" + std::to_string(I),
                                            NEdgesSize, NVertLayers);
+      NormalBaroclinicVelocityH[I] =
+          HostArray2DReal("NormalBaroclinicVelocity" + std::to_string(I),
+                          NEdgesSize, NVertLayers);
+      NormalBarotropicVelocityH[I] = HostArray1DReal(
+          "NormalBarotropicVelocity" + std::to_string(I), NEdgesSize);
+      BarotropicPressureAnomalyH[I] = HostArray1DReal(
+          "BarotropicPressureAnomaly" + std::to_string(I), NCellsSize);
    }
 
    // Allocate state device arrays
    PseudoThickness.resize(NTimeLevels);
    NormalVelocity.resize(NTimeLevels);
+   NormalBaroclinicVelocity.resize(NTimeLevels);
+   NormalBarotropicVelocity.resize(NTimeLevels);
+   BarotropicPressureAnomaly.resize(NTimeLevels);
 
    // Create device arrays and copy host data
    for (int I = 0; I < NTimeLevels; I++) {
@@ -121,6 +134,20 @@ OceanState::OceanState(
                                        NCellsSize, NVertLayers);
       NormalVelocity[I]  = Array2DReal("NormalVelocity" + std::to_string(I),
                                        NEdgesSize, NVertLayers);
+      NormalBaroclinicVelocity[I] =
+          Array2DReal("NormalBaroclinicVelocity" + std::to_string(I),
+                      NEdgesSize, NVertLayers);
+      NormalBarotropicVelocity[I] = Array1DReal(
+          "NormalBarotropicVelocity" + std::to_string(I), NEdgesSize);
+      BarotropicPressureAnomaly[I] = Array1DReal(
+          "BarotropicPressureAnomaly" + std::to_string(I), NCellsSize);
+
+      deepCopy(NormalBaroclinicVelocityH[I], 0.);
+      deepCopy(NormalBarotropicVelocityH[I], 0.);
+      deepCopy(BarotropicPressureAnomalyH[I], 0.);
+      deepCopy(NormalBaroclinicVelocity[I], 0.);
+      deepCopy(NormalBarotropicVelocity[I], 0.);
+      deepCopy(BarotropicPressureAnomaly[I], 0.);
    }
 
    // Apply edge layer mask to NormalVelocity for all time levels so that
@@ -181,6 +208,9 @@ OceanState::~OceanState() {
    FieldGroup::destroy(StateGroupName);
    Field::destroy(PseudoThicknessFldName);
    Field::destroy(NormalVelocityFldName);
+   Field::destroy(NormalBaroclinicVelocityFldName);
+   Field::destroy(NormalBarotropicVelocityFldName);
+   Field::destroy(BarotropicPressureAnomalyFldName);
 
 } // end destructor
 
@@ -206,11 +236,18 @@ void OceanState::clear() {
 // Define IO fields and metadata
 void OceanState::defineFields() {
 
-   PseudoThicknessFldName = "PseudoThickness";
-   NormalVelocityFldName  = "NormalVelocity";
+   PseudoThicknessFldName           = "PseudoThickness";
+   NormalVelocityFldName            = "NormalVelocity";
+   NormalBaroclinicVelocityFldName  = "NormalBaroclinicVelocity";
+   NormalBarotropicVelocityFldName  = "NormalBarotropicVelocity";
+   BarotropicPressureAnomalyFldName = "BarotropicPressureAnomaly";
+
    if (Name != "Default") {
       PseudoThicknessFldName.append(Name);
       NormalVelocityFldName.append(Name);
+      NormalBaroclinicVelocityFldName.append(Name);
+      NormalBarotropicVelocityFldName.append(Name);
+      BarotropicPressureAnomalyFldName.append(Name);
    }
 
    // Create fields for state variables
@@ -244,6 +281,28 @@ void OceanState::defineFields() {
    // Create a field group for state fields. VertCoord initializes before
    // OceanState and owns SurfacePressure, which it also adds to this "State"
    // group, so the group may already exist; reuse it if so.
+   DimNames[0]                        = "NEdges";
+   DimNames[1]                        = "NVertLayers";
+   auto NormalBaroclinicVelocityField = Field::create(
+       NormalBaroclinicVelocityFldName, // field name
+       "Baroclinic velocity component normal to edge", "m/s",
+       "sea_water_velocity", -9.99E+10, 9.99E+10, NDims, DimNames);
+
+   NDims       = 1;
+   DimNames[0] = "NEdges";
+   DimNames.resize(NDims);
+   auto NormalBarotropicVelocityField = Field::create(
+       NormalBarotropicVelocityFldName, // field name
+       "Barotropic velocity component normal to edge", "m/s",
+       "barotropic_sea_water_velocity", -9.99E+10, 9.99E+10, NDims, DimNames);
+
+   DimNames[0]                         = "NCells";
+   auto BarotropicPressureAnomalyField = Field::create(
+       BarotropicPressureAnomalyFldName, // field name
+       "Barotropic pressure anomaly", "Pa", "barotropic_pressure_anomaly",
+       -9.99E+30, 9.99E+30, NDims, DimNames);
+
+   // Create a field group for state fields
    StateGroupName = "State";
    if (Name != "Default") {
       StateGroupName.append(Name);
@@ -263,12 +322,21 @@ void OceanState::defineFields() {
 
    FieldGroup::addFieldToGroup(NormalVelocityFldName, "Restart");
    FieldGroup::addFieldToGroup(PseudoThicknessFldName, "Restart");
+   FieldGroup::addFieldToGroup(NormalBaroclinicVelocityFldName, "Restart");
+   FieldGroup::addFieldToGroup(NormalBarotropicVelocityFldName, "Restart");
+   FieldGroup::addFieldToGroup(BarotropicPressureAnomalyFldName, "Restart");
 
    // Associate Field with data
    const I4 TimeIndex = getTimeIndex(0);
 
    NormalVelocityField->attachData<Array2DReal>(NormalVelocity[TimeIndex]);
    PseudoThicknessField->attachData<Array2DReal>(PseudoThickness[TimeIndex]);
+   NormalBaroclinicVelocityField->attachData<Array2DReal>(
+       NormalBaroclinicVelocity[TimeIndex]);
+   NormalBarotropicVelocityField->attachData<Array1DReal>(
+       NormalBarotropicVelocity[TimeIndex]);
+   BarotropicPressureAnomalyField->attachData<Array1DReal>(
+       BarotropicPressureAnomaly[TimeIndex]);
 
 } // end defineIOFields
 
@@ -301,6 +369,51 @@ HostArray2DReal OceanState::getNormalVelocityH(const I4 TimeLevel) const {
 }
 
 //------------------------------------------------------------------------------
+// Get normal baroclinic velocity device array
+Array2DReal OceanState::getNormalBaroclinicVelocity(const I4 TimeLevel) const {
+   const I4 TimeIndex = getTimeIndex(TimeLevel);
+   return NormalBaroclinicVelocity[TimeIndex];
+}
+
+//------------------------------------------------------------------------------
+// Get normal baroclinic velocity host array
+HostArray2DReal
+OceanState::getNormalBaroclinicVelocityH(const I4 TimeLevel) const {
+   const I4 TimeIndex = getTimeIndex(TimeLevel);
+   return NormalBaroclinicVelocityH[TimeIndex];
+}
+
+//------------------------------------------------------------------------------
+// Get normal barotropic velocity device array
+Array1DReal OceanState::getNormalBarotropicVelocity(const I4 TimeLevel) const {
+   const I4 TimeIndex = getTimeIndex(TimeLevel);
+   return NormalBarotropicVelocity[TimeIndex];
+}
+
+//------------------------------------------------------------------------------
+// Get normal barotropic velocity host array
+HostArray1DReal
+OceanState::getNormalBarotropicVelocityH(const I4 TimeLevel) const {
+   const I4 TimeIndex = getTimeIndex(TimeLevel);
+   return NormalBarotropicVelocityH[TimeIndex];
+}
+
+//------------------------------------------------------------------------------
+// Get barotropic pressure anomaly device array
+Array1DReal OceanState::getBarotropicPressureAnomaly(const I4 TimeLevel) const {
+   const I4 TimeIndex = getTimeIndex(TimeLevel);
+   return BarotropicPressureAnomaly[TimeIndex];
+}
+
+//------------------------------------------------------------------------------
+// Get barotropic pressure anomaly host array
+HostArray1DReal
+OceanState::getBarotropicPressureAnomalyH(const I4 TimeLevel) const {
+   const I4 TimeIndex = getTimeIndex(TimeLevel);
+   return BarotropicPressureAnomalyH[TimeIndex];
+}
+
+//------------------------------------------------------------------------------
 // Perform copy to device for state variables
 // TimeLevel == [1:new, 0:current, -1:previous, -2:two times ago, ...]
 void OceanState::copyToDevice(const I4 TimeLevel) {
@@ -309,6 +422,12 @@ void OceanState::copyToDevice(const I4 TimeLevel) {
 
    deepCopy(PseudoThickness[TimeIndex], PseudoThicknessH[TimeIndex]);
    deepCopy(NormalVelocity[TimeIndex], NormalVelocityH[TimeIndex]);
+   deepCopy(NormalBaroclinicVelocity[TimeIndex],
+            NormalBaroclinicVelocityH[TimeIndex]);
+   deepCopy(NormalBarotropicVelocity[TimeIndex],
+            NormalBarotropicVelocityH[TimeIndex]);
+   deepCopy(BarotropicPressureAnomaly[TimeIndex],
+            BarotropicPressureAnomalyH[TimeIndex]);
 } // end copyToDevice
 
 //------------------------------------------------------------------------------
@@ -320,6 +439,12 @@ void OceanState::copyToHost(const I4 TimeLevel) {
 
    deepCopy(PseudoThicknessH[TimeIndex], PseudoThickness[TimeIndex]);
    deepCopy(NormalVelocityH[TimeIndex], NormalVelocity[TimeIndex]);
+   deepCopy(NormalBaroclinicVelocityH[TimeIndex],
+            NormalBaroclinicVelocity[TimeIndex]);
+   deepCopy(NormalBarotropicVelocityH[TimeIndex],
+            NormalBarotropicVelocity[TimeIndex]);
+   deepCopy(BarotropicPressureAnomalyH[TimeIndex],
+            BarotropicPressureAnomaly[TimeIndex]);
 } // end copyToHost
 
 //------------------------------------------------------------------------------
@@ -346,6 +471,10 @@ void OceanState::exchangeHalo(const I4 TimeLevel) {
 
    MeshHalo->exchangeFullArrayHalo(PseudoThickness[TimeIndex], OnCell);
    MeshHalo->exchangeFullArrayHalo(NormalVelocity[TimeIndex], OnEdge);
+   MeshHalo->exchangeFullArrayHalo(NormalBaroclinicVelocity[TimeIndex], OnEdge);
+   MeshHalo->exchangeFullArrayHalo(NormalBarotropicVelocity[TimeIndex], OnEdge);
+   MeshHalo->exchangeFullArrayHalo(BarotropicPressureAnomaly[TimeIndex],
+                                   OnCell);
 
 } // end exchangeHalo
 
@@ -368,6 +497,15 @@ void OceanState::updateTimeLevels() {
                                        NormalVelocity[CurTimeIndex], false);
    Field::attachFieldData<Array2DReal>(PseudoThicknessFldName,
                                        PseudoThickness[CurTimeIndex], false);
+   Field::attachFieldData<Array2DReal>(NormalBaroclinicVelocityFldName,
+                                       NormalBaroclinicVelocity[CurTimeIndex],
+                                       false);
+   Field::attachFieldData<Array1DReal>(NormalBarotropicVelocityFldName,
+                                       NormalBarotropicVelocity[CurTimeIndex],
+                                       false);
+   Field::attachFieldData<Array1DReal>(BarotropicPressureAnomalyFldName,
+                                       BarotropicPressureAnomaly[CurTimeIndex],
+                                       false);
 
 } // end updateTimeLevels
 

--- a/components/omega/src/ocn/OceanState.cpp
+++ b/components/omega/src/ocn/OceanState.cpp
@@ -61,9 +61,15 @@ int OceanState::init() {
       return -2;
    }
 
+   // Only the mode-split time steppers carry the split velocity and barotropic
+   // pressure fields; every other stepper leaves them unallocated.
+   const TimeStepperType StepperType = DefTimeStepper->getType();
+   const bool UseModeSplit = StepperType == TimeStepperType::SplitExplicitRK2 ||
+                             StepperType == TimeStepperType::UnsplitRK2;
+
    // Create the default state and set pointer to it
-   OceanState::DefaultOceanState =
-       create("Default", DefHorzMesh, DefHalo, NVertLayers, NTimeLevels);
+   OceanState::DefaultOceanState = create(
+       "Default", DefHorzMesh, DefHalo, NVertLayers, NTimeLevels, UseModeSplit);
 
    // State values are filled by a later read of the initial state or
    // restart file
@@ -79,8 +85,11 @@ OceanState::OceanState(
     HorzMesh *Mesh,           //< [in] HorzMesh for state
     Halo *MeshHalo_,          //< [in] Halo for Mesh
     const int NVertLayers_,   //< [in] number of vertical layers
-    const int NTimeLevels_    //< [in] number of time levels
+    const int NTimeLevels_,   //< [in] number of time levels
+    const bool UseModeSplit_  //< [in] carry split velocity/barotropic pressure
 ) {
+
+   UseModeSplit = UseModeSplit_;
 
    // Retrieve mesh cell/edge/vertex totals from Decomp
    NCellsOwned = Mesh->NCellsOwned;
@@ -103,30 +112,17 @@ OceanState::OceanState(
    // Allocate state host arrays
    PseudoThicknessH.resize(NTimeLevels);
    NormalVelocityH.resize(NTimeLevels);
-   NormalBaroclinicVelocityH.resize(NTimeLevels);
-   NormalBarotropicVelocityH.resize(NTimeLevels);
-   BarotropicPressureAnomalyH.resize(NTimeLevels);
 
    for (int I = 0; I < NTimeLevels; I++) {
       PseudoThicknessH[I] = HostArray2DReal(
           "PseudoThickness" + std::to_string(I), NCellsSize, NVertLayers);
       NormalVelocityH[I] = HostArray2DReal("NormalVelocity" + std::to_string(I),
                                            NEdgesSize, NVertLayers);
-      NormalBaroclinicVelocityH[I] =
-          HostArray2DReal("NormalBaroclinicVelocity" + std::to_string(I),
-                          NEdgesSize, NVertLayers);
-      NormalBarotropicVelocityH[I] = HostArray1DReal(
-          "NormalBarotropicVelocity" + std::to_string(I), NEdgesSize);
-      BarotropicPressureAnomalyH[I] = HostArray1DReal(
-          "BarotropicPressureAnomaly" + std::to_string(I), NCellsSize);
    }
 
    // Allocate state device arrays
    PseudoThickness.resize(NTimeLevels);
    NormalVelocity.resize(NTimeLevels);
-   NormalBaroclinicVelocity.resize(NTimeLevels);
-   NormalBarotropicVelocity.resize(NTimeLevels);
-   BarotropicPressureAnomaly.resize(NTimeLevels);
 
    // Create device arrays and copy host data
    for (int I = 0; I < NTimeLevels; I++) {
@@ -134,20 +130,42 @@ OceanState::OceanState(
                                        NCellsSize, NVertLayers);
       NormalVelocity[I]  = Array2DReal("NormalVelocity" + std::to_string(I),
                                        NEdgesSize, NVertLayers);
-      NormalBaroclinicVelocity[I] =
-          Array2DReal("NormalBaroclinicVelocity" + std::to_string(I),
-                      NEdgesSize, NVertLayers);
-      NormalBarotropicVelocity[I] = Array1DReal(
-          "NormalBarotropicVelocity" + std::to_string(I), NEdgesSize);
-      BarotropicPressureAnomaly[I] = Array1DReal(
-          "BarotropicPressureAnomaly" + std::to_string(I), NCellsSize);
+   }
 
-      deepCopy(NormalBaroclinicVelocityH[I], 0.);
-      deepCopy(NormalBarotropicVelocityH[I], 0.);
-      deepCopy(BarotropicPressureAnomalyH[I], 0.);
-      deepCopy(NormalBaroclinicVelocity[I], 0.);
-      deepCopy(NormalBarotropicVelocity[I], 0.);
-      deepCopy(BarotropicPressureAnomaly[I], 0.);
+   // The split velocity and barotropic pressure are only carried by the
+   // mode-split time steppers.
+   if (UseModeSplit) {
+      NormalBaroclinicVelocityH.resize(NTimeLevels);
+      NormalBarotropicVelocityH.resize(NTimeLevels);
+      BarotropicPressureAnomalyH.resize(NTimeLevels);
+      NormalBaroclinicVelocity.resize(NTimeLevels);
+      NormalBarotropicVelocity.resize(NTimeLevels);
+      BarotropicPressureAnomaly.resize(NTimeLevels);
+
+      for (int I = 0; I < NTimeLevels; I++) {
+         NormalBaroclinicVelocityH[I] =
+             HostArray2DReal("NormalBaroclinicVelocity" + std::to_string(I),
+                             NEdgesSize, NVertLayers);
+         NormalBarotropicVelocityH[I] = HostArray1DReal(
+             "NormalBarotropicVelocity" + std::to_string(I), NEdgesSize);
+         BarotropicPressureAnomalyH[I] = HostArray1DReal(
+             "BarotropicPressureAnomaly" + std::to_string(I), NCellsSize);
+
+         NormalBaroclinicVelocity[I] =
+             Array2DReal("NormalBaroclinicVelocity" + std::to_string(I),
+                         NEdgesSize, NVertLayers);
+         NormalBarotropicVelocity[I] = Array1DReal(
+             "NormalBarotropicVelocity" + std::to_string(I), NEdgesSize);
+         BarotropicPressureAnomaly[I] = Array1DReal(
+             "BarotropicPressureAnomaly" + std::to_string(I), NCellsSize);
+
+         deepCopy(NormalBaroclinicVelocityH[I], 0.);
+         deepCopy(NormalBarotropicVelocityH[I], 0.);
+         deepCopy(BarotropicPressureAnomalyH[I], 0.);
+         deepCopy(NormalBaroclinicVelocity[I], 0.);
+         deepCopy(NormalBarotropicVelocity[I], 0.);
+         deepCopy(BarotropicPressureAnomaly[I], 0.);
+      }
    }
 
    // Apply edge layer mask to NormalVelocity for all time levels so that
@@ -170,7 +188,8 @@ OceanState::create(const std::string &Name, //< [in] Name for new state
                    HorzMesh *Mesh,          //< [in] HorzMesh for state
                    Halo *MeshHalo,          //< [in] Halo for Mesh
                    const int NVertLayers,   //< [in] number of vertical layers
-                   const int NTimeLevels    //< [in] number of time levels
+                   const int NTimeLevels,   //< [in] number of time levels
+                   const bool UseModeSplit  //< [in] carry split velocity fields
 ) {
 
    OMEGA_REQUIRE(Mesh,
@@ -192,8 +211,8 @@ OceanState::create(const std::string &Name, //< [in] Name for new state
 
    // create a new state on the heap and put it in a map of
    // unique_ptrs, which will manage its lifetime
-   auto *NewOceanState =
-       new OceanState(Name, Mesh, MeshHalo, NVertLayers, NTimeLevels);
+   auto *NewOceanState = new OceanState(Name, Mesh, MeshHalo, NVertLayers,
+                                        NTimeLevels, UseModeSplit);
    AllOceanStates.emplace(Name, NewOceanState);
 
    return NewOceanState;
@@ -208,9 +227,11 @@ OceanState::~OceanState() {
    FieldGroup::destroy(StateGroupName);
    Field::destroy(PseudoThicknessFldName);
    Field::destroy(NormalVelocityFldName);
-   Field::destroy(NormalBaroclinicVelocityFldName);
-   Field::destroy(NormalBarotropicVelocityFldName);
-   Field::destroy(BarotropicPressureAnomalyFldName);
+   if (UseModeSplit) {
+      Field::destroy(NormalBaroclinicVelocityFldName);
+      Field::destroy(NormalBarotropicVelocityFldName);
+      Field::destroy(BarotropicPressureAnomalyFldName);
+   }
 
 } // end destructor
 
@@ -278,31 +299,37 @@ void OceanState::defineFields() {
                      DimNames          // dimension names
        );
 
+   // The mode-split fields exist only when a split time stepper carries them.
+   std::shared_ptr<Field> NormalBaroclinicVelocityField;
+   std::shared_ptr<Field> NormalBarotropicVelocityField;
+   std::shared_ptr<Field> BarotropicPressureAnomalyField;
+   if (UseModeSplit) {
+      DimNames[0]                   = "NEdges";
+      DimNames[1]                   = "NVertLayers";
+      NormalBaroclinicVelocityField = Field::create(
+          NormalBaroclinicVelocityFldName, // field name
+          "Baroclinic velocity component normal to edge", "m/s",
+          "sea_water_velocity", -9.99E+10, 9.99E+10, NDims, DimNames);
+
+      NDims       = 1;
+      DimNames[0] = "NEdges";
+      DimNames.resize(NDims);
+      NormalBarotropicVelocityField =
+          Field::create(NormalBarotropicVelocityFldName, // field name
+                        "Barotropic velocity component normal to edge", "m/s",
+                        "barotropic_sea_water_velocity", -9.99E+10, 9.99E+10,
+                        NDims, DimNames);
+
+      DimNames[0]                    = "NCells";
+      BarotropicPressureAnomalyField = Field::create(
+          BarotropicPressureAnomalyFldName, // field name
+          "Barotropic pressure anomaly", "Pa", "barotropic_pressure_anomaly",
+          -9.99E+30, 9.99E+30, NDims, DimNames);
+   }
+
    // Create a field group for state fields. VertCoord initializes before
    // OceanState and owns SurfacePressure, which it also adds to this "State"
    // group, so the group may already exist; reuse it if so.
-   DimNames[0]                        = "NEdges";
-   DimNames[1]                        = "NVertLayers";
-   auto NormalBaroclinicVelocityField = Field::create(
-       NormalBaroclinicVelocityFldName, // field name
-       "Baroclinic velocity component normal to edge", "m/s",
-       "sea_water_velocity", -9.99E+10, 9.99E+10, NDims, DimNames);
-
-   NDims       = 1;
-   DimNames[0] = "NEdges";
-   DimNames.resize(NDims);
-   auto NormalBarotropicVelocityField = Field::create(
-       NormalBarotropicVelocityFldName, // field name
-       "Barotropic velocity component normal to edge", "m/s",
-       "barotropic_sea_water_velocity", -9.99E+10, 9.99E+10, NDims, DimNames);
-
-   DimNames[0]                         = "NCells";
-   auto BarotropicPressureAnomalyField = Field::create(
-       BarotropicPressureAnomalyFldName, // field name
-       "Barotropic pressure anomaly", "Pa", "barotropic_pressure_anomaly",
-       -9.99E+30, 9.99E+30, NDims, DimNames);
-
-   // Create a field group for state fields
    StateGroupName = "State";
    if (Name != "Default") {
       StateGroupName.append(Name);
@@ -322,21 +349,25 @@ void OceanState::defineFields() {
 
    FieldGroup::addFieldToGroup(NormalVelocityFldName, "Restart");
    FieldGroup::addFieldToGroup(PseudoThicknessFldName, "Restart");
-   FieldGroup::addFieldToGroup(NormalBaroclinicVelocityFldName, "Restart");
-   FieldGroup::addFieldToGroup(NormalBarotropicVelocityFldName, "Restart");
-   FieldGroup::addFieldToGroup(BarotropicPressureAnomalyFldName, "Restart");
 
    // Associate Field with data
    const I4 TimeIndex = getTimeIndex(0);
 
    NormalVelocityField->attachData<Array2DReal>(NormalVelocity[TimeIndex]);
    PseudoThicknessField->attachData<Array2DReal>(PseudoThickness[TimeIndex]);
-   NormalBaroclinicVelocityField->attachData<Array2DReal>(
-       NormalBaroclinicVelocity[TimeIndex]);
-   NormalBarotropicVelocityField->attachData<Array1DReal>(
-       NormalBarotropicVelocity[TimeIndex]);
-   BarotropicPressureAnomalyField->attachData<Array1DReal>(
-       BarotropicPressureAnomaly[TimeIndex]);
+
+   if (UseModeSplit) {
+      FieldGroup::addFieldToGroup(NormalBaroclinicVelocityFldName, "Restart");
+      FieldGroup::addFieldToGroup(NormalBarotropicVelocityFldName, "Restart");
+      FieldGroup::addFieldToGroup(BarotropicPressureAnomalyFldName, "Restart");
+
+      NormalBaroclinicVelocityField->attachData<Array2DReal>(
+          NormalBaroclinicVelocity[TimeIndex]);
+      NormalBarotropicVelocityField->attachData<Array1DReal>(
+          NormalBarotropicVelocity[TimeIndex]);
+      BarotropicPressureAnomalyField->attachData<Array1DReal>(
+          BarotropicPressureAnomaly[TimeIndex]);
+   }
 
 } // end defineIOFields
 
@@ -371,6 +402,10 @@ HostArray2DReal OceanState::getNormalVelocityH(const I4 TimeLevel) const {
 //------------------------------------------------------------------------------
 // Get normal baroclinic velocity device array
 Array2DReal OceanState::getNormalBaroclinicVelocity(const I4 TimeLevel) const {
+   OMEGA_REQUIRE(UseModeSplit,
+                 "OceanState {}: {} requires a mode-split time "
+                 "stepper; the field is not allocated otherwise",
+                 Name, "NormalBaroclinicVelocity");
    const I4 TimeIndex = getTimeIndex(TimeLevel);
    return NormalBaroclinicVelocity[TimeIndex];
 }
@@ -379,6 +414,10 @@ Array2DReal OceanState::getNormalBaroclinicVelocity(const I4 TimeLevel) const {
 // Get normal baroclinic velocity host array
 HostArray2DReal
 OceanState::getNormalBaroclinicVelocityH(const I4 TimeLevel) const {
+   OMEGA_REQUIRE(UseModeSplit,
+                 "OceanState {}: {} requires a mode-split time "
+                 "stepper; the field is not allocated otherwise",
+                 Name, "NormalBaroclinicVelocityH");
    const I4 TimeIndex = getTimeIndex(TimeLevel);
    return NormalBaroclinicVelocityH[TimeIndex];
 }
@@ -386,6 +425,10 @@ OceanState::getNormalBaroclinicVelocityH(const I4 TimeLevel) const {
 //------------------------------------------------------------------------------
 // Get normal barotropic velocity device array
 Array1DReal OceanState::getNormalBarotropicVelocity(const I4 TimeLevel) const {
+   OMEGA_REQUIRE(UseModeSplit,
+                 "OceanState {}: {} requires a mode-split time "
+                 "stepper; the field is not allocated otherwise",
+                 Name, "NormalBarotropicVelocity");
    const I4 TimeIndex = getTimeIndex(TimeLevel);
    return NormalBarotropicVelocity[TimeIndex];
 }
@@ -394,6 +437,10 @@ Array1DReal OceanState::getNormalBarotropicVelocity(const I4 TimeLevel) const {
 // Get normal barotropic velocity host array
 HostArray1DReal
 OceanState::getNormalBarotropicVelocityH(const I4 TimeLevel) const {
+   OMEGA_REQUIRE(UseModeSplit,
+                 "OceanState {}: {} requires a mode-split time "
+                 "stepper; the field is not allocated otherwise",
+                 Name, "NormalBarotropicVelocityH");
    const I4 TimeIndex = getTimeIndex(TimeLevel);
    return NormalBarotropicVelocityH[TimeIndex];
 }
@@ -401,6 +448,10 @@ OceanState::getNormalBarotropicVelocityH(const I4 TimeLevel) const {
 //------------------------------------------------------------------------------
 // Get barotropic pressure anomaly device array
 Array1DReal OceanState::getBarotropicPressureAnomaly(const I4 TimeLevel) const {
+   OMEGA_REQUIRE(UseModeSplit,
+                 "OceanState {}: {} requires a mode-split time "
+                 "stepper; the field is not allocated otherwise",
+                 Name, "BarotropicPressureAnomaly");
    const I4 TimeIndex = getTimeIndex(TimeLevel);
    return BarotropicPressureAnomaly[TimeIndex];
 }
@@ -409,6 +460,10 @@ Array1DReal OceanState::getBarotropicPressureAnomaly(const I4 TimeLevel) const {
 // Get barotropic pressure anomaly host array
 HostArray1DReal
 OceanState::getBarotropicPressureAnomalyH(const I4 TimeLevel) const {
+   OMEGA_REQUIRE(UseModeSplit,
+                 "OceanState {}: {} requires a mode-split time "
+                 "stepper; the field is not allocated otherwise",
+                 Name, "BarotropicPressureAnomalyH");
    const I4 TimeIndex = getTimeIndex(TimeLevel);
    return BarotropicPressureAnomalyH[TimeIndex];
 }
@@ -422,12 +477,14 @@ void OceanState::copyToDevice(const I4 TimeLevel) {
 
    deepCopy(PseudoThickness[TimeIndex], PseudoThicknessH[TimeIndex]);
    deepCopy(NormalVelocity[TimeIndex], NormalVelocityH[TimeIndex]);
-   deepCopy(NormalBaroclinicVelocity[TimeIndex],
-            NormalBaroclinicVelocityH[TimeIndex]);
-   deepCopy(NormalBarotropicVelocity[TimeIndex],
-            NormalBarotropicVelocityH[TimeIndex]);
-   deepCopy(BarotropicPressureAnomaly[TimeIndex],
-            BarotropicPressureAnomalyH[TimeIndex]);
+   if (UseModeSplit) {
+      deepCopy(NormalBaroclinicVelocity[TimeIndex],
+               NormalBaroclinicVelocityH[TimeIndex]);
+      deepCopy(NormalBarotropicVelocity[TimeIndex],
+               NormalBarotropicVelocityH[TimeIndex]);
+      deepCopy(BarotropicPressureAnomaly[TimeIndex],
+               BarotropicPressureAnomalyH[TimeIndex]);
+   }
 } // end copyToDevice
 
 //------------------------------------------------------------------------------
@@ -439,12 +496,14 @@ void OceanState::copyToHost(const I4 TimeLevel) {
 
    deepCopy(PseudoThicknessH[TimeIndex], PseudoThickness[TimeIndex]);
    deepCopy(NormalVelocityH[TimeIndex], NormalVelocity[TimeIndex]);
-   deepCopy(NormalBaroclinicVelocityH[TimeIndex],
-            NormalBaroclinicVelocity[TimeIndex]);
-   deepCopy(NormalBarotropicVelocityH[TimeIndex],
-            NormalBarotropicVelocity[TimeIndex]);
-   deepCopy(BarotropicPressureAnomalyH[TimeIndex],
-            BarotropicPressureAnomaly[TimeIndex]);
+   if (UseModeSplit) {
+      deepCopy(NormalBaroclinicVelocityH[TimeIndex],
+               NormalBaroclinicVelocity[TimeIndex]);
+      deepCopy(NormalBarotropicVelocityH[TimeIndex],
+               NormalBarotropicVelocity[TimeIndex]);
+      deepCopy(BarotropicPressureAnomalyH[TimeIndex],
+               BarotropicPressureAnomaly[TimeIndex]);
+   }
 } // end copyToHost
 
 //------------------------------------------------------------------------------
@@ -471,10 +530,14 @@ void OceanState::exchangeHalo(const I4 TimeLevel) {
 
    MeshHalo->exchangeFullArrayHalo(PseudoThickness[TimeIndex], OnCell);
    MeshHalo->exchangeFullArrayHalo(NormalVelocity[TimeIndex], OnEdge);
-   MeshHalo->exchangeFullArrayHalo(NormalBaroclinicVelocity[TimeIndex], OnEdge);
-   MeshHalo->exchangeFullArrayHalo(NormalBarotropicVelocity[TimeIndex], OnEdge);
-   MeshHalo->exchangeFullArrayHalo(BarotropicPressureAnomaly[TimeIndex],
-                                   OnCell);
+   if (UseModeSplit) {
+      MeshHalo->exchangeFullArrayHalo(NormalBaroclinicVelocity[TimeIndex],
+                                      OnEdge);
+      MeshHalo->exchangeFullArrayHalo(NormalBarotropicVelocity[TimeIndex],
+                                      OnEdge);
+      MeshHalo->exchangeFullArrayHalo(BarotropicPressureAnomaly[TimeIndex],
+                                      OnCell);
+   }
 
 } // end exchangeHalo
 
@@ -497,15 +560,17 @@ void OceanState::updateTimeLevels() {
                                        NormalVelocity[CurTimeIndex], false);
    Field::attachFieldData<Array2DReal>(PseudoThicknessFldName,
                                        PseudoThickness[CurTimeIndex], false);
-   Field::attachFieldData<Array2DReal>(NormalBaroclinicVelocityFldName,
-                                       NormalBaroclinicVelocity[CurTimeIndex],
-                                       false);
-   Field::attachFieldData<Array1DReal>(NormalBarotropicVelocityFldName,
-                                       NormalBarotropicVelocity[CurTimeIndex],
-                                       false);
-   Field::attachFieldData<Array1DReal>(BarotropicPressureAnomalyFldName,
-                                       BarotropicPressureAnomaly[CurTimeIndex],
-                                       false);
+   if (UseModeSplit) {
+      Field::attachFieldData<Array2DReal>(
+          NormalBaroclinicVelocityFldName,
+          NormalBaroclinicVelocity[CurTimeIndex], false);
+      Field::attachFieldData<Array1DReal>(
+          NormalBarotropicVelocityFldName,
+          NormalBarotropicVelocity[CurTimeIndex], false);
+      Field::attachFieldData<Array1DReal>(
+          BarotropicPressureAnomalyFldName,
+          BarotropicPressureAnomaly[CurTimeIndex], false);
+   }
 
 } // end updateTimeLevels
 

--- a/components/omega/src/ocn/OceanState.h
+++ b/components/omega/src/ocn/OceanState.h
@@ -89,10 +89,31 @@ class OceanState {
    std::vector<Array2DReal> NormalVelocity; ///< Device NormalVelocity array
    std::vector<HostArray2DReal> NormalVelocityH; ///< Host NormalVelocity array
 
+   std::vector<Array2DReal>
+       NormalBaroclinicVelocity; ///< Device baroclinic velocity array
+   std::vector<HostArray2DReal>
+       NormalBaroclinicVelocityH; ///< Host baroclinic velocity array
+
+   std::vector<Array1DReal>
+       NormalBarotropicVelocity; ///< Device barotropic velocity array
+   std::vector<HostArray1DReal>
+       NormalBarotropicVelocityH; ///< Host barotropic velocity array
+
+   std::vector<Array1DReal>
+       BarotropicPressureAnomaly; ///< Device barotropic pressure anomaly array
+   std::vector<HostArray1DReal>
+       BarotropicPressureAnomalyH; ///< Host barotropic pressure anomaly array
+
    // Field names
    // These are appended with the State name for non-Default state instances
    std::string PseudoThicknessFldName; ///< Field name for PseudoThickness
    std::string NormalVelocityFldName;  ///< Field name for NormalVelocity
+   std::string NormalBaroclinicVelocityFldName;  ///< Field name for
+                                                 ///< NormalBaroclinicVelocity
+   std::string NormalBarotropicVelocityFldName;  ///< Field name for
+                                                 ///< NormalBarotropicVelocity
+   std::string BarotropicPressureAnomalyFldName; ///< Field name for
+                                                 ///< BarotropicPressureAnomaly
    std::string StateGroupName;
 
    // Methods
@@ -125,6 +146,24 @@ class OceanState {
    /// Apply layer masks to NormalVelocity, PseudoThickness, Temperature, and
    /// Salinity after reading an IC or restart file
    void applyLayerMasks(const I4 TimeLevel);
+
+   /// Get normal baroclinic velocity device array at given time level
+   Array2DReal getNormalBaroclinicVelocity(const I4 TimeLevel) const;
+
+   /// Get normal baroclinic velocity host array at given time level
+   HostArray2DReal getNormalBaroclinicVelocityH(const I4 TimeLevel) const;
+
+   /// Get normal barotropic velocity device array at given time level
+   Array1DReal getNormalBarotropicVelocity(const I4 TimeLevel) const;
+
+   /// Get normal barotropic velocity host array at given time level
+   HostArray1DReal getNormalBarotropicVelocityH(const I4 TimeLevel) const;
+
+   /// Get barotropic pressure anomaly device array at given time level
+   Array1DReal getBarotropicPressureAnomaly(const I4 TimeLevel) const;
+
+   /// Get barotropic pressure anomaly host array at given time level
+   HostArray1DReal getBarotropicPressureAnomalyH(const I4 TimeLevel) const;
 
    /// Exchange halo
    void exchangeHalo(const I4 TimeLevel);

--- a/components/omega/src/ocn/OceanState.h
+++ b/components/omega/src/ocn/OceanState.h
@@ -41,7 +41,8 @@ class OceanState {
               HorzMesh *Mesh,          ///< [in] Horizontal mesh
               Halo *MeshHalo_,         ///< [in] Halo for Mesh
               const int NVertLayers_,  ///< [in] Number of vertical layers
-              const int NTimeLevels_   ///< [in] Number of time levels
+              const int NTimeLevels_,  ///< [in] Number of time levels
+              const bool UseModeSplit_ ///< [in] carry split velocity fields
    );
 
    // Forbid copy and move construction
@@ -50,6 +51,9 @@ class OceanState {
 
    /// Get the current time level index associated with a time level
    I4 getTimeIndex(const I4 TimeLevel) const;
+
+   /// Whether the mode-split velocity/pressure arrays are allocated
+   bool UseModeSplit = false;
 
  public:
    // Variables
@@ -128,8 +132,10 @@ class OceanState {
           HorzMesh *Mesh,          ///< [in] Horizontal mesh
           Halo *MeshHalo,          ///< [in] Halo for Mesh
           const int NVertLayers,   ///< [in] Number of vertical layers
-          const int NTimeLevels    ///< [in] Number of time levels
-   );
+          const int NTimeLevels,   ///< [in] Number of time levels
+          ///< [in] carry the mode-split velocity split and barotropic
+          ///< pressure; only the mode-split time steppers need them
+          const bool UseModeSplit = false);
 
    /// Get pseudo-thickness device array at given time level
    Array2DReal getPseudoThickness(const I4 TimeLevel) const;
@@ -147,7 +153,12 @@ class OceanState {
    /// Salinity after reading an IC or restart file
    void applyLayerMasks(const I4 TimeLevel);
 
+   /// True when this state carries the mode-split velocity split and
+   /// barotropic pressure; false leaves those arrays unallocated
+   bool isModeSplit() const { return UseModeSplit; }
+
    /// Get normal baroclinic velocity device array at given time level
+   /// Requires a mode-split state
    Array2DReal getNormalBaroclinicVelocity(const I4 TimeLevel) const;
 
    /// Get normal baroclinic velocity host array at given time level

--- a/components/omega/src/ocn/PGrad.cpp
+++ b/components/omega/src/ocn/PGrad.cpp
@@ -93,7 +93,7 @@ PressureGrad::PressureGrad(
     Config *Options)         ///< [in] Configuration options
     : MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
       MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop), CenteredPGrad(Mesh, VCoord),
-      HighOrderPGrad(Mesh, VCoord) {
+      HighOrderPGrad(Mesh, VCoord), BarotropicPGrad(Mesh, VCoord) {
 
    // store mesh sizes
    NEdgesAll     = Mesh->NEdgesAll;
@@ -230,6 +230,33 @@ void PressureGrad::computePressureGrad(Array2DReal &Tend,
 } // end compute pressure gradient
 
 //------------------------------------------------------------------------------
+// Compute the barotropic pressure anomaly gradient and add into Tend array
+void PressureGrad::computeBarotropicPressureGrad(
+    Array2DReal &Tend,                  ///< [inout] velocity tendency
+    const Array1DReal &BtrPressAnomaly, ///< [in] barotropic pressure anomaly
+    const Array1DReal &DepthMeanSpecVol ///< [in] depth-mean specific volume
+) const {
+
+   OMEGA_SCOPE(LocBarotropicPGrad, BarotropicPGrad);
+   OMEGA_SCOPE(LocMinLayerEdgeBot, MinLayerEdgeBot);
+   OMEGA_SCOPE(LocMaxLayerEdgeTop, MaxLayerEdgeTop);
+
+   parallelForOuter(
+       "pgrad-barotropic", {NEdgesAll},
+       KOKKOS_LAMBDA(I4 IEdge, const TeamMember &Team) {
+          const int KMin   = LocMinLayerEdgeBot(IEdge);
+          const int KMax   = LocMaxLayerEdgeTop(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocBarotropicPGrad(Tend, IEdge, KChunk, BtrPressAnomaly,
+                                    DepthMeanSpecVol);
+              });
+       });
+} // end compute barotropic pressure gradient
+
+//------------------------------------------------------------------------------
 // Constructor for centered pressure gradient functor
 PressureGradCentered::PressureGradCentered(
     const HorzMesh *Mesh,   ///< [in] Horizontal mesh
@@ -242,6 +269,16 @@ PressureGradCentered::PressureGradCentered(
 //------------------------------------------------------------------------------
 // Constructor for high order pressure gradient functor
 PressureGradHighOrder::PressureGradHighOrder(
+    const HorzMesh *Mesh,   ///< [in] Horizontal mesh
+    const VertCoord *VCoord ///< [in] Vertical coordinate
+    )
+    : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge),
+      EdgeMask(VCoord->EdgeMask), MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
+
+//------------------------------------------------------------------------------
+// Constructor for barotropic pressure gradient functor
+BarotropicPressureGradOnEdge::BarotropicPressureGradOnEdge(
     const HorzMesh *Mesh,   ///< [in] Horizontal mesh
     const VertCoord *VCoord ///< [in] Vertical coordinate
     )

--- a/components/omega/src/ocn/PGrad.h
+++ b/components/omega/src/ocn/PGrad.h
@@ -203,10 +203,10 @@ class PressureGrad {
                             const Array2DReal &PseudoThick) const;
 
    // Compute the barotropic pressure anomaly gradient and add into Tend array
-   void computeBarotropicPressureGrad(
-       Array2DReal &Tend,
-       const Array1DReal &BtrPressAnomaly,
-       const Array1DReal &DepthMeanSpecVol ) const;
+   void
+   computeBarotropicPressureGrad(Array2DReal &Tend,
+                                 const Array1DReal &BtrPressAnomaly,
+                                 const Array1DReal &DepthMeanSpecVol) const;
 
  private:
    // Construct a new pressure gradient object

--- a/components/omega/src/ocn/PGrad.h
+++ b/components/omega/src/ocn/PGrad.h
@@ -124,6 +124,46 @@ class PressureGradHighOrder {
    Array1DI4 MaxLayerEdgeTop;
 };
 
+// Barotropic pressure anomaly gradient functor, for mode-split integration.
+class BarotropicPressureGradOnEdge {
+ public:
+   // constructor declaration
+   BarotropicPressureGradOnEdge(
+       const HorzMesh *Mesh,   ///< [in] Horizontal mesh
+       const VertCoord *VCoord ///< [in] Vertical coordinate
+   );
+
+   KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
+                                   const Array1DReal &BtrPressAnomaly,
+                                   const Array1DReal &DepthMeanSpecVol) const {
+
+      // Computing the depth-mean specific volume times the barotropic pressure
+      // anomaly gradient on edges and adding it to every active vertical layer
+      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
+      const I4 ICell0 = CellsOnEdge(IEdge, 0);
+      const I4 ICell1 = CellsOnEdge(IEdge, 1);
+      const Real InvDcEdge = 1._Real / DcEdge(IEdge);
+      const Real MeanSpecVol =
+          0.5_Real * (DepthMeanSpecVol(ICell0) + DepthMeanSpecVol(ICell1));
+      const Real BtrPressGradTend =
+          MeanSpecVol * (BtrPressAnomaly(ICell1) - BtrPressAnomaly(ICell0)) *
+          InvDcEdge;
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K = KStart + KVec;
+         Tend(IEdge, K) += EdgeMask(IEdge, K) * BtrPressGradTend;
+      }
+   }
+
+ private:
+   Array2DI4 CellsOnEdge;
+   Array1DReal DcEdge;
+   Array2DReal EdgeMask;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
+};
+
 // Pressure gradient manager class
 class PressureGrad {
  public:
@@ -162,6 +202,12 @@ class PressureGrad {
                             const Array2DReal &GeomZInterface,
                             const Array2DReal &PseudoThick) const;
 
+   // Compute the barotropic pressure anomaly gradient and add into Tend array
+   void computeBarotropicPressureGrad(
+       Array2DReal &Tend,
+       const Array1DReal &BtrPressAnomaly,
+       const Array1DReal &DepthMeanSpecVol ) const;
+
  private:
    // Construct a new pressure gradient object
    PressureGrad(const HorzMesh *Mesh, const VertCoord *VCoord, Config *Options);
@@ -191,6 +237,7 @@ class PressureGrad {
    // Instances of functors
    PressureGradCentered CenteredPGrad;
    PressureGradHighOrder HighOrderPGrad;
+   BarotropicPressureGradOnEdge BarotropicPGrad;
 
    // Choice from config
    PressureGradType PressureGradChoice = PressureGradType::Centered;

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -934,30 +934,15 @@ void Tendencies::computeTracerTendencies(
     const Array3DReal &TracerArray, ///< [in] Tracer array
     int ThickTimeLevel,             ///< [in] Time level
     int VelTimeLevel,               ///< [in] Time level
-    TimeInstant Time                ///< [in] Time
+    TimeInstant Time,               ///< [in] Time
+    TimeInterval ProjDt ///< [in] Time interval for projection over the current
+                        ///< time stepper stage
 ) {
-   Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
-   Array2DReal NormalVelEdge   = State->getNormalVelocity(VelTimeLevel);
-   OMEGA_SCOPE(TracerAux, AuxState->TracerAux);
-   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
-   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
-   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
-   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
    Pacer::start("Tend:computeTracerTendencies", 1);
 
-   const auto &MeanPseudoThickEdge =
-       AuxState->PseudoThicknessAux.MeanPseudoThickEdge;
-   Pacer::start("Tend:computeTracerAuxCell", 2);
-   parallelForOuter(
-       "computeTracerAuxCell",
-       LaunchConfig({NTracers, Mesh->NCellsAll},
-                    TeamScratch<Real>(VCoord->NVertLayers)),
-       KOKKOS_LAMBDA(int LTracer, int ICell, const TeamMember &Team) {
-          TracerAux.computeVarsOnCells(Team, LTracer, ICell,
-                                       MeanPseudoThickEdge, TracerArray);
-       });
-   Pacer::stop("Tend:computeTracerAuxCell", 2);
+   AuxState->computeTracerAux(State, TracerArray, ThickTimeLevel, VelTimeLevel,
+                              ProjDt);
 
    computeTracerTendenciesOnly(State, AuxState, TracerArray, ThickTimeLevel,
                                VelTimeLevel, Time);

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -472,12 +472,12 @@ Tendencies::Tendencies(const std::string &Name_, ///< [in] Name for tendencies
                        CustomTendencyType InCustomVelocityTend)
     : Mesh(Mesh), VCoord(VCoord), VAdv(VAdv),
       PseudoThicknessFluxDiv(Mesh, VCoord), PotentialVortHAdv(Mesh, VCoord),
-      KEGrad(Mesh, VCoord), SSHGrad(Mesh, VCoord),
-      VelocityDiffusion(Mesh, VCoord), VelocityHyperDiff(Mesh, VCoord),
-      SfcStressForcing(Mesh, VCoord), ExplicitBottomDrag(Mesh, VCoord),
-      TracerDiffusion(Mesh, VCoord), TracerHyperDiff(Mesh, VCoord),
-      TracerHorzAdv(Mesh, VCoord), SurfaceTracerRestoring(Mesh),
-      CustomThicknessTend(InCustomThicknessTend),
+      CoriolisAcceleration(Mesh, VCoord), KEGrad(Mesh, VCoord),
+      SSHGrad(Mesh, VCoord), VelocityDiffusion(Mesh, VCoord),
+      VelocityHyperDiff(Mesh, VCoord), SfcStressForcing(Mesh, VCoord),
+      ExplicitBottomDrag(Mesh, VCoord), TracerDiffusion(Mesh, VCoord),
+      TracerHyperDiff(Mesh, VCoord), TracerHorzAdv(Mesh, VCoord),
+      SurfaceTracerRestoring(Mesh), CustomThicknessTend(InCustomThicknessTend),
       CustomVelocityTend(InCustomVelocityTend), EqState(EqState), PGrad(PGrad),
       VMix(VMix) {
 
@@ -552,6 +552,61 @@ Tendencies *Tendencies::create(const std::string &Name,
 }
 
 //------------------------------------------------------------------------------
+// Accumulate f times tangential velocity reconstruction for edge-centered 2D
+// fields
+void Tendencies::computeCoriolisAccelerationOnEdge(
+    const Array2DReal &Tend,          ///< [inout] velocity tendency
+    const Array2DReal &NormalVelEdge, ///< [in] normal velocity on edges
+    const Array1DReal &FEdge          ///< [in] Coriolis parameter on edges
+) const {
+
+   // Coriolis acceleration should be turned off if the PV tendency is disabled.
+   if (!PotentialVortHAdv.Enabled)
+      return;
+
+   OMEGA_SCOPE(LocCoriolisAcceleration, CoriolisAcceleration);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   Pacer::start("Tend:coriolisAccelerationOnEdge2D", 2);
+   parallelForOuter(
+       {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocCoriolisAcceleration(Tend, IEdge, KChunk, NormalVelEdge,
+                                         FEdge);
+              });
+       });
+   Pacer::stop("Tend:coriolisAccelerationOnEdge2D", 2);
+}
+
+//------------------------------------------------------------------------------
+// Accumulate f times tangential velocity reconstruction for edge-centered 1D
+// fields
+void Tendencies::computeCoriolisAccelerationOnEdge(
+    const Array1DReal &Tend,          ///< [inout] barotropic velocity tendency
+    const Array1DReal &NormalVelEdge, ///< [in] normal velocity on edges
+    const Array1DReal &FEdge          ///< [in] Coriolis parameter on edges
+) const {
+
+   // Shares PVTendencyEnable with the 2D overload above
+   if (!PotentialVortHAdv.Enabled)
+      return;
+
+   OMEGA_SCOPE(LocCoriolisAcceleration, CoriolisAcceleration);
+
+   Pacer::start("Tend:coriolisAccelerationOnEdge1D", 2);
+   parallelFor(
+       {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
+          LocCoriolisAcceleration(Tend, IEdge, NormalVelEdge, FEdge);
+       });
+   Pacer::stop("Tend:coriolisAccelerationOnEdge1D", 2);
+}
+
+//------------------------------------------------------------------------------
 // Compute tendencies for the pseudo-thickness equation
 void Tendencies::computePseudoThicknessTendenciesOnly(
     const OceanState *State,        ///< [in] State variables
@@ -561,12 +616,25 @@ void Tendencies::computePseudoThicknessTendenciesOnly(
     TimeInstant Time                ///< [in] Time
 ) {
 
+   Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
+
+   computePseudoThicknessTendenciesOnly(State, AuxState, ThickTimeLevel,
+                                        VelTimeLevel, NormalVelEdge, Time);
+}
+
+void Tendencies::computePseudoThicknessTendenciesOnly(
+    const OceanState *State,          ///< [in] State variables
+    const AuxiliaryState *AuxState,   ///< [in] Auxilary state variables
+    int ThickTimeLevel,               ///< [in] Time level
+    int VelTimeLevel,                 ///< [in] Time level
+    const Array2DReal &NormalVelEdge, ///< [in] normal velocity on edges
+    TimeInstant Time                  ///< [in] Time
+) {
+
    OMEGA_SCOPE(LocPseudoThicknessTend, PseudoThicknessTend);
    OMEGA_SCOPE(LocThicknessFluxDiv, PseudoThicknessFluxDiv);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
-
-   Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
 
    Pacer::start("Tend:computePseudoThicknessTendenciesOnly", 1);
 
@@ -774,6 +842,236 @@ void Tendencies::computeVelocityTendenciesOnly(
 
 } // end velocity tendency compute
 
+//------------------------------------------------------------------------------
+// Compute baroclinic velocity tendencies for the split-explicit forcing term
+void Tendencies::computeBaroclinicVelocityTendenciesOnly(
+    const OceanState *State,         ///< [in] State variables
+    const AuxiliaryState *AuxState,  ///< [in] Auxilary state variables
+    const Array3DReal &TracerArray,  ///< [in] Tracer array
+    int ThickTimeLevel,              ///< [in] Time level
+    int VelTimeLevel,                ///< [in] Time level
+    int BarotropicVelocityTimeLevel, ///< [in] Barotropic velocity time level
+    int BarotropicPressureTimeLevel, ///< [in] Barotropic pressure time level
+    Real SplitFactor,                ///< [in] Split-explicit forcing factor
+    TimeInstant Time                 ///< [in] Time
+) {
+   OMEGA_SCOPE(LocNormalVelocityTend, NormalVelocityTend);
+   OMEGA_SCOPE(LocPotentialVortHAdv, PotentialVortHAdv);
+   OMEGA_SCOPE(LocKEGrad, KEGrad);
+   OMEGA_SCOPE(LocSSHGrad, SSHGrad);
+   OMEGA_SCOPE(LocVelocityDiffusion, VelocityDiffusion);
+   OMEGA_SCOPE(LocVelocityHyperDiff, VelocityHyperDiff);
+   OMEGA_SCOPE(LocSfcStressForcing, SfcStressForcing);
+   OMEGA_SCOPE(LocExplicitBottomDrag, ExplicitBottomDrag);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+   OMEGA_SCOPE(LocSshCell, VCoord->SshCell);
+
+   Pacer::start("Tend:computeBaroclinicVelocityTendenciesOnly", 1);
+
+   parallelForOuter(
+       {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin = MinLayerEdgeBot(IEdge);
+          const int KMax = MaxLayerEdgeTop(IEdge);
+
+          parallelForInner(
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(int K) { LocNormalVelocityTend(IEdge, K) = 0; });
+       });
+
+   const Array2DReal &FluxPseudoThickEdge =
+       AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
+   Array2DReal NormVelEdge = State->getNormalVelocity(VelTimeLevel);
+
+   // Compute baroclinic relative-vorticity horizontal advection
+   const Array2DReal &NormRVortEdge = AuxState->VorticityAux.NormRelVortEdge;
+   if (LocPotentialVortHAdv.Enabled) {
+      Pacer::start("Tend:BclVortHAdv", 2);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocPotentialVortHAdv(LocNormalVelocityTend, IEdge, KChunk,
+                                         NormRVortEdge, FluxPseudoThickEdge,
+                                         NormVelEdge);
+                 });
+          });
+      Pacer::stop("Tend:BclVortHAdv", 2);
+   }
+
+   // Compute kinetic energy gradient
+   const Array2DReal &KECell = AuxState->KineticAux.KineticEnergyCell;
+   if (LocKEGrad.Enabled) {
+      Pacer::start("Tend:BclKEGrad", 2);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocKEGrad(LocNormalVelocityTend, IEdge, KChunk, KECell);
+                 });
+          });
+      Pacer::stop("Tend:BclKEGrad", 2);
+   }
+
+   // Compute del2 horizontal diffusion
+   const Array2DReal &DivCell     = AuxState->KineticAux.VelocityDivCell;
+   const Array2DReal &RVortVertex = AuxState->VorticityAux.RelVortVertex;
+   if (LocVelocityDiffusion.Enabled) {
+      Pacer::start("Tend:bclVelocityDiffusion", 2);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocVelocityDiffusion(LocNormalVelocityTend, IEdge, KChunk,
+                                         DivCell, RVortVertex);
+                 });
+          });
+      Pacer::stop("Tend:bclVelocityDiffusion", 2);
+   }
+
+   // Compute del4 horizontal diffusion
+   const Array2DReal &Del2DivCell = AuxState->VelocityDel2Aux.Del2DivCell;
+   const Array2DReal &Del2RVortVertex =
+       AuxState->VelocityDel2Aux.Del2RelVortVertex;
+   if (LocVelocityHyperDiff.Enabled) {
+      Pacer::start("Tend:bclVelocityHyperDiff", 2);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocVelocityHyperDiff(LocNormalVelocityTend, IEdge, KChunk,
+                                         Del2DivCell, Del2RVortVertex);
+                 });
+          });
+      Pacer::stop("Tend:bclVelocityHyperDiff", 2);
+   }
+
+   Pacer::start("Tend:computeBaroclinicVelocityVAdvTend", 2);
+   VAdv->computeVelocityVAdvTend(LocNormalVelocityTend, NormVelEdge,
+                                 FluxPseudoThickEdge);
+   Pacer::stop("Tend:computeBaroclinicVelocityVAdvTend", 2);
+
+   // Compute pressure gradient
+   if (PGrad->Enabled) {
+
+      Pacer::start("Tend:bclPressureGradTerm", 2);
+      Array2DReal PseudoThick       = State->getPseudoThickness(ThickTimeLevel);
+      const auto &PressureMid       = VCoord->PressureMid;
+      const auto &PressureInterface = VCoord->PressureInterface;
+      const auto &SpecVol           = EqState->SpecVol;
+      const auto &GeomZInterface    = VCoord->GeomZInterface;
+      PGrad->computePressureGrad(LocNormalVelocityTend, PressureMid,
+                                 PressureInterface, SpecVol, GeomZInterface,
+                                 PseudoThick);
+      Pacer::stop("Tend:bclPressureGradTerm", 2);
+   }
+
+   // Compute the barotropic pressure anomaly gradient term for split-explicit
+   // integration. This term is required to cancel the barotropic contribution
+   // in the full pressure gradient and must not depend on the legacy shallow-
+   // water SSH tendency switch.
+   if (SplitFactor != 0._Real) {
+      const Array1DReal &BtrPressAnomaly =
+          State->getBarotropicPressureAnomaly(BarotropicPressureTimeLevel);
+      const Array1DReal &DepthMeanSpecVol = EqState->DepthMeanSpecificVolume;
+
+      Pacer::start("Tend:BclBtrPressureGrad", 2);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocSSHGrad(LocNormalVelocityTend, IEdge, KChunk,
+                               BtrPressAnomaly, DepthMeanSpecVol);
+                 });
+          });
+      Pacer::stop("Tend:BclBtrPressureGrad", 2);
+   }
+
+   // Compute surface stress forcing
+   const auto *ForcingState = Forcing::getDefault();
+   const auto &NormalStressEdge =
+       ForcingState->SfcStressForcing.NormalStressEdge;
+   const auto &MeanPseudoThickEdge =
+       AuxState->PseudoThicknessAux.MeanPseudoThickEdge;
+   if (LocSfcStressForcing.Enabled) {
+      Pacer::start("Tend:sfcStressForcing", 2);
+      parallelForOuter(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin   = MinLayerEdgeBot(IEdge);
+             const int KMax   = MaxLayerEdgeTop(IEdge);
+             const int KRange = vertRangeChunked(KMin, KMax);
+             parallelForInner(
+                 Team, KRange, INNER_LAMBDA(int KChunk) {
+                    LocSfcStressForcing(LocNormalVelocityTend, IEdge, KChunk,
+                                        NormalStressEdge, MeanPseudoThickEdge);
+                 });
+          });
+      Pacer::stop("Tend:sfcStressForcing", 2);
+   }
+
+   // Compute bottom drag
+   if (LocExplicitBottomDrag.Enabled) {
+      Pacer::start("Tend:explicitBottomDrag", 2);
+      parallelFor(
+          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
+             LocExplicitBottomDrag(LocNormalVelocityTend, IEdge, NormVelEdge,
+                                   KECell, MeanPseudoThickEdge);
+          });
+      Pacer::stop("Tend:explicitBottomDrag", 2);
+   }
+
+   if (CustomVelocityTend) {
+      Pacer::start("Tend:customVelocityTend", 2);
+      CustomVelocityTend(LocNormalVelocityTend, State, AuxState, ThickTimeLevel,
+                         VelTimeLevel, Time);
+      Pacer::stop("Tend:customVelocityTend", 2);
+   }
+
+   Pacer::stop("Tend:computeBaroclinicVelocityTendenciesOnly", 1);
+
+} // end baroclinic velocity tendency compute
+
+void Tendencies::computeBaroclinicVelocityTendencies(
+    const OceanState *State,         ///< [in] State variables
+    const AuxiliaryState *AuxState,  ///< [in] Auxilary state variables
+    const Array3DReal &TracerArray,  ///< [in] Tracer array
+    int ThickTimeLevel,              ///< [in] Time level
+    int VelTimeLevel,                ///< [in] Time level
+    int BarotropicVelocityTimeLevel, ///< [in] Barotropic velocity time level
+    int BarotropicPressureTimeLevel, ///< [in] Barotropic pressure time level
+    Real SplitFactor,                ///< [in] Split-explicit forcing factor
+    TimeInstant Time,                ///< [in] Time
+    TimeInterval ProjDt ///< [in] Time interval for projection over the current
+                        ///< time stepper stage
+) {
+   Pacer::start("Tend:computeBaroclinicVelocityTendencies", 1);
+
+   AuxState->computeMomAux(State, TracerArray, ThickTimeLevel, VelTimeLevel,
+                           ProjDt);
+   computeBaroclinicVelocityTendenciesOnly(
+       State, AuxState, TracerArray, ThickTimeLevel, VelTimeLevel,
+       BarotropicVelocityTimeLevel, BarotropicPressureTimeLevel, SplitFactor,
+       Time);
+
+   Pacer::stop("Tend:computeBaroclinicVelocityTendencies", 1);
+}
+
 void Tendencies::computeTracerTendenciesOnly(
     const OceanState *State,        ///< [in] State variables
     const AuxiliaryState *AuxState, ///< [in] Auxilary state variables
@@ -781,6 +1079,21 @@ void Tendencies::computeTracerTendenciesOnly(
     int ThickTimeLevel,             ///< [in] Time level
     int VelTimeLevel,               ///< [in] Time level
     TimeInstant Time                ///< [in] Time
+) {
+
+   Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
+   computeTracerTendenciesOnly(State, AuxState, TracerArray, ThickTimeLevel,
+                               NormalVelEdge, Time, TimeStep);
+}
+
+void Tendencies::computeTracerTendenciesOnly(
+    const OceanState *State,          ///< [in] State variables
+    const AuxiliaryState *AuxState,   ///< [in] Auxilary state variables
+    const Array3DReal &TracerArray,   ///< [in] Tracer array
+    int ThickTimeLevel,               ///< [in] Time level
+    const Array2DReal &NormalVelEdge, ///< [in] normal velocity on edges
+    TimeInstant Time,                 ///< [in] Time
+    const TimeInterval ProjDt         ///< [in] projection time interval
 ) {
    OMEGA_SCOPE(LocTracerTend, TracerTend);
    OMEGA_SCOPE(LocTracerHorzAdv, TracerHorzAdv);
@@ -809,6 +1122,7 @@ void Tendencies::computeTracerTendenciesOnly(
        AuxState->TransportAux.NormalTransportVelocity;
    const Array2DReal &FluxPseudoThickEdge =
        AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
+
    if (LocTracerHorzAdv.Enabled) {
       Pacer::start("Tend:tracerHorzAdv", 2);
       parallelForOuter(
@@ -864,7 +1178,7 @@ void Tendencies::computeTracerTendenciesOnly(
       ThicknessForVAdv = AuxState->PseudoThicknessAux.ProvPseudoThickness;
    }
    VAdv->computeTracerVAdvTend(LocTracerTend, TracerArray, ThicknessForVAdv,
-                               TimeStep);
+                               ProjDt);
    Pacer::stop("Tend:computeTracerVAdvTend", 2);
 
    // compute tracer surface restoring

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -600,6 +600,42 @@ void Tendencies::computeCoriolisAccelerationOnEdge(
 }
 
 //------------------------------------------------------------------------------
+// Write a base tendency plus f times tangential velocity reconstruction into a
+// separate output array, for iterative Coriolis solves
+void Tendencies::computeCoriolisAccelerationOnEdge(
+    const Array2DReal &Tend,          ///< [out] base plus Coriolis tendency
+    const Array2DReal &BaseTend,      ///< [in] tendency without Coriolis
+    const Array2DReal &NormalVelEdge, ///< [in] normal velocity on edges
+    const Array1DReal &FEdge          ///< [in] Coriolis parameter on edges
+) const {
+
+   // Coriolis acceleration should be turned off if the PV tendency is disabled,
+   // in which case the output is just the base tendency.
+   if (!PotentialVortHAdv.Enabled) {
+      deepCopy(Tend, BaseTend);
+      return;
+   }
+
+   OMEGA_SCOPE(LocCoriolisAcceleration, CoriolisAcceleration);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   Pacer::start("Tend:coriolisAccelerationOnEdge2DBase", 2);
+   parallelForOuter(
+       {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocCoriolisAcceleration(Tend, BaseTend, IEdge, KChunk,
+                                         NormalVelEdge, FEdge);
+              });
+       });
+   Pacer::stop("Tend:coriolisAccelerationOnEdge2DBase", 2);
+}
+
+//------------------------------------------------------------------------------
 // Accumulate f times tangential velocity reconstruction for edge-centered 1D
 // fields
 void Tendencies::computeCoriolisAccelerationOnEdge(
@@ -732,8 +768,9 @@ void Tendencies::computeVelocityTendenciesOnly(
    VCoord->zeroEdgeField(NormalVelocityTend, Mesh->NEdgesAll);
 
    // Compute vorticity horizontal advection.
-   // With CoriolisTendMode::Separate only the relative vorticity is advected here; the time stepper adds the
-   // linear Coriolis acceleration itself so it can be iterated implicitly.
+   // With CoriolisTendMode::Separate only the relative vorticity is advected
+   // here; the time stepper adds the linear Coriolis acceleration itself so it
+   // can be iterated.
    const Array2DReal &FluxPseudoThickEdge =
        AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
    const Array2DReal &NormRVortEdge = AuxState->VorticityAux.NormRelVortEdge;

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -780,8 +780,8 @@ void Tendencies::computeVelocityTendenciesOnly(
                           TeamScratch<Real>(VCoord->NVertLayers)),
              KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
                 LocPotentialVortHAdv(Team, LocNormalVelocityTend, IEdge,
-                                     NormRVortEdge, NormFEdge, FluxPseudoThickEdge,
-                                     NormVelEdge);
+                                     NormRVortEdge, NormFEdge,
+                                     FluxPseudoThickEdge, NormVelEdge);
              });
       }
       Pacer::stop("Tend:PotentialVortHAdv", 2);

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -583,6 +583,8 @@ void Tendencies::computePseudoThicknessTendenciesOnly(
    // Compute pseudo-thickness flux divergence
    const Array2DReal &ThickFluxEdge =
        AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
+   const auto &NormalTransportVelocity =
+       AuxState->TransportAux.NormalTransportVelocity;
 
    if (LocThicknessFluxDiv.Enabled) {
       Pacer::start("Tend:thicknessFluxDiv", 2);
@@ -591,7 +593,7 @@ void Tendencies::computePseudoThicknessTendenciesOnly(
                        TeamScratch<Real>(VCoord->NVertLayers)),
           KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
              LocThicknessFluxDiv(Team, LocPseudoThicknessTend, ICell,
-                                 ThickFluxEdge, NormalVelEdge);
+                                 ThickFluxEdge, NormalTransportVelocity);
           });
       Pacer::stop("Tend:thicknessFluxDiv", 2);
    }
@@ -803,7 +805,8 @@ void Tendencies::computeTracerTendenciesOnly(
        });
 
    // compute tracer horizotal advection
-   Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
+   const auto &NormalTransportVelocity =
+       AuxState->TransportAux.NormalTransportVelocity;
    const Array2DReal &FluxPseudoThickEdge =
        AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
    if (LocTracerHorzAdv.Enabled) {
@@ -813,7 +816,7 @@ void Tendencies::computeTracerTendenciesOnly(
                        TeamScratch<Real>(VCoord->NVertLayers)),
           KOKKOS_LAMBDA(int L, int IEdge, const TeamMember &Team) {
              LocTracerHorzAdv(Team, L, IEdge, TracerArray, FluxPseudoThickEdge,
-                              NormalVelEdge);
+                              NormalTransportVelocity);
           });
       parallelForOuter(
           LaunchConfig({NTracers, Mesh->NCellsAll},

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -404,6 +404,22 @@ void Tendencies::readConfig(Config *OmegaConfig ///< [in] Omega config
 }
 
 //------------------------------------------------------------------------------
+// Configure the velocity tendency for a mode-split time stepper
+void Tendencies::setModeSplit(CoriolisTendMode Mode, ///< [in] Coriolis mode
+                              Real SplitFactorIn ///< [in] split-explicit factor
+) {
+
+   if (SplitFactorIn != 0._Real && this->SSHGrad.Enabled) {
+      ABORT_ERROR("Tendencies: SSHTendencyEnable must be false for a "
+                  "mode-split time stepper, which uses the barotropic "
+                  "pressure anomaly gradient instead");
+   }
+
+   this->CoriolisMode = Mode;
+   this->SplitFactor  = SplitFactorIn;
+}
+
+//------------------------------------------------------------------------------
 // Define fields associated with tendencies
 void Tendencies::defineFields() {
    std::string PseudoThicknessTendFieldName = "PseudoThicknessTend";
@@ -715,7 +731,9 @@ void Tendencies::computeVelocityTendenciesOnly(
    // keep their FillValueReal from attachData().
    VCoord->zeroEdgeField(NormalVelocityTend, Mesh->NEdgesAll);
 
-   // Compute potential vorticity horizontal advection
+   // Compute vorticity horizontal advection.
+   // With CoriolisTendMode::Separate only the relative vorticity is advected here; the time stepper adds the
+   // linear Coriolis acceleration itself so it can be iterated implicitly.
    const Array2DReal &FluxPseudoThickEdge =
        AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
    const Array2DReal &NormRVortEdge = AuxState->VorticityAux.NormRelVortEdge;
@@ -723,14 +741,25 @@ void Tendencies::computeVelocityTendenciesOnly(
    Array2DReal NormVelEdge          = State->getNormalVelocity(VelTimeLevel);
    if (LocPotentialVortHAdv.Enabled) {
       Pacer::start("Tend:PotentialVortHAdv", 2);
-      parallelForOuter(
-          LaunchConfig({Mesh->NEdgesAll},
-                       TeamScratch<Real>(VCoord->NVertLayers)),
-          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-             LocPotentialVortHAdv(Team, LocNormalVelocityTend, IEdge,
-                                  NormRVortEdge, NormFEdge, FluxPseudoThickEdge,
-                                  NormVelEdge);
-          });
+      if (CoriolisMode == CoriolisTendMode::Separate) {
+         parallelForOuter(
+             LaunchConfig({Mesh->NEdgesAll},
+                          TeamScratch<Real>(VCoord->NVertLayers)),
+             KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+                LocPotentialVortHAdv(Team, LocNormalVelocityTend, IEdge,
+                                     NormRVortEdge, FluxPseudoThickEdge,
+                                     NormVelEdge);
+             });
+      } else {
+         parallelForOuter(
+             LaunchConfig({Mesh->NEdgesAll},
+                          TeamScratch<Real>(VCoord->NVertLayers)),
+             KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+                LocPotentialVortHAdv(Team, LocNormalVelocityTend, IEdge,
+                                     NormRVortEdge, NormFEdge, FluxPseudoThickEdge,
+                                     NormVelEdge);
+             });
+      }
       Pacer::stop("Tend:PotentialVortHAdv", 2);
    }
 
@@ -745,9 +774,17 @@ void Tendencies::computeVelocityTendenciesOnly(
       Pacer::stop("Tend:KEGrad", 2);
    }
 
-   // Compute sea surface height gradient
+   // Compute the barotropic pressure gradient for the mode-split time steppers
    const Array1DReal &SSHCell = LocSshCell;
-   if (LocSSHGrad.Enabled) {
+   if (SplitFactor != 0._Real) {
+      Pacer::start("Tend:barotropicPressureGradTerm", 2);
+      const Array1DReal &BtrPressAnomaly =
+          State->getBarotropicPressureAnomaly(VelTimeLevel);
+      const Array1DReal &DepthMeanSpecVol = EqState->DepthMeanSpecificVolume;
+      PGrad->computeBarotropicPressureGrad(LocNormalVelocityTend,
+                                           BtrPressAnomaly, DepthMeanSpecVol);
+      Pacer::stop("Tend:barotropicPressureGradTerm", 2);
+   } else if (LocSSHGrad.Enabled) {
       Pacer::start("Tend:SSHGrad", 2);
       parallelForOuter(
           {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
@@ -841,236 +878,6 @@ void Tendencies::computeVelocityTendenciesOnly(
    Pacer::stop("Tend:computeVelocityTendenciesOnly", 1);
 
 } // end velocity tendency compute
-
-//------------------------------------------------------------------------------
-// Compute baroclinic velocity tendencies for the split-explicit forcing term
-void Tendencies::computeBaroclinicVelocityTendenciesOnly(
-    const OceanState *State,         ///< [in] State variables
-    const AuxiliaryState *AuxState,  ///< [in] Auxilary state variables
-    const Array3DReal &TracerArray,  ///< [in] Tracer array
-    int ThickTimeLevel,              ///< [in] Time level
-    int VelTimeLevel,                ///< [in] Time level
-    int BarotropicVelocityTimeLevel, ///< [in] Barotropic velocity time level
-    int BarotropicPressureTimeLevel, ///< [in] Barotropic pressure time level
-    Real SplitFactor,                ///< [in] Split-explicit forcing factor
-    TimeInstant Time                 ///< [in] Time
-) {
-   OMEGA_SCOPE(LocNormalVelocityTend, NormalVelocityTend);
-   OMEGA_SCOPE(LocPotentialVortHAdv, PotentialVortHAdv);
-   OMEGA_SCOPE(LocKEGrad, KEGrad);
-   OMEGA_SCOPE(LocSSHGrad, SSHGrad);
-   OMEGA_SCOPE(LocVelocityDiffusion, VelocityDiffusion);
-   OMEGA_SCOPE(LocVelocityHyperDiff, VelocityHyperDiff);
-   OMEGA_SCOPE(LocSfcStressForcing, SfcStressForcing);
-   OMEGA_SCOPE(LocExplicitBottomDrag, ExplicitBottomDrag);
-   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
-   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
-   OMEGA_SCOPE(LocSshCell, VCoord->SshCell);
-
-   Pacer::start("Tend:computeBaroclinicVelocityTendenciesOnly", 1);
-
-   parallelForOuter(
-       {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-          const int KMin = MinLayerEdgeBot(IEdge);
-          const int KMax = MaxLayerEdgeTop(IEdge);
-
-          parallelForInner(
-              Team, Range{KMin, KMax},
-              INNER_LAMBDA(int K) { LocNormalVelocityTend(IEdge, K) = 0; });
-       });
-
-   const Array2DReal &FluxPseudoThickEdge =
-       AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
-   Array2DReal NormVelEdge = State->getNormalVelocity(VelTimeLevel);
-
-   // Compute baroclinic relative-vorticity horizontal advection
-   const Array2DReal &NormRVortEdge = AuxState->VorticityAux.NormRelVortEdge;
-   if (LocPotentialVortHAdv.Enabled) {
-      Pacer::start("Tend:BclVortHAdv", 2);
-      parallelForOuter(
-          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-             const int KMin   = MinLayerEdgeBot(IEdge);
-             const int KMax   = MaxLayerEdgeTop(IEdge);
-             const int KRange = vertRangeChunked(KMin, KMax);
-
-             parallelForInner(
-                 Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocPotentialVortHAdv(LocNormalVelocityTend, IEdge, KChunk,
-                                         NormRVortEdge, FluxPseudoThickEdge,
-                                         NormVelEdge);
-                 });
-          });
-      Pacer::stop("Tend:BclVortHAdv", 2);
-   }
-
-   // Compute kinetic energy gradient
-   const Array2DReal &KECell = AuxState->KineticAux.KineticEnergyCell;
-   if (LocKEGrad.Enabled) {
-      Pacer::start("Tend:BclKEGrad", 2);
-      parallelForOuter(
-          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-             const int KMin   = MinLayerEdgeBot(IEdge);
-             const int KMax   = MaxLayerEdgeTop(IEdge);
-             const int KRange = vertRangeChunked(KMin, KMax);
-             parallelForInner(
-                 Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocKEGrad(LocNormalVelocityTend, IEdge, KChunk, KECell);
-                 });
-          });
-      Pacer::stop("Tend:BclKEGrad", 2);
-   }
-
-   // Compute del2 horizontal diffusion
-   const Array2DReal &DivCell     = AuxState->KineticAux.VelocityDivCell;
-   const Array2DReal &RVortVertex = AuxState->VorticityAux.RelVortVertex;
-   if (LocVelocityDiffusion.Enabled) {
-      Pacer::start("Tend:bclVelocityDiffusion", 2);
-      parallelForOuter(
-          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-             const int KMin   = MinLayerEdgeBot(IEdge);
-             const int KMax   = MaxLayerEdgeTop(IEdge);
-             const int KRange = vertRangeChunked(KMin, KMax);
-             parallelForInner(
-                 Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocVelocityDiffusion(LocNormalVelocityTend, IEdge, KChunk,
-                                         DivCell, RVortVertex);
-                 });
-          });
-      Pacer::stop("Tend:bclVelocityDiffusion", 2);
-   }
-
-   // Compute del4 horizontal diffusion
-   const Array2DReal &Del2DivCell = AuxState->VelocityDel2Aux.Del2DivCell;
-   const Array2DReal &Del2RVortVertex =
-       AuxState->VelocityDel2Aux.Del2RelVortVertex;
-   if (LocVelocityHyperDiff.Enabled) {
-      Pacer::start("Tend:bclVelocityHyperDiff", 2);
-      parallelForOuter(
-          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-             const int KMin   = MinLayerEdgeBot(IEdge);
-             const int KMax   = MaxLayerEdgeTop(IEdge);
-             const int KRange = vertRangeChunked(KMin, KMax);
-             parallelForInner(
-                 Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocVelocityHyperDiff(LocNormalVelocityTend, IEdge, KChunk,
-                                         Del2DivCell, Del2RVortVertex);
-                 });
-          });
-      Pacer::stop("Tend:bclVelocityHyperDiff", 2);
-   }
-
-   Pacer::start("Tend:computeBaroclinicVelocityVAdvTend", 2);
-   VAdv->computeVelocityVAdvTend(LocNormalVelocityTend, NormVelEdge,
-                                 FluxPseudoThickEdge);
-   Pacer::stop("Tend:computeBaroclinicVelocityVAdvTend", 2);
-
-   // Compute pressure gradient
-   if (PGrad->Enabled) {
-
-      Pacer::start("Tend:bclPressureGradTerm", 2);
-      Array2DReal PseudoThick       = State->getPseudoThickness(ThickTimeLevel);
-      const auto &PressureMid       = VCoord->PressureMid;
-      const auto &PressureInterface = VCoord->PressureInterface;
-      const auto &SpecVol           = EqState->SpecVol;
-      const auto &GeomZInterface    = VCoord->GeomZInterface;
-      PGrad->computePressureGrad(LocNormalVelocityTend, PressureMid,
-                                 PressureInterface, SpecVol, GeomZInterface,
-                                 PseudoThick);
-      Pacer::stop("Tend:bclPressureGradTerm", 2);
-   }
-
-   // Compute the barotropic pressure anomaly gradient term for split-explicit
-   // integration. This term is required to cancel the barotropic contribution
-   // in the full pressure gradient and must not depend on the legacy shallow-
-   // water SSH tendency switch.
-   if (SplitFactor != 0._Real) {
-      const Array1DReal &BtrPressAnomaly =
-          State->getBarotropicPressureAnomaly(BarotropicPressureTimeLevel);
-      const Array1DReal &DepthMeanSpecVol = EqState->DepthMeanSpecificVolume;
-
-      Pacer::start("Tend:BclBtrPressureGrad", 2);
-      parallelForOuter(
-          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-             const int KMin   = MinLayerEdgeBot(IEdge);
-             const int KMax   = MaxLayerEdgeTop(IEdge);
-             const int KRange = vertRangeChunked(KMin, KMax);
-             parallelForInner(
-                 Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocSSHGrad(LocNormalVelocityTend, IEdge, KChunk,
-                               BtrPressAnomaly, DepthMeanSpecVol);
-                 });
-          });
-      Pacer::stop("Tend:BclBtrPressureGrad", 2);
-   }
-
-   // Compute surface stress forcing
-   const auto *ForcingState = Forcing::getDefault();
-   const auto &NormalStressEdge =
-       ForcingState->SfcStressForcing.NormalStressEdge;
-   const auto &MeanPseudoThickEdge =
-       AuxState->PseudoThicknessAux.MeanPseudoThickEdge;
-   if (LocSfcStressForcing.Enabled) {
-      Pacer::start("Tend:sfcStressForcing", 2);
-      parallelForOuter(
-          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-             const int KMin   = MinLayerEdgeBot(IEdge);
-             const int KMax   = MaxLayerEdgeTop(IEdge);
-             const int KRange = vertRangeChunked(KMin, KMax);
-             parallelForInner(
-                 Team, KRange, INNER_LAMBDA(int KChunk) {
-                    LocSfcStressForcing(LocNormalVelocityTend, IEdge, KChunk,
-                                        NormalStressEdge, MeanPseudoThickEdge);
-                 });
-          });
-      Pacer::stop("Tend:sfcStressForcing", 2);
-   }
-
-   // Compute bottom drag
-   if (LocExplicitBottomDrag.Enabled) {
-      Pacer::start("Tend:explicitBottomDrag", 2);
-      parallelFor(
-          {Mesh->NEdgesAll}, KOKKOS_LAMBDA(int IEdge) {
-             LocExplicitBottomDrag(LocNormalVelocityTend, IEdge, NormVelEdge,
-                                   KECell, MeanPseudoThickEdge);
-          });
-      Pacer::stop("Tend:explicitBottomDrag", 2);
-   }
-
-   if (CustomVelocityTend) {
-      Pacer::start("Tend:customVelocityTend", 2);
-      CustomVelocityTend(LocNormalVelocityTend, State, AuxState, ThickTimeLevel,
-                         VelTimeLevel, Time);
-      Pacer::stop("Tend:customVelocityTend", 2);
-   }
-
-   Pacer::stop("Tend:computeBaroclinicVelocityTendenciesOnly", 1);
-
-} // end baroclinic velocity tendency compute
-
-void Tendencies::computeBaroclinicVelocityTendencies(
-    const OceanState *State,         ///< [in] State variables
-    const AuxiliaryState *AuxState,  ///< [in] Auxilary state variables
-    const Array3DReal &TracerArray,  ///< [in] Tracer array
-    int ThickTimeLevel,              ///< [in] Time level
-    int VelTimeLevel,                ///< [in] Time level
-    int BarotropicVelocityTimeLevel, ///< [in] Barotropic velocity time level
-    int BarotropicPressureTimeLevel, ///< [in] Barotropic pressure time level
-    Real SplitFactor,                ///< [in] Split-explicit forcing factor
-    TimeInstant Time,                ///< [in] Time
-    TimeInterval ProjDt ///< [in] Time interval for projection over the current
-                        ///< time stepper stage
-) {
-   Pacer::start("Tend:computeBaroclinicVelocityTendencies", 1);
-
-   AuxState->computeMomAux(State, TracerArray, ThickTimeLevel, VelTimeLevel,
-                           ProjDt);
-   computeBaroclinicVelocityTendenciesOnly(
-       State, AuxState, TracerArray, ThickTimeLevel, VelTimeLevel,
-       BarotropicVelocityTimeLevel, BarotropicPressureTimeLevel, SplitFactor,
-       Time);
-
-   Pacer::stop("Tend:computeBaroclinicVelocityTendencies", 1);
-}
 
 void Tendencies::computeTracerTendenciesOnly(
     const OceanState *State,        ///< [in] State variables

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -889,29 +889,17 @@ void Tendencies::computeTracerTendenciesOnly(
 void Tendencies::computePseudoThicknessTendencies(
     const OceanState *State,        ///< [in] State variables
     const AuxiliaryState *AuxState, ///< [in] Auxilary state variables
+    const Array3DReal &TracerArray, ///< [in] Tracer array
     int ThickTimeLevel,             ///< [in] Time level
     int VelTimeLevel,               ///< [in] Time level
-    TimeInstant Time                ///< [in] Time
+    TimeInstant Time,               ///< [in] Time
+    TimeInterval ProjDt ///< [in] Time interval for projection over the current
+                        ///< time stepper stage
 ) {
-   // only need PseudoThicknessAux on edge
-   Array2DReal PseudoThick = State->getPseudoThickness(ThickTimeLevel);
-   Array2DReal NormVel     = State->getNormalVelocity(VelTimeLevel);
-   OMEGA_SCOPE(PseudoThicknessAux, AuxState->PseudoThicknessAux);
-   OMEGA_SCOPE(PseudoThickCell, PseudoThick);
-   OMEGA_SCOPE(NormalVelEdge, NormVel);
-   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
-   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
-
    Pacer::start("Tend:computePseudoThicknessTendencies", 1);
 
-   Pacer::start("Tend:computePseudoThickAux", 2);
-   parallelForOuter(
-       "computePseudoThickAux", {Mesh->NEdgesAll},
-       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-          PseudoThicknessAux.computeVarsOnEdge(Team, IEdge, PseudoThickCell,
-                                               NormalVelEdge);
-       });
-   Pacer::stop("Tend:computePseudoThickAux", 2);
+   AuxState->computePseudoThicknessAux(State, TracerArray, ThickTimeLevel,
+                                       VelTimeLevel, ProjDt);
 
    computePseudoThicknessTendenciesOnly(State, AuxState, ThickTimeLevel,
                                         VelTimeLevel, Time);

--- a/components/omega/src/ocn/Tendencies.cpp
+++ b/components/omega/src/ocn/Tendencies.cpp
@@ -670,19 +670,6 @@ void Tendencies::computePseudoThicknessTendenciesOnly(
 
    Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
 
-   computePseudoThicknessTendenciesOnly(State, AuxState, ThickTimeLevel,
-                                        VelTimeLevel, NormalVelEdge, Time);
-}
-
-void Tendencies::computePseudoThicknessTendenciesOnly(
-    const OceanState *State,          ///< [in] State variables
-    const AuxiliaryState *AuxState,   ///< [in] Auxilary state variables
-    int ThickTimeLevel,               ///< [in] Time level
-    int VelTimeLevel,                 ///< [in] Time level
-    const Array2DReal &NormalVelEdge, ///< [in] normal velocity on edges
-    TimeInstant Time                  ///< [in] Time
-) {
-
    OMEGA_SCOPE(LocPseudoThicknessTend, PseudoThicknessTend);
    OMEGA_SCOPE(LocThicknessFluxDiv, PseudoThicknessFluxDiv);
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
@@ -924,21 +911,8 @@ void Tendencies::computeTracerTendenciesOnly(
     int VelTimeLevel,               ///< [in] Time level
     TimeInstant Time                ///< [in] Time
 ) {
-
    Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
-   computeTracerTendenciesOnly(State, AuxState, TracerArray, ThickTimeLevel,
-                               NormalVelEdge, Time, TimeStep);
-}
 
-void Tendencies::computeTracerTendenciesOnly(
-    const OceanState *State,          ///< [in] State variables
-    const AuxiliaryState *AuxState,   ///< [in] Auxilary state variables
-    const Array3DReal &TracerArray,   ///< [in] Tracer array
-    int ThickTimeLevel,               ///< [in] Time level
-    const Array2DReal &NormalVelEdge, ///< [in] normal velocity on edges
-    TimeInstant Time,                 ///< [in] Time
-    const TimeInterval ProjDt         ///< [in] projection time interval
-) {
    OMEGA_SCOPE(LocTracerTend, TracerTend);
    OMEGA_SCOPE(LocTracerHorzAdv, TracerHorzAdv);
    OMEGA_SCOPE(LocTracerDiffusion, TracerDiffusion);
@@ -1022,7 +996,7 @@ void Tendencies::computeTracerTendenciesOnly(
       ThicknessForVAdv = AuxState->PseudoThicknessAux.ProvPseudoThickness;
    }
    VAdv->computeTracerVAdvTend(LocTracerTend, TracerArray, ThicknessForVAdv,
-                               ProjDt);
+                               TimeStep);
    Pacer::stop("Tend:computeTracerVAdvTend", 2);
 
    // compute tracer surface restoring

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -95,9 +95,7 @@ class Tendencies {
    std::string Name;
 
    /// Configure the velocity tendency for a mode-split time stepper
-   void setModeSplit(CoriolisTendMode Mode,
-                     Real SplitFactorIn
-   );
+   void setModeSplit(CoriolisTendMode Mode, Real SplitFactorIn);
 
    // Methods to compute tendency groups
    void computePseudoThicknessTendencies(const OceanState *State,
@@ -151,6 +149,12 @@ class Tendencies {
                                     const TimeInterval ProjDt);
    void computeCoriolisAccelerationOnEdge(
        const Array2DReal &Tend,          ///< [inout] velocity tendency
+       const Array2DReal &NormalVelEdge, ///< [in] normal velocity on edges
+       const Array1DReal &FEdge          ///< [in] Coriolis parameter on edges
+   ) const;
+   void computeCoriolisAccelerationOnEdge(
+       const Array2DReal &Tend,          ///< [out] base plus Coriolis tendency
+       const Array2DReal &BaseTend,      ///< [in] tendency without Coriolis
        const Array2DReal &NormalVelEdge, ///< [in] normal velocity on edges
        const Array1DReal &FEdge          ///< [in] Coriolis parameter on edges
    ) const;

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -84,8 +84,9 @@ class Tendencies {
    // Methods to compute tendency groups
    void computePseudoThicknessTendencies(const OceanState *State,
                                          const AuxiliaryState *AuxState,
+                                         const Array3DReal &TracerArray,
                                          int ThickTimeLevel, int VelTimeLevel,
-                                         TimeInstant Time);
+                                         TimeInstant Time, TimeInterval ProjDt);
    void computeVelocityTendencies(const OceanState *State,
                                   const AuxiliaryState *AuxState,
                                   const Array3DReal &TracerArray,

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -68,6 +68,7 @@ class Tendencies {
    // Instances of tendency terms
    PseudoThicknessFluxDivOnCell PseudoThicknessFluxDiv;
    PotentialVortHAdvOnEdge PotentialVortHAdv;
+   CoriolisAccelerationOnEdge CoriolisAcceleration;
    KEGradOnEdge KEGrad;
    SSHGradOnEdge SSHGrad;
    VelocityDiffusionOnEdge VelocityDiffusion;
@@ -108,16 +109,49 @@ class Tendencies {
                                              int ThickTimeLevel,
                                              int VelTimeLevel,
                                              TimeInstant Time);
+   void computePseudoThicknessTendenciesOnly(const OceanState *State,
+                                             const AuxiliaryState *AuxState,
+                                             int ThickTimeLevel,
+                                             int VelTimeLevel,
+                                             const Array2DReal &NormalVelEdge,
+                                             TimeInstant Time);
    void computeVelocityTendenciesOnly(const OceanState *State,
                                       const AuxiliaryState *AuxState,
                                       const Array3DReal &TracerArray,
                                       int ThickTimeLevel, int VelTimeLevel,
                                       int TracerTimeLevel, TimeInstant Time);
+   void computeBaroclinicVelocityTendencies(
+       const OceanState *State, const AuxiliaryState *AuxState,
+       const Array3DReal &TracerArray, int ThickTimeLevel, int VelTimeLevel,
+       int BarotropicVelocityTimeLevel, int BarotropicPressureTimeLevel,
+       Real SplitFactor, TimeInstant Time, TimeInterval ProjDt);
+   void computeBaroclinicVelocityTendenciesOnly(
+       const OceanState *State, const AuxiliaryState *AuxState,
+       const Array3DReal &TracerArray, int ThickTimeLevel, int VelTimeLevel,
+       int BarotropicVelocityTimeLevel, int BarotropicPressureTimeLevel,
+       Real SplitFactor, TimeInstant Time);
    void computeTracerTendenciesOnly(const OceanState *State,
                                     const AuxiliaryState *AuxState,
                                     const Array3DReal &TracerArray,
                                     int ThickTimeLevel, int VelTimeLevel,
                                     TimeInstant Time);
+   void computeTracerTendenciesOnly(const OceanState *State,
+                                    const AuxiliaryState *AuxState,
+                                    const Array3DReal &TracerArray,
+                                    int ThickTimeLevel,
+                                    const Array2DReal &NormalVelEdge,
+                                    TimeInstant Time,
+                                    const TimeInterval ProjDt);
+   void computeCoriolisAccelerationOnEdge(
+       const Array2DReal &Tend,          ///< [inout] velocity tendency
+       const Array2DReal &NormalVelEdge, ///< [in] normal velocity on edges
+       const Array1DReal &FEdge          ///< [in] Coriolis parameter on edges
+   ) const;
+   void computeCoriolisAccelerationOnEdge(
+       const Array1DReal &Tend, ///< [inout] barotropic velocity tendency
+       const Array1DReal &NormalVelEdge, ///< [in] normal velocity on edges
+       const Array1DReal &FEdge          ///< [in] Coriolis parameter on edges
+   ) const;
 
    // Create a non-default group of tendencies
    static Tendencies *

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -53,6 +53,12 @@
 
 namespace OMEGA {
 
+/// Describes how the Coriolis force enters the normal velocity tendency.
+enum class CoriolisTendMode {
+   PVFlux,  ///< planetary vorticity carried inside the PV flux term (default)
+   Separate ///< relative vorticity only, Coriolis applied by the time stepper
+};
+
 /// A class that can be used to calculate the thickness,
 /// velocity, and tracer tendencies within the timestepping algorithm.
 class Tendencies {
@@ -80,7 +86,18 @@ class Tendencies {
    TracerHyperDiffOnCell TracerHyperDiff;
    SurfaceTracerRestoringOnCell SurfaceTracerRestoring;
 
+   /// Mode-split configuration of the velocity tendency
+   ///  - Coriolis treatment in the vorticity flux term
+   CoriolisTendMode CoriolisMode = CoriolisTendMode::PVFlux;
+   //   - The split factor for the barotropic pressure anomaly gradient
+   Real SplitFactor = 0._Real;
+
    std::string Name;
+
+   /// Configure the velocity tendency for a mode-split time stepper
+   void setModeSplit(CoriolisTendMode Mode,
+                     Real SplitFactorIn
+   );
 
    // Methods to compute tendency groups
    void computePseudoThicknessTendencies(const OceanState *State,
@@ -120,16 +137,6 @@ class Tendencies {
                                       const Array3DReal &TracerArray,
                                       int ThickTimeLevel, int VelTimeLevel,
                                       int TracerTimeLevel, TimeInstant Time);
-   void computeBaroclinicVelocityTendencies(
-       const OceanState *State, const AuxiliaryState *AuxState,
-       const Array3DReal &TracerArray, int ThickTimeLevel, int VelTimeLevel,
-       int BarotropicVelocityTimeLevel, int BarotropicPressureTimeLevel,
-       Real SplitFactor, TimeInstant Time, TimeInterval ProjDt);
-   void computeBaroclinicVelocityTendenciesOnly(
-       const OceanState *State, const AuxiliaryState *AuxState,
-       const Array3DReal &TracerArray, int ThickTimeLevel, int VelTimeLevel,
-       int BarotropicVelocityTimeLevel, int BarotropicPressureTimeLevel,
-       Real SplitFactor, TimeInstant Time);
    void computeTracerTendenciesOnly(const OceanState *State,
                                     const AuxiliaryState *AuxState,
                                     const Array3DReal &TracerArray,

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -124,12 +124,6 @@ class Tendencies {
                                              int ThickTimeLevel,
                                              int VelTimeLevel,
                                              TimeInstant Time);
-   void computePseudoThicknessTendenciesOnly(const OceanState *State,
-                                             const AuxiliaryState *AuxState,
-                                             int ThickTimeLevel,
-                                             int VelTimeLevel,
-                                             const Array2DReal &NormalVelEdge,
-                                             TimeInstant Time);
    void computeVelocityTendenciesOnly(const OceanState *State,
                                       const AuxiliaryState *AuxState,
                                       const Array3DReal &TracerArray,
@@ -140,13 +134,6 @@ class Tendencies {
                                     const Array3DReal &TracerArray,
                                     int ThickTimeLevel, int VelTimeLevel,
                                     TimeInstant Time);
-   void computeTracerTendenciesOnly(const OceanState *State,
-                                    const AuxiliaryState *AuxState,
-                                    const Array3DReal &TracerArray,
-                                    int ThickTimeLevel,
-                                    const Array2DReal &NormalVelEdge,
-                                    TimeInstant Time,
-                                    const TimeInterval ProjDt);
    void computeCoriolisAccelerationOnEdge(
        const Array2DReal &Tend,          ///< [inout] velocity tendency
        const Array2DReal &NormalVelEdge, ///< [in] normal velocity on edges

--- a/components/omega/src/ocn/Tendencies.h
+++ b/components/omega/src/ocn/Tendencies.h
@@ -97,7 +97,7 @@ class Tendencies {
                                 const AuxiliaryState *AuxState,
                                 const Array3DReal &TracerArray,
                                 int ThickTimeLevel, int VelTimeLevel,
-                                TimeInstant Time);
+                                TimeInstant Time, TimeInterval ProjDt);
    void computeAllTendencies(const OceanState *State,
                              const AuxiliaryState *AuxState,
                              const Array3DReal &TracerArray, int ThickTimeLevel,

--- a/components/omega/src/ocn/TendencyTerms.cpp
+++ b/components/omega/src/ocn/TendencyTerms.cpp
@@ -34,6 +34,13 @@ PotentialVortHAdvOnEdge::PotentialVortHAdvOnEdge(const HorzMesh *Mesh,
       EdgeMask(VCoord->EdgeMask), MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
       MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
 
+CoriolisAccelerationOnEdge::CoriolisAccelerationOnEdge(const HorzMesh *Mesh,
+                                                       const VertCoord *VCoord)
+    : NEdgesOnEdge(Mesh->NEdgesOnEdge), EdgesOnEdge(Mesh->EdgesOnEdge),
+      WeightsOnEdge(Mesh->WeightsOnEdge),
+      MinLayerEdgeBot(VCoord->MinLayerEdgeBot),
+      MaxLayerEdgeTop(VCoord->MaxLayerEdgeTop) {}
+
 KEGradOnEdge::KEGradOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord)
     : CellsOnEdge(Mesh->CellsOnEdge), DcEdge(Mesh->DcEdge),
       EdgeMask(VCoord->EdgeMask), MinLayerEdgeBot(VCoord->MinLayerEdgeBot),

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -129,32 +129,37 @@ class PotentialVortHAdvOnEdge {
 
    /// Relative vorticity horizontal advection without Coriolis. Used for the
    /// split-explicit baroclinic velocity forcing term.
-   KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
+   KOKKOS_FUNCTION void operator()(const TeamMember &Team,
+                                   const Array2DReal &Tend, I4 IEdge,
                                    const Array2DReal &NormRVortEdge,
                                    const Array2DReal &FluxPseudoThickEdge,
                                    const Array2DReal &NormVelEdge) const {
 
-      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
-      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
-      Real VortTmp[VecLength] = {0};
+      ScratchArray1DReal VortTmp(teamScratch(Team), NVertLayers);
+
+      const int KMin = MinLayerEdgeBot(IEdge);
+      const int KMax = MaxLayerEdgeTop(IEdge);
+
+      parallelForInner(
+          Team, NVertLayers, INNER_LAMBDA(int K) { VortTmp(K) = 0; });
 
       for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
-         const I4 JEdge = EdgesOnEdge(IEdge, J);
-         for (int KVec = 0; KVec < KLen; ++KVec) {
-            const I4 K = KStart + KVec;
-            const Real NormVort =
-                (NormRVortEdge(IEdge, K) + NormRVortEdge(JEdge, K)) * 0.5_Real;
+         I4 JEdge = EdgesOnEdge(IEdge, J);
+         parallelForInner(
+             Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
+                const Real NormVort =
+                    (NormRVortEdge(IEdge, K) + NormRVortEdge(JEdge, K)) * 0.5_Real;
 
-            VortTmp[KVec] += WeightsOnEdge(IEdge, J) *
-                             FluxPseudoThickEdge(JEdge, K) *
-                             NormVelEdge(JEdge, K) * NormVort;
-         }
+                VortTmp(K) += WeightsOnEdge(IEdge, J) *
+                              FluxPseudoThickEdge(JEdge, K) *
+                              NormVelEdge(JEdge, K) * NormVort;
+             });
       }
 
-      for (int KVec = 0; KVec < KLen; ++KVec) {
-         const I4 K = KStart + KVec;
-         Tend(IEdge, K) += EdgeMask(IEdge, K) * VortTmp[KVec];
-      }
+      parallelForInner(
+          Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
+             Tend(IEdge, K) += EdgeMask(IEdge, K) * VortTmp(K);
+          });
    }
 
  private:
@@ -291,46 +296,6 @@ class SSHGradOnEdge {
              Tend(IEdge, K) -= EdgeMask(IEdge, K) * Gravity *
                                (SshCell(ICell1) - SshCell(ICell0)) * InvDcEdge;
           });
-   }
-
-   /// Computes depth-mean specific volume times the barotropic pressure
-   /// gradient on edges.
-   KOKKOS_FUNCTION void operator()(const Array1DReal &Tend, I4 IEdge,
-                                   const Array1DReal &BtrPressAnomaly,
-                                   const Array1DReal &DepthMeanSpecVol) const {
-
-      const I4 JCell0      = CellsOnEdge(IEdge, 0);
-      const I4 JCell1      = CellsOnEdge(IEdge, 1);
-      const Real InvDcEdge = 1._Real / DcEdge(IEdge);
-      const Real MeanSpecVol =
-          0.5_Real * (DepthMeanSpecVol(JCell0) + DepthMeanSpecVol(JCell1));
-
-      Tend(IEdge) += MeanSpecVol *
-                     (BtrPressAnomaly(JCell1) - BtrPressAnomaly(JCell0)) *
-                     InvDcEdge;
-   }
-
-   /// Computes depth-mean specific volume times the barotropic pressure
-   /// gradient on edges and adds it to every active vertical layer.
-   KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
-                                   const Array1DReal &BtrPressAnomaly,
-                                   const Array1DReal &DepthMeanSpecVol) const {
-
-      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
-      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
-      const I4 JCell0 = CellsOnEdge(IEdge, 0);
-      const I4 JCell1 = CellsOnEdge(IEdge, 1);
-      const Real InvDcEdge = 1._Real / DcEdge(IEdge);
-      const Real MeanSpecVol =
-          0.5_Real * (DepthMeanSpecVol(JCell0) + DepthMeanSpecVol(JCell1));
-      const Real BtrPressGradTend =
-          MeanSpecVol * (BtrPressAnomaly(JCell1) - BtrPressAnomaly(JCell0)) *
-          InvDcEdge;
-
-      for (int KVec = 0; KVec < KLen; ++KVec) {
-         const I4 K = KStart + KVec;
-         Tend(IEdge, K) += EdgeMask(IEdge, K) * BtrPressGradTend;
-      }
    }
 
  private:

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -127,12 +127,99 @@ class PotentialVortHAdvOnEdge {
           });
    }
 
+   /// Relative vorticity horizontal advection without Coriolis. Used for the
+   /// split-explicit baroclinic velocity forcing term.
+   KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
+                                   const Array2DReal &NormRVortEdge,
+                                   const Array2DReal &FluxPseudoThickEdge,
+                                   const Array2DReal &NormVelEdge) const {
+
+      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
+      Real VortTmp[VecLength] = {0};
+
+      for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
+         const I4 JEdge = EdgesOnEdge(IEdge, J);
+         for (int KVec = 0; KVec < KLen; ++KVec) {
+            const I4 K = KStart + KVec;
+            const Real NormVort =
+                (NormRVortEdge(IEdge, K) + NormRVortEdge(JEdge, K)) * 0.5_Real;
+
+            VortTmp[KVec] += WeightsOnEdge(IEdge, J) *
+                             FluxPseudoThickEdge(JEdge, K) *
+                             NormVelEdge(JEdge, K) * NormVort;
+         }
+      }
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K = KStart + KVec;
+         Tend(IEdge, K) += EdgeMask(IEdge, K) * VortTmp[KVec];
+      }
+   }
+
  private:
    Array1DI4 NEdgesOnEdge;
    Array2DI4 EdgesOnEdge;
    Array2DReal WeightsOnEdge;
    I4 NVertLayers;
    Array2DReal EdgeMask;
+   Array1DI4 MinLayerEdgeBot;
+   Array1DI4 MaxLayerEdgeTop;
+};
+
+/// Coriolis acceleration on edges, f times tangential velocity reconstruction
+class CoriolisAccelerationOnEdge {
+ public:
+   /// constructor declaration
+   CoriolisAccelerationOnEdge(const HorzMesh *Mesh, const VertCoord *VCoord);
+
+   /// The functor takes edge index, vertical chunk index, velocity on edges,
+   /// and Coriolis parameter on edges as inputs, updates the tendency array
+   KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
+                                   const Array2DReal &NormalVelEdge,
+                                   const Array1DReal &FEdge) const {
+
+      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
+
+      Real AccelTmp[VecLength] = {0};
+
+      for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
+         const I4 JEdge = EdgesOnEdge(IEdge, J);
+         for (int KVec = 0; KVec < KLen; ++KVec) {
+            const I4 K = KStart + KVec;
+            AccelTmp[KVec] += WeightsOnEdge(IEdge, J) *
+                              NormalVelEdge(JEdge, K) * FEdge(JEdge);
+         }
+      }
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K = KStart + KVec;
+         Tend(IEdge, K) += AccelTmp[KVec];
+      }
+   }
+
+   /// The functor takes edge index, barotropic velocity on edges, and Coriolis
+   /// parameter on edges as inputs, updates the barotropic tendency array
+   KOKKOS_FUNCTION void operator()(const Array1DReal &Tend, I4 IEdge,
+                                   const Array1DReal &NormalVelEdge,
+                                   const Array1DReal &FEdge) const {
+
+      Real AccelTmp = 0._Real;
+
+      for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
+         const I4 JEdge = EdgesOnEdge(IEdge, J);
+         AccelTmp +=
+             WeightsOnEdge(IEdge, J) * NormalVelEdge(JEdge) * FEdge(JEdge);
+      }
+
+      Tend(IEdge) += AccelTmp;
+   }
+
+ private:
+   Array1DI4 NEdgesOnEdge;
+   Array2DI4 EdgesOnEdge;
+   Array2DReal WeightsOnEdge;
    Array1DI4 MinLayerEdgeBot;
    Array1DI4 MaxLayerEdgeTop;
 };
@@ -204,6 +291,46 @@ class SSHGradOnEdge {
              Tend(IEdge, K) -= EdgeMask(IEdge, K) * Gravity *
                                (SshCell(ICell1) - SshCell(ICell0)) * InvDcEdge;
           });
+   }
+
+   /// Computes depth-mean specific volume times the barotropic pressure
+   /// gradient on edges.
+   KOKKOS_FUNCTION void operator()(const Array1DReal &Tend, I4 IEdge,
+                                   const Array1DReal &BtrPressAnomaly,
+                                   const Array1DReal &DepthMeanSpecVol) const {
+
+      const I4 JCell0      = CellsOnEdge(IEdge, 0);
+      const I4 JCell1      = CellsOnEdge(IEdge, 1);
+      const Real InvDcEdge = 1._Real / DcEdge(IEdge);
+      const Real MeanSpecVol =
+          0.5_Real * (DepthMeanSpecVol(JCell0) + DepthMeanSpecVol(JCell1));
+
+      Tend(IEdge) += MeanSpecVol *
+                     (BtrPressAnomaly(JCell1) - BtrPressAnomaly(JCell0)) *
+                     InvDcEdge;
+   }
+
+   /// Computes depth-mean specific volume times the barotropic pressure
+   /// gradient on edges and adds it to every active vertical layer.
+   KOKKOS_FUNCTION void operator()(const Array2DReal &Tend, I4 IEdge, I4 KChunk,
+                                   const Array1DReal &BtrPressAnomaly,
+                                   const Array1DReal &DepthMeanSpecVol) const {
+
+      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
+      const I4 JCell0 = CellsOnEdge(IEdge, 0);
+      const I4 JCell1 = CellsOnEdge(IEdge, 1);
+      const Real InvDcEdge = 1._Real / DcEdge(IEdge);
+      const Real MeanSpecVol =
+          0.5_Real * (DepthMeanSpecVol(JCell0) + DepthMeanSpecVol(JCell1));
+      const Real BtrPressGradTend =
+          MeanSpecVol * (BtrPressAnomaly(JCell1) - BtrPressAnomaly(JCell0)) *
+          InvDcEdge;
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K = KStart + KVec;
+         Tend(IEdge, K) += EdgeMask(IEdge, K) * BtrPressGradTend;
+      }
    }
 
  private:

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -148,7 +148,8 @@ class PotentialVortHAdvOnEdge {
          parallelForInner(
              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
                 const Real NormVort =
-                    (NormRVortEdge(IEdge, K) + NormRVortEdge(JEdge, K)) * 0.5_Real;
+                    (NormRVortEdge(IEdge, K) + NormRVortEdge(JEdge, K)) *
+                    0.5_Real;
 
                 VortTmp(K) += WeightsOnEdge(IEdge, J) *
                               FluxPseudoThickEdge(JEdge, K) *

--- a/components/omega/src/ocn/TendencyTerms.h
+++ b/components/omega/src/ocn/TendencyTerms.h
@@ -204,6 +204,33 @@ class CoriolisAccelerationOnEdge {
       }
    }
 
+   /// As above, but writes BaseTend plus the Coriolis acceleration into a
+   /// separate output array instead of accumulating in place.
+   KOKKOS_FUNCTION void operator()(const Array2DReal &Tend,
+                                   const Array2DReal &BaseTend, I4 IEdge,
+                                   I4 KChunk, const Array2DReal &NormalVelEdge,
+                                   const Array1DReal &FEdge) const {
+
+      const I4 KStart = chunkStart(KChunk, MinLayerEdgeBot(IEdge));
+      const I4 KLen   = chunkLength(KChunk, KStart, MaxLayerEdgeTop(IEdge));
+
+      Real AccelTmp[VecLength] = {0};
+
+      for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
+         const I4 JEdge = EdgesOnEdge(IEdge, J);
+         for (int KVec = 0; KVec < KLen; ++KVec) {
+            const I4 K = KStart + KVec;
+            AccelTmp[KVec] += WeightsOnEdge(IEdge, J) *
+                              NormalVelEdge(JEdge, K) * FEdge(JEdge);
+         }
+      }
+
+      for (int KVec = 0; KVec < KLen; ++KVec) {
+         const I4 K     = KStart + KVec;
+         Tend(IEdge, K) = BaseTend(IEdge, K) + AccelTmp[KVec];
+      }
+   }
+
    /// The functor takes edge index, barotropic velocity on edges, and Coriolis
    /// parameter on edges as inputs, updates the barotropic tendency array
    KOKKOS_FUNCTION void operator()(const Array1DReal &Tend, I4 IEdge,

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -71,14 +71,22 @@ VertAdv::VertAdv(const std::string &Name_,  //< [in] name for new VertAdv
    // Allocate member arrays
    VerticalPseudoVelocity =
        Array2DReal("VerticalPseudoVelocity", NCellsSize, NVertLayersP1);
+   VerticalTransportPseudoVelocity = Array2DReal(
+       "VerticalTransportPseudoVelocity", NCellsSize, NVertLayersP1);
    TotalVerticalPseudoVelocity =
        Array2DReal("TotalVerticalPseudoVelocity", NCellsSize, NVertLayersP1);
+   TotalVerticalTransportPseudoVelocity = Array2DReal(
+       "TotalVerticalTransportPseudoVelocity", NCellsSize, NVertLayersP1);
    VertFlux = Array3DReal("VertFlux", NTracers, NCellsSize, NVertLayersP1);
 
    // Allocate host copies
    VerticalPseudoVelocityH = createHostMirrorCopy(VerticalPseudoVelocity);
+   VerticalTransportPseudoVelocityH =
+       createHostMirrorCopy(VerticalTransportPseudoVelocity);
    TotalVerticalPseudoVelocityH =
        createHostMirrorCopy(TotalVerticalPseudoVelocity);
+   TotalVerticalTransportPseudoVelocityH =
+       createHostMirrorCopy(TotalVerticalTransportPseudoVelocity);
    VertFluxH = createHostMirrorCopy(VertFlux);
 
    // Low-order flux array only needed for flux-corrected transport
@@ -128,10 +136,14 @@ VertAdv *VertAdv::create(const std::string &Name, //< [in] name for new VertAdv
 void VertAdv::defineFields() {
 
    // set field names (append Name if not default)
-   VerticalPseudoVelocityFldName  = "VerticalPseudoVelocity";
-   TotalVertPseudoVelocityFldName = "TotalVerticalPseudoVelocity";
-   VertFluxFldName                = "VertFlux";
-   LowOrderVertFluxFldName        = "LowOrderVertFlux";
+   VerticalPseudoVelocityFldName = VerticalPseudoVelocity.label();
+   VerticalTransportPseudoVelocityFldName =
+       VerticalTransportPseudoVelocity.label();
+   TotalVertPseudoVelocityFldName = TotalVerticalPseudoVelocity.label();
+   TotalVertTransportPseudoVelocityFldName =
+       TotalVerticalTransportPseudoVelocity.label();
+   VertFluxFldName         = "VertFlux";
+   LowOrderVertFluxFldName = "LowOrderVertFlux";
 
    if (Name != "Default") {
       VerticalPseudoVelocityFldName.append(Name);
@@ -158,6 +170,20 @@ void VertAdv::defineFields() {
        DimNames                          // dimension names
    );
 
+   auto VerticalTransportPseudoVelocityField =
+       Field::create(VerticalTransportPseudoVelocityFldName, // field name
+                     "Vertical transport pseudo-velocity across a "
+                     "pseudo-height surface",          // long name
+                                                       // or
+                                                       // description
+                     "m s^-1",                         // units
+                     "",                               // CF standard Name
+                     std::numeric_limits<Real>::min(), // min valid value
+                     std::numeric_limits<Real>::max(), // max valid value
+                     NDims,                            // number of dimensions
+                     DimNames                          // dimension names
+       );
+
    auto TotalVertPseudoVelocityField =
        Field::create(TotalVertPseudoVelocityFldName, // field name
                      "Total vertical pseudo-velocity across a moving, tilted "
@@ -169,6 +195,18 @@ void VertAdv::defineFields() {
                      NDims,                            // number of dimensions
                      DimNames                          // dimension names
        );
+
+   auto TotalVertTransportPseudoVelocityField = Field::create(
+       TotalVertTransportPseudoVelocityFldName, // field name
+       "Total vertical transport pseudo-velocity across a moving, tilted "
+       "pseudo-height surface",          // long name or description
+       "m s^-1",                         // units
+       "",                               // CF standard Name
+       std::numeric_limits<Real>::min(), // min valid value
+       std::numeric_limits<Real>::max(), // max valid value
+       NDims,                            // number of dimensions
+       DimNames                          // dimension names
+   );
 
    NDims = 3;
    DimNames.resize(NDims);
@@ -208,14 +246,20 @@ void VertAdv::defineFields() {
    auto VertAdvGroup = FieldGroup::create(GroupName);
 
    VertAdvGroup->addField(VerticalPseudoVelocityFldName);
+   VertAdvGroup->addField(VerticalTransportPseudoVelocityFldName);
    VertAdvGroup->addField(TotalVertPseudoVelocityFldName);
+   VertAdvGroup->addField(TotalVertTransportPseudoVelocityFldName);
    VertAdvGroup->addField(VertFluxFldName);
    VertAdvGroup->addField(LowOrderVertFluxFldName);
 
    // Associate Fields with data
    VerticalPseudoVelocityField->attachData<Array2DReal>(VerticalPseudoVelocity);
+   VerticalTransportPseudoVelocityField->attachData<Array2DReal>(
+       VerticalTransportPseudoVelocity);
    TotalVertPseudoVelocityField->attachData<Array2DReal>(
        TotalVerticalPseudoVelocity);
+   TotalVertTransportPseudoVelocityField->attachData<Array2DReal>(
+       TotalVerticalTransportPseudoVelocity);
    VertFluxField->attachData<Array3DReal>(VertFlux);
    LowOrderVertFluxField->attachData<Array3DReal>(LowOrderVertFlux);
 
@@ -227,7 +271,9 @@ VertAdv::~VertAdv() {
 
    if (FieldGroup::exists(GroupName)) {
       Field::destroy(VerticalPseudoVelocityFldName);
+      Field::destroy(VerticalTransportPseudoVelocityFldName);
       Field::destroy(TotalVertPseudoVelocityFldName);
+      Field::destroy(TotalVertTransportPseudoVelocityFldName);
       Field::destroy(VertFluxFldName);
       Field::destroy(LowOrderVertFluxFldName);
       FieldGroup::destroy(GroupName);

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -574,7 +574,7 @@ void VertAdv::computePseudoThicknessVAdvTend(
 
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
-   OMEGA_SCOPE(LocTotVertVelocity, TotalVerticalPseudoVelocity);
+   OMEGA_SCOPE(LocTotVertTransVel, TotalVerticalTransportPseudoVelocity);
 
    // Loop over every owned cell, pseudo-thickness tendency is simply
    // difference in pseudo velocity between bottom and top interface for
@@ -592,8 +592,8 @@ void VertAdv::computePseudoThicknessVAdvTend(
                  const I4 KLen   = chunkLength(KChunk, KStart, KMax);
                  for (int KVec = 0; KVec < KLen; ++KVec) {
                     const I4 K = KStart + KVec;
-                    ThickTend(ICell, K) += LocTotVertVelocity(ICell, K + 1) -
-                                           LocTotVertVelocity(ICell, K);
+                    ThickTend(ICell, K) += LocTotVertTransVel(ICell, K + 1) -
+                                           LocTotVertTransVel(ICell, K);
                  }
               });
        });
@@ -730,7 +730,7 @@ void VertAdv::computeVerticalFluxes(
 
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
-   OMEGA_SCOPE(LocTotVertVel, TotalVerticalPseudoVelocity);
+   OMEGA_SCOPE(LocTotVertTransVel, TotalVerticalTransportPseudoVelocity);
    OMEGA_SCOPE(LocVertFlux, VertFlux);
    OMEGA_SCOPE(LocLowOrderVertFlux, LowOrderVertFlux);
    OMEGA_SCOPE(LocCoef3rdOrder, Coef3rdOrder);
@@ -760,7 +760,7 @@ void VertAdv::computeVerticalFluxes(
                        const Real VerticalWeightKm1 =
                            PseudoThickness(ICell, K) * InvPseudoThickSum;
                        LocVertFlux(L, ICell, K) =
-                           LocTotVertVel(ICell, K) *
+                           LocTotVertTransVel(ICell, K) *
                            (VerticalWeightK * Tracers(L, ICell, K) +
                             VerticalWeightKm1 * Tracers(L, ICell, K - 1));
                     }
@@ -782,13 +782,13 @@ void VertAdv::computeVerticalFluxes(
                     for (int KVec = 0; KVec < KLen; ++KVec) {
                        const I4 K = KStart + KVec;
                        LocVertFlux(L, ICell, K) =
-                           (LocTotVertVel(ICell, K) *
+                           (LocTotVertTransVel(ICell, K) *
                                 (7._Real * (Tracers(L, ICell, K) +
                                             Tracers(L, ICell, K - 1)) -
                                  (Tracers(L, ICell, K + 1) +
                                   Tracers(L, ICell, K - 2))) -
                             LocCoef3rdOrder *
-                                std::abs(LocTotVertVel(ICell, K)) *
+                                std::abs(LocTotVertTransVel(ICell, K)) *
                                 ((Tracers(L, ICell, K + 1) -
                                   Tracers(L, ICell, K - 2)) -
                                  3._Real * (Tracers(L, ICell, K) -
@@ -813,7 +813,7 @@ void VertAdv::computeVerticalFluxes(
                     for (int KVec = 0; KVec < KLen; ++KVec) {
                        const I4 K = KStart + KVec;
                        LocVertFlux(L, ICell, K) =
-                           LocTotVertVel(ICell, K) *
+                           LocTotVertTransVel(ICell, K) *
                            (7._Real * (Tracers(L, ICell, K) +
                                        Tracers(L, ICell, K - 1)) -
                             (Tracers(L, ICell, K + 1) +
@@ -845,7 +845,7 @@ void VertAdv::computeVerticalFluxes(
              const Real VerticalWeightKm1 =
                  PseudoThickness(ICell, K) * InvPseudoThickSum;
              LocVertFlux(L, ICell, K) =
-                 LocTotVertVel(ICell, K) *
+                 LocTotVertTransVel(ICell, K) *
                  (VerticalWeightK * Tracers(L, ICell, K) +
                   VerticalWeightKm1 * Tracers(L, ICell, K - 1));
           }
@@ -871,9 +871,9 @@ void VertAdv::computeVerticalFluxes(
                     for (int KVec = 0; KVec < KLen; ++KVec) {
                        const I4 K = KStart + KVec;
                        LocLowOrderVertFlux(L, ICell, K) =
-                           Kokkos::min(0._Real, LocTotVertVel(ICell, K)) *
+                           Kokkos::min(0._Real, LocTotVertTransVel(ICell, K)) *
                                Tracers(L, ICell, K - 1) +
-                           Kokkos::max(0._Real, LocTotVertVel(ICell, K)) *
+                           Kokkos::max(0._Real, LocTotVertTransVel(ICell, K)) *
                                Tracers(L, ICell, K);
 
                        LocVertFlux(L, ICell, K) -=
@@ -932,7 +932,7 @@ void VertAdv::computeFCTVAdvTend(
 
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
-   OMEGA_SCOPE(LocTotVertVel, TotalVerticalPseudoVelocity);
+   OMEGA_SCOPE(LocTotVertTransVel, TotalVerticalTransportPseudoVelocity);
    OMEGA_SCOPE(LocVertFlux, VertFlux);
    OMEGA_SCOPE(LocLowOrderVertFlux, LowOrderVertFlux);
    OMEGA_SCOPE(LocNVertLayers, NVertLayers);
@@ -963,8 +963,8 @@ void VertAdv::computeFCTVAdvTend(
                     const I4 K = KStart + KVec;
                     InvNewProvThick(K) =
                         1._Real / (ProvPseudoThickness(ICell, K) +
-                                   Dt * (LocTotVertVel(ICell, K + 1) -
-                                         LocTotVertVel(ICell, K)));
+                                   Dt * (LocTotVertTransVel(ICell, K + 1) -
+                                         LocTotVertTransVel(ICell, K)));
                     Real TracerMax;
                     Real TracerMin;
                     // Determine bounds on tracer from neighbor values for

--- a/components/omega/src/ocn/VertAdv.cpp
+++ b/components/omega/src/ocn/VertAdv.cpp
@@ -422,12 +422,48 @@ void VertAdv::computeVerticalPseudoVelocity(
     const Real Dt                           //< [in] time interval
 ) {
 
+   computeVerticalPseudoVelocityImpl(
+       VerticalPseudoVelocity, TotalVerticalPseudoVelocity, NormalVelocity,
+       FluxPseudoThickEdge, PseudoThickness, Dt);
+
+} // end computeVerticalPseudoVelocity
+
+//------------------------------------------------------------------------------
+// Compute VerticalTransportPseudoVelocity and
+// TotalVerticalTransportPseudoVelocity from the horizontal transport velocity
+// (NormalTransportVelocity), the pseudo-thickness used for fluxes through edges
+// (FluxPseudoThickEdge), and the cell-based PseudoThickness.
+void VertAdv::computeVerticalTransportPseudoVelocity(
+    const Array2DReal
+        &NormalTransportVelocity, //< [in] horizontal transport velocity
+    const Array2DReal &FluxPseudoThickEdge, //< [in] pseudo-thickness at edges
+    const Array2DReal &PseudoThickness,     //< [in] pseudo-thickness of layer
+    const Real Dt                           //< [in] time interval
+) {
+
+   computeVerticalPseudoVelocityImpl(
+       VerticalTransportPseudoVelocity, TotalVerticalTransportPseudoVelocity,
+       NormalTransportVelocity, FluxPseudoThickEdge, PseudoThickness, Dt);
+
+} // end computeVerticalTransportPseudoVelocity
+
+//------------------------------------------------------------------------------
+// Compute VertPseudoVel and TotalVertPseudoVel from the
+// horizontal velocity (NormalVelocity), the pseudo-thickness used for fluxes
+// through edges (FluxPseudoThickEdge), and the cell-based PseudoThickness.
+void VertAdv::computeVerticalPseudoVelocityImpl(
+    const Array2DReal &VertPseudoVel,       ///< [out] vertical velocity
+    const Array2DReal &TotalVertPseudoVel,  ///< [out] total vertical velocity
+    const Array2DReal &NormalVelocity,      //< [in] horizontal velocity
+    const Array2DReal &FluxPseudoThickEdge, //< [in] pseudo-thickness at edges
+    const Array2DReal &PseudoThickness,     //< [in] pseudo-thickness of layer
+    const Real Dt                           //< [in] time interval
+) {
+
    // Return if mesh only has a single vertical layer
    if (NVertLayers == 1)
       return;
 
-   OMEGA_SCOPE(LocVertVel, VerticalPseudoVelocity);
-   OMEGA_SCOPE(LocTotVertVel, TotalVerticalPseudoVelocity);
    OMEGA_SCOPE(LocPseudoThickTarget, VCoord->PseudoThicknessTarget);
    OMEGA_SCOPE(LocNVertLayers, NVertLayers);
    OMEGA_SCOPE(LocAreaCell, Mesh->AreaCell);
@@ -484,10 +520,10 @@ void VertAdv::computeVerticalPseudoVelocity(
           // Set velocity through top and bottom interfaces to zero
           Kokkos::single(
               PerTeam(Team), INNER_LAMBDA() {
-                 LocVertVel(ICell, KMin)        = 0.;
-                 LocVertVel(ICell, KMax + 1)    = 0.;
-                 LocTotVertVel(ICell, KMin)     = 0.;
-                 LocTotVertVel(ICell, KMax + 1) = 0.;
+                 VertPseudoVel(ICell, KMin)          = 0.;
+                 VertPseudoVel(ICell, KMax + 1)      = 0.;
+                 TotalVertPseudoVel(ICell, KMin)     = 0.;
+                 TotalVertPseudoVel(ICell, KMax + 1) = 0.;
               });
           KRange = vertRange(KMin + 1, KMax);
 
@@ -499,12 +535,12 @@ void VertAdv::computeVerticalPseudoVelocity(
                  Accum -= DivHU(KRev);
 
                  if (IsFinal) {
-                    LocVertVel(ICell, KRev) = Accum;
+                    VertPseudoVel(ICell, KRev) = Accum;
                  }
               });
 
           // Add contribution to transport pseudo-velocity from movement of
-          // layer interfaces, store in TotalVerticalPseudoVelocity.
+          // layer interfaces, store in TotalVertPseudoVel.
           parallelScanInner(
               Team, KRange, INNER_LAMBDA(int K, Real &Accum, bool IsFinal) {
                  const I4 KRev      = KMax - K;
@@ -515,12 +551,12 @@ void VertAdv::computeVerticalPseudoVelocity(
                  Accum -= DivHU(KRev) + AleTerm;
 
                  if (IsFinal) {
-                    LocTotVertVel(ICell, KRev) = Accum;
+                    TotalVertPseudoVel(ICell, KRev) = Accum;
                  }
               });
        });
 
-} // end computeVerticalPseudoVelocity
+} // end computeVerticalPseudoVelocityImpl
 
 //------------------------------------------------------------------------------
 // Compute thickness tendency due to vertical advection

--- a/components/omega/src/ocn/VertAdv.h
+++ b/components/omega/src/ocn/VertAdv.h
@@ -63,14 +63,21 @@ class VertAdv {
    Real Coef3rdOrder;
 
    Array2DReal VerticalPseudoVelocity; ///< pseudo-velocity through top of cell
-   Array2DReal TotalVerticalPseudoVelocity; ///< transport pseudo-velocity
-                                            ///< through top of cell
-   Array3DReal VertFlux;                    ///< fluxes at vertical interfaces
-   Array3DReal LowOrderVertFlux;            ///< low-order fluxes for FCT
+   Array2DReal VerticalTransportPseudoVelocity; ///< transport pseudo-velocity
+                                                ///< through top of cell
+   Array2DReal TotalVerticalPseudoVelocity;     ///< total pseudo-velocity
+                                                ///< through top of cell
+   Array2DReal TotalVerticalTransportPseudoVelocity; ///< total transport
+                                                     ///< pseudo-velocity
+                                                     ///< through top of cell
+   Array3DReal VertFlux;         ///< fluxes at vertical interfaces
+   Array3DReal LowOrderVertFlux; ///< low-order fluxes for FCT
 
    // Arrays on host
    HostArray2DReal VerticalPseudoVelocityH;
+   HostArray2DReal VerticalTransportPseudoVelocityH;
    HostArray2DReal TotalVerticalPseudoVelocityH;
+   HostArray2DReal TotalVerticalTransportPseudoVelocityH;
    HostArray3DReal VertFluxH;
    HostArray3DReal LowOrderVertFluxH;
 
@@ -80,7 +87,9 @@ class VertAdv {
 
    // Field names
    std::string VerticalPseudoVelocityFldName;
+   std::string VerticalTransportPseudoVelocityFldName;
    std::string TotalVertPseudoVelocityFldName;
+   std::string TotalVertTransportPseudoVelocityFldName;
    std::string VertFluxFldName;
    std::string LowOrderVertFluxFldName;
 

--- a/components/omega/src/ocn/VertAdv.h
+++ b/components/omega/src/ocn/VertAdv.h
@@ -131,10 +131,22 @@ class VertAdv {
    /// Read and set config options
    void readConfigOptions(Config *Options);
 
-   /// Determine transport due to vertical advection from divergence of
-   /// horizontal advection and movement of vertical interfaces.
+   /// Determine pseudo-velocity for vertical advection of velocity from
+   /// divergence of horizontal velocity and movement of vertical interfaces.
    void computeVerticalPseudoVelocity(
        const Array2DReal &NormalVelocity, ///< [in] horizontal velocity
+       const Array2DReal
+           &FluxPseudoThickEdge,           ///< [in] pseudo-thickness at edges
+       const Array2DReal &PseudoThickness, ///< [in] pseudo-thickness of layer
+       const Real Dt                       ///< [in] time interval
+   );
+
+   /// Determine transport pseudo-velocity for vertical advection of
+   /// pseudo-thickness and tracers from divergence of horizontal transport
+   /// velocity and movement of vertical interfaces.
+   void computeVerticalTransportPseudoVelocity(
+       const Array2DReal
+           &NormalTransportVelocity, ///< [in] horizontal transport velocity
        const Array2DReal
            &FluxPseudoThickEdge,           ///< [in] pseudo-thickness at edges
        const Array2DReal &PseudoThickness, ///< [in] pseudo-thickness of layer
@@ -224,6 +236,18 @@ class VertAdv {
 
    /// define field metadata
    void defineFields();
+
+   /// implementation of vertical pseudo-velocity computation with output
+   /// arguments
+   void computeVerticalPseudoVelocityImpl(
+       const Array2DReal &VertPseudoVel,      ///< [out] vertical velocity
+       const Array2DReal &TotalVertPseudoVel, ///< [out] total vertical velocity
+       const Array2DReal &NormalVelocity,     ///< [in] horizontal velocity
+       const Array2DReal
+           &FluxPseudoThickEdge,           ///< [in] pseudo-thickness at edges
+       const Array2DReal &PseudoThickness, ///< [in] pseudo-thickness of layer
+       const Real Dt                       ///< [in] time interval
+   );
 
    // Forbid copy and move construction
    VertAdv(const VertAdv &) = delete;

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -150,10 +150,16 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    SurfacePressure = Array1DReal("SurfacePressure", NCellsSize);
    PressureInterface =
        Array2DReal("PressureInterface", NCellsSize, NVertLayersP1);
-   PressureMid     = Array2DReal("PressureMid", NCellsSize, NVertLayers);
-   GeomZInterface  = Array2DReal("GeomZInterface", NCellsSize, NVertLayersP1);
-   GeomZMid        = Array2DReal("GeomZMid", NCellsSize, NVertLayers);
-   SshCell         = Array1DReal("SshCell", NCellsSize);
+   PressureMid    = Array2DReal("PressureMid", NCellsSize, NVertLayers);
+   GeomZInterface = Array2DReal("GeomZInterface", NCellsSize, NVertLayersP1);
+   GeomZMid       = Array2DReal("GeomZMid", NCellsSize, NVertLayers);
+   SshCell        = Array1DReal("SshCell", NCellsSize);
+   TotalPseudoThickness    = Array1DReal("TotalPseudoThickness", NCellsSize);
+   TotalGeometricThickness = Array1DReal("TotalGeometricThickness", NCellsSize);
+   deepCopy(SshCell, 0._Real);
+   deepCopy(TotalPseudoThickness, 0._Real);
+   deepCopy(TotalGeometricThickness, 0._Real);
+
    GeopotentialMid = Array2DReal("GeopotentialMid", NCellsSize, NVertLayers);
    PseudoThicknessTarget =
        Array2DReal("PseudoThicknessTarget", NCellsSize, NVertLayers);
@@ -163,13 +169,15 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
        Array1DReal("VertCoordMovementWeights", NVertLayers);
 
    // Make host copies for device arrays not being read from file
-   PressureInterfaceH     = createHostMirrorCopy(PressureInterface);
-   PressureMidH           = createHostMirrorCopy(PressureMid);
-   SshCellH               = createHostMirrorCopy(SshCell);
-   GeomZInterfaceH        = createHostMirrorCopy(GeomZInterface);
-   GeomZMidH              = createHostMirrorCopy(GeomZMid);
-   GeopotentialMidH       = createHostMirrorCopy(GeopotentialMid);
-   PseudoThicknessTargetH = createHostMirrorCopy(PseudoThicknessTarget);
+   PressureInterfaceH       = createHostMirrorCopy(PressureInterface);
+   PressureMidH             = createHostMirrorCopy(PressureMid);
+   SshCellH                 = createHostMirrorCopy(SshCell);
+   GeomZInterfaceH          = createHostMirrorCopy(GeomZInterface);
+   GeomZMidH                = createHostMirrorCopy(GeomZMid);
+   GeopotentialMidH         = createHostMirrorCopy(GeopotentialMid);
+   PseudoThicknessTargetH   = createHostMirrorCopy(PseudoThicknessTarget);
+   TotalPseudoThicknessH    = createHostMirrorCopy(TotalPseudoThickness);
+   TotalGeometricThicknessH = createHostMirrorCopy(TotalGeometricThickness);
 
    // SurfacePressure is read from the initial-state/restart stream later, in
    // OceanInit; its host mirror is refreshed then by initSurfacePressure().
@@ -244,6 +252,8 @@ void VertCoord::defineFields() {
    GeopotFldName                = "GeopotentialMid";
    PseudoThicknessTargetFldName = "PseudoThicknessTarget";
    SurfacePressureFldName       = "SurfacePressure";
+   TotalPseudoThickFldName      = "TotalPseudoThickness";
+   TotalGeomThickFldName        = "TotalGeometricThickness";
 
    if (Name != "Default") {
       MinLayerCellFldName.append(Name);
@@ -259,6 +269,8 @@ void VertCoord::defineFields() {
       PseudoThicknessTargetFldName.append(Name);
       SshFldName.append(Name);
       SurfacePressureFldName.append(Name);
+      TotalPseudoThickFldName.append(Name);
+      TotalGeomThickFldName.append(Name);
    }
 
    // Create fields for VertCoord variables
@@ -327,6 +339,28 @@ void VertCoord::defineFields() {
    // SurfacePressure is optional in the initial-state/restart file; when it is
    // absent the read is skipped and it defaults to zero in initSurfacePressure.
    SurfacePressureField->setOptionalRead(true);
+
+   auto TotalPseudoThicknessField =
+       Field::create(TotalPseudoThickFldName,                      // field name
+                     "Total pseudo thickness in each cell column", // long name
+                     "m",                                          // units
+                     "",       // CF standard Name
+                     0.0,      // min valid value
+                     9.99E+10, // max valid value
+                     NDims,    // number of dimensions
+                     DimNames  // dimension names
+       );
+
+   auto TotalGeometricThicknessField = Field::create(
+       TotalGeomThickFldName,                           // field name
+       "Total geometric thickness in each cell column", // long name
+       "m",                                             // units
+       "",                                              // CF standard Name
+       0.0,                                             // min valid value
+       9.99E+10,                                        // max valid value
+       NDims,                                           // number of dimensions
+       DimNames                                         // dimension names
+   );
 
    NDims = 2;
    DimNames.resize(NDims);
@@ -467,6 +501,8 @@ void VertCoord::defineFields() {
    VCoordGroup->addField(GeopotFldName);
    VCoordGroup->addField(PseudoThicknessTargetFldName);
    VCoordGroup->addField(SshFldName);
+   VCoordGroup->addField(TotalPseudoThickFldName);
+   VCoordGroup->addField(TotalGeomThickFldName);
 
    // Associate Field with data
    PressureInterfaceField->attachData<Array2DReal>(PressureInterface);
@@ -476,6 +512,9 @@ void VertCoord::defineFields() {
    GeopotentialMidField->attachData<Array2DReal>(GeopotentialMid);
    PseudoThicknessTargetField->attachData<Array2DReal>(PseudoThicknessTarget);
    SshField->attachData<Array1DReal>(SshCell);
+   TotalPseudoThicknessField->attachData<Array1DReal>(TotalPseudoThickness);
+   TotalGeometricThicknessField->attachData<Array1DReal>(
+       TotalGeometricThickness);
 
    // Add SurfacePressure to the State and Restart groups so it is written to
    // the history/restart files and read from the initial-state and restart
@@ -520,6 +559,8 @@ VertCoord::~VertCoord() {
       Field::destroy(GeopotFldName);
       Field::destroy(PseudoThicknessTargetFldName);
       Field::destroy(SshFldName);
+      Field::destroy(TotalPseudoThickFldName);
+      Field::destroy(TotalGeomThickFldName);
       FieldGroup::destroy(GroupName);
    }
 
@@ -1056,6 +1097,8 @@ void VertCoord::computePressure(
     const Array1DReal &SurfacePressure  // [in] surface pressure
 ) {
 
+   computeTotalPseudoThickness(PseudoThickness);
+
    OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocPressInterf, PressureInterface);
@@ -1082,6 +1125,37 @@ void VertCoord::computePressure(
               });
        });
 } // end computePressure
+
+//------------------------------------------------------------------------------
+// Compute total pseudo thickness in each cell column.
+void VertCoord::computeTotalPseudoThickness(
+    const Array2DReal &PseudoThickness // [in] pseudo thickness
+) {
+
+   OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
+   OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
+   OMEGA_SCOPE(LocTotalPseudoThickness, TotalPseudoThickness);
+
+   parallelForOuter(
+       "computeTotalPseudoThickness", {NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          const I4 KMin = LocMinLayerCell(ICell);
+          const I4 KMax = LocMaxLayerCell(ICell);
+
+          Real ColumnThickness = 0._Real;
+          parallelReduceInner(
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(const int K, Real &Accum) {
+                 Accum += PseudoThickness(ICell, K);
+              },
+              ColumnThickness);
+
+          Kokkos::single(
+              PerTeam(Team), INNER_LAMBDA() {
+                 LocTotalPseudoThickness(ICell) = ColumnThickness;
+              });
+       });
+} // end computeTotalPseudoThickness
 
 //------------------------------------------------------------------------------
 // Compute geometric height z at layer interfaces and midpoints given the
@@ -1130,6 +1204,21 @@ void VertCoord::computeGeomZHeight(
 //------------------------------------------------------------------------------
 // Compute geopotential given GeomZMid, TidalPotential, and
 // SelfAttractionLoading.
+void VertCoord::computeTotalGeometricThickness(
+    const Array1DReal &DepthIntegSpecificVolume // [in]
+) {
+
+   OMEGA_SCOPE(LocTotalGeometricThickness, TotalGeometricThickness);
+
+   parallelFor(
+       "computeTotalGeometricThickness", {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+          LocTotalGeometricThickness(ICell) =
+              RhoSw * DepthIntegSpecificVolume(ICell);
+       });
+} // end computeTotalGeometricThickness
+
+//------------------------------------------------------------------------------
+// Compute geopotential given Zmid, TidalPotential, and SelfAttractionLoading.
 // Nested parallel_fors loop over all cells and all active layers in a column to
 // compute the geopotential at the midpoint of each layer. The tidal potential
 // and SAL are configurable, default-off features. When off these arrays will
@@ -1224,6 +1313,8 @@ void VertCoord::copyToHost() {
    deepCopy(GeomZInterfaceH, GeomZInterface);
    deepCopy(GeomZMidH, GeomZMid);
    deepCopy(SshCellH, SshCell);
+   deepCopy(TotalPseudoThicknessH, TotalPseudoThickness);
+   deepCopy(TotalGeometricThicknessH, TotalGeometricThickness);
    deepCopy(GeopotentialMidH, GeopotentialMid);
    deepCopy(PseudoThicknessTargetH, PseudoThicknessTarget);
    deepCopy(RefPseudoThicknessH, RefPseudoThickness);
@@ -1238,6 +1329,8 @@ void VertCoord::copyToDevice() {
    deepCopy(GeomZInterface, GeomZInterfaceH);
    deepCopy(GeomZMid, GeomZMidH);
    deepCopy(SshCell, SshCellH);
+   deepCopy(TotalPseudoThickness, TotalPseudoThicknessH);
+   deepCopy(TotalGeometricThickness, TotalGeometricThicknessH);
    deepCopy(GeopotentialMid, GeopotentialMidH);
    deepCopy(PseudoThicknessTarget, PseudoThicknessTargetH);
    deepCopy(RefPseudoThickness, RefPseudoThicknessH);

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -1077,8 +1077,6 @@ void VertCoord::computePressure(
     const Array1DReal &SurfacePressure  // [in] surface pressure
 ) {
 
-   computeTotalPseudoThickness(PseudoThickness);
-
    OMEGA_SCOPE(LocMinLayerCell, MinLayerCell);
    OMEGA_SCOPE(LocMaxLayerCell, MaxLayerCell);
    OMEGA_SCOPE(LocPressInterf, PressureInterface);

--- a/components/omega/src/ocn/VertCoord.cpp
+++ b/components/omega/src/ocn/VertCoord.cpp
@@ -154,11 +154,9 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
    GeomZInterface = Array2DReal("GeomZInterface", NCellsSize, NVertLayersP1);
    GeomZMid       = Array2DReal("GeomZMid", NCellsSize, NVertLayers);
    SshCell        = Array1DReal("SshCell", NCellsSize);
-   TotalPseudoThickness    = Array1DReal("TotalPseudoThickness", NCellsSize);
-   TotalGeometricThickness = Array1DReal("TotalGeometricThickness", NCellsSize);
+   TotalPseudoThickness = Array1DReal("TotalPseudoThickness", NCellsSize);
    deepCopy(SshCell, 0._Real);
    deepCopy(TotalPseudoThickness, 0._Real);
-   deepCopy(TotalGeometricThickness, 0._Real);
 
    GeopotentialMid = Array2DReal("GeopotentialMid", NCellsSize, NVertLayers);
    PseudoThicknessTarget =
@@ -169,15 +167,14 @@ VertCoord::VertCoord(const std::string &Name_, //< [in] Name for new VertCoord
        Array1DReal("VertCoordMovementWeights", NVertLayers);
 
    // Make host copies for device arrays not being read from file
-   PressureInterfaceH       = createHostMirrorCopy(PressureInterface);
-   PressureMidH             = createHostMirrorCopy(PressureMid);
-   SshCellH                 = createHostMirrorCopy(SshCell);
-   GeomZInterfaceH          = createHostMirrorCopy(GeomZInterface);
-   GeomZMidH                = createHostMirrorCopy(GeomZMid);
-   GeopotentialMidH         = createHostMirrorCopy(GeopotentialMid);
-   PseudoThicknessTargetH   = createHostMirrorCopy(PseudoThicknessTarget);
-   TotalPseudoThicknessH    = createHostMirrorCopy(TotalPseudoThickness);
-   TotalGeometricThicknessH = createHostMirrorCopy(TotalGeometricThickness);
+   PressureInterfaceH     = createHostMirrorCopy(PressureInterface);
+   PressureMidH           = createHostMirrorCopy(PressureMid);
+   SshCellH               = createHostMirrorCopy(SshCell);
+   GeomZInterfaceH        = createHostMirrorCopy(GeomZInterface);
+   GeomZMidH              = createHostMirrorCopy(GeomZMid);
+   GeopotentialMidH       = createHostMirrorCopy(GeopotentialMid);
+   PseudoThicknessTargetH = createHostMirrorCopy(PseudoThicknessTarget);
+   TotalPseudoThicknessH  = createHostMirrorCopy(TotalPseudoThickness);
 
    // SurfacePressure is read from the initial-state/restart stream later, in
    // OceanInit; its host mirror is refreshed then by initSurfacePressure().
@@ -253,7 +250,6 @@ void VertCoord::defineFields() {
    PseudoThicknessTargetFldName = "PseudoThicknessTarget";
    SurfacePressureFldName       = "SurfacePressure";
    TotalPseudoThickFldName      = "TotalPseudoThickness";
-   TotalGeomThickFldName        = "TotalGeometricThickness";
 
    if (Name != "Default") {
       MinLayerCellFldName.append(Name);
@@ -270,7 +266,6 @@ void VertCoord::defineFields() {
       SshFldName.append(Name);
       SurfacePressureFldName.append(Name);
       TotalPseudoThickFldName.append(Name);
-      TotalGeomThickFldName.append(Name);
    }
 
    // Create fields for VertCoord variables
@@ -350,17 +345,6 @@ void VertCoord::defineFields() {
                      NDims,    // number of dimensions
                      DimNames  // dimension names
        );
-
-   auto TotalGeometricThicknessField = Field::create(
-       TotalGeomThickFldName,                           // field name
-       "Total geometric thickness in each cell column", // long name
-       "m",                                             // units
-       "",                                              // CF standard Name
-       0.0,                                             // min valid value
-       9.99E+10,                                        // max valid value
-       NDims,                                           // number of dimensions
-       DimNames                                         // dimension names
-   );
 
    NDims = 2;
    DimNames.resize(NDims);
@@ -502,7 +486,6 @@ void VertCoord::defineFields() {
    VCoordGroup->addField(PseudoThicknessTargetFldName);
    VCoordGroup->addField(SshFldName);
    VCoordGroup->addField(TotalPseudoThickFldName);
-   VCoordGroup->addField(TotalGeomThickFldName);
 
    // Associate Field with data
    PressureInterfaceField->attachData<Array2DReal>(PressureInterface);
@@ -513,8 +496,6 @@ void VertCoord::defineFields() {
    PseudoThicknessTargetField->attachData<Array2DReal>(PseudoThicknessTarget);
    SshField->attachData<Array1DReal>(SshCell);
    TotalPseudoThicknessField->attachData<Array1DReal>(TotalPseudoThickness);
-   TotalGeometricThicknessField->attachData<Array1DReal>(
-       TotalGeometricThickness);
 
    // Add SurfacePressure to the State and Restart groups so it is written to
    // the history/restart files and read from the initial-state and restart
@@ -560,7 +541,6 @@ VertCoord::~VertCoord() {
       Field::destroy(PseudoThicknessTargetFldName);
       Field::destroy(SshFldName);
       Field::destroy(TotalPseudoThickFldName);
-      Field::destroy(TotalGeomThickFldName);
       FieldGroup::destroy(GroupName);
    }
 
@@ -1202,22 +1182,6 @@ void VertCoord::computeGeomZHeight(
 } // end computeGeomZHeight
 
 //------------------------------------------------------------------------------
-// Compute geopotential given GeomZMid, TidalPotential, and
-// SelfAttractionLoading.
-void VertCoord::computeTotalGeometricThickness(
-    const Array1DReal &DepthIntegSpecificVolume // [in]
-) {
-
-   OMEGA_SCOPE(LocTotalGeometricThickness, TotalGeometricThickness);
-
-   parallelFor(
-       "computeTotalGeometricThickness", {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
-          LocTotalGeometricThickness(ICell) =
-              RhoSw * DepthIntegSpecificVolume(ICell);
-       });
-} // end computeTotalGeometricThickness
-
-//------------------------------------------------------------------------------
 // Compute geopotential given Zmid, TidalPotential, and SelfAttractionLoading.
 // Nested parallel_fors loop over all cells and all active layers in a column to
 // compute the geopotential at the midpoint of each layer. The tidal potential
@@ -1314,7 +1278,6 @@ void VertCoord::copyToHost() {
    deepCopy(GeomZMidH, GeomZMid);
    deepCopy(SshCellH, SshCell);
    deepCopy(TotalPseudoThicknessH, TotalPseudoThickness);
-   deepCopy(TotalGeometricThicknessH, TotalGeometricThickness);
    deepCopy(GeopotentialMidH, GeopotentialMid);
    deepCopy(PseudoThicknessTargetH, PseudoThicknessTarget);
    deepCopy(RefPseudoThicknessH, RefPseudoThickness);
@@ -1330,7 +1293,6 @@ void VertCoord::copyToDevice() {
    deepCopy(GeomZMid, GeomZMidH);
    deepCopy(SshCell, SshCellH);
    deepCopy(TotalPseudoThickness, TotalPseudoThicknessH);
-   deepCopy(TotalGeometricThickness, TotalGeometricThicknessH);
    deepCopy(GeopotentialMid, GeopotentialMidH);
    deepCopy(PseudoThicknessTarget, PseudoThicknessTargetH);
    deepCopy(RefPseudoThickness, RefPseudoThicknessH);

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -101,7 +101,6 @@ class VertCoord {
    Array2DReal PseudoThicknessTarget;
    Array1DReal SshCell;
    Array1DReal TotalPseudoThickness;
-   Array1DReal TotalGeometricThickness;
 
    HostArray2DReal PressureInterfaceH;
    HostArray2DReal PressureMidH;
@@ -111,7 +110,6 @@ class VertCoord {
    HostArray2DReal PseudoThicknessTargetH;
    HostArray1DReal SshCellH;
    HostArray1DReal TotalPseudoThicknessH;
-   HostArray1DReal TotalGeometricThicknessH;
 
    // Vertical loop bounds
    Array1DI4 MinLayerCell;
@@ -205,8 +203,6 @@ class VertCoord {
    std::string SshFldName;              ///< Field name for sea surface height
    std::string SurfacePressureFldName;  ///< Field name for SurfacePressure
    std::string TotalPseudoThickFldName; ///< Field name for total pseudo
-                                        ///< thickness
-   std::string TotalGeomThickFldName;   ///< Field name for total geometric
                                         ///< thickness
 
    // methods
@@ -304,13 +300,6 @@ class VertCoord {
    void computeGeomZHeight(
        const Array2DReal &PseudoThickness, ///< [in] pseudo-thickness
        const Array2DReal &SpecVol);        ///< [in] specific volume
-
-   /// Compute total geometric column thickness from depth-integrated specific
-   /// volume
-   void computeTotalGeometricThickness(
-       const Array1DReal
-           &DepthIntegSpecificVolume ///< [in] depth-integrated specific volume
-   );
 
    /// Sum the geometric height times g, the tidal potential, and self
    /// attraction and loading

--- a/components/omega/src/ocn/VertCoord.h
+++ b/components/omega/src/ocn/VertCoord.h
@@ -100,6 +100,8 @@ class VertCoord {
    Array2DReal GeopotentialMid;
    Array2DReal PseudoThicknessTarget;
    Array1DReal SshCell;
+   Array1DReal TotalPseudoThickness;
+   Array1DReal TotalGeometricThickness;
 
    HostArray2DReal PressureInterfaceH;
    HostArray2DReal PressureMidH;
@@ -108,6 +110,8 @@ class VertCoord {
    HostArray2DReal GeopotentialMidH;
    HostArray2DReal PseudoThicknessTargetH;
    HostArray1DReal SshCellH;
+   HostArray1DReal TotalPseudoThicknessH;
+   HostArray1DReal TotalGeometricThicknessH;
 
    // Vertical loop bounds
    Array1DI4 MinLayerCell;
@@ -197,9 +201,13 @@ class VertCoord {
    std::string GeomZMidFldName; ///< Field name for midpoint geometric height
    std::string GeopotFldName;   ///< Field name for geopotential
    std::string
-       PseudoThicknessTargetFldName;   ///< Field name for target thickness
-   std::string SshFldName;             ///< Field name for sea surface height
-   std::string SurfacePressureFldName; ///< Field name for SurfacePressure
+       PseudoThicknessTargetFldName;    ///< Field name for target thickness
+   std::string SshFldName;              ///< Field name for sea surface height
+   std::string SurfacePressureFldName;  ///< Field name for SurfacePressure
+   std::string TotalPseudoThickFldName; ///< Field name for total pseudo
+                                        ///< thickness
+   std::string TotalGeomThickFldName;   ///< Field name for total geometric
+                                        ///< thickness
 
    // methods
 
@@ -286,11 +294,23 @@ class VertCoord {
        const Array1DReal &SurfacePressure  ///< [in] relative surface pressure
    );
 
+   /// Sum pseudo thickness vertically within each cell column
+   void computeTotalPseudoThickness(
+       const Array2DReal &PseudoThickness ///< [in] pseudo thickness
+   );
+
    /// Sum the mass thickness times specific volume from the bottom layer up,
    /// starting with the bottom elevation
    void computeGeomZHeight(
        const Array2DReal &PseudoThickness, ///< [in] pseudo-thickness
        const Array2DReal &SpecVol);        ///< [in] specific volume
+
+   /// Compute total geometric column thickness from depth-integrated specific
+   /// volume
+   void computeTotalGeometricThickness(
+       const Array1DReal
+           &DepthIntegSpecificVolume ///< [in] depth-integrated specific volume
+   );
 
    /// Sum the geometric height times g, the tidal potential, and self
    /// attraction and loading

--- a/components/omega/src/ocn/VertMix.cpp
+++ b/components/omega/src/ocn/VertMix.cpp
@@ -711,7 +711,7 @@ void VertMix::VertMixImplicit(OceanState *State, AuxiliaryState *AuxState,
    }
 
    // Update Pressure, SpecVol
-   AuxState->computeMomVertAux(State, TracerArray, TimeLevel, TimeLevel);
+   AuxState->computeMomVertAux(State, TracerArray, TimeLevel);
 
    // Compute Brunt-Vaisala frequency squared
    EqState->computeBruntVaisalaFreqSq(

--- a/components/omega/src/ocn/auxiliaryVars/TransportAuxVars.cpp
+++ b/components/omega/src/ocn/auxiliaryVars/TransportAuxVars.cpp
@@ -1,0 +1,57 @@
+#include "TransportAuxVars.h"
+#include "DataTypes.h"
+#include "Field.h"
+
+#include <limits>
+
+namespace OMEGA {
+
+TransportAuxVars::TransportAuxVars(const std::string &AuxStateSuffix,
+                                   const HorzMesh *Mesh,
+                                   const VertCoord *VCoord)
+    : NormalTransportVelocity("NormalTransportVelocity" + AuxStateSuffix,
+                              Mesh->NEdgesSize, VCoord->NVertLayers) {}
+
+void TransportAuxVars::registerFields(
+    const std::string &AuxGroupName, // name of Auxiliary field group
+    const std::string &MeshName      // name of horizontal mesh
+) const {
+
+   // Create/define fields
+   int NDims = 2;
+   std::vector<std::string> DimNames(NDims);
+   std::string DimSuffix;
+   if (MeshName == "Default") {
+      DimSuffix = "";
+   } else {
+      DimSuffix = MeshName;
+   }
+
+   DimNames[0] = "NEdges" + DimSuffix;
+   DimNames[1] = "NVertLayers";
+
+   auto NormalTransportVelocityField =
+       Field::create(NormalTransportVelocity.label(), // field name
+                     "horizontal velocity used to transport pseudo-thickness "
+                     "and tracers", // long Name or description
+                     "m/s",         // units
+                     "",            // CF standard Name
+                     std::numeric_limits<Real>::lowest(), // min valid value
+                     std::numeric_limits<Real>::max(),    // max valid value
+                     NDims,   // number of dimensions
+                     DimNames // dimension names
+       );
+
+   // Add fields to FieldGroup
+   FieldGroup::addFieldToGroup(NormalTransportVelocity.label(), AuxGroupName);
+
+   // Attach data
+   NormalTransportVelocityField->attachData<Array2DReal>(
+       NormalTransportVelocity);
+}
+
+void TransportAuxVars::unregisterFields() const {
+   Field::destroy(NormalTransportVelocity.label());
+}
+
+} // namespace OMEGA

--- a/components/omega/src/ocn/auxiliaryVars/TransportAuxVars.h
+++ b/components/omega/src/ocn/auxiliaryVars/TransportAuxVars.h
@@ -1,0 +1,25 @@
+#ifndef OMEGA_AUX_TRANSPORT_H
+#define OMEGA_AUX_TRANSPORT_H
+
+#include "DataTypes.h"
+#include "HorzMesh.h"
+#include "VertCoord.h"
+
+#include <string>
+
+namespace OMEGA {
+
+class TransportAuxVars {
+ public:
+   Array2DReal NormalTransportVelocity;
+
+   TransportAuxVars(const std::string &AuxStateSuffix, const HorzMesh *Mesh,
+                    const VertCoord *VCoord);
+
+   void registerFields(const std::string &AuxGroupName,
+                       const std::string &MeshName) const;
+   void unregisterFields() const;
+};
+
+} // namespace OMEGA
+#endif

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -84,7 +84,8 @@ void ForwardBackwardStepper::doStep(
 
    // R_phi^{n} = RHS_phi(u^{n+1}, h^{n+1}, phi^{n}, t^{n})
    Tend->computeTracerTendencies(State, AuxState, CurTracerArray,
-                                 ThickNextLevel, VelNextLevel, SimTime);
+                                 ThickNextLevel, VelNextLevel, SimTime,
+                                 TimeStep);
 
    // phi^{n+1} = (phi^{n} * h^{n} + R_phi^{n}) / h^{n+1}
    updateTracersByTend(NextTracerArray, CurTracerArray, State, ThickNextLevel,

--- a/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
+++ b/components/omega/src/timeStepping/ForwardBackwardStepper.cpp
@@ -73,8 +73,9 @@ void ForwardBackwardStepper::doStep(
    Pacer::stop("ForwardBackward:velHaloExch", 3);
 
    // R_h^{n} = RHS_h(u^{n+1}, h^{n}, t^{n})
-   Tend->computePseudoThicknessTendencies(State, AuxState, ThickCurLevel,
-                                          VelNextLevel, SimTime);
+   Tend->computePseudoThicknessTendencies(State, AuxState, CurTracerArray,
+                                          ThickCurLevel, VelNextLevel, SimTime,
+                                          TimeStep);
 
    // h^{n+1} = h^{n} + R_h^{n}
    updateThicknessByTend(State, ThickNextLevel, State, ThickCurLevel, TimeStep);

--- a/components/omega/src/timeStepping/SplitExplicitBarotropicPCStepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitBarotropicPCStepper.cpp
@@ -17,38 +17,83 @@
 
 namespace OMEGA {
 
+namespace {
+
+/// Blends an old and a new subcycle value with the forward-backward feedback
+/// weight Gamma, i.e. (1-Gamma)*Old + Gamma*New.
+KOKKOS_INLINE_FUNCTION Real feedbackBlend(Real Gamma, Real Old, Real New) {
+   return (1._Real - Gamma) * Old + Gamma * New;
+}
+
+/// Edge value of the barotropic pressure deviation from the reference column,
+/// centered or upwinded to match the flux-thickness choice used elsewhere.
+KOKKOS_INLINE_FUNCTION Real deltaBtrPressureEdge(Real Delta0, Real Delta1,
+                                                 Real NormalBtrVelEdge,
+                                                 bool Upwind) {
+   if (!Upwind)
+      return 0.5_Real * (Delta0 + Delta1);
+   if (NormalBtrVelEdge > 0._Real)
+      return Delta0;
+   if (NormalBtrVelEdge < 0._Real)
+      return Delta1;
+   return Kokkos::max(Delta0, Delta1);
+}
+
+} // anonymous namespace
+
+//------------------------------------------------------------------------------
+void SplitExplicitBarotropicPCStepper::init(const AuxiliaryState *InAuxState,
+                                            SplitExplicitScratch *InScratch,
+                                            const SplitExplicitConfig *InConfig,
+                                            const HorzMesh *InMesh,
+                                            Halo *InMeshHalo,
+                                            const VertCoord *InVCoord) {
+
+   if (!InAuxState)
+      LOG_CRITICAL("Invalid auxiliary state");
+   if (!InScratch)
+      LOG_CRITICAL("Invalid split-explicit scratch data");
+   if (!InConfig)
+      LOG_CRITICAL("Invalid split-explicit config");
+   if (!InMesh)
+      LOG_CRITICAL("Invalid mesh");
+   if (!InMeshHalo)
+      LOG_CRITICAL("Invalid MeshHalo");
+   if (!InVCoord)
+      LOG_CRITICAL("Invalid vertical coordinate");
+   if (InConfig->NBtrSubcycles < 1)
+      LOG_CRITICAL("Invalid split-explicit barotropic subcycle count");
+
+   AuxState = InAuxState;
+   Scratch  = InScratch;
+   SEConfig = InConfig;
+   Mesh     = InMesh;
+   MeshHalo = InMeshHalo;
+   VCoord   = InVCoord;
+}
+
 //------------------------------------------------------------------------------
 void SplitExplicitBarotropicPCStepper::doBarotropicVelocityUpdate(
-    OceanState *State, const AuxiliaryState *AuxState,
-    SplitExplicitScratch &Scratch, const SplitExplicitConfig &SEConfig,
-    const HorzMesh *Mesh, Halo *MeshHalo, const VertCoord *VCoord, I4 CurLevel,
-    I4 NextLevel, const TimeInstant &StageTime,
+    OceanState *State, I4 CurLevel, I4 NextLevel,
     const TimeInterval &StageTimeStep) const {
 
-   if (SEConfig.NBtrSubcycles < 1)
-      LOG_CRITICAL("Invalid split-explicit barotropic subcycle count");
-   if (!MeshHalo)
-      LOG_CRITICAL("Invalid MeshHalo");
-   if (!AuxState)
-      LOG_CRITICAL("Invalid auxiliary state");
-
-   // Keep the arguments live in this framework implementation. The barotropic
-   // tendency terms will use them once the full split-explicit equations land.
-   (void)StageTime;
+   if (!Scratch)
+      LOG_CRITICAL("Split-explicit barotropic time stepper not initialized");
 
    Eos *EqState = Eos::getInstance();
 
    R8 StageTimeStepSeconds;
    StageTimeStep.get(StageTimeStepSeconds, TimeUnits::Seconds);
 
-   const I4 NBtrSubcycles       = 2 * SEConfig.NBtrSubcycles;
-   const Real BtrDt             = StageTimeStepSeconds / SEConfig.NBtrSubcycles;
-   const Real InvBtrVelAvgCount = 1._Real / (NBtrSubcycles + 1);
+   const I4 NBtrSubcycles = 2 * SEConfig->NBtrSubcycles;
+   const Real BtrDt       = StageTimeStepSeconds / SEConfig->NBtrSubcycles;
+   const Real InvBtrVelAvgCount  = 1._Real / (NBtrSubcycles + 1);
    const Real InvBtrFluxAvgCount = 1._Real / NBtrSubcycles;
-   constexpr Real Gamma1         = 0.5333_Real;
-   constexpr Real Gamma2         = 0.5333_Real;
-   constexpr Real Gamma3         = 1.0_Real;
-   constexpr Real RhoGravity     = RhoSw * Gravity;
+   // Forward-backward feedback weights for the predictor-corrector subcycle.
+   constexpr Real Gamma1     = 0.5333_Real;
+   constexpr Real Gamma2     = 0.5333_Real;
+   constexpr Real Gamma3     = 1.0_Real;
+   constexpr Real RhoGravity = RhoSw * Gravity;
 
    Pacer::start("SE-RK2:stage2BtrPC", 2);
 
@@ -64,23 +109,23 @@ void SplitExplicitBarotropicPCStepper::doBarotropicVelocityUpdate(
    // Pre: the predictor output
    // Cor: the corrector output
    Array1DReal NormalBtrVelSubcycleCur =
-       Scratch.NormalBarotropicVelocitySubcycleCur;
+       Scratch->NormalBarotropicVelocitySubcycleCur;
    Array1DReal NormalBtrVelSubcyclePre =
-       Scratch.NormalBarotropicVelocitySubcyclePre;
+       Scratch->NormalBarotropicVelocitySubcyclePre;
    Array1DReal NormalBtrVelSubcycleCor =
-       Scratch.NormalBarotropicVelocitySubcycleCor;
+       Scratch->NormalBarotropicVelocitySubcycleCor;
    Array1DReal BtrPressAnomalySubcycleCur =
-       Scratch.BarotropicPressureAnomalySubcycleCur;
+       Scratch->BarotropicPressureAnomalySubcycleCur;
    Array1DReal BtrPressAnomalySubcyclePre =
-       Scratch.BarotropicPressureAnomalySubcyclePre;
+       Scratch->BarotropicPressureAnomalySubcyclePre;
    Array1DReal BtrPressAnomalySubcycleCor =
-       Scratch.BarotropicPressureAnomalySubcycleCor;
+       Scratch->BarotropicPressureAnomalySubcycleCor;
 
-   Array1DReal BtrForcing = Scratch.BarotropicForcing;
-   Array1DReal BtrFlux    = Scratch.BarotropicFlux;
+   Array1DReal BtrForcing = Scratch->BarotropicForcing;
+   Array1DReal BtrFlux    = Scratch->BarotropicFlux;
 
    Array1DReal BaroclinicPseudoThicknessEdge =
-       Scratch.BaroclinicPseudoThicknessEdge;
+       Scratch->BaroclinicPseudoThicknessEdge;
 
    const Array2DReal FluxPseudoThickEdge =
        AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
@@ -219,8 +264,8 @@ void SplitExplicitBarotropicPCStepper::doBarotropicVelocityUpdate(
                 const I4 Cell0 = CellsOnEdge(JEdge, 0);
                 const I4 Cell1 = CellsOnEdge(JEdge, 1);
                 const Real NormalBtrVelEdge =
-                    (1._Real - Gamma1) * NormalBtrVelSubcycleCur(JEdge) +
-                    Gamma1 * NormalBtrVelSubcyclePre(JEdge);
+                    feedbackBlend(Gamma1, NormalBtrVelSubcycleCur(JEdge),
+                                  NormalBtrVelSubcyclePre(JEdge));
 
                 const Real DeltaBtrPressure0 =
                     BtrPressAnomalySubcycleCur(Cell0) -
@@ -228,17 +273,9 @@ void SplitExplicitBarotropicPCStepper::doBarotropicVelocityUpdate(
                 const Real DeltaBtrPressure1 =
                     BtrPressAnomalySubcycleCur(Cell1) -
                     BtrPressAnomalyNext(Cell1);
-                Real DeltaBtrPressureEdge =
-                    0.5_Real * (DeltaBtrPressure0 + DeltaBtrPressure1);
-                if (UpwindFluxThickness) {
-                   if (NormalBtrVelEdge > 0._Real)
-                      DeltaBtrPressureEdge = DeltaBtrPressure0;
-                   else if (NormalBtrVelEdge < 0._Real)
-                      DeltaBtrPressureEdge = DeltaBtrPressure1;
-                   else
-                      DeltaBtrPressureEdge =
-                          Kokkos::max(DeltaBtrPressure0, DeltaBtrPressure1);
-                }
+                const Real DeltaBtrPressureEdge =
+                    deltaBtrPressureEdge(DeltaBtrPressure0, DeltaBtrPressure1,
+                                         NormalBtrVelEdge, UpwindFluxThickness);
 
                 const Real BtrPressureEdge =
                     RhoGravity * BaroclinicPseudoThicknessEdge(JEdge) +
@@ -279,12 +316,12 @@ void SplitExplicitBarotropicPCStepper::doBarotropicVelocityUpdate(
              }
 
              const Real BtrPressure0 =
-                 (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell0) +
-                 Gamma2 * BtrPressAnomalySubcyclePre(Cell0);
+                 feedbackBlend(Gamma2, BtrPressAnomalySubcycleCur(Cell0),
+                               BtrPressAnomalySubcyclePre(Cell0));
 
              const Real BtrPressure1 =
-                 (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell1) +
-                 Gamma2 * BtrPressAnomalySubcyclePre(Cell1);
+                 feedbackBlend(Gamma2, BtrPressAnomalySubcycleCur(Cell1),
+                               BtrPressAnomalySubcyclePre(Cell1));
 
              const Real MeanSpecVolEdge =
                  0.5_Real * (DepthMeanSpecVol(Cell0) + DepthMeanSpecVol(Cell1));
@@ -314,32 +351,24 @@ void SplitExplicitBarotropicPCStepper::doBarotropicVelocityUpdate(
                 const I4 Cell1 = CellsOnEdge(JEdge, 1);
 
                 const Real BtrPressure0 =
-                    (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell0) +
-                    Gamma2 * BtrPressAnomalySubcyclePre(Cell0);
+                    feedbackBlend(Gamma2, BtrPressAnomalySubcycleCur(Cell0),
+                                  BtrPressAnomalySubcyclePre(Cell0));
 
                 const Real BtrPressure1 =
-                    (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell1) +
-                    Gamma2 * BtrPressAnomalySubcyclePre(Cell1);
+                    feedbackBlend(Gamma2, BtrPressAnomalySubcycleCur(Cell1),
+                                  BtrPressAnomalySubcyclePre(Cell1));
 
                 const Real NormalBtrVelEdge =
-                    (1._Real - Gamma3) * NormalBtrVelSubcycleCur(JEdge) +
-                    Gamma3 * NormalBtrVelSubcycleCor(JEdge);
+                    feedbackBlend(Gamma3, NormalBtrVelSubcycleCur(JEdge),
+                                  NormalBtrVelSubcycleCor(JEdge));
 
                 const Real DeltaBtrPressure0 =
                     BtrPressure0 - BtrPressAnomalyNext(Cell0);
                 const Real DeltaBtrPressure1 =
                     BtrPressure1 - BtrPressAnomalyNext(Cell1);
-                Real DeltaBtrPressureEdge =
-                    0.5_Real * (DeltaBtrPressure0 + DeltaBtrPressure1);
-                if (UpwindFluxThickness) {
-                   if (NormalBtrVelEdge > 0._Real)
-                      DeltaBtrPressureEdge = DeltaBtrPressure0;
-                   else if (NormalBtrVelEdge < 0._Real)
-                      DeltaBtrPressureEdge = DeltaBtrPressure1;
-                   else
-                      DeltaBtrPressureEdge =
-                          Kokkos::max(DeltaBtrPressure0, DeltaBtrPressure1);
-                }
+                const Real DeltaBtrPressureEdge =
+                    deltaBtrPressureEdge(DeltaBtrPressure0, DeltaBtrPressure1,
+                                         NormalBtrVelEdge, UpwindFluxThickness);
 
                 const Real BtrPressureEdge =
                     RhoGravity * BaroclinicPseudoThicknessEdge(JEdge) +
@@ -371,32 +400,24 @@ void SplitExplicitBarotropicPCStepper::doBarotropicVelocityUpdate(
              const I4 Cell1 = CellsOnEdge(IEdge, 1);
 
              const Real BtrPressure0 =
-                 (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell0) +
-                 Gamma2 * BtrPressAnomalySubcycleCor(Cell0);
+                 feedbackBlend(Gamma2, BtrPressAnomalySubcycleCur(Cell0),
+                               BtrPressAnomalySubcycleCor(Cell0));
 
              const Real BtrPressure1 =
-                 (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell1) +
-                 Gamma2 * BtrPressAnomalySubcycleCor(Cell1);
+                 feedbackBlend(Gamma2, BtrPressAnomalySubcycleCur(Cell1),
+                               BtrPressAnomalySubcycleCor(Cell1));
 
              const Real NormalBtrVelEdge =
-                 (1._Real - Gamma3) * NormalBtrVelSubcycleCur(IEdge) +
-                 Gamma3 * NormalBtrVelSubcycleCor(IEdge);
+                 feedbackBlend(Gamma3, NormalBtrVelSubcycleCur(IEdge),
+                               NormalBtrVelSubcycleCor(IEdge));
 
              const Real DeltaBtrPressure0 =
                  BtrPressure0 - BtrPressAnomalyNext(Cell0);
              const Real DeltaBtrPressure1 =
                  BtrPressure1 - BtrPressAnomalyNext(Cell1);
-             Real DeltaBtrPressureEdge =
-                 0.5_Real * (DeltaBtrPressure0 + DeltaBtrPressure1);
-             if (UpwindFluxThickness) {
-                if (NormalBtrVelEdge > 0._Real)
-                   DeltaBtrPressureEdge = DeltaBtrPressure0;
-                else if (NormalBtrVelEdge < 0._Real)
-                   DeltaBtrPressureEdge = DeltaBtrPressure1;
-                else
-                   DeltaBtrPressureEdge =
-                       Kokkos::max(DeltaBtrPressure0, DeltaBtrPressure1);
-             }
+             const Real DeltaBtrPressureEdge =
+                 deltaBtrPressureEdge(DeltaBtrPressure0, DeltaBtrPressure1,
+                                      NormalBtrVelEdge, UpwindFluxThickness);
 
              const Real BtrPressureEdge =
                  RhoGravity * BaroclinicPseudoThicknessEdge(IEdge) +

--- a/components/omega/src/timeStepping/SplitExplicitBarotropicPCStepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitBarotropicPCStepper.cpp
@@ -1,0 +1,428 @@
+//===-- SplitExplicitBarotropicPCStepper.cpp - SE stage 2 -----*- C++ -*-===//
+//
+// Framework for the explicitly subcycled forward-backward
+// predictor-corrector barotropic velocity update.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SplitExplicitBarotropicPCStepper.h"
+#include "AuxiliaryState.h"
+#include "Eos.h"
+#include "GlobalConstants.h"
+#include "Logging.h"
+#include "OmegaKokkos.h"
+#include "Pacer.h"
+
+#include <utility>
+
+namespace OMEGA {
+
+//------------------------------------------------------------------------------
+void SplitExplicitBarotropicPCStepper::doBarotropicVelocityUpdate(
+    OceanState *State, const AuxiliaryState *AuxState,
+    SplitExplicitScratch &Scratch, const SplitExplicitConfig &SEConfig,
+    const HorzMesh *Mesh, Halo *MeshHalo, const VertCoord *VCoord, I4 CurLevel,
+    I4 NextLevel, const TimeInstant &StageTime,
+    const TimeInterval &StageTimeStep) const {
+
+   if (SEConfig.NBtrSubcycles < 1)
+      LOG_CRITICAL("Invalid split-explicit barotropic subcycle count");
+   if (!MeshHalo)
+      LOG_CRITICAL("Invalid MeshHalo");
+   if (!AuxState)
+      LOG_CRITICAL("Invalid auxiliary state");
+
+   // Keep the arguments live in this framework implementation. The barotropic
+   // tendency terms will use them once the full split-explicit equations land.
+   (void)StageTime;
+
+   Eos *EqState = Eos::getInstance();
+
+   R8 StageTimeStepSeconds;
+   StageTimeStep.get(StageTimeStepSeconds, TimeUnits::Seconds);
+
+   const I4 NBtrSubcycles       = 2 * SEConfig.NBtrSubcycles;
+   const Real BtrDt             = StageTimeStepSeconds / SEConfig.NBtrSubcycles;
+   const Real InvBtrVelAvgCount = 1._Real / (NBtrSubcycles + 1);
+   const Real InvBtrFluxAvgCount = 1._Real / NBtrSubcycles;
+   constexpr Real Gamma1         = 0.5333_Real;
+   constexpr Real Gamma2         = 0.5333_Real;
+   constexpr Real Gamma3         = 1.0_Real;
+   constexpr Real RhoGravity     = RhoSw * Gravity;
+
+   Pacer::start("SE-RK2:stage2BtrPC", 2);
+
+   // Get array required
+   Array1DReal NormalBtrVelCur = State->getNormalBarotropicVelocity(CurLevel);
+   Array1DReal BtrPressAnomalyCur =
+       State->getBarotropicPressureAnomaly(CurLevel);
+   Array1DReal NormalBtrVelNext = State->getNormalBarotropicVelocity(NextLevel);
+   Array1DReal BtrPressAnomalyNext =
+       State->getBarotropicPressureAnomaly(NextLevel);
+
+   // Cur: the state at the start of the subcycle
+   // Pre: the predictor output
+   // Cor: the corrector output
+   Array1DReal NormalBtrVelSubcycleCur =
+       Scratch.NormalBarotropicVelocitySubcycleCur;
+   Array1DReal NormalBtrVelSubcyclePre =
+       Scratch.NormalBarotropicVelocitySubcyclePre;
+   Array1DReal NormalBtrVelSubcycleCor =
+       Scratch.NormalBarotropicVelocitySubcycleCor;
+   Array1DReal BtrPressAnomalySubcycleCur =
+       Scratch.BarotropicPressureAnomalySubcycleCur;
+   Array1DReal BtrPressAnomalySubcyclePre =
+       Scratch.BarotropicPressureAnomalySubcyclePre;
+   Array1DReal BtrPressAnomalySubcycleCor =
+       Scratch.BarotropicPressureAnomalySubcycleCor;
+
+   Array1DReal BtrForcing = Scratch.BarotropicForcing;
+   Array1DReal BtrFlux    = Scratch.BarotropicFlux;
+
+   Array1DReal BaroclinicPseudoThicknessEdge =
+       Scratch.BaroclinicPseudoThicknessEdge;
+
+   const Array2DReal FluxPseudoThickEdge =
+       AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
+   const bool UpwindFluxThickness =
+       AuxState->PseudoThicknessAux.FluxThickEdgeChoice ==
+       FluxThickEdgeOption::Upwind;
+
+   OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
+   OMEGA_SCOPE(NEdgesOnCell, Mesh->NEdgesOnCell);
+   OMEGA_SCOPE(EdgesOnCell, Mesh->EdgesOnCell);
+   OMEGA_SCOPE(EdgeSignOnCell, Mesh->EdgeSignOnCell);
+   OMEGA_SCOPE(NEdgesOnEdge, Mesh->NEdgesOnEdge);
+   OMEGA_SCOPE(EdgesOnEdge, Mesh->EdgesOnEdge);
+   OMEGA_SCOPE(WeightsOnEdge, Mesh->WeightsOnEdge);
+   OMEGA_SCOPE(DcEdge, Mesh->DcEdge);
+   OMEGA_SCOPE(DvEdge, Mesh->DvEdge);
+   OMEGA_SCOPE(AreaCell, Mesh->AreaCell);
+   OMEGA_SCOPE(FEdge, Mesh->FEdge);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+   OMEGA_SCOPE(EdgeMask, VCoord->EdgeMask);
+   OMEGA_SCOPE(DepthMeanSpecVol, EqState->DepthMeanSpecificVolume);
+
+   // Initialize barotropic vars
+   deepCopy(NormalBtrVelSubcycleCur, NormalBtrVelCur);
+   deepCopy(BtrPressAnomalySubcycleCur, BtrPressAnomalyCur);
+   deepCopy(NormalBtrVelNext, NormalBtrVelSubcycleCur);
+   deepCopy(BtrFlux, 0._Real);
+
+   // Compute the baroclinic pseudo thickness on edges
+   parallelForOuter(
+       "computeBtrBaroclinicPseudoThicknessEdge", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(I4 IEdge, const TeamMember &Team) {
+          const I4 KMin = MinLayerEdgeBot(IEdge);
+          const I4 KMax = MaxLayerEdgeTop(IEdge);
+
+          Real PseudoThicknessSum = 0._Real;
+          parallelReduceInner(
+              Team, Range{KMin, KMax},
+              INNER_LAMBDA(I4 K, Real & Sum) {
+                 Sum += FluxPseudoThickEdge(IEdge, K);
+              },
+              PseudoThicknessSum);
+
+          Kokkos::single(
+              PerTeam(Team), INNER_LAMBDA() {
+                 BaroclinicPseudoThicknessEdge(IEdge) = PseudoThicknessSum;
+              });
+       });
+
+   //-----------------------------------------------------------------------
+   // Communication-avoiding barotropic subcycling:
+   //   - Each kernel can fill one halo layer less than its inputs cover,
+   //     so the ranges below shrink in turn, and the last of them sets the
+   //     floor on HaloWidth. Halo exchange is conducted once at the top
+   //     of each subcycle.
+   const I4 HaloWidth = static_cast<I4>(Mesh->NCellsHaloH.extent(0));
+
+   // Every kernel downstream loses the layers its stencil reaches past
+   // what its inputs cover.
+   constexpr I4 VelPredShrink   = 0;
+   constexpr I4 PressPredShrink = 1;
+   constexpr I4 VelCorrShrink   = 1;
+   constexpr I4 PressCorrShrink = 2;
+
+   constexpr I4 MinHaloWidth =
+       1 + Kokkos::max(Kokkos::max(VelPredShrink, PressPredShrink),
+                       Kokkos::max(VelCorrShrink, PressCorrShrink));
+
+   if (HaloWidth < MinHaloWidth)
+      ABORT_ERROR("Split-explicit barotropic subcycling needs a Decomp "
+                  "HaloWidth of at least {}, got {}",
+                  MinHaloWidth, HaloWidth);
+
+   // A halo deeper than the minimum just leaves every range deeper.
+   const I4 HaloAll            = HaloWidth - 1;
+   const I4 VelPredEdgeRange   = Mesh->NEdgesHaloH(HaloAll - VelPredShrink);
+   const I4 PressPredCellRange = Mesh->NCellsHaloH(HaloAll - PressPredShrink);
+   const I4 VelCorrEdgeRange   = Mesh->NEdgesHaloH(HaloAll - VelCorrShrink);
+   const I4 PressCorrCellRange = Mesh->NCellsHaloH(HaloAll - PressCorrShrink);
+
+   // Start the barotrolic subcycling
+   for (I4 Subcycle = 0; Subcycle < NBtrSubcycles; ++Subcycle) {
+
+      // Restore buffers. This is the only communication inside the subcycle.
+      MeshHalo->exchangeFullArrayHalo(NormalBtrVelSubcycleCur, OnEdge);
+      MeshHalo->exchangeFullArrayHalo(BtrPressAnomalySubcycleCur, OnCell);
+
+      // Barotropic velocity predictor
+      parallelFor(
+          "btrVelocityPredictor", {VelPredEdgeRange}, KOKKOS_LAMBDA(I4 IEdge) {
+             const I4 KMin = MinLayerEdgeBot(IEdge);
+             if (MaxLayerEdgeTop(IEdge) < KMin) {
+                NormalBtrVelSubcyclePre(IEdge) = 0._Real;
+                return;
+             }
+
+             const I4 Cell0 = CellsOnEdge(IEdge, 0);
+             const I4 Cell1 = CellsOnEdge(IEdge, 1);
+
+             const Real Mask = EdgeMask(IEdge, KMin);
+
+             Real CoriolisTend = 0._Real;
+             for (I4 J = 0; J < NEdgesOnEdge(IEdge); ++J) {
+                const I4 JEdge = EdgesOnEdge(IEdge, J);
+                CoriolisTend += WeightsOnEdge(IEdge, J) *
+                                NormalBtrVelSubcycleCur(JEdge) * FEdge(JEdge);
+             }
+
+             const Real MeanSpecVolEdge =
+                 0.5_Real * (DepthMeanSpecVol(Cell0) + DepthMeanSpecVol(Cell1));
+
+             const Real BtrPressAnomalyGrad =
+                 (BtrPressAnomalySubcycleCur(Cell1) -
+                  BtrPressAnomalySubcycleCur(Cell0)) /
+                 DcEdge(IEdge);
+
+             NormalBtrVelSubcyclePre(IEdge) =
+                 Mask * (NormalBtrVelSubcycleCur(IEdge) +
+                         BtrDt * (CoriolisTend -
+                                  MeanSpecVolEdge * BtrPressAnomalyGrad +
+                                  BtrForcing(IEdge)));
+          });
+
+      // Barotropic pressure anomaly predictor
+      parallelFor(
+          "btrPressurePredictor", {PressPredCellRange},
+          KOKKOS_LAMBDA(I4 ICell) {
+             Real BtrFluxDivTend = 0._Real;
+
+             for (I4 J = 0; J < NEdgesOnCell(ICell); ++J) {
+                const I4 JEdge = EdgesOnCell(ICell, J);
+                if (MaxLayerEdgeTop(JEdge) < MinLayerEdgeBot(JEdge))
+                   continue;
+
+                const I4 Cell0 = CellsOnEdge(JEdge, 0);
+                const I4 Cell1 = CellsOnEdge(JEdge, 1);
+                const Real NormalBtrVelEdge =
+                    (1._Real - Gamma1) * NormalBtrVelSubcycleCur(JEdge) +
+                    Gamma1 * NormalBtrVelSubcyclePre(JEdge);
+
+                const Real DeltaBtrPressure0 =
+                    BtrPressAnomalySubcycleCur(Cell0) -
+                    BtrPressAnomalyNext(Cell0);
+                const Real DeltaBtrPressure1 =
+                    BtrPressAnomalySubcycleCur(Cell1) -
+                    BtrPressAnomalyNext(Cell1);
+                Real DeltaBtrPressureEdge =
+                    0.5_Real * (DeltaBtrPressure0 + DeltaBtrPressure1);
+                if (UpwindFluxThickness) {
+                   if (NormalBtrVelEdge > 0._Real)
+                      DeltaBtrPressureEdge = DeltaBtrPressure0;
+                   else if (NormalBtrVelEdge < 0._Real)
+                      DeltaBtrPressureEdge = DeltaBtrPressure1;
+                   else
+                      DeltaBtrPressureEdge =
+                          Kokkos::max(DeltaBtrPressure0, DeltaBtrPressure1);
+                }
+
+                const Real BtrPressureEdge =
+                    RhoGravity * BaroclinicPseudoThicknessEdge(JEdge) +
+                    DeltaBtrPressureEdge;
+                const Real PredictorBtrFlux =
+                    BtrPressureEdge * NormalBtrVelEdge;
+
+                BtrFluxDivTend +=
+                    EdgeSignOnCell(ICell, J) * DvEdge(JEdge) * PredictorBtrFlux;
+             }
+
+             constexpr Real SurfaceFreshwaterFlux = 0._Real;
+             BtrPressAnomalySubcyclePre(ICell) =
+                 BtrPressAnomalySubcycleCur(ICell) +
+                 BtrDt * (BtrFluxDivTend / AreaCell(ICell) +
+                          RhoGravity * SurfaceFreshwaterFlux);
+          });
+
+      // Barotropic velocity corrector
+      parallelFor(
+          "btrVelocityCorrector", {VelCorrEdgeRange}, KOKKOS_LAMBDA(I4 IEdge) {
+             const I4 KMin = MinLayerEdgeBot(IEdge);
+             if (MaxLayerEdgeTop(IEdge) < KMin) {
+                NormalBtrVelSubcycleCor(IEdge) = 0._Real;
+                return;
+             }
+
+             const Real Mask = EdgeMask(IEdge, KMin);
+             const I4 Cell0  = CellsOnEdge(IEdge, 0);
+             const I4 Cell1  = CellsOnEdge(IEdge, 1);
+
+             Real CoriolisTend = 0._Real;
+
+             for (I4 J = 0; J < NEdgesOnEdge(IEdge); ++J) {
+                const I4 JEdge = EdgesOnEdge(IEdge, J);
+                CoriolisTend += WeightsOnEdge(IEdge, J) *
+                                NormalBtrVelSubcyclePre(JEdge) * FEdge(JEdge);
+             }
+
+             const Real BtrPressure0 =
+                 (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell0) +
+                 Gamma2 * BtrPressAnomalySubcyclePre(Cell0);
+
+             const Real BtrPressure1 =
+                 (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell1) +
+                 Gamma2 * BtrPressAnomalySubcyclePre(Cell1);
+
+             const Real MeanSpecVolEdge =
+                 0.5_Real * (DepthMeanSpecVol(Cell0) + DepthMeanSpecVol(Cell1));
+
+             const Real BtrPressureGrad =
+                 (BtrPressure1 - BtrPressure0) / DcEdge(IEdge);
+
+             NormalBtrVelSubcycleCor(IEdge) =
+                 Mask *
+                 (NormalBtrVelSubcycleCur(IEdge) +
+                  BtrDt * (CoriolisTend - MeanSpecVolEdge * BtrPressureGrad +
+                           BtrForcing(IEdge)));
+          });
+
+      // Barotropic pressure anomaly corrector
+      parallelFor(
+          "btrPressureCorrector", {PressCorrCellRange},
+          KOKKOS_LAMBDA(I4 ICell) {
+             Real BtrFluxDivTend = 0._Real;
+
+             for (I4 J = 0; J < NEdgesOnCell(ICell); ++J) {
+                const I4 JEdge = EdgesOnCell(ICell, J);
+                if (MaxLayerEdgeTop(JEdge) < MinLayerEdgeBot(JEdge))
+                   continue;
+
+                const I4 Cell0 = CellsOnEdge(JEdge, 0);
+                const I4 Cell1 = CellsOnEdge(JEdge, 1);
+
+                const Real BtrPressure0 =
+                    (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell0) +
+                    Gamma2 * BtrPressAnomalySubcyclePre(Cell0);
+
+                const Real BtrPressure1 =
+                    (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell1) +
+                    Gamma2 * BtrPressAnomalySubcyclePre(Cell1);
+
+                const Real NormalBtrVelEdge =
+                    (1._Real - Gamma3) * NormalBtrVelSubcycleCur(JEdge) +
+                    Gamma3 * NormalBtrVelSubcycleCor(JEdge);
+
+                const Real DeltaBtrPressure0 =
+                    BtrPressure0 - BtrPressAnomalyNext(Cell0);
+                const Real DeltaBtrPressure1 =
+                    BtrPressure1 - BtrPressAnomalyNext(Cell1);
+                Real DeltaBtrPressureEdge =
+                    0.5_Real * (DeltaBtrPressure0 + DeltaBtrPressure1);
+                if (UpwindFluxThickness) {
+                   if (NormalBtrVelEdge > 0._Real)
+                      DeltaBtrPressureEdge = DeltaBtrPressure0;
+                   else if (NormalBtrVelEdge < 0._Real)
+                      DeltaBtrPressureEdge = DeltaBtrPressure1;
+                   else
+                      DeltaBtrPressureEdge =
+                          Kokkos::max(DeltaBtrPressure0, DeltaBtrPressure1);
+                }
+
+                const Real BtrPressureEdge =
+                    RhoGravity * BaroclinicPseudoThicknessEdge(JEdge) +
+                    DeltaBtrPressureEdge;
+
+                const Real CorrectorBtrFlux =
+                    BtrPressureEdge * NormalBtrVelEdge;
+                BtrFluxDivTend +=
+                    EdgeSignOnCell(ICell, J) * DvEdge(JEdge) * CorrectorBtrFlux;
+             }
+
+             BtrPressAnomalySubcycleCor(ICell) =
+                 BtrPressAnomalySubcycleCur(ICell) +
+                 BtrDt * BtrFluxDivTend / AreaCell(ICell);
+          });
+
+      // Accumulate the corrector barotropic velocity and flux for the
+      // time-averaged transport used by the barotropic-baroclinic velocity
+      // correction.
+      parallelFor(
+          "btrCorrectorAccumulate", {Mesh->NEdgesOwned},
+          KOKKOS_LAMBDA(I4 IEdge) {
+             NormalBtrVelNext(IEdge) += NormalBtrVelSubcycleCor(IEdge);
+
+             if (MaxLayerEdgeTop(IEdge) < MinLayerEdgeBot(IEdge))
+                return;
+
+             const I4 Cell0 = CellsOnEdge(IEdge, 0);
+             const I4 Cell1 = CellsOnEdge(IEdge, 1);
+
+             const Real BtrPressure0 =
+                 (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell0) +
+                 Gamma2 * BtrPressAnomalySubcycleCor(Cell0);
+
+             const Real BtrPressure1 =
+                 (1._Real - Gamma2) * BtrPressAnomalySubcycleCur(Cell1) +
+                 Gamma2 * BtrPressAnomalySubcycleCor(Cell1);
+
+             const Real NormalBtrVelEdge =
+                 (1._Real - Gamma3) * NormalBtrVelSubcycleCur(IEdge) +
+                 Gamma3 * NormalBtrVelSubcycleCor(IEdge);
+
+             const Real DeltaBtrPressure0 =
+                 BtrPressure0 - BtrPressAnomalyNext(Cell0);
+             const Real DeltaBtrPressure1 =
+                 BtrPressure1 - BtrPressAnomalyNext(Cell1);
+             Real DeltaBtrPressureEdge =
+                 0.5_Real * (DeltaBtrPressure0 + DeltaBtrPressure1);
+             if (UpwindFluxThickness) {
+                if (NormalBtrVelEdge > 0._Real)
+                   DeltaBtrPressureEdge = DeltaBtrPressure0;
+                else if (NormalBtrVelEdge < 0._Real)
+                   DeltaBtrPressureEdge = DeltaBtrPressure1;
+                else
+                   DeltaBtrPressureEdge =
+                       Kokkos::max(DeltaBtrPressure0, DeltaBtrPressure1);
+             }
+
+             const Real BtrPressureEdge =
+                 RhoGravity * BaroclinicPseudoThicknessEdge(IEdge) +
+                 DeltaBtrPressureEdge;
+
+             BtrFlux(IEdge) += BtrPressureEdge * NormalBtrVelEdge;
+          });
+
+      // Rotate the subcycle buffers: the corrector output becomes the state
+      // at the start of the next subcycle.
+      std::swap(NormalBtrVelSubcycleCur, NormalBtrVelSubcycleCor);
+      std::swap(BtrPressAnomalySubcycleCur, BtrPressAnomalySubcycleCor);
+   } // Subcycle
+
+   parallelFor(
+       "btrSubcycleAverage", {Mesh->NEdgesOwned}, KOKKOS_LAMBDA(I4 IEdge) {
+          NormalBtrVelNext(IEdge) *= InvBtrVelAvgCount;
+          BtrFlux(IEdge) *= InvBtrFluxAvgCount;
+       });
+
+   deepCopy(BtrPressAnomalyNext, BtrPressAnomalySubcycleCur);
+   MeshHalo->exchangeFullArrayHalo(NormalBtrVelNext, OnEdge);
+   MeshHalo->exchangeFullArrayHalo(BtrFlux, OnEdge);
+   MeshHalo->exchangeFullArrayHalo(BtrPressAnomalyNext, OnCell);
+
+   Pacer::stop("SE-RK2:stage2BtrPC", 2);
+}
+
+} // namespace OMEGA

--- a/components/omega/src/timeStepping/SplitExplicitBarotropicPCStepper.h
+++ b/components/omega/src/timeStepping/SplitExplicitBarotropicPCStepper.h
@@ -1,0 +1,40 @@
+#ifndef OMEGA_SPLIT_EXPLICIT_BAROTROPIC_PC_STEPPER_H
+#define OMEGA_SPLIT_EXPLICIT_BAROTROPIC_PC_STEPPER_H
+//===-- SplitExplicitBarotropicPCStepper.h - SE stage 2 ------*- C++ -*-===//
+//
+/// \file
+/// \brief Forward-backward predictor-corrector barotropic subcycle framework.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Halo.h"
+#include "HorzMesh.h"
+#include "OceanState.h"
+#include "SplitExplicitTypes.h"
+#include "TimeMgr.h"
+#include "VertCoord.h"
+
+namespace OMEGA {
+
+class AuxiliaryState;
+
+class SplitExplicitBarotropicPCStepper {
+ public:
+   void doBarotropicVelocityUpdate(
+       OceanState *State,              ///< [inout] model state
+       const AuxiliaryState *AuxState, ///< [in] provisional auxiliary state
+       SplitExplicitScratch &Scratch,  ///< [inout] split-explicit scratch data
+       const SplitExplicitConfig &Config, ///< [in] split-explicit options
+       const HorzMesh *Mesh,              ///< [in] horizontal mesh
+       Halo *MeshHalo,                    ///< [in] mesh halo exchange
+       const VertCoord *VCoord,           ///< [in] vertical coordinate
+       I4 CurLevel,                       ///< [in] state time level to update
+       I4 NextLevel,                      ///< [in] state time level to update
+       const TimeInstant &StageTime,      ///< [in] current stage time
+       const TimeInterval &StageTimeStep  ///< [in] current stage time step
+   ) const;
+};
+
+} // namespace OMEGA
+
+#endif

--- a/components/omega/src/timeStepping/SplitExplicitBarotropicPCStepper.h
+++ b/components/omega/src/timeStepping/SplitExplicitBarotropicPCStepper.h
@@ -20,19 +20,29 @@ class AuxiliaryState;
 
 class SplitExplicitBarotropicPCStepper {
  public:
+   void
+   init(const AuxiliaryState *InAuxState, ///< [in] provisional auxiliary state
+        SplitExplicitScratch *InScratch,  ///< [inout] split-explicit scratch
+        const SplitExplicitConfig *InConfig, ///< [in] split-explicit options
+        const HorzMesh *InMesh,              ///< [in] horizontal mesh
+        Halo *InMeshHalo,                    ///< [in] mesh halo exchange
+        const VertCoord *InVCoord            ///< [in] vertical coordinate
+   );
+
    void doBarotropicVelocityUpdate(
-       OceanState *State,              ///< [inout] model state
-       const AuxiliaryState *AuxState, ///< [in] provisional auxiliary state
-       SplitExplicitScratch &Scratch,  ///< [inout] split-explicit scratch data
-       const SplitExplicitConfig &Config, ///< [in] split-explicit options
-       const HorzMesh *Mesh,              ///< [in] horizontal mesh
-       Halo *MeshHalo,                    ///< [in] mesh halo exchange
-       const VertCoord *VCoord,           ///< [in] vertical coordinate
-       I4 CurLevel,                       ///< [in] state time level to update
-       I4 NextLevel,                      ///< [in] state time level to update
-       const TimeInstant &StageTime,      ///< [in] current stage time
-       const TimeInterval &StageTimeStep  ///< [in] current stage time step
+       OceanState *State,                ///< [inout] model state
+       I4 CurLevel,                      ///< [in] state time level to update
+       I4 NextLevel,                     ///< [in] state time level to update
+       const TimeInterval &StageTimeStep ///< [in] current stage time step
    ) const;
+
+ private:
+   const AuxiliaryState *AuxState      = nullptr;
+   SplitExplicitScratch *Scratch       = nullptr;
+   const SplitExplicitConfig *SEConfig = nullptr;
+   const HorzMesh *Mesh                = nullptr;
+   Halo *MeshHalo                      = nullptr;
+   const VertCoord *VCoord             = nullptr;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/SplitExplicitInit.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitInit.cpp
@@ -171,8 +171,8 @@ void SplitExplicitInit::allocateScratch(SplitExplicitScratch &Scratch,
        Array1DReal("BaroclinicPseudoThicknessEdge" + Name, Mesh->NEdgesSize);
    Scratch.IterVelocityTend = Array2DReal(
        "IterVelocityTend" + Name, Mesh->NEdgesSize, VCoord->NVertLayers);
-   Scratch.NormalTransportVelocity = Array2DReal(
-       "NormalTransportVelocity" + Name, Mesh->NEdgesSize, VCoord->NVertLayers);
+   Scratch.TransportVelocityAdd = Array2DReal(
+       "TransportVelocityAdd" + Name, Mesh->NEdgesSize, VCoord->NVertLayers);
 
    parallelFor(
        "initializeCell1D", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
@@ -192,7 +192,7 @@ void SplitExplicitInit::allocateScratch(SplitExplicitScratch &Scratch,
        });
 
    deepCopy(Scratch.IterVelocityTend, 0.);
-   deepCopy(Scratch.NormalTransportVelocity, 0.);
+   deepCopy(Scratch.TransportVelocityAdd, 0.);
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/timeStepping/SplitExplicitInit.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitInit.cpp
@@ -1,0 +1,390 @@
+//===-- SplitExplicitInit.cpp - split-explicit initialization --*- C++ -*-===//
+//
+// Utilities for initializing split-explicit time stepping state.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SplitExplicitInit.h"
+#include "Config.h"
+#include "Error.h"
+#include "GlobalConstants.h"
+#include "Logging.h"
+#include "OmegaKokkos.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace OMEGA {
+
+//------------------------------------------------------------------------------
+SplitExplicitConfig
+SplitExplicitInit::readConfigOptions(const TimeInterval &TimeStep,
+                                     bool IsUnsplit) {
+
+   SplitExplicitConfig SEConfig;
+
+   Config *OmegaConfig = Config::getOmegaConfig();
+   Config TimeIntConfig("TimeIntegration");
+   Error Err = OmegaConfig->get(TimeIntConfig);
+   CHECK_ERROR_ABORT(Err, "TimeIntegration group not found in Config");
+
+   Config ModeSplitShareConfig("ModeSplitShare");
+   Error ShareErr = TimeIntConfig.get(ModeSplitShareConfig);
+   CHECK_ERROR_ABORT(ShareErr,
+                     "TimeIntegration::ModeSplitShare group not found in "
+                     "Config; it is required by the split time steppers");
+
+   // For the unsplit schemes, SplitFactor is 0.
+   if (IsUnsplit) {
+      SEConfig.SplitFactor = 0._Real;
+   }
+
+   if (!IsUnsplit) {
+      std::string BtrTimeStepperStr;
+      if (ModeSplitShareConfig.get("BtrTimeStepper", BtrTimeStepperStr)
+              .isSuccess()) {
+         SEConfig.BtrTimeStepper = getBtrTimeStepperFromStr(BtrTimeStepperStr);
+      }
+
+      std::string BtrTimeStepStr;
+      Error BtrErr = ModeSplitShareConfig.get("BtrTimeStep", BtrTimeStepStr);
+      CHECK_ERROR_ABORT(BtrErr,
+                        "TimeIntegration::ModeSplitShare::BtrTimeStep not "
+                        "found in Config; it is required by SplitExplicitRK2");
+      SEConfig.BtrTimeStep = TimeInterval(BtrTimeStepStr);
+   }
+
+   I4 NTimeStepIteration = SEConfig.NTimeStepIteration;
+   if (ModeSplitShareConfig.get("NTimeStepIteration", NTimeStepIteration)
+           .isSuccess()) {
+      if (NTimeStepIteration < 1) {
+         ABORT_ERROR("NTimeStepIteration must be greater than zero");
+      }
+      SEConfig.NTimeStepIteration = NTimeStepIteration;
+   }
+
+   I4 NBclCoriolisIteration = SEConfig.NBclCoriolisIteration;
+   if (ModeSplitShareConfig.get("NBclCoriolisIteration", NBclCoriolisIteration)
+           .isSuccess()) {
+      if (NBclCoriolisIteration < 1) {
+         ABORT_ERROR("NBclCoriolisIteration must be greater than zero");
+      }
+      SEConfig.NBclCoriolisIteration = NBclCoriolisIteration;
+   }
+
+   ModeSplitShareConfig.get("ReinitSplitVelocity",
+                            SEConfig.ReinitSplitVelocity);
+
+   // For the unsplit schemes, the linear Coriolis iteration is 1.
+   if (IsUnsplit) {
+      SEConfig.NBclCoriolisIteration = 1;
+   }
+
+   // Report the resolved options
+   R8 TimeStepSeconds;
+   TimeStep.get(TimeStepSeconds, TimeUnits::Seconds);
+
+   if (IsUnsplit) {
+      LOG_INFO("UnsplitRK2: NTimeStepIteration={}, TimeStep={} s",
+               SEConfig.NTimeStepIteration, TimeStepSeconds);
+   } else {
+      SEConfig.NBtrSubcycles =
+          computeSubcycleCount(TimeStep, SEConfig.BtrTimeStep);
+
+      R8 BtrTimeStepSeconds;
+      SEConfig.BtrTimeStep.get(BtrTimeStepSeconds, TimeUnits::Seconds);
+      LOG_INFO("SplitExplicitRK2: TimeStep={} s, BtrTimeStep={} s, "
+               "NBtrSubcycles={}, BtrDt={} s, NTimeStepIteration={}, "
+               "NBclCoriolisIteration={}",
+               TimeStepSeconds, BtrTimeStepSeconds, SEConfig.NBtrSubcycles,
+               TimeStepSeconds / SEConfig.NBtrSubcycles,
+               SEConfig.NTimeStepIteration, SEConfig.NBclCoriolisIteration);
+   }
+
+   return SEConfig;
+}
+
+//------------------------------------------------------------------------------
+SplitExplicitBarotropicStepperType
+SplitExplicitInit::getBtrTimeStepperFromStr(const std::string &InString) {
+
+   if (InString == "Predictor-Corrector") {
+      return SplitExplicitBarotropicStepperType::PredictorCorrector;
+   }
+
+   ABORT_ERROR("BtrTimeStepper should be 'Predictor-Corrector' but got {}",
+               InString);
+   return SplitExplicitBarotropicStepperType::Invalid;
+}
+
+//------------------------------------------------------------------------------
+I4 SplitExplicitInit::computeSubcycleCount(const TimeInterval &TimeStep,
+                                           const TimeInterval &BtrTimeStep) {
+
+   R8 TimeStepSeconds;
+   R8 BtrTimeStepSeconds;
+   TimeStep.get(TimeStepSeconds, TimeUnits::Seconds);
+   BtrTimeStep.get(BtrTimeStepSeconds, TimeUnits::Seconds);
+
+   if (BtrTimeStepSeconds <= 0.) {
+      ABORT_ERROR("BtrTimeStep must be greater than zero");
+   }
+
+   if (BtrTimeStepSeconds >= TimeStepSeconds) {
+      ABORT_ERROR("BtrTimeStep ({} s) must be smaller than the baroclinic "
+                  "TimeStep ({} s) so that the barotropic mode is subcycled",
+                  BtrTimeStepSeconds, TimeStepSeconds);
+   }
+
+   return std::max<I4>(
+       1, static_cast<I4>(std::ceil(TimeStepSeconds / BtrTimeStepSeconds)));
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitInit::allocateScratch(SplitExplicitScratch &Scratch,
+                                        const HorzMesh *Mesh,
+                                        const VertCoord *VCoord,
+                                        const std::string &Name) {
+
+   if (!Mesh)
+      LOG_CRITICAL("Invalid mesh");
+   if (!VCoord)
+      LOG_CRITICAL("Invalid vertical coordinate");
+
+   Scratch.NormalBarotropicVelocitySubcycleCur = Array1DReal(
+       "NormalBarotropicVelocitySubcycleCur" + Name, Mesh->NEdgesSize);
+   Scratch.NormalBarotropicVelocitySubcyclePre = Array1DReal(
+       "NormalBarotropicVelocitySubcyclePre" + Name, Mesh->NEdgesSize);
+   Scratch.NormalBarotropicVelocitySubcycleCor = Array1DReal(
+       "NormalBarotropicVelocitySubcycleCor" + Name, Mesh->NEdgesSize);
+   Scratch.BarotropicPressureAnomalySubcycleCur = Array1DReal(
+       "BarotropicPressureAnomalySubcycleCur" + Name, Mesh->NCellsSize);
+   Scratch.BarotropicPressureAnomalySubcyclePre = Array1DReal(
+       "BarotropicPressureAnomalySubcyclePre" + Name, Mesh->NCellsSize);
+   Scratch.BarotropicPressureAnomalySubcycleCor = Array1DReal(
+       "BarotropicPressureAnomalySubcycleCor" + Name, Mesh->NCellsSize);
+   Scratch.BarotropicPressure =
+       Array1DReal("BarotropicPressure" + Name, Mesh->NCellsSize);
+   Scratch.BarotropicForcing =
+       Array1DReal("BarotropicForcing" + Name, Mesh->NEdgesSize);
+   Scratch.BarotropicFlux =
+       Array1DReal("BarotropicFlux" + Name, Mesh->NEdgesSize);
+   Scratch.BaroclinicPseudoThicknessEdge =
+       Array1DReal("BaroclinicPseudoThicknessEdge" + Name, Mesh->NEdgesSize);
+   Scratch.BaseVelocityTend = Array2DReal(
+       "BaseVelocityTend" + Name, Mesh->NEdgesSize, VCoord->NVertLayers);
+   Scratch.NormalTransportVelocity = Array2DReal(
+       "NormalTransportVelocity" + Name, Mesh->NEdgesSize, VCoord->NVertLayers);
+
+   parallelFor(
+       "initializeCell1D", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          Scratch.BarotropicPressureAnomalySubcycleCur(ICell) = 0._Real;
+          Scratch.BarotropicPressureAnomalySubcyclePre(ICell) = 0._Real;
+          Scratch.BarotropicPressureAnomalySubcycleCor(ICell) = 0._Real;
+          Scratch.BarotropicPressure(ICell)                   = 0._Real;
+       });
+
+   parallelFor(
+       "initializeCell1D", {Mesh->NEdgesAll}, KOKKOS_LAMBDA(I4 IEdge) {
+          Scratch.NormalBarotropicVelocitySubcycleCur(IEdge) = 0._Real;
+          Scratch.NormalBarotropicVelocitySubcyclePre(IEdge) = 0._Real;
+          Scratch.NormalBarotropicVelocitySubcycleCor(IEdge) = 0._Real;
+          Scratch.BarotropicForcing(IEdge)                   = 0._Real;
+          Scratch.BarotropicFlux(IEdge)                      = 0._Real;
+          Scratch.BaroclinicPseudoThicknessEdge(IEdge)       = 0._Real;
+       });
+
+   deepCopy(Scratch.BaseVelocityTend, 0.);
+   deepCopy(Scratch.NormalTransportVelocity, 0.);
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitInit::computeVelocitySplit(OceanState *State,
+                                             const HorzMesh *Mesh,
+                                             const VertCoord *VCoord,
+                                             I4 TimeLevel) {
+
+   if (!State)
+      LOG_CRITICAL("Invalid State");
+
+   Array2DReal NormalVelocity  = State->getNormalVelocity(TimeLevel);
+   Array2DReal PseudoThickness = State->getPseudoThickness(TimeLevel);
+   Array2DReal NormalBaroclinicVelocity =
+       State->getNormalBaroclinicVelocity(TimeLevel);
+   Array1DReal NormalBarotropicVelocity =
+       State->getNormalBarotropicVelocity(TimeLevel);
+
+   OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+   OMEGA_SCOPE(EdgeMask, VCoord->EdgeMask);
+
+   deepCopy(NormalBaroclinicVelocity, 0.);
+   deepCopy(NormalBarotropicVelocity, 0.);
+
+   parallelForOuter(
+       "SplitVelocity", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(I4 IEdge, const TeamMember &Team) {
+          const I4 KMin = MinLayerEdgeBot(IEdge);
+          const I4 KMax = MaxLayerEdgeTop(IEdge);
+
+          Real BarotropicVelocity = 0._Real;
+
+          if (KMax >= KMin) {
+             const I4 Cell0 = CellsOnEdge(IEdge, 0);
+             const I4 Cell1 = CellsOnEdge(IEdge, 1);
+
+             Real ThicknessSum = 0._Real;
+             Real FluxSum      = 0._Real;
+
+             parallelReduceInner(
+                 Team, Range{KMin, KMax},
+                 INNER_LAMBDA(const int K, Real &ThickAccum, Real &FluxAccum) {
+                    const Real ThickEdge =
+                        0.5_Real *
+                        (PseudoThickness(Cell0, K) + PseudoThickness(Cell1, K));
+
+                    ThickAccum += ThickEdge;
+                    FluxAccum += ThickEdge * NormalVelocity(IEdge, K);
+                 },
+                 ThicknessSum, FluxSum);
+
+             BarotropicVelocity = FluxSum / ThicknessSum;
+
+             Kokkos::single(
+                 PerTeam(Team), INNER_LAMBDA() {
+                    NormalBarotropicVelocity(IEdge) =
+                        BarotropicVelocity * EdgeMask(IEdge, KMin);
+                 });
+
+          } else {
+
+             Kokkos::single(
+                 PerTeam(Team),
+                 INNER_LAMBDA() { NormalBarotropicVelocity(IEdge) = 0._Real; });
+          }
+
+          parallelForInner(
+              Team, Range{KMin, KMax}, INNER_LAMBDA(I4 K) {
+                 NormalBaroclinicVelocity(IEdge, K) =
+                     NormalVelocity(IEdge, K) - BarotropicVelocity;
+              });
+       });
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitInit::computeUnsplitVelocitySplit(OceanState *State,
+                                                    const HorzMesh *Mesh,
+                                                    const VertCoord *VCoord,
+                                                    I4 CurLevel, I4 NextLevel) {
+
+   if (!State)
+      LOG_CRITICAL("Invalid State");
+
+   Array2DReal NormalVelocityCur = State->getNormalVelocity(CurLevel);
+   Array2DReal NormalVelocityNew = State->getNormalVelocity(NextLevel);
+   Array2DReal NormalBaroclinicVelocityCur =
+       State->getNormalBaroclinicVelocity(CurLevel);
+   Array2DReal NormalBaroclinicVelocityNew =
+       State->getNormalBaroclinicVelocity(NextLevel);
+   Array1DReal NormalBarotropicVelocityCur =
+       State->getNormalBarotropicVelocity(CurLevel);
+   Array1DReal NormalBarotropicVelocityNew =
+       State->getNormalBarotropicVelocity(NextLevel);
+
+   deepCopy(NormalBaroclinicVelocityCur, 0.);
+   deepCopy(NormalBaroclinicVelocityNew, 0.);
+
+   deepCopy(NormalBarotropicVelocityCur, 0.);
+   deepCopy(NormalBarotropicVelocityNew, 0.);
+
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   parallelForOuter(
+       "UnsplitVelocity", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(I4 IEdge, const TeamMember &Team) {
+          const I4 KMin = MinLayerEdgeBot(IEdge);
+          const I4 KMax = MaxLayerEdgeTop(IEdge);
+
+          parallelForInner(
+              Team, Range{KMin, KMax}, INNER_LAMBDA(I4 K) {
+                 NormalBaroclinicVelocityCur(IEdge, K) =
+                     NormalVelocityCur(IEdge, K);
+                 NormalBaroclinicVelocityNew(IEdge, K) =
+                     NormalVelocityNew(IEdge, K);
+              });
+       });
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitInit::initializeBarotropicPressure(
+    SplitExplicitScratch &Scratch, OceanState *State, const HorzMesh *Mesh,
+    const VertCoord *VCoord, I4 TimeLevel) {
+
+   if (!State)
+      LOG_CRITICAL("Invalid State");
+   if (!Mesh)
+      LOG_CRITICAL("Invalid mesh");
+   if (!VCoord)
+      LOG_CRITICAL("Invalid vertical coordinate");
+
+   Array1DReal BtrPressure     = Scratch.BarotropicPressure;
+   Array1DReal BtrPressAnomaly = State->getBarotropicPressureAnomaly(TimeLevel);
+   Array1DReal SurfacePressure = VCoord->SurfacePressure;
+   Array2DReal PressureInterface = VCoord->PressureInterface;
+   Array1DReal BottomGeomDepth   = VCoord->BottomGeomDepth;
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
+   parallelFor(
+       "initializeBarotropicPressure", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell) {
+          const I4 KMax = MaxLayerCell(ICell);
+
+          const Real Pressure =
+              PressureInterface(ICell, KMax + 1) - SurfacePressure(ICell);
+          BtrPressure(ICell) = Pressure;
+          BtrPressAnomaly(ICell) =
+              Pressure - RhoSw * Gravity * BottomGeomDepth(ICell);
+          Scratch.BarotropicPressureAnomalySubcycleCur(ICell) =
+              BtrPressAnomaly(ICell);
+          Scratch.BarotropicPressureAnomalySubcyclePre(ICell) =
+              BtrPressAnomaly(ICell);
+          Scratch.BarotropicPressureAnomalySubcycleCor(ICell) =
+              BtrPressAnomaly(ICell);
+       });
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitInit::combineVelocitySplit(OceanState *State,
+                                             const HorzMesh *Mesh,
+                                             const VertCoord *VCoord,
+                                             I4 TimeLevel) {
+
+   if (!State)
+      LOG_CRITICAL("Invalid State");
+
+   Array2DReal NormalVelocity = State->getNormalVelocity(TimeLevel);
+   Array2DReal NormalBaroclinicVelocity =
+       State->getNormalBaroclinicVelocity(TimeLevel);
+   Array1DReal NormalBarotropicVelocity =
+       State->getNormalBarotropicVelocity(TimeLevel);
+
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   parallelFor(
+       "combineSplitExplicitVelocity", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge) {
+          const I4 KMin = MinLayerEdgeBot(IEdge);
+          const I4 KMax = MaxLayerEdgeTop(IEdge);
+
+          const Real BarotropicVelocity = NormalBarotropicVelocity(IEdge);
+          for (I4 K = KMin; K <= KMax; ++K) {
+             NormalVelocity(IEdge, K) =
+                 NormalBaroclinicVelocity(IEdge, K) + BarotropicVelocity;
+          }
+       });
+}
+
+} // namespace OMEGA

--- a/components/omega/src/timeStepping/SplitExplicitInit.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitInit.cpp
@@ -163,16 +163,14 @@ void SplitExplicitInit::allocateScratch(SplitExplicitScratch &Scratch,
        "BarotropicPressureAnomalySubcyclePre" + Name, Mesh->NCellsSize);
    Scratch.BarotropicPressureAnomalySubcycleCor = Array1DReal(
        "BarotropicPressureAnomalySubcycleCor" + Name, Mesh->NCellsSize);
-   Scratch.BarotropicPressure =
-       Array1DReal("BarotropicPressure" + Name, Mesh->NCellsSize);
    Scratch.BarotropicForcing =
        Array1DReal("BarotropicForcing" + Name, Mesh->NEdgesSize);
    Scratch.BarotropicFlux =
        Array1DReal("BarotropicFlux" + Name, Mesh->NEdgesSize);
    Scratch.BaroclinicPseudoThicknessEdge =
        Array1DReal("BaroclinicPseudoThicknessEdge" + Name, Mesh->NEdgesSize);
-   Scratch.BaseVelocityTend = Array2DReal(
-       "BaseVelocityTend" + Name, Mesh->NEdgesSize, VCoord->NVertLayers);
+   Scratch.IterVelocityTend = Array2DReal(
+       "IterVelocityTend" + Name, Mesh->NEdgesSize, VCoord->NVertLayers);
    Scratch.NormalTransportVelocity = Array2DReal(
        "NormalTransportVelocity" + Name, Mesh->NEdgesSize, VCoord->NVertLayers);
 
@@ -181,11 +179,10 @@ void SplitExplicitInit::allocateScratch(SplitExplicitScratch &Scratch,
           Scratch.BarotropicPressureAnomalySubcycleCur(ICell) = 0._Real;
           Scratch.BarotropicPressureAnomalySubcyclePre(ICell) = 0._Real;
           Scratch.BarotropicPressureAnomalySubcycleCor(ICell) = 0._Real;
-          Scratch.BarotropicPressure(ICell)                   = 0._Real;
        });
 
    parallelFor(
-       "initializeCell1D", {Mesh->NEdgesAll}, KOKKOS_LAMBDA(I4 IEdge) {
+       "initializeEdge1D", {Mesh->NEdgesAll}, KOKKOS_LAMBDA(I4 IEdge) {
           Scratch.NormalBarotropicVelocitySubcycleCur(IEdge) = 0._Real;
           Scratch.NormalBarotropicVelocitySubcyclePre(IEdge) = 0._Real;
           Scratch.NormalBarotropicVelocitySubcycleCor(IEdge) = 0._Real;
@@ -194,7 +191,7 @@ void SplitExplicitInit::allocateScratch(SplitExplicitScratch &Scratch,
           Scratch.BaroclinicPseudoThicknessEdge(IEdge)       = 0._Real;
        });
 
-   deepCopy(Scratch.BaseVelocityTend, 0.);
+   deepCopy(Scratch.IterVelocityTend, 0.);
    deepCopy(Scratch.NormalTransportVelocity, 0.);
 }
 
@@ -329,7 +326,6 @@ void SplitExplicitInit::initializeBarotropicPressure(
    if (!VCoord)
       LOG_CRITICAL("Invalid vertical coordinate");
 
-   Array1DReal BtrPressure     = Scratch.BarotropicPressure;
    Array1DReal BtrPressAnomaly = State->getBarotropicPressureAnomaly(TimeLevel);
    Array1DReal SurfacePressure = VCoord->SurfacePressure;
    Array2DReal PressureInterface = VCoord->PressureInterface;
@@ -343,7 +339,6 @@ void SplitExplicitInit::initializeBarotropicPressure(
 
           const Real Pressure =
               PressureInterface(ICell, KMax + 1) - SurfacePressure(ICell);
-          BtrPressure(ICell) = Pressure;
           BtrPressAnomaly(ICell) =
               Pressure - RhoSw * Gravity * BottomGeomDepth(ICell);
           Scratch.BarotropicPressureAnomalySubcycleCur(ICell) =
@@ -352,38 +347,6 @@ void SplitExplicitInit::initializeBarotropicPressure(
               BtrPressAnomaly(ICell);
           Scratch.BarotropicPressureAnomalySubcycleCor(ICell) =
               BtrPressAnomaly(ICell);
-       });
-}
-
-//------------------------------------------------------------------------------
-void SplitExplicitInit::combineVelocitySplit(OceanState *State,
-                                             const HorzMesh *Mesh,
-                                             const VertCoord *VCoord,
-                                             I4 TimeLevel) {
-
-   if (!State)
-      LOG_CRITICAL("Invalid State");
-
-   Array2DReal NormalVelocity = State->getNormalVelocity(TimeLevel);
-   Array2DReal NormalBaroclinicVelocity =
-       State->getNormalBaroclinicVelocity(TimeLevel);
-   Array1DReal NormalBarotropicVelocity =
-       State->getNormalBarotropicVelocity(TimeLevel);
-
-   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
-   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
-
-   parallelFor(
-       "combineSplitExplicitVelocity", {Mesh->NEdgesAll},
-       KOKKOS_LAMBDA(int IEdge) {
-          const I4 KMin = MinLayerEdgeBot(IEdge);
-          const I4 KMax = MaxLayerEdgeTop(IEdge);
-
-          const Real BarotropicVelocity = NormalBarotropicVelocity(IEdge);
-          for (I4 K = KMin; K <= KMax; ++K) {
-             NormalVelocity(IEdge, K) =
-                 NormalBaroclinicVelocity(IEdge, K) + BarotropicVelocity;
-          }
        });
 }
 

--- a/components/omega/src/timeStepping/SplitExplicitInit.h
+++ b/components/omega/src/timeStepping/SplitExplicitInit.h
@@ -51,13 +51,6 @@ class SplitExplicitInit {
        I4 TimeLevel                   ///< [in] state time level to initialize
    );
 
-   static void
-   combineVelocitySplit(OceanState *State,       ///< [inout] ocean state
-                        const HorzMesh *Mesh,    ///< [in] horizontal mesh
-                        const VertCoord *VCoord, ///< [in] vertical coordinate
-                        I4 TimeLevel ///< [in] state time level to update
-   );
-
  private:
    static SplitExplicitBarotropicStepperType getBtrTimeStepperFromStr(
        const std::string &InString ///< [in] barotropic stepping method

--- a/components/omega/src/timeStepping/SplitExplicitInit.h
+++ b/components/omega/src/timeStepping/SplitExplicitInit.h
@@ -1,0 +1,74 @@
+#ifndef OMEGA_SPLIT_EXPLICIT_INIT_H
+#define OMEGA_SPLIT_EXPLICIT_INIT_H
+//===-- SplitExplicitInit.h - split-explicit initialization ----*- C++ -*-===//
+//
+/// \file
+/// \brief Initialization helpers for split-explicit time stepping.
+//
+//===----------------------------------------------------------------------===//
+
+#include "HorzMesh.h"
+#include "OceanState.h"
+#include "SplitExplicitTypes.h"
+#include "VertCoord.h"
+
+namespace OMEGA {
+
+class SplitExplicitInit {
+ public:
+   static SplitExplicitConfig readConfigOptions(
+       const TimeInterval &TimeStep, ///< [in] full baroclinic time step
+       bool IsUnsplit ///< [in] true for UnsplitRK2 (no barotropic split)
+   );
+
+   static void allocateScratch(
+       SplitExplicitScratch &Scratch, ///< [inout] split-explicit scratch data
+       const HorzMesh *Mesh,          ///< [in] horizontal mesh
+       const VertCoord *VCoord,       ///< [in] vertical coordinate
+       const std::string &Name        ///< [in] owning time stepper name
+   );
+
+   static void
+   computeVelocitySplit(OceanState *State,       ///< [inout] ocean state
+                        const HorzMesh *Mesh,    ///< [in] horizontal mesh
+                        const VertCoord *VCoord, ///< [in] vertical coordinate
+                        I4 TimeLevel ///< [in] state time level to split
+   );
+
+   static void computeUnsplitVelocitySplit(
+       OceanState *State,       ///< [inout] ocean state
+       const HorzMesh *Mesh,    ///< [in] horizontal mesh
+       const VertCoord *VCoord, ///< [in] vertical coordinate
+       I4 CurLevel,             ///< [in] state current level to initialize
+       I4 NextLevel             ///< [in] state next level to initialize
+   );
+
+   static void initializeBarotropicPressure(
+       SplitExplicitScratch &Scratch, ///< [inout] split-explicit scratch data
+       OceanState *State,             ///< [inout] ocean state
+       const HorzMesh *Mesh,          ///< [in] horizontal mesh
+       const VertCoord *VCoord,       ///< [in] vertical coordinate
+       I4 TimeLevel                   ///< [in] state time level to initialize
+   );
+
+   static void
+   combineVelocitySplit(OceanState *State,       ///< [inout] ocean state
+                        const HorzMesh *Mesh,    ///< [in] horizontal mesh
+                        const VertCoord *VCoord, ///< [in] vertical coordinate
+                        I4 TimeLevel ///< [in] state time level to update
+   );
+
+ private:
+   static SplitExplicitBarotropicStepperType getBtrTimeStepperFromStr(
+       const std::string &InString ///< [in] barotropic stepping method
+   );
+
+   static I4 computeSubcycleCount(
+       const TimeInterval &TimeStep,   ///< [in] full baroclinic time step
+       const TimeInterval &BtrTimeStep ///< [in] requested barotropic time step
+   );
+};
+
+} // namespace OMEGA
+
+#endif

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
@@ -128,20 +128,18 @@ void SplitExplicitRK2Stepper::doThicknessTracerUpdate(
        SEScratch.NormalTransportVelocity;
    // Compute thickness auxiliary variables at the new time level
    AuxState->computePseudoThicknessTracerAux(State, NextTracerArray, NextLevel,
-                                             NormalTransportVelocity,
-                                             StageTimeStep);
+                                             NextLevel, StageTimeStep);
 
    computeVerticalPseudoVelocity(State, NextLevel, NormalTransportVelocity,
                                  StageTimeStep);
 
    // Compute thickness and tracer tendencies at the new time level
    Tend->computePseudoThicknessTendenciesOnly(
-       State, AuxState, NextLevel, NextLevel, NormalTransportVelocity,
-       StageTime + 0.5 * StageTimeStep);
+       State, AuxState, NextLevel, NextLevel, StageTime + 0.5 * StageTimeStep);
 
-   Tend->computeTracerTendenciesOnly(
-       State, AuxState, NextTracerArray, NextLevel, NormalTransportVelocity,
-       StageTime + 0.5 * StageTimeStep, StageTimeStep);
+   Tend->computeTracerTendenciesOnly(State, AuxState, NextTracerArray,
+                                     NextLevel, NextLevel,
+                                     StageTime + 0.5 * StageTimeStep);
 
    if (FinalIteration) {
       // Retain the full-step conservative update on the final iteration.

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
@@ -122,16 +122,13 @@ void SplitExplicitRK2Stepper::doThicknessTracerUpdate(
    // prescribeState(State, NextLevel, State, CurLevel,
    //               StageTime + 0.5 * StageTimeStep);
 
-   // NormalTransportVelocity is the corrected transport velocity provided by
+   // TransportVelocityAdd is the correction to transport velocity provided by
    // computeTransportVelocity before this stage.
-   const Array2DReal NormalTransportVelocity =
-       SEScratch.NormalTransportVelocity;
+   const Array2DReal TransportVelAdd = SEScratch.TransportVelocityAdd;
    // Compute thickness auxiliary variables at the new time level
    AuxState->computePseudoThicknessTracerAux(State, NextTracerArray, NextLevel,
-                                             NextLevel, StageTimeStep);
-
-   computeVerticalPseudoVelocity(State, NextLevel, NormalTransportVelocity,
-                                 StageTimeStep);
+                                             NextLevel, StageTimeStep,
+                                             TransportVelAdd);
 
    // Compute thickness and tracer tendencies at the new time level
    Tend->computePseudoThicknessTendenciesOnly(
@@ -167,8 +164,8 @@ void SplitExplicitRK2Stepper::computeTransportVelocity(OceanState *State,
 
    Pacer::start("SE-RK2:computeTransportVelocity", 2);
 
-   Array2DReal NormalVel          = State->getNormalVelocity(TimeLevel);
-   Array2DReal NormalTransportVel = SEScratch.NormalTransportVelocity;
+   Array2DReal NormalVel       = State->getNormalVelocity(TimeLevel);
+   Array2DReal TransportVelAdd = SEScratch.TransportVelocityAdd;
    Array2DReal NormalBclVel    = State->getNormalBaroclinicVelocity(TimeLevel);
    Array1DReal NormalBtrVel    = State->getNormalBarotropicVelocity(TimeLevel);
    Array2DReal PseudoThickCell = State->getPseudoThickness(TimeLevel);
@@ -220,8 +217,8 @@ void SplitExplicitRK2Stepper::computeTransportVelocity(OceanState *State,
                  const Real TotalVel =
                      NormalBtrVel(IEdge) + NormalBclVel(IEdge, K);
 
-                 NormalVel(IEdge, K)          = TotalVel;
-                 NormalTransportVel(IEdge, K) = TotalVel + VelCorrection;
+                 NormalVel(IEdge, K)       = TotalVel;
+                 TransportVelAdd(IEdge, K) = VelCorrection;
               });
        });
 

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
@@ -43,8 +43,14 @@ void SplitExplicitRK2Stepper::finalizeInit() {
    // weight to use for the surface pressure gradient.
    Tend->setModeSplit(CoriolisTendMode::Separate, SEConfig.SplitFactor);
 
+   if (SEConfig.BtrTimeStepper !=
+       SplitExplicitBarotropicStepperType::PredictorCorrector)
+      LOG_CRITICAL("Invalid split-explicit barotropic time stepper");
+
    SplitExplicitInit::allocateScratch(SEScratch, Mesh, VCoord, Name);
-   initBarotropicStepper();
+
+   BarotropicPCStepper.init(AuxState, &SEScratch, &SEConfig, Mesh, MeshHalo,
+                            VCoord);
 }
 
 //------------------------------------------------------------------------------
@@ -73,24 +79,6 @@ void SplitExplicitRK2Stepper::initializeStateFromInput(OceanState *State,
 }
 
 //------------------------------------------------------------------------------
-void SplitExplicitRK2Stepper::initBarotropicStepper() {
-
-   if (SEConfig.BtrTimeStepper ==
-       SplitExplicitBarotropicStepperType::PredictorCorrector) {
-      BarotropicUpdate = [this](OceanState *State, I4 CurLevel, I4 NextLevel,
-                                const TimeInstant &StageTime,
-                                const TimeInterval &StageTimeStep) {
-         BarotropicPCStepper.doBarotropicVelocityUpdate(
-             State, AuxState, SEScratch, SEConfig, Mesh, MeshHalo, VCoord,
-             CurLevel, NextLevel, StageTime, StageTimeStep);
-      };
-      return;
-   }
-
-   LOG_CRITICAL("Invalid split-explicit barotropic time stepper");
-}
-
-//------------------------------------------------------------------------------
 void SplitExplicitRK2Stepper::doBaroclinicVelocityUpdate(
     OceanState *State, const Array3DReal &TendencyTracerArray, I4 CurLevel,
     I4 NextLevel, const TimeInstant &StageTime,
@@ -102,21 +90,13 @@ void SplitExplicitRK2Stepper::doBaroclinicVelocityUpdate(
    // prescribeState(State, CurLevel, State, CurLevel, StageTime);
 
    // Compute baroclinic velocity tendencies and update baroclinic velocity for
-   // the first half of the stage time step. This is the same entry point the
-   // unsplit time steppers use; the split-specific terms are selected by the
-   // mode set in finalizeInit.
+   // the first half of the stage time step
    Tend->computeVelocityTendencies(State, AuxState, TendencyTracerArray,
                                    NextLevel, NextLevel, NextLevel, StageTime,
                                    StageTimeStep);
 
-   // Save the baroclinic velocity tendencies before the baroclinic velocity
-   // update
-   // TODO: this can be optimized in the future.
-   deepCopy(SEScratch.BaseVelocityTend, Tend->NormalVelocityTend);
-
-   // Perform baroclinic velocity iteration with Coriolis acceleration.
-   doBaroclinicCoriolisIteration(State, SEScratch.BaseVelocityTend, CurLevel,
-                                 NextLevel, StageTimeStep);
+   // Perform baroclinic velocity iteration with Coriolis acceleration
+   doBaroclinicCoriolisIteration(State, CurLevel, NextLevel, StageTimeStep);
 
    Pacer::stop("SE-RK2:stage1Bcl", 2);
 }
@@ -173,17 +153,6 @@ void SplitExplicitRK2Stepper::doThicknessTracerUpdate(
    finalizeTimeStepIterationState(State, CurLevel, NextLevel, FinalIteration);
 
    Pacer::stop("SE-RK2:stage3TrThick", 2);
-}
-
-//------------------------------------------------------------------------------
-void SplitExplicitRK2Stepper::doBarotropicVelocityUpdate(
-    OceanState *State, I4 CurLevel, I4 NextLevel, const TimeInstant &StageTime,
-    const TimeInterval &StageTimeStep) const {
-
-   if (!BarotropicUpdate)
-      LOG_CRITICAL("Split-explicit barotropic time stepper not initialized");
-
-   BarotropicUpdate(State, CurLevel, NextLevel, StageTime, StageTimeStep);
 }
 
 //------------------------------------------------------------------------------
@@ -255,33 +224,33 @@ void SplitExplicitRK2Stepper::computeTransportVelocity(OceanState *State,
 
 //------------------------------------------------------------------------------
 void SplitExplicitRK2Stepper::doBaroclinicCoriolisIteration(
-    OceanState *State, const Array2DReal &BaseVelocityTend, I4 CurLevel,
-    I4 NextLevel, const TimeInterval &StageTimeStep) const {
+    OceanState *State, I4 CurLevel, I4 NextLevel,
+    const TimeInterval &StageTimeStep) const {
 
    Pacer::start("SE-RK2:bclCoriolisIter", 2);
 
    const Array1DReal &FEdge = Mesh->FEdge;
+
+   // The non-Coriolis tendency is left untouched so every iteration can re-read
+   // it; each iteration writes base plus Coriolis into scratch instead.
+   const Array2DReal BaseVelocityTend = Tend->NormalVelocityTend;
+   const Array2DReal IterVelocityTend = SEScratch.IterVelocityTend;
+
    for (I4 Iter = 0; Iter < SEConfig.NBclCoriolisIteration; ++Iter) {
 
       const bool FinalCoriolisIter = Iter + 1 == SEConfig.NBclCoriolisIteration;
 
-      if (Iter > 0) {
-         deepCopy(Tend->NormalVelocityTend, BaseVelocityTend);
-      }
-
       Array2DReal NormalBclVelEdge =
           State->getNormalBaroclinicVelocity(NextLevel);
 
-      // Compute the baroclinic part of the Coriolis acceleration
-      Tend->computeCoriolisAccelerationOnEdge(Tend->NormalVelocityTend,
-                                              NormalBclVelEdge, FEdge);
+      // IterVelocityTend = BaseVelocityTend + Coriolis(NormalBclVelEdge)
+      Tend->computeCoriolisAccelerationOnEdge(
+          IterVelocityTend, BaseVelocityTend, NormalBclVelEdge, FEdge);
 
-      // Compute the barotropic forcing
-      computeBarotropicForcing(State, CurLevel, NextLevel, StageTimeStep);
-
-      // Update the baroclinic velocity by tendency at (n+1/2)
-      updateBaroclinicVelocityByTend(State, NextLevel, State, CurLevel,
-                                     0.5 * StageTimeStep);
+      // Remove the barotropic forcing and update the baroclinic velocity to
+      // (n+1/2) in a single pass over the edge column.
+      updateBaroclinicVelocityWithBarotropicForcing(State, CurLevel, NextLevel,
+                                                    StageTimeStep);
 
       if (!FinalCoriolisIter) {
          Pacer::start("SE-RK2:haloBclVelIter", 3);
@@ -303,121 +272,83 @@ void SplitExplicitRK2Stepper::doBaroclinicCoriolisIteration(
 }
 
 //------------------------------------------------------------------------------
-void SplitExplicitRK2Stepper::computeBarotropicForcing(
+void SplitExplicitRK2Stepper::updateBaroclinicVelocityWithBarotropicForcing(
     OceanState *State, I4 CurLevel, I4 NextLevel,
     const TimeInterval &StageTimeStep) const {
 
+   Pacer::start("SE-RK2:bclVelUpdate", 2);
+
+   Array2DReal NormalBclVelCur  = State->getNormalBaroclinicVelocity(CurLevel);
+   Array2DReal NormalBclVelNext = State->getNormalBaroclinicVelocity(NextLevel);
+   Array2DReal IterVelocityTend = SEScratch.IterVelocityTend;
+   Array1DReal BtrForcing       = SEScratch.BarotropicForcing;
+
    const Real LocSplitFactor = SEConfig.SplitFactor;
-
-   // Return if the unsplit time stepper (i.e., BarotropicForcing = 0)
-   if (LocSplitFactor == 0._Real)
-      return;
-
-   Pacer::start("SE-RK2:barotropicForcing", 2);
-
-   Array2DReal NormalBclVelCur = State->getNormalBaroclinicVelocity(CurLevel);
-   Array2DReal PseudoThickCell = State->getPseudoThickness(NextLevel);
-   Array2DReal NormalVelTend   = Tend->NormalVelocityTend;
-   Array1DReal BtrForcing      = SEScratch.BarotropicForcing;
 
    R8 DtSecondsR8;
    StageTimeStep.get(DtSecondsR8, TimeUnits::Seconds);
+   const Real InvDtSeconds = 1._Real / DtSecondsR8;
    const Real DtSeconds    = DtSecondsR8;
-   const Real InvDtSeconds = 1._Real / DtSeconds;
 
+   R8 HalfDtSecondsR8;
+   TimeInterval HalfStageTimeStep = 0.5 * StageTimeStep;
+   HalfStageTimeStep.get(HalfDtSecondsR8, TimeUnits::Seconds);
+   const Real HalfDtSeconds = HalfDtSecondsR8;
+
+   OMEGA_SCOPE(MeanPseudoThickEdge,
+               AuxState->PseudoThicknessAux.MeanPseudoThickEdge);
    OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
    OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
-   OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
 
    parallelForOuter(
-       "computeBarotropicForcing", {Mesh->NEdgesAll},
+       "updateBclVelWithBtrForcing", {Mesh->NEdgesAll},
        KOKKOS_LAMBDA(I4 IEdge, const TeamMember &Team) {
           const I4 KMin = MinLayerEdgeBot(IEdge);
           const I4 KMax = MaxLayerEdgeTop(IEdge);
 
-          if (KMax >= KMin) {
+          // The barotropic forcing is the thickness-weighted column mean of the
+          // provisional baroclinic tendency.It is zero for the UnsplitRK2
+          // stepper, which carries the barotropic mode here instead.
+          Real Forcing = 0._Real;
 
-             const I4 Cell0 = CellsOnEdge(IEdge, 0);
-             const I4 Cell1 = CellsOnEdge(IEdge, 1);
+          if (LocSplitFactor != 0._Real) {
 
-             Real ThicknessSum = 0._Real;
-             parallelReduceInner(
-                 Team, Range{KMin, KMax},
-                 INNER_LAMBDA(I4 K, Real & ThickAccum) {
-                    const Real ThickEdge =
-                        0.5_Real *
-                        (PseudoThickCell(Cell0, K) + PseudoThickCell(Cell1, K));
+             if (KMax >= KMin) {
+                Real ThicknessSum = 0._Real;
+                Real FluxSum      = 0._Real;
 
-                    ThickAccum += ThickEdge;
-                 },
-                 ThicknessSum);
+                parallelReduceInner(
+                    Team, Range{KMin, KMax},
+                    INNER_LAMBDA(I4 K, Real & ThickAccum, Real & FluxAccum) {
+                       const Real ThickEdge = MeanPseudoThickEdge(IEdge, K);
+                       const Real ProvisionalBclVel =
+                           NormalBclVelCur(IEdge, K) +
+                           DtSeconds * IterVelocityTend(IEdge, K);
+                       ThickAccum += ThickEdge;
+                       FluxAccum += ThickEdge * ProvisionalBclVel;
+                    },
+                    ThicknessSum, FluxSum);
 
-             Real NormalThicknessFluxSum = 0._Real;
-             parallelReduceInner(
-                 Team, Range{KMin, KMax},
-                 INNER_LAMBDA(I4 K, Real & FluxAccum) {
-                    const Real ProvisionalBclVel =
-                        NormalBclVelCur(IEdge, K) +
-                        DtSeconds * NormalVelTend(IEdge, K);
-
-                    const Real ThickEdge =
-                        0.5_Real *
-                        (PseudoThickCell(Cell0, K) + PseudoThickCell(Cell1, K));
-
-                    FluxAccum += (ThickEdge / ThicknessSum) * ProvisionalBclVel;
-                 },
-                 NormalThicknessFluxSum);
-
-             const Real Forcing =
-                 LocSplitFactor * NormalThicknessFluxSum * InvDtSeconds;
+                Forcing =
+                    LocSplitFactor * (FluxSum / ThicknessSum) * InvDtSeconds;
+             }
 
              Kokkos::single(
                  PerTeam(Team),
                  INNER_LAMBDA() { BtrForcing(IEdge) = Forcing; });
-
-             parallelForInner(
-                 Team, Range{KMin, KMax},
-                 INNER_LAMBDA(I4 K) { NormalVelTend(IEdge, K) -= Forcing; });
-
-          } else {
-
-             Kokkos::single(
-                 PerTeam(Team),
-                 INNER_LAMBDA() { BtrForcing(IEdge) = 0._Real; });
           }
-       });
 
-   Pacer::stop("SE-RK2:barotropicForcing", 2);
-}
-
-//------------------------------------------------------------------------------
-void SplitExplicitRK2Stepper::updateBaroclinicVelocityByTend(
-    OceanState *State1, I4 TimeLevel1, OceanState *State2, I4 TimeLevel2,
-    TimeInterval Coeff) const {
-
-   Array2DReal NormalBclVel1 = State1->getNormalBaroclinicVelocity(TimeLevel1);
-   Array2DReal NormalBclVel2 = State2->getNormalBaroclinicVelocity(TimeLevel2);
-
-   R8 CoeffSeconds;
-   Coeff.get(CoeffSeconds, TimeUnits::Seconds);
-
-   OMEGA_SCOPE(NormalVelTend, Tend->NormalVelocityTend);
-   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
-   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
-
-   parallelForOuter(
-       "updateBclVelByTend", {Mesh->NEdgesAll},
-       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-          const int KMin = MinLayerEdgeBot(IEdge);
-          const int KMax = MaxLayerEdgeTop(IEdge);
-
+          // Update the baroclinic velocity to the stage midpoint, removing the
+          // barotropic forcing in the process.
           parallelForInner(
-              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
-                 NormalBclVel1(IEdge, K) =
-                     NormalBclVel2(IEdge, K) +
-                     CoeffSeconds * NormalVelTend(IEdge, K);
+              Team, Range{KMin, KMax}, INNER_LAMBDA(I4 K) {
+                 NormalBclVelNext(IEdge, K) =
+                     NormalBclVelCur(IEdge, K) +
+                     HalfDtSeconds * (IterVelocityTend(IEdge, K) - Forcing);
               });
        });
+
+   Pacer::stop("SE-RK2:bclVelUpdate", 2);
 }
 
 //------------------------------------------------------------------------------
@@ -510,8 +441,9 @@ void SplitExplicitRK2Stepper::initializeNextState(
 }
 
 //------------------------------------------------------------------------------
-void SplitExplicitRK2Stepper::reconstructNormalVelocity(
-    OceanState *State, I4 CurLevel, I4 NextLevel, bool FinalIteration) const {
+void SplitExplicitRK2Stepper::reconstructNormalVelocity(OceanState *State,
+                                                        I4 CurLevel,
+                                                        I4 NextLevel) const {
 
    Array2DReal NormalVelNext    = State->getNormalVelocity(NextLevel);
    Array2DReal NormalBclVelCur  = State->getNormalBaroclinicVelocity(CurLevel);
@@ -521,39 +453,22 @@ void SplitExplicitRK2Stepper::reconstructNormalVelocity(
    OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
    OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
-   if (FinalIteration) {
+   // Extrapolate the baroclinic velocity from n+1/2 to n+1. Intermediate
+   // iterations need only NormalBclVel + NormalBtrVel, which
+   // computeTransportVelocity has already stored into NormalVelocity.
+   parallelForOuter(
+       "reconstructFinalNormalVelocity", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin = MinLayerEdgeBot(IEdge);
+          const int KMax = MaxLayerEdgeTop(IEdge);
 
-      parallelForOuter(
-          "reconstructFinalNormalVelocity", {Mesh->NEdgesAll},
-          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-             const int KMin = MinLayerEdgeBot(IEdge);
-             const int KMax = MaxLayerEdgeTop(IEdge);
-
-             // Reconstruct NormalBclVel at n+1 if FinalIteration
-             parallelForInner(
-                 Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
-                    NormalVelNext(IEdge, K) =
-                        2._Real * NormalBclVelNext(IEdge, K) -
-                        NormalBclVelCur(IEdge, K) + NormalBtrVelNext(IEdge);
-                 });
-          });
-
-   } else {
-
-      parallelForOuter(
-          "reconstructFinalNormalVelocity", {Mesh->NEdgesAll},
-          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
-             const int KMin = MinLayerEdgeBot(IEdge);
-             const int KMax = MaxLayerEdgeTop(IEdge);
-
-             // Reconstruct NormalVel at n+0.5
-             parallelForInner(
-                 Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
-                    NormalVelNext(IEdge, K) =
-                        NormalBclVelNext(IEdge, K) + NormalBtrVelNext(IEdge);
-                 });
-          });
-   } // FinalIteration
+          parallelForInner(
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
+                 NormalVelNext(IEdge, K) =
+                     2._Real * NormalBclVelNext(IEdge, K) -
+                     NormalBclVelCur(IEdge, K) + NormalBtrVelNext(IEdge);
+              });
+       });
 }
 
 //------------------------------------------------------------------------------
@@ -563,7 +478,8 @@ void SplitExplicitRK2Stepper::finalizeTimeStepIterationState(
    Pacer::start("SE-RK2:finalizeTimeStepIterationState", 2);
 
    // Reconstruction of NormalVelocity Next
-   reconstructNormalVelocity(State, CurLevel, NextLevel, FinalIteration);
+   if (FinalIteration)
+      reconstructNormalVelocity(State, CurLevel, NextLevel);
 
    if (SEConfig.SplitFactor == 0._Real) {
 
@@ -594,19 +510,6 @@ void SplitExplicitRK2Stepper::finalizeTimeStepIterationState(
 
       Pacer::stop("SE-RK2:finalizeTimeStepIterationState", 2);
    }
-}
-
-//------------------------------------------------------------------------------
-void SplitExplicitRK2Stepper::computeVerticalPseudoVelocity(
-    OceanState *State, I4 ThickTimeLevel, I4 VelTimeLevel,
-    TimeInterval StageTimeStep) const {
-
-   if (!State)
-      LOG_CRITICAL("Invalid State");
-
-   Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
-   computeVerticalPseudoVelocity(State, ThickTimeLevel, NormalVelEdge,
-                                 StageTimeStep);
 }
 
 //------------------------------------------------------------------------------
@@ -683,8 +586,8 @@ void SplitExplicitRK2Stepper::doStep(OceanState *State,
 
       if (SEConfig.SplitFactor != 0._Real) {
          // Stage 2: Barotropic velocity advance, explicitly subcycled
-         doBarotropicVelocityUpdate(State, CurLevel, NextLevel,
-                                    StageTime + 0.5 * TimeStep, TimeStep);
+         BarotropicPCStepper.doBarotropicVelocityUpdate(State, CurLevel,
+                                                        NextLevel, TimeStep);
       }
 
       // Compute physical total velocity and the corrected transport velocity

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
@@ -625,16 +625,11 @@ void SplitExplicitRK2Stepper::doStep(OceanState *State,
    OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
    OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
    parallelForOuter(
-       "refreshFinalKineticAux", {Mesh->NCellsAll},
+       "refreshFinalKineticAux",
+       LaunchConfig({Mesh->NCellsAll},
+                    TeamScratch<Real>(2 * VCoord->NVertLayers)),
        KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
-          const int KMin   = MinLayerCell(ICell);
-          const int KMax   = MaxLayerCell(ICell);
-          const int KRange = vertRangeChunked(KMin, KMax);
-
-          parallelForInner(
-              Team, KRange, INNER_LAMBDA(int KChunk) {
-                 LocKineticAux.computeVarsOnCell(ICell, KChunk, NormalVelCur);
-              });
+          LocKineticAux.computeVarsOnCell(Team, ICell, NormalVelCur);
        });
 
    // Apply implicit vertical mixing

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
@@ -1,0 +1,748 @@
+//===-- SplitExplicitRK2Stepper.cpp - split-explicit RK2 ------*- C++ -*-===//
+//
+// Framework for split-explicit RK2 time stepping. Stage 1 and Stage 3 live
+// here, with Stage 2 delegated to the configured barotropic substepper.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SplitExplicitRK2Stepper.h"
+#include "Eos.h"
+#include "GlobalConstants.h"
+#include "Logging.h"
+#include "Pacer.h"
+#include "SplitExplicitInit.h"
+#include "VertAdv.h"
+#include "VertMix.h"
+
+namespace OMEGA {
+
+//------------------------------------------------------------------------------
+SplitExplicitRK2Stepper::SplitExplicitRK2Stepper(
+    const std::string &InName, TimeStepperType InType,
+    const TimeInterval &InTimeStep, const TimeInstant &InStartTime,
+    std::optional<TimeInstant> InStopTime)
+    : TimeStepper(InName, InType, 2, InTimeStep, InStartTime, InStopTime),
+      SEConfig(SplitExplicitInit::readConfigOptions(
+          InTimeStep, InType == TimeStepperType::UnsplitRK2)) {}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::finalizeInit() {
+
+   if (!Tend)
+      LOG_CRITICAL("Tendency not initialized");
+   if (!Mesh)
+      LOG_CRITICAL("Invalid mesh");
+   if (!VCoord)
+      LOG_CRITICAL("Invalid vertical coordinate");
+   if (!MeshHalo)
+      LOG_CRITICAL("Invalid MeshHalo");
+
+   SplitExplicitInit::allocateScratch(SEScratch, Mesh, VCoord, Name);
+   initBarotropicStepper();
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::initializeStateFromInput(OceanState *State,
+                                                       bool ReadRestart) const {
+
+   if (!State)
+      LOG_CRITICAL("Invalid State");
+
+   constexpr I4 CurLevel  = 0;
+   constexpr I4 NextLevel = 1;
+
+   Array3DReal CurTracerArray = Tracers::getAll(CurLevel);
+   AuxState->computeMomVertAux(State, CurTracerArray, CurLevel);
+
+   if (SEConfig.SplitFactor == 0._Real) {
+      SplitExplicitInit::computeUnsplitVelocitySplit(State, Mesh, VCoord,
+                                                     CurLevel, NextLevel);
+   } else if (!ReadRestart) {
+      SplitExplicitInit::initializeBarotropicPressure(SEScratch, State, Mesh,
+                                                      VCoord, CurLevel);
+      SplitExplicitInit::computeVelocitySplit(State, Mesh, VCoord, CurLevel);
+   }
+
+   initializeNextState(State, CurLevel, NextLevel, SEConfig.SplitFactor, false);
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::initBarotropicStepper() {
+
+   if (SEConfig.BtrTimeStepper ==
+       SplitExplicitBarotropicStepperType::PredictorCorrector) {
+      BarotropicUpdate = [this](OceanState *State, I4 CurLevel, I4 NextLevel,
+                                const TimeInstant &StageTime,
+                                const TimeInterval &StageTimeStep) {
+         BarotropicPCStepper.doBarotropicVelocityUpdate(
+             State, AuxState, SEScratch, SEConfig, Mesh, MeshHalo, VCoord,
+             CurLevel, NextLevel, StageTime, StageTimeStep);
+      };
+      return;
+   }
+
+   LOG_CRITICAL("Invalid split-explicit barotropic time stepper");
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::doBaroclinicVelocityUpdate(
+    OceanState *State, const Array3DReal &TendencyTracerArray, I4 CurLevel,
+    I4 NextLevel, const TimeInstant &StageTime,
+    const TimeInterval &StageTimeStep) const {
+
+   Pacer::start("SE-RK2:stage1Bcl", 2);
+
+   // TODO: A placeholder at this moment.
+   // prescribeState(State, CurLevel, State, CurLevel, StageTime);
+
+   // Compute baroclinic velocity tendencies and update baroclinic velocity for
+   // the first half of the stage time step.
+   Tend->computeBaroclinicVelocityTendencies(
+       State, AuxState, TendencyTracerArray, NextLevel, NextLevel, NextLevel,
+       NextLevel, SEConfig.SplitFactor, StageTime, StageTimeStep);
+
+   // Save the baroclinic velocity tendencies before the baroclinic velocity
+   // update
+   // TODO: this can be optimized in the future.
+   deepCopy(SEScratch.BaseVelocityTend, Tend->NormalVelocityTend);
+
+   // Perform baroclinic velocity iteration with Coriolis acceleration.
+   doBaroclinicCoriolisIteration(State, SEScratch.BaseVelocityTend, CurLevel,
+                                 NextLevel, StageTimeStep);
+
+   Pacer::stop("SE-RK2:stage1Bcl", 2);
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::doThicknessTracerUpdate(
+    OceanState *State, const Array3DReal &CurTracerArray,
+    const Array3DReal &NextTracerArray, I4 CurLevel, I4 NextLevel,
+    const TimeInstant &StageTime, const TimeInterval &StageTimeStep,
+    bool FinalIteration) const {
+
+   Pacer::start("SE-RK2:stage3TrThick", 2);
+
+   // TODO: A placeholder at this moment
+   // prescribeState(State, NextLevel, State, CurLevel,
+   //               StageTime + 0.5 * StageTimeStep);
+
+   // NormalTransportVelocity is the corrected transport velocity provided by
+   // computeTransportVelocity before this stage.
+   const Array2DReal NormalTransportVelocity =
+       SEScratch.NormalTransportVelocity;
+   // Compute thickness auxiliary variables at the new time level
+   AuxState->computePseudoThicknessTracerAux(State, NextTracerArray, NextLevel,
+                                             NormalTransportVelocity,
+                                             StageTimeStep);
+
+   computeVerticalPseudoVelocity(State, NextLevel, NormalTransportVelocity,
+                                 StageTimeStep);
+
+   // Compute thickness and tracer tendencies at the new time level
+   Tend->computePseudoThicknessTendenciesOnly(
+       State, AuxState, NextLevel, NextLevel, NormalTransportVelocity,
+       StageTime + 0.5 * StageTimeStep);
+
+   Tend->computeTracerTendenciesOnly(
+       State, AuxState, NextTracerArray, NextLevel, NormalTransportVelocity,
+       StageTime + 0.5 * StageTimeStep, StageTimeStep);
+
+   if (FinalIteration) {
+      // Retain the full-step conservative update on the final iteration.
+      updateThicknessByTend(State, NextLevel, State, CurLevel, StageTimeStep);
+      updateTracersByTend(NextTracerArray, CurTracerArray, State, NextLevel,
+                          State, CurLevel, StageTimeStep);
+   } else {
+      // Construct the RK2 midpoint state. Tracer concentration is the average
+      // of its old and provisional full-step values, rather than a conservative
+      // update over half a time step.
+      updateThicknessByTend(State, NextLevel, State, CurLevel,
+                            0.5 * StageTimeStep);
+      updateTracersToMidpoint(NextTracerArray, CurTracerArray, State, CurLevel,
+                              StageTimeStep);
+   }
+
+   finalizeTimeStepIterationState(State, CurLevel, NextLevel, FinalIteration);
+
+   Pacer::stop("SE-RK2:stage3TrThick", 2);
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::doBarotropicVelocityUpdate(
+    OceanState *State, I4 CurLevel, I4 NextLevel, const TimeInstant &StageTime,
+    const TimeInterval &StageTimeStep) const {
+
+   if (!BarotropicUpdate)
+      LOG_CRITICAL("Split-explicit barotropic time stepper not initialized");
+
+   BarotropicUpdate(State, CurLevel, NextLevel, StageTime, StageTimeStep);
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::computeTransportVelocity(OceanState *State,
+                                                       I4 TimeLevel) const {
+
+   Pacer::start("SE-RK2:computeTransportVelocity", 2);
+
+   Array2DReal NormalVel          = State->getNormalVelocity(TimeLevel);
+   Array2DReal NormalTransportVel = SEScratch.NormalTransportVelocity;
+   Array2DReal NormalBclVel    = State->getNormalBaroclinicVelocity(TimeLevel);
+   Array1DReal NormalBtrVel    = State->getNormalBarotropicVelocity(TimeLevel);
+   Array2DReal PseudoThickCell = State->getPseudoThickness(TimeLevel);
+   Array1DReal BtrFlux         = SEScratch.BarotropicFlux;
+   const Real LocSplitFactor   = SEConfig.SplitFactor;
+   constexpr Real RhoGravity   = RhoSw * Gravity;
+
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+   OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
+
+   parallelForOuter(
+       "computeSplitExplicitTransportVelocity", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(I4 IEdge, const TeamMember &Team) {
+          const I4 KMin      = MinLayerEdgeBot(IEdge);
+          const I4 KMax      = MaxLayerEdgeTop(IEdge);
+          Real VelCorrection = 0._Real;
+
+          if (LocSplitFactor != 0._Real) {
+
+             if (KMax >= KMin) {
+                const I4 Cell0 = CellsOnEdge(IEdge, 0);
+                const I4 Cell1 = CellsOnEdge(IEdge, 1);
+
+                Real ThickSum     = 0._Real;
+                Real TransportSum = 0._Real;
+
+                parallelReduceInner(
+                    Team, Range{KMin, KMax},
+                    INNER_LAMBDA(I4 K, Real & ThickAccum, Real & FluxAccum) {
+                       const Real TransportVel =
+                           NormalBtrVel(IEdge) + NormalBclVel(IEdge, K);
+                       const Real ThickEdge =
+                           0.5_Real * (PseudoThickCell(Cell0, K) +
+                                       PseudoThickCell(Cell1, K));
+                       ThickAccum += ThickEdge;
+                       FluxAccum += ThickEdge * TransportVel;
+                    },
+                    ThickSum, TransportSum);
+
+                VelCorrection =
+                    (BtrFlux(IEdge) / RhoGravity - TransportSum) / ThickSum;
+             }
+
+          } // if SplitFactor
+
+          parallelForInner(
+              Team, Range{KMin, KMax}, INNER_LAMBDA(I4 K) {
+                 const Real TotalVel =
+                     NormalBtrVel(IEdge) + NormalBclVel(IEdge, K);
+
+                 NormalVel(IEdge, K)          = TotalVel;
+                 NormalTransportVel(IEdge, K) = TotalVel + VelCorrection;
+              });
+       });
+
+   Pacer::stop("SE-RK2:computeTransportVelocity", 2);
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::doBaroclinicCoriolisIteration(
+    OceanState *State, const Array2DReal &BaseVelocityTend, I4 CurLevel,
+    I4 NextLevel, const TimeInterval &StageTimeStep) const {
+
+   Pacer::start("SE-RK2:bclCoriolisIter", 2);
+
+   const Array1DReal &FEdge = Mesh->FEdge;
+   for (I4 Iter = 0; Iter < SEConfig.NBclCoriolisIteration; ++Iter) {
+
+      const bool FinalCoriolisIter = Iter + 1 == SEConfig.NBclCoriolisIteration;
+
+      if (Iter > 0) {
+         deepCopy(Tend->NormalVelocityTend, BaseVelocityTend);
+      }
+
+      Array2DReal NormalBclVelEdge =
+          State->getNormalBaroclinicVelocity(NextLevel);
+
+      // Compute the baroclinic part of the Coriolis acceleration
+      Tend->computeCoriolisAccelerationOnEdge(Tend->NormalVelocityTend,
+                                              NormalBclVelEdge, FEdge);
+
+      // Compute the barotropic forcing
+      computeBarotropicForcing(State, CurLevel, NextLevel, StageTimeStep);
+
+      // Update the baroclinic velocity by tendency at (n+1/2)
+      updateBaroclinicVelocityByTend(State, NextLevel, State, CurLevel,
+                                     0.5 * StageTimeStep);
+
+      if (!FinalCoriolisIter) {
+         Pacer::start("SE-RK2:haloBclVelIter", 3);
+         Array2DReal NormalBclVelIter =
+             State->getNormalBaroclinicVelocity(NextLevel);
+         MeshHalo->exchangeFullArrayHalo(NormalBclVelIter, OnEdge);
+         Pacer::stop("SE-RK2:haloBclVelIter", 3);
+      }
+   }
+
+   if (SEConfig.SplitFactor != 0._Real) {
+      Pacer::start("SE-RK2:haloBtrForcing", 3);
+      Array1DReal BtrForcing = SEScratch.BarotropicForcing;
+      MeshHalo->exchangeFullArrayHalo(BtrForcing, OnEdge);
+      Pacer::stop("SE-RK2:haloBtrForcing", 3);
+   }
+
+   Pacer::stop("SE-RK2:bclCoriolisIter", 2);
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::computeBarotropicForcing(
+    OceanState *State, I4 CurLevel, I4 NextLevel,
+    const TimeInterval &StageTimeStep) const {
+
+   const Real LocSplitFactor = SEConfig.SplitFactor;
+
+   // Return if the unsplit time stepper (i.e., BarotropicForcing = 0)
+   if (LocSplitFactor == 0._Real)
+      return;
+
+   Pacer::start("SE-RK2:barotropicForcing", 2);
+
+   Array2DReal NormalBclVelCur = State->getNormalBaroclinicVelocity(CurLevel);
+   Array2DReal PseudoThickCell = State->getPseudoThickness(NextLevel);
+   Array2DReal NormalVelTend   = Tend->NormalVelocityTend;
+   Array1DReal BtrForcing      = SEScratch.BarotropicForcing;
+
+   R8 DtSecondsR8;
+   StageTimeStep.get(DtSecondsR8, TimeUnits::Seconds);
+   const Real DtSeconds    = DtSecondsR8;
+   const Real InvDtSeconds = 1._Real / DtSeconds;
+
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+   OMEGA_SCOPE(CellsOnEdge, Mesh->CellsOnEdge);
+
+   parallelForOuter(
+       "computeBarotropicForcing", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(I4 IEdge, const TeamMember &Team) {
+          const I4 KMin = MinLayerEdgeBot(IEdge);
+          const I4 KMax = MaxLayerEdgeTop(IEdge);
+
+          if (KMax >= KMin) {
+
+             const I4 Cell0 = CellsOnEdge(IEdge, 0);
+             const I4 Cell1 = CellsOnEdge(IEdge, 1);
+
+             Real ThicknessSum = 0._Real;
+             parallelReduceInner(
+                 Team, Range{KMin, KMax},
+                 INNER_LAMBDA(I4 K, Real & ThickAccum) {
+                    const Real ThickEdge =
+                        0.5_Real *
+                        (PseudoThickCell(Cell0, K) + PseudoThickCell(Cell1, K));
+
+                    ThickAccum += ThickEdge;
+                 },
+                 ThicknessSum);
+
+             Real NormalThicknessFluxSum = 0._Real;
+             parallelReduceInner(
+                 Team, Range{KMin, KMax},
+                 INNER_LAMBDA(I4 K, Real & FluxAccum) {
+                    const Real ProvisionalBclVel =
+                        NormalBclVelCur(IEdge, K) +
+                        DtSeconds * NormalVelTend(IEdge, K);
+
+                    const Real ThickEdge =
+                        0.5_Real *
+                        (PseudoThickCell(Cell0, K) + PseudoThickCell(Cell1, K));
+
+                    FluxAccum += (ThickEdge / ThicknessSum) * ProvisionalBclVel;
+                 },
+                 NormalThicknessFluxSum);
+
+             const Real Forcing =
+                 LocSplitFactor * NormalThicknessFluxSum * InvDtSeconds;
+
+             Kokkos::single(
+                 PerTeam(Team),
+                 INNER_LAMBDA() { BtrForcing(IEdge) = Forcing; });
+
+             parallelForInner(
+                 Team, Range{KMin, KMax},
+                 INNER_LAMBDA(I4 K) { NormalVelTend(IEdge, K) -= Forcing; });
+
+          } else {
+
+             Kokkos::single(
+                 PerTeam(Team),
+                 INNER_LAMBDA() { BtrForcing(IEdge) = 0._Real; });
+          }
+       });
+
+   Pacer::stop("SE-RK2:barotropicForcing", 2);
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::updateBaroclinicVelocityByTend(
+    OceanState *State1, I4 TimeLevel1, OceanState *State2, I4 TimeLevel2,
+    TimeInterval Coeff) const {
+
+   Array2DReal NormalBclVel1 = State1->getNormalBaroclinicVelocity(TimeLevel1);
+   Array2DReal NormalBclVel2 = State2->getNormalBaroclinicVelocity(TimeLevel2);
+
+   R8 CoeffSeconds;
+   Coeff.get(CoeffSeconds, TimeUnits::Seconds);
+
+   OMEGA_SCOPE(NormalVelTend, Tend->NormalVelocityTend);
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   parallelForOuter(
+       "updateBclVelByTend", {Mesh->NEdgesAll},
+       KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin = MinLayerEdgeBot(IEdge);
+          const int KMax = MaxLayerEdgeTop(IEdge);
+
+          parallelForInner(
+              Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
+                 NormalBclVel1(IEdge, K) =
+                     NormalBclVel2(IEdge, K) +
+                     CoeffSeconds * NormalVelTend(IEdge, K);
+              });
+       });
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::updateTracersToMidpoint(
+    const Array3DReal &MidpointTracers, const Array3DReal &CurTracers,
+    OceanState *State, I4 CurLevel, const TimeInterval &StageTimeStep) const {
+
+   const Array2DReal CurPseudoThickness = State->getPseudoThickness(CurLevel);
+
+   R8 DtSeconds;
+   StageTimeStep.get(DtSeconds, TimeUnits::Seconds);
+
+   OMEGA_SCOPE(PseudoThicknessTend, Tend->PseudoThicknessTend);
+   OMEGA_SCOPE(TracerTend, Tend->TracerTend);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+
+   const I4 NTracers = TracerTend.extent_int(0);
+   parallelForOuter(
+       "updateTracersToMidpoint", {NTracers, Mesh->NCellsAll},
+       KOKKOS_LAMBDA(I4 L, I4 ICell, const TeamMember &Team) {
+          const I4 KMin = MinLayerCell(ICell);
+          const I4 KMax = MaxLayerCell(ICell);
+
+          parallelForInner(
+              Team, Range{KMin, KMax}, INNER_LAMBDA(I4 K) {
+                 const Real CurThickness = CurPseudoThickness(ICell, K);
+                 const Real EndThickness =
+                     CurThickness + DtSeconds * PseudoThicknessTend(ICell, K);
+                 const Real EndTracer =
+                     (CurTracers(L, ICell, K) * CurThickness +
+                      DtSeconds * TracerTend(L, ICell, K)) /
+                     EndThickness;
+
+                 MidpointTracers(L, ICell, K) =
+                     0.5_Real * (CurTracers(L, ICell, K) + EndTracer);
+              });
+       });
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::initializeNextState(
+    OceanState *State, I4 CurLevel, I4 NextLevel, Real SplitFactor,
+    bool ReinitSplitVelocity) const {
+
+   const bool RecomputeSplit = ReinitSplitVelocity && SplitFactor != 0._Real;
+   if (RecomputeSplit) {
+      SplitExplicitInit::computeVelocitySplit(State, Mesh, VCoord, CurLevel);
+   }
+
+   Array2DReal PseudoThickCur   = State->getPseudoThickness(CurLevel);
+   Array2DReal PseudoThickNext  = State->getPseudoThickness(NextLevel);
+   Array2DReal NormalVelCur     = State->getNormalVelocity(CurLevel);
+   Array2DReal NormalVelNext    = State->getNormalVelocity(NextLevel);
+   Array2DReal NormalBclVelCur  = State->getNormalBaroclinicVelocity(CurLevel);
+   Array2DReal NormalBclVelNext = State->getNormalBaroclinicVelocity(NextLevel);
+   Array1DReal NormalBtrVelCur  = State->getNormalBarotropicVelocity(CurLevel);
+   Array1DReal NormalBtrVelNext = State->getNormalBarotropicVelocity(NextLevel);
+
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   if (!RecomputeSplit) {
+      parallelForOuter(
+          "initializeNormalBaroclinicVelocity", {Mesh->NEdgesAll},
+          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin = MinLayerEdgeBot(IEdge);
+             const int KMax = MaxLayerEdgeTop(IEdge);
+
+             parallelForInner(
+                 Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
+                    NormalBclVelCur(IEdge, K) =
+                        NormalVelCur(IEdge, K) - NormalBtrVelCur(IEdge);
+                 });
+          });
+   }
+
+   deepCopy(NormalBclVelNext, NormalBclVelCur);
+   deepCopy(PseudoThickNext, PseudoThickCur);
+   deepCopy(NormalVelNext, NormalVelCur);
+
+   if (SplitFactor != 0._Real) {
+      Array1DReal BtrPressAnomalyCur =
+          State->getBarotropicPressureAnomaly(CurLevel);
+      Array1DReal BtrPressAnomalyNext =
+          State->getBarotropicPressureAnomaly(NextLevel);
+      deepCopy(NormalBtrVelNext, NormalBtrVelCur);
+      deepCopy(BtrPressAnomalyNext, BtrPressAnomalyCur);
+   }
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::reconstructNormalVelocity(
+    OceanState *State, I4 CurLevel, I4 NextLevel, bool FinalIteration) const {
+
+   Array2DReal NormalVelNext    = State->getNormalVelocity(NextLevel);
+   Array2DReal NormalBclVelCur  = State->getNormalBaroclinicVelocity(CurLevel);
+   Array2DReal NormalBclVelNext = State->getNormalBaroclinicVelocity(NextLevel);
+   Array1DReal NormalBtrVelNext = State->getNormalBarotropicVelocity(NextLevel);
+
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+
+   if (FinalIteration) {
+
+      parallelForOuter(
+          "reconstructFinalNormalVelocity", {Mesh->NEdgesAll},
+          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin = MinLayerEdgeBot(IEdge);
+             const int KMax = MaxLayerEdgeTop(IEdge);
+
+             // Reconstruct NormalBclVel at n+1 if FinalIteration
+             parallelForInner(
+                 Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
+                    NormalVelNext(IEdge, K) =
+                        2._Real * NormalBclVelNext(IEdge, K) -
+                        NormalBclVelCur(IEdge, K) + NormalBtrVelNext(IEdge);
+                 });
+          });
+
+   } else {
+
+      parallelForOuter(
+          "reconstructFinalNormalVelocity", {Mesh->NEdgesAll},
+          KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+             const int KMin = MinLayerEdgeBot(IEdge);
+             const int KMax = MaxLayerEdgeTop(IEdge);
+
+             // Reconstruct NormalVel at n+0.5
+             parallelForInner(
+                 Team, Range{KMin, KMax}, INNER_LAMBDA(int K) {
+                    NormalVelNext(IEdge, K) =
+                        NormalBclVelNext(IEdge, K) + NormalBtrVelNext(IEdge);
+                 });
+          });
+   } // FinalIteration
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::finalizeTimeStepIterationState(
+    OceanState *State, I4 CurLevel, I4 NextLevel, bool FinalIteration) const {
+
+   Pacer::start("SE-RK2:finalizeTimeStepIterationState", 2);
+
+   // Reconstruction of NormalVelocity Next
+   reconstructNormalVelocity(State, CurLevel, NextLevel, FinalIteration);
+
+   if (SEConfig.SplitFactor == 0._Real) {
+
+      Pacer::stop("SE-RK2:finalizeTimeStepIterationState", 2);
+      return;
+
+   } else {
+
+      // Keep the barotropic pressure anomaly consistent with the most recently
+      // updated column pseudo-thickness.
+      Array2DReal PseudoThickNext = State->getPseudoThickness(NextLevel);
+      VCoord->computeTotalPseudoThickness(PseudoThickNext);
+
+      Array1DReal BtrPressAnomalyNext =
+          State->getBarotropicPressureAnomaly(NextLevel);
+      constexpr Real RhoGravity = RhoSw * Gravity;
+
+      OMEGA_SCOPE(TotalPseudoThickness, VCoord->TotalPseudoThickness);
+      OMEGA_SCOPE(BottomGeomDepth, VCoord->BottomGeomDepth);
+
+      parallelFor(
+          "resetBarotropicPressureAnomaly", {Mesh->NCellsAll},
+          KOKKOS_LAMBDA(I4 ICell) {
+             BtrPressAnomalyNext(ICell) =
+                 RhoGravity *
+                 (TotalPseudoThickness(ICell) - BottomGeomDepth(ICell));
+          });
+
+      Pacer::stop("SE-RK2:finalizeTimeStepIterationState", 2);
+   }
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::computeVerticalPseudoVelocity(
+    OceanState *State, I4 ThickTimeLevel, I4 VelTimeLevel,
+    TimeInterval StageTimeStep) const {
+
+   if (!State)
+      LOG_CRITICAL("Invalid State");
+
+   Array2DReal NormalVelEdge = State->getNormalVelocity(VelTimeLevel);
+   computeVerticalPseudoVelocity(State, ThickTimeLevel, NormalVelEdge,
+                                 StageTimeStep);
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::computeVerticalPseudoVelocity(
+    OceanState *State, I4 ThickTimeLevel, const Array2DReal &NormalVelEdge,
+    TimeInterval StageTimeStep) const {
+
+   if (!State)
+      LOG_CRITICAL("Invalid State");
+
+   Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
+
+   R8 DtSeconds;
+   StageTimeStep.get(DtSeconds, TimeUnits::Seconds);
+
+   VertAdv *VertAdvection = VertAdv::getDefault();
+   if (!VertAdvection)
+      LOG_CRITICAL("Invalid vertical advection");
+
+   const auto &FluxPseudoThickEdge =
+       AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
+   VertAdvection->computeVerticalPseudoVelocity(
+       NormalVelEdge, FluxPseudoThickEdge, PseudoThickCell, DtSeconds);
+}
+
+//------------------------------------------------------------------------------
+void SplitExplicitRK2Stepper::doStep(OceanState *State,
+                                     TimeInstant &SimTime) const {
+
+   if (!State)
+      LOG_CRITICAL("Invalid State");
+
+   const MPI_Comm Comm = MeshHalo->getComm();
+
+   const int CurLevel  = 0;
+   const int NextLevel = 1;
+   int NTracers        = Tracers::getNumTracers();
+
+   Array3DReal CurTracerArray  = Tracers::getAll(CurLevel);
+   Array3DReal NextTracerArray = Tracers::getAll(NextLevel);
+
+   VertMix *VMix = VertMix::getInstance();
+
+   // Initialize NextLevel from CurLevel
+   // TODO: This can be optimized in the future.
+   initializeNextState(State, CurLevel, NextLevel, SEConfig.SplitFactor,
+                       SEConfig.ReinitSplitVelocity);
+   deepCopy(NextTracerArray, CurTracerArray);
+
+   const TimeInstant StageTime = SimTime;
+   for (I4 TimeStepIteration = 0;
+        TimeStepIteration < SEConfig.NTimeStepIteration; ++TimeStepIteration) {
+
+      const bool FinalIteration =
+          TimeStepIteration + 1 == SEConfig.NTimeStepIteration;
+
+      // The first iteration evaluates the momentum right-hand side at the
+      // n state copied into NextLevel; every later iteration sees the
+      // midpoint state left by its predecessor, so time-dependent terms must
+      // be sampled at n+1/2 to keep the predictor-corrector second order.
+      const TimeInstant VelStageTime =
+          TimeStepIteration == 0 ? StageTime : StageTime + 0.5 * TimeStep;
+
+      // Stage 1: Baroclinic velocity advance, with long time step
+      doBaroclinicVelocityUpdate(State, NextTracerArray, CurLevel, NextLevel,
+                                 VelStageTime, TimeStep);
+
+      Pacer::timingBarrier("SE-RK2:haloStage1Barrier", 3, Comm);
+      Pacer::start("SE-RK2:haloStage1", 3);
+      Array2DReal NormalBclVelNext =
+          State->getNormalBaroclinicVelocity(NextLevel);
+      MeshHalo->exchangeFullArrayHalo(NormalBclVelNext, OnEdge);
+      Pacer::stop("SE-RK2:haloStage1", 3);
+
+      if (SEConfig.SplitFactor != 0._Real) {
+         // Stage 2: Barotropic velocity advance, explicitly subcycled
+         doBarotropicVelocityUpdate(State, CurLevel, NextLevel,
+                                    StageTime + 0.5 * TimeStep, TimeStep);
+      }
+
+      // Compute physical total velocity and the corrected transport velocity
+      // used in Stage 3.
+      computeTransportVelocity(State, NextLevel);
+
+      // Stage 3: Update thickness, tracers, other diagnostics
+      doThicknessTracerUpdate(State, CurTracerArray, NextTracerArray, CurLevel,
+                              NextLevel, StageTime, TimeStep, FinalIteration);
+
+      if (TimeStepIteration + 1 < SEConfig.NTimeStepIteration) {
+         Pacer::timingBarrier("SE-RK2:haloTimeStepIterationBarrier", 3, Comm);
+         Pacer::start("SE-RK2:haloTimeStepIteration", 3);
+         State->exchangeHalo(NextLevel);
+         MeshHalo->exchangeFullArrayHalo(NextTracerArray, OnCell);
+         Pacer::stop("SE-RK2:haloTimeStepIteration", 3);
+      }
+   }
+
+   // Update time levels (New -> Old) of prognostic variables with halo
+   // exchanges
+   Pacer::timingBarrier("SE-RK2:haloExchBarrier", 3, Comm);
+   Pacer::start("SE-RK2:haloExch", 3);
+   State->updateTimeLevels();
+   Tracers::updateTimeLevels();
+   Pacer::stop("SE-RK2:haloExch", 3);
+
+   // Refresh kinetic diagnostics from the completed n+dt velocity before
+   // validation and history output.
+   const Array2DReal NormalVelCur = State->getNormalVelocity(CurLevel);
+   OMEGA_SCOPE(LocKineticAux, AuxState->KineticAux);
+   OMEGA_SCOPE(MinLayerCell, VCoord->MinLayerCell);
+   OMEGA_SCOPE(MaxLayerCell, VCoord->MaxLayerCell);
+   parallelForOuter(
+       "refreshFinalKineticAux", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(int ICell, const TeamMember &Team) {
+          const int KMin   = MinLayerCell(ICell);
+          const int KMax   = MaxLayerCell(ICell);
+          const int KRange = vertRangeChunked(KMin, KMax);
+
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 LocKineticAux.computeVarsOnCell(ICell, KChunk, NormalVelCur);
+              });
+       });
+
+   // Apply implicit vertical mixing
+   CurTracerArray = Tracers::getAll(CurLevel);
+   if (VMix->VelVertMixSetup.Enabled or VMix->TracerVertMixSetup.Enabled) {
+      VMix->VertMixImplicit(State, AuxState, CurTracerArray, NTracers,
+                            CurLevel);
+
+      // Re-exchange halos after vertical mixing
+      Pacer::timingBarrier("SE-RK2:vMixHaloExchBarrier", 3, Comm);
+      Pacer::start("SE-RK2:vMixHaloExch", 3);
+      State->exchangeHalo(CurLevel);
+      Tracers::exchangeHalo(CurLevel);
+      Pacer::stop("SE-RK2:vMixHaloExch", 3);
+   }
+
+   validateOceanState(State, AuxState, VertCoord::getDefault(), CurLevel);
+
+   // Advance the clock and update the simulation time
+   StepClock->advance();
+   SimTime = StepClock->getCurrentTime();
+   ++StepCount;
+}
+
+} // namespace OMEGA

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
@@ -78,6 +78,12 @@ void SplitExplicitRK2Stepper::initializeStateFromInput(OceanState *State,
    }
 
    initializeNextState(State, CurLevel, NextLevel, SEConfig.SplitFactor, false);
+
+   // The velocity split is computed over all edges, so halo edges whose
+   // neighboring cells lie outside the halo must be refreshed from their
+   // owners before the newly split arrays are copied to the host
+   State->exchangeHalo(CurLevel);
+   State->copyToHost(CurLevel);
 }
 
 //------------------------------------------------------------------------------

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
@@ -37,6 +37,12 @@ void SplitExplicitRK2Stepper::finalizeInit() {
    if (!MeshHalo)
       LOG_CRITICAL("Invalid MeshHalo");
 
+   // The velocity tendency is shared with the unsplit time steppers. Tell it
+   // to leave the linear Coriolis acceleration out of the vorticity flux, so
+   // that doBaroclinicCoriolisIteration can iterate it, and which barotropic
+   // weight to use for the surface pressure gradient.
+   Tend->setModeSplit(CoriolisTendMode::Separate, SEConfig.SplitFactor);
+
    SplitExplicitInit::allocateScratch(SEScratch, Mesh, VCoord, Name);
    initBarotropicStepper();
 }
@@ -96,10 +102,12 @@ void SplitExplicitRK2Stepper::doBaroclinicVelocityUpdate(
    // prescribeState(State, CurLevel, State, CurLevel, StageTime);
 
    // Compute baroclinic velocity tendencies and update baroclinic velocity for
-   // the first half of the stage time step.
-   Tend->computeBaroclinicVelocityTendencies(
-       State, AuxState, TendencyTracerArray, NextLevel, NextLevel, NextLevel,
-       NextLevel, SEConfig.SplitFactor, StageTime, StageTimeStep);
+   // the first half of the stage time step. This is the same entry point the
+   // unsplit time steppers use; the split-specific terms are selected by the
+   // mode set in finalizeInit.
+   Tend->computeVelocityTendencies(State, AuxState, TendencyTracerArray,
+                                   NextLevel, NextLevel, NextLevel, StageTime,
+                                   StageTimeStep);
 
    // Save the baroclinic velocity tendencies before the baroclinic velocity
    // update

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
@@ -25,6 +25,8 @@ SplitExplicitRK2Stepper::SplitExplicitRK2Stepper(
       SEConfig(SplitExplicitInit::readConfigOptions(
           InTimeStep, InType == TimeStepperType::UnsplitRK2)) {}
 
+bool SplitExplicitRK2Stepper::isSplit() const { return true; }
+
 //------------------------------------------------------------------------------
 void SplitExplicitRK2Stepper::finalizeInit() {
 

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.cpp
@@ -516,29 +516,6 @@ void SplitExplicitRK2Stepper::finalizeTimeStepIterationState(
 }
 
 //------------------------------------------------------------------------------
-void SplitExplicitRK2Stepper::computeVerticalPseudoVelocity(
-    OceanState *State, I4 ThickTimeLevel, const Array2DReal &NormalVelEdge,
-    TimeInterval StageTimeStep) const {
-
-   if (!State)
-      LOG_CRITICAL("Invalid State");
-
-   Array2DReal PseudoThickCell = State->getPseudoThickness(ThickTimeLevel);
-
-   R8 DtSeconds;
-   StageTimeStep.get(DtSeconds, TimeUnits::Seconds);
-
-   VertAdv *VertAdvection = VertAdv::getDefault();
-   if (!VertAdvection)
-      LOG_CRITICAL("Invalid vertical advection");
-
-   const auto &FluxPseudoThickEdge =
-       AuxState->PseudoThicknessAux.FluxPseudoThickEdge;
-   VertAdvection->computeVerticalPseudoVelocity(
-       NormalVelEdge, FluxPseudoThickEdge, PseudoThickCell, DtSeconds);
-}
-
-//------------------------------------------------------------------------------
 void SplitExplicitRK2Stepper::doStep(OceanState *State,
                                      TimeInstant &SimTime) const {
 

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
@@ -114,13 +114,6 @@ class SplitExplicitRK2Stepper : public TimeStepper {
        const TimeInterval &StageTimeStep ///< [in] current stage time step
    ) const;
 
-   void computeVerticalPseudoVelocity(
-       OceanState *State,                ///< [inout] model state
-       I4 ThickTimeLevel,                ///< [in] thickness time level
-       const Array2DReal &NormalVelEdge, ///< [in] velocity on edges
-       TimeInterval StageTimeStep        ///< [in] current stage time step
-   ) const;
-
    SplitExplicitConfig SEConfig;
    mutable SplitExplicitScratch SEScratch;
    SplitExplicitBarotropicPCStepper BarotropicPCStepper;

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
@@ -11,8 +11,6 @@
 #include "SplitExplicitTypes.h"
 #include "TimeStepper.h"
 
-#include <functional>
-
 namespace OMEGA {
 
 class SplitExplicitRK2Stepper : public TimeStepper {
@@ -62,41 +60,25 @@ class SplitExplicitRK2Stepper : public TimeStepper {
        bool FinalIteration ///< [in] true on the final time-step iteration
    ) const;
 
-   using BarotropicUpdateFunction = std::function<void(
-       OceanState *, I4, I4, const TimeInstant &, const TimeInterval &)>;
-
-   void initBarotropicStepper();
-
-   void doBarotropicVelocityUpdate(OceanState *State, I4 CurLevel, I4 NextLevel,
-                                   const TimeInstant &StageTime,
-                                   const TimeInterval &StageTimeStep) const;
-
    void
    computeTransportVelocity(OceanState *State, ///< [inout] model state
                             I4 TimeLevel ///< [in] time level for split velocity
    ) const;
 
    void doBaroclinicCoriolisIteration(
-       OceanState *State,                   ///< [inout] model state
-       const Array2DReal &BaseVelocityTend, ///< [in] non-Coriolis tendency
-       I4 CurLevel,                         ///< [in] current time level
-       I4 NextLevel,                        ///< [in] next time level
-       const TimeInterval &StageTimeStep    ///< [in] current stage time step
-   ) const;
-
-   void computeBarotropicForcing(
        OceanState *State,                ///< [inout] model state
        I4 CurLevel,                      ///< [in] current time level
-       I4 NewLevel,                      ///< [in] next time level
+       I4 NextLevel,                     ///< [in] next time level
        const TimeInterval &StageTimeStep ///< [in] current stage time step
    ) const;
 
-   void updateBaroclinicVelocityByTend(
-       OceanState *State1, ///< [out] updated state
-       I4 TimeLevel1,      ///< [in] time level index for new time
-       OceanState *State2, ///< [in] state for current time
-       I4 TimeLevel2,      ///< [in] time level index for current time
-       TimeInterval Coeff  ///< [in] time-related coeff for tendency
+   /// Removes the barotropic forcing from the iterated baroclinic tendency and
+   /// advances the baroclinic velocity to the stage midpoint, in one pass.
+   void updateBaroclinicVelocityWithBarotropicForcing(
+       OceanState *State,                ///< [inout] model state
+       I4 CurLevel,                      ///< [in] current time level
+       I4 NextLevel,                     ///< [in] next time level
+       const TimeInterval &StageTimeStep ///< [in] current stage time step
    ) const;
 
    void updateTracersToMidpoint(
@@ -115,11 +97,11 @@ class SplitExplicitRK2Stepper : public TimeStepper {
                                                      ///< recompute the split
    ) const;
 
-   void reconstructNormalVelocity(
-       OceanState *State,  ///< [inout] model state
-       I4 CurLevel,        ///< [in] current time level
-       I4 NextLevel,       ///< [in] next time level
-       bool FinalIteration ///< [in] true on the final time-step iteration
+   /// Extrapolates NormalVelocity from the stage midpoint to the new time
+   /// level. Only needed on the final time-step iteration.
+   void reconstructNormalVelocity(OceanState *State, ///< [inout] model state
+                                  I4 CurLevel, ///< [in] current time level
+                                  I4 NextLevel ///< [in] next time level
    ) const;
 
    void finalizeTimeStepIterationState(
@@ -130,12 +112,6 @@ class SplitExplicitRK2Stepper : public TimeStepper {
    ) const;
 
    void computeVerticalPseudoVelocity(
-       OceanState *State,         ///< [inout] model state
-       I4 ThickTimeLevel,         ///< [in] thickness time level
-       I4 VelTimeLevel,           ///< [in] reconstructed velocity time level
-       TimeInterval StageTimeStep ///< [in] current stage time step
-   ) const;
-   void computeVerticalPseudoVelocity(
        OceanState *State,                ///< [inout] model state
        I4 ThickTimeLevel,                ///< [in] thickness time level
        const Array2DReal &NormalVelEdge, ///< [in] velocity on edges
@@ -144,7 +120,6 @@ class SplitExplicitRK2Stepper : public TimeStepper {
 
    SplitExplicitConfig SEConfig;
    mutable SplitExplicitScratch SEScratch;
-   BarotropicUpdateFunction BarotropicUpdate;
    SplitExplicitBarotropicPCStepper BarotropicPCStepper;
 };
 

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
@@ -24,6 +24,9 @@ class SplitExplicitRK2Stepper : public TimeStepper {
        ///< [in] stop time for time stepping, missing in coupled mode
        std::optional<TimeInstant> InStopTime = std::nullopt);
 
+   /// Indicate that this is a split time stepper
+   bool isSplit() const override;
+
    /// Advance the state by one split-explicit RK2 step.
    void doStep(OceanState *State,   ///< [inout] model state
                TimeInstant &SimTime ///< [inout] current simulation time

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
@@ -1,0 +1,153 @@
+#ifndef OMEGA_TS_SPLIT_EXPLICIT_RK2_H
+#define OMEGA_TS_SPLIT_EXPLICIT_RK2_H
+//===-- SplitExplicitRK2Stepper.h - split-explicit RK2 step ---*- C++ -*-===//
+//
+/// \file
+/// \brief Contains the framework for split-explicit RK2 time stepping.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SplitExplicitBarotropicPCStepper.h"
+#include "SplitExplicitTypes.h"
+#include "TimeStepper.h"
+
+#include <functional>
+
+namespace OMEGA {
+
+class SplitExplicitRK2Stepper : public TimeStepper {
+ public:
+   SplitExplicitRK2Stepper(
+       const std::string &InName, ///< [in] name of time stepper
+       ///< [in] SplitExplicitRK2 or UnsplitRK2
+       TimeStepperType InType,
+       const TimeInterval &InTimeStep, ///< [in] time step
+       const TimeInstant &InStartTime, ///< [in] start time for time stepping
+       ///< [in] stop time for time stepping, missing in coupled mode
+       std::optional<TimeInstant> InStopTime = std::nullopt);
+
+   /// Advance the state by one split-explicit RK2 step.
+   void doStep(OceanState *State,   ///< [inout] model state
+               TimeInstant &SimTime ///< [inout] current simulation time
+   ) const override;
+
+   /// Initialize split-explicit state after initial/restart input is read.
+   void initializeStateFromInput(
+       OceanState *State, ///< [inout] model state after input has been read
+       bool ReadRestart   ///< [in] true if restart input initialized the state
+   ) const override;
+
+ protected:
+   /// Performs additional initialization for split-explicit scratch fields.
+   void finalizeInit() override;
+
+ private:
+   void doBaroclinicVelocityUpdate(
+       OceanState *State,                      ///< [inout] model state
+       const Array3DReal &TendencyTracerArray, ///< [in] tracers for tendencies
+       I4 CurLevel,                            ///< [in] current time level
+       I4 NextLevel,                           ///< [in] next time level
+       const TimeInstant &StageTime,           ///< [in] current stage time
+       const TimeInterval &StageTimeStep       ///< [in] current stage time step
+   ) const;
+
+   void doThicknessTracerUpdate(
+       OceanState *State,                  ///< [inout] model state
+       const Array3DReal &CurTracerArray,  ///< [in] current tracers
+       const Array3DReal &NextTracerArray, ///< [out] next tracers
+       I4 CurLevel,                        ///< [in] current time level
+       I4 NextLevel,                       ///< [in] next time level
+       const TimeInstant &StageTime,       ///< [in] current stage time
+       const TimeInterval &StageTimeStep,  ///< [in] current stage time step
+       bool FinalIteration ///< [in] true on the final time-step iteration
+   ) const;
+
+   using BarotropicUpdateFunction = std::function<void(
+       OceanState *, I4, I4, const TimeInstant &, const TimeInterval &)>;
+
+   void initBarotropicStepper();
+
+   void doBarotropicVelocityUpdate(OceanState *State, I4 CurLevel, I4 NextLevel,
+                                   const TimeInstant &StageTime,
+                                   const TimeInterval &StageTimeStep) const;
+
+   void
+   computeTransportVelocity(OceanState *State, ///< [inout] model state
+                            I4 TimeLevel ///< [in] time level for split velocity
+   ) const;
+
+   void doBaroclinicCoriolisIteration(
+       OceanState *State,                   ///< [inout] model state
+       const Array2DReal &BaseVelocityTend, ///< [in] non-Coriolis tendency
+       I4 CurLevel,                         ///< [in] current time level
+       I4 NextLevel,                        ///< [in] next time level
+       const TimeInterval &StageTimeStep    ///< [in] current stage time step
+   ) const;
+
+   void computeBarotropicForcing(
+       OceanState *State,                ///< [inout] model state
+       I4 CurLevel,                      ///< [in] current time level
+       I4 NewLevel,                      ///< [in] next time level
+       const TimeInterval &StageTimeStep ///< [in] current stage time step
+   ) const;
+
+   void updateBaroclinicVelocityByTend(
+       OceanState *State1, ///< [out] updated state
+       I4 TimeLevel1,      ///< [in] time level index for new time
+       OceanState *State2, ///< [in] state for current time
+       I4 TimeLevel2,      ///< [in] time level index for current time
+       TimeInterval Coeff  ///< [in] time-related coeff for tendency
+   ) const;
+
+   void updateTracersToMidpoint(
+       const Array3DReal &MidpointTracers, ///< [out] midpoint tracers
+       const Array3DReal &CurTracers,      ///< [in] current tracers
+       OceanState *State,                  ///< [in] model state
+       I4 CurLevel,                        ///< [in] current state time level
+       const TimeInterval &StageTimeStep   ///< [in] full stage time step
+   ) const;
+
+   void initializeNextState(OceanState *State, ///< [inout] model state
+                            I4 CurLevel,       ///< [in] current time level
+                            I4 NextLevel,      ///< [in] next time level
+                            Real SplitFactor,  ///< [in] split factor
+                            bool ReinitSplitVelocity ///< [in] whether to
+                                                     ///< recompute the split
+   ) const;
+
+   void reconstructNormalVelocity(
+       OceanState *State,  ///< [inout] model state
+       I4 CurLevel,        ///< [in] current time level
+       I4 NextLevel,       ///< [in] next time level
+       bool FinalIteration ///< [in] true on the final time-step iteration
+   ) const;
+
+   void finalizeTimeStepIterationState(
+       OceanState *State,  ///< [inout] model state
+       I4 CurLevel,        ///< [in] current time level
+       I4 NextLevel,       ///< [in] next time level
+       bool FinalIteration ///< [in] true on the final time-step iteration
+   ) const;
+
+   void computeVerticalPseudoVelocity(
+       OceanState *State,         ///< [inout] model state
+       I4 ThickTimeLevel,         ///< [in] thickness time level
+       I4 VelTimeLevel,           ///< [in] reconstructed velocity time level
+       TimeInterval StageTimeStep ///< [in] current stage time step
+   ) const;
+   void computeVerticalPseudoVelocity(
+       OceanState *State,                ///< [inout] model state
+       I4 ThickTimeLevel,                ///< [in] thickness time level
+       const Array2DReal &NormalVelEdge, ///< [in] velocity on edges
+       TimeInterval StageTimeStep        ///< [in] current stage time step
+   ) const;
+
+   SplitExplicitConfig SEConfig;
+   mutable SplitExplicitScratch SEScratch;
+   BarotropicUpdateFunction BarotropicUpdate;
+   SplitExplicitBarotropicPCStepper BarotropicPCStepper;
+};
+
+} // namespace OMEGA
+
+#endif

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
@@ -35,41 +35,10 @@ class SplitExplicitRK2Stepper : public TimeStepper {
        bool ReadRestart   ///< [in] true if restart input initialized the state
    ) const override;
 
- protected:
-   /// Performs additional initialization for split-explicit scratch fields.
-   void finalizeInit() override;
-
- private:
-   void doBaroclinicVelocityUpdate(
-       OceanState *State,                      ///< [inout] model state
-       const Array3DReal &TendencyTracerArray, ///< [in] tracers for tendencies
-       I4 CurLevel,                            ///< [in] current time level
-       I4 NextLevel,                           ///< [in] next time level
-       const TimeInstant &StageTime,           ///< [in] current stage time
-       const TimeInterval &StageTimeStep       ///< [in] current stage time step
-   ) const;
-
-   void doThicknessTracerUpdate(
-       OceanState *State,                  ///< [inout] model state
-       const Array3DReal &CurTracerArray,  ///< [in] current tracers
-       const Array3DReal &NextTracerArray, ///< [out] next tracers
-       I4 CurLevel,                        ///< [in] current time level
-       I4 NextLevel,                       ///< [in] next time level
-       const TimeInstant &StageTime,       ///< [in] current stage time
-       const TimeInterval &StageTimeStep,  ///< [in] current stage time step
-       bool FinalIteration ///< [in] true on the final time-step iteration
-   ) const;
 
    void
    computeTransportVelocity(OceanState *State, ///< [inout] model state
                             I4 TimeLevel ///< [in] time level for split velocity
-   ) const;
-
-   void doBaroclinicCoriolisIteration(
-       OceanState *State,                ///< [inout] model state
-       I4 CurLevel,                      ///< [in] current time level
-       I4 NextLevel,                     ///< [in] next time level
-       const TimeInterval &StageTimeStep ///< [in] current stage time step
    ) const;
 
    /// Removes the barotropic forcing from the iterated baroclinic tendency and
@@ -109,6 +78,38 @@ class SplitExplicitRK2Stepper : public TimeStepper {
        I4 CurLevel,        ///< [in] current time level
        I4 NextLevel,       ///< [in] next time level
        bool FinalIteration ///< [in] true on the final time-step iteration
+   ) const;
+
+ protected:
+   /// Performs additional initialization for split-explicit scratch fields.
+   void finalizeInit() override;
+
+ private:
+   void doBaroclinicVelocityUpdate(
+       OceanState *State,                      ///< [inout] model state
+       const Array3DReal &TendencyTracerArray, ///< [in] tracers for tendencies
+       I4 CurLevel,                            ///< [in] current time level
+       I4 NextLevel,                           ///< [in] next time level
+       const TimeInstant &StageTime,           ///< [in] current stage time
+       const TimeInterval &StageTimeStep       ///< [in] current stage time step
+   ) const;
+
+   void doThicknessTracerUpdate(
+       OceanState *State,                  ///< [inout] model state
+       const Array3DReal &CurTracerArray,  ///< [in] current tracers
+       const Array3DReal &NextTracerArray, ///< [out] next tracers
+       I4 CurLevel,                        ///< [in] current time level
+       I4 NextLevel,                       ///< [in] next time level
+       const TimeInstant &StageTime,       ///< [in] current stage time
+       const TimeInterval &StageTimeStep,  ///< [in] current stage time step
+       bool FinalIteration ///< [in] true on the final time-step iteration
+   ) const;
+
+   void doBaroclinicCoriolisIteration(
+       OceanState *State,                ///< [inout] model state
+       I4 CurLevel,                      ///< [in] current time level
+       I4 NextLevel,                     ///< [in] next time level
+       const TimeInterval &StageTimeStep ///< [in] current stage time step
    ) const;
 
    void computeVerticalPseudoVelocity(

--- a/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
+++ b/components/omega/src/timeStepping/SplitExplicitRK2Stepper.h
@@ -35,7 +35,6 @@ class SplitExplicitRK2Stepper : public TimeStepper {
        bool ReadRestart   ///< [in] true if restart input initialized the state
    ) const override;
 
-
    void
    computeTransportVelocity(OceanState *State, ///< [inout] model state
                             I4 TimeLevel ///< [in] time level for split velocity

--- a/components/omega/src/timeStepping/SplitExplicitTypes.h
+++ b/components/omega/src/timeStepping/SplitExplicitTypes.h
@@ -44,7 +44,7 @@ struct SplitExplicitScratch {
    Array1DReal BarotropicFlux;
    Array1DReal BaroclinicPseudoThicknessEdge;
    Array2DReal IterVelocityTend;
-   Array2DReal NormalTransportVelocity;
+   Array2DReal TransportVelocityAdd;
 };
 
 } // namespace OMEGA

--- a/components/omega/src/timeStepping/SplitExplicitTypes.h
+++ b/components/omega/src/timeStepping/SplitExplicitTypes.h
@@ -1,0 +1,53 @@
+#ifndef OMEGA_SPLIT_EXPLICIT_TYPES_H
+#define OMEGA_SPLIT_EXPLICIT_TYPES_H
+//===-- SplitExplicitTypes.h - split-explicit shared types -----*- C++ -*-===//
+//
+/// \file
+/// \brief Contains shared configuration and scratch arrays for SE time
+/// stepping.
+//
+//===----------------------------------------------------------------------===//
+
+#include "DataTypes.h"
+#include "TimeMgr.h"
+
+namespace OMEGA {
+
+enum class SplitExplicitBarotropicStepperType { PredictorCorrector, Invalid };
+
+struct SplitExplicitConfig {
+   TimeInterval BtrTimeStep;
+   SplitExplicitBarotropicStepperType BtrTimeStepper =
+       SplitExplicitBarotropicStepperType::PredictorCorrector;
+   I4 NBtrSubcycles = 1;
+   // Two iterations are required for the RK2 predictor-corrector structure;
+   // a single iteration leaves only the predictor and degrades the scheme to
+   // forward Euler.
+   I4 NTimeStepIteration    = 2;
+   I4 NBclCoriolisIteration = 2;
+   bool ReinitSplitVelocity = false;
+   Real SplitFactor         = 1._Real;
+};
+
+struct SplitExplicitScratch {
+   // The barotropic subcycle keeps three buffers per field:
+   //    - the state at the start of the subcycle (Cur)
+   //    - the predictor output (Pre)
+   //    - the corrector output (Cor).
+   Array1DReal NormalBarotropicVelocitySubcycleCur;
+   Array1DReal NormalBarotropicVelocitySubcyclePre;
+   Array1DReal NormalBarotropicVelocitySubcycleCor;
+   Array1DReal BarotropicPressureAnomalySubcycleCur;
+   Array1DReal BarotropicPressureAnomalySubcyclePre;
+   Array1DReal BarotropicPressureAnomalySubcycleCor;
+   Array1DReal BarotropicPressure;
+   Array1DReal BarotropicForcing;
+   Array1DReal BarotropicFlux;
+   Array1DReal BaroclinicPseudoThicknessEdge;
+   Array2DReal BaseVelocityTend;
+   Array2DReal NormalTransportVelocity;
+};
+
+} // namespace OMEGA
+
+#endif

--- a/components/omega/src/timeStepping/SplitExplicitTypes.h
+++ b/components/omega/src/timeStepping/SplitExplicitTypes.h
@@ -40,11 +40,10 @@ struct SplitExplicitScratch {
    Array1DReal BarotropicPressureAnomalySubcycleCur;
    Array1DReal BarotropicPressureAnomalySubcyclePre;
    Array1DReal BarotropicPressureAnomalySubcycleCor;
-   Array1DReal BarotropicPressure;
    Array1DReal BarotropicForcing;
    Array1DReal BarotropicFlux;
    Array1DReal BaroclinicPseudoThicknessEdge;
-   Array2DReal BaseVelocityTend;
+   Array2DReal IterVelocityTend;
    Array2DReal NormalTransportVelocity;
 };
 

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -432,6 +432,10 @@ void TimeStepper::changeTimeStep(const TimeInterval &TimeStepIn) {
 I8 TimeStepper::getStepCount() const { return StepCount; }
 
 //------------------------------------------------------------------------------
+// Is this a split time stepper. False by default
+bool TimeStepper::isSplit() const { return false; }
+
+//------------------------------------------------------------------------------
 // Retrieval functions
 
 // Get the default time stepper

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -11,6 +11,7 @@
 #include "Logging.h"
 #include "RungeKutta2Stepper.h"
 #include "RungeKutta4Stepper.h"
+#include "SplitExplicitRK2Stepper.h"
 
 namespace OMEGA {
 //------------------------------------------------------------------------------
@@ -39,9 +40,14 @@ TimeStepperType getTimeStepperFromStr(const std::string &InString) {
       TimeStepperChoice = TimeStepperType::RungeKutta4;
    } else if (InString == "RungeKutta2") {
       TimeStepperChoice = TimeStepperType::RungeKutta2;
+   } else if (InString == "SplitExplicitRK2") {
+      TimeStepperChoice = TimeStepperType::SplitExplicitRK2;
+   } else if (InString == "UnsplitRK2") {
+      TimeStepperChoice = TimeStepperType::UnsplitRK2;
    } else {
       ABORT_ERROR("TimeStepper should be one of 'Forward-Backward', "
-                  "'RungeKutta4' or 'RungeKutta2' but got {}:",
+                  "'RungeKutta4', 'RungeKutta2', 'SplitExplicitRK2' or "
+                  "'UnsplitRK2' but got {}:",
                   InString);
    }
 
@@ -192,6 +198,14 @@ TimeStepper *TimeStepper::create(
    case TimeStepperType::RungeKutta2:
       NewTimeStepper =
           new RungeKutta2Stepper(InName, InTimeStep, InStartTime, InStopTime);
+      break;
+   // Both share an implementation; the type selects whether the barotropic
+   // mode is split off (SplitFactor 1) or carried in the baroclinic solve
+   // (SplitFactor 0).
+   case TimeStepperType::SplitExplicitRK2:
+   case TimeStepperType::UnsplitRK2:
+      NewTimeStepper = new SplitExplicitRK2Stepper(InName, InType, InTimeStep,
+                                                   InStartTime, InStopTime);
       break;
    case TimeStepperType::Invalid:
       ABORT_ERROR("Invalid time stepping method");

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -221,6 +221,9 @@ class TimeStepper {
    /// Get number of doStep calls made on this instance
    I8 getStepCount() const;
 
+   /// Is this a split time stepper. False by default
+   virtual bool isSplit() const;
+
    // these should be protected, they are public only because of CUDA
    // limitations
 

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -18,11 +18,27 @@
 ///    # Default is the No Leap (Gregorian calendar with no leap years)
 ///    CalendarType: No Leap
 ///    # Algorithm to use for the dynamics time integration
-///    # Supported options are Forward-Backward (default), RungeKutta2 and
-///    # RungeKutta4
+///    # Supported options are Forward-Backward (default), RungeKutta2,
+///    # RungeKutta4, SplitExplicitRK2 and UnsplitRK2
 ///    TimeStepper: Forward-Backward
 ///    # Time step to use, in form of DDDD_hh:mm:ss (days, hours, minutes, secs)
 ///    TimeStep: 0000_00:10:00
+///    # Options shared by the split time steppers SplitExplicitRK2 and
+///    # UnsplitRK2. The subgroup is required whenever one of those steppers
+///    # is selected. BtrTimeStep is required within it for SplitExplicitRK2
+///    # and must be smaller than TimeStep; the remaining keys are optional
+///    # and fall back to the SplitExplicitConfig defaults.
+///    ModeSplitShare:
+///      # BtrTimeStepper and BtrTimeStep are ignored by UnsplitRK2, which
+///      # has no barotropic subcycle
+///      BtrTimeStepper: Predictor-Corrector
+///      BtrTimeStep: 0000_00:00:20
+///      # Iterations over stages 1-3. Two are needed for the RK2 predictor-
+///      # corrector structure; one degrades the scheme to forward Euler.
+///      NTimeStepIteration: 2
+///      NBclCoriolisIteration: 2
+///      # Recompute the velocity split from NormalVelocity at every slow step
+///      ReinitSplitVelocity: false
 ///    # Start time of full simulation (YYYY-MM-DD_hh:mm:ss)
 ///    StartTime: 0001-01-01_00:00:00
 ///    # Either stop time or run duration must be supplied with Duration
@@ -61,6 +77,8 @@ enum class TimeStepperType {
    ForwardBackward,
    RungeKutta4,
    RungeKutta2,
+   SplitExplicitRK2,
+   UnsplitRK2,
    Invalid
 };
 
@@ -104,6 +122,12 @@ class TimeStepper {
    virtual void doStep(OceanState *State,   ///< [inout] model state
                        TimeInstant &SimTime ///< [inout] current simulation time
    ) const = 0;
+
+   /// Optional method-specific state initialization after initial/restart read.
+   virtual void initializeStateFromInput(
+       OceanState *, ///< [inout] model state after input has been read
+       bool          ///< [in] true if restart input initialized the state
+   ) const {}
 
    /// 1st phase of Initialization for the default time stepper
    static void init1();

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -386,7 +386,11 @@ void testDepthMeanSpecificVolume() {
    deepCopy(TestEos->SpecVol, 2._Real);
    deepCopy(LayerThickness, 3._Real);
    deepCopy(TestEos->DepthMeanSpecificVolume, 0._Real);
-   VCoord->computeTotalPseudoThickness(LayerThickness);
+   deepCopy(VCoord->SurfacePressure, 100._Real);
+   deepCopy(VCoord->BottomGeomDepth, 500._Real);
+
+   VCoord->computePressure(LayerThickness, VCoord->SurfacePressure);
+   VCoord->computeGeomZHeight(LayerThickness, TestEos->SpecVol);
 
    TestEos->computeDepthMeanSpecificVolume(LayerThickness);
 

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -374,8 +374,8 @@ void testEosConstant() {
    return;
 }
 
-/// Test depth-integrated specific volume calculation
-void testDepthIntegratedSpecificVolume() {
+/// Test depth-mean specific volume calculation
+void testDepthMeanSpecificVolume() {
    const auto Mesh   = HorzMesh::getDefault();
    const auto VCoord = VertCoord::getDefault();
    Eos *TestEos      = Eos::getInstance();
@@ -385,27 +385,27 @@ void testDepthIntegratedSpecificVolume() {
 
    deepCopy(TestEos->SpecVol, 2._Real);
    deepCopy(LayerThickness, 3._Real);
-   deepCopy(TestEos->DepthIntegSpecificVolume, 0._Real);
+   deepCopy(TestEos->DepthMeanSpecificVolume, 0._Real);
+   VCoord->computeTotalPseudoThickness(LayerThickness);
 
-   TestEos->computeDepthIntegratedSpecificVolume(LayerThickness);
+   TestEos->computeDepthMeanSpecificVolume(LayerThickness);
 
-   auto DepthIntegSpecificVolumeH =
-       createHostMirrorCopy(TestEos->DepthIntegSpecificVolume);
+   auto DepthMeanSpecificVolumeH =
+       createHostMirrorCopy(TestEos->DepthMeanSpecificVolume);
 
    int NumMismatches = 0;
    for (int ICell = 0; ICell < Mesh->NCellsAll; ++ICell) {
-      const Real Expected = 6._Real * (VCoord->MaxLayerCellH(ICell) -
-                                       VCoord->MinLayerCellH(ICell) + 1);
-      if (!isApprox(DepthIntegSpecificVolumeH(ICell), Expected, RTol)) {
-         LOG_ERROR("EosTest: DepthIntegSpecificVolume Bad Value: "
-                   "DepthIntegSpecificVolume({}) = {}; Expected {}",
-                   ICell, DepthIntegSpecificVolumeH(ICell), Expected);
+      const Real Expected = 2._Real;
+      if (!isApprox(DepthMeanSpecificVolumeH(ICell), Expected, RTol)) {
+         LOG_ERROR("EosTest: DepthMeanSpecificVolume Bad Value: "
+                   "DepthMeanSpecificVolume({}) = {}; Expected {}",
+                   ICell, DepthMeanSpecificVolumeH(ICell), Expected);
          ++NumMismatches;
       }
    }
 
    if (NumMismatches != 0) {
-      ABORT_ERROR("EosTest: DepthIntegSpecificVolume FAIL with {} bad values",
+      ABORT_ERROR("EosTest: DepthMeanSpecificVolume FAIL with {} bad values",
                   NumMismatches);
    }
 
@@ -1531,7 +1531,7 @@ void eosTest(const std::string &MeshFile = "OmegaMesh.nc") {
    testEosLinear();
    testEosLinearDisplaced();
    testEosConstant();
-   testDepthIntegratedSpecificVolume();
+   testDepthMeanSpecificVolume();
    testBruntVaisalaFreqSqLinear();
    testEosTeos10();
    testEosTeos10Displaced();

--- a/components/omega/test/ocn/EosTest.cpp
+++ b/components/omega/test/ocn/EosTest.cpp
@@ -374,6 +374,44 @@ void testEosConstant() {
    return;
 }
 
+/// Test depth-integrated specific volume calculation
+void testDepthIntegratedSpecificVolume() {
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
+   Eos *TestEos      = Eos::getInstance();
+
+   Array2DReal LayerThickness("LayerThickness", Mesh->NCellsSize,
+                              VCoord->NVertLayers);
+
+   deepCopy(TestEos->SpecVol, 2._Real);
+   deepCopy(LayerThickness, 3._Real);
+   deepCopy(TestEos->DepthIntegSpecificVolume, 0._Real);
+
+   TestEos->computeDepthIntegratedSpecificVolume(LayerThickness);
+
+   auto DepthIntegSpecificVolumeH =
+       createHostMirrorCopy(TestEos->DepthIntegSpecificVolume);
+
+   int NumMismatches = 0;
+   for (int ICell = 0; ICell < Mesh->NCellsAll; ++ICell) {
+      const Real Expected = 6._Real * (VCoord->MaxLayerCellH(ICell) -
+                                       VCoord->MinLayerCellH(ICell) + 1);
+      if (!isApprox(DepthIntegSpecificVolumeH(ICell), Expected, RTol)) {
+         LOG_ERROR("EosTest: DepthIntegSpecificVolume Bad Value: "
+                   "DepthIntegSpecificVolume({}) = {}; Expected {}",
+                   ICell, DepthIntegSpecificVolumeH(ICell), Expected);
+         ++NumMismatches;
+      }
+   }
+
+   if (NumMismatches != 0) {
+      ABORT_ERROR("EosTest: DepthIntegSpecificVolume FAIL with {} bad values",
+                  NumMismatches);
+   }
+
+   return;
+}
+
 /// Test linear squared Brunt-Vaisala frequency calculation for all cells/layers
 void testBruntVaisalaFreqSqLinear() {
    /// Get mesh and coordinate info
@@ -1493,6 +1531,7 @@ void eosTest(const std::string &MeshFile = "OmegaMesh.nc") {
    testEosLinear();
    testEosLinearDisplaced();
    testEosConstant();
+   testDepthIntegratedSpecificVolume();
    testBruntVaisalaFreqSqLinear();
    testEosTeos10();
    testEosTeos10Displaced();

--- a/components/omega/test/ocn/TendencyTermsTest.cpp
+++ b/components/omega/test/ocn/TendencyTermsTest.cpp
@@ -523,6 +523,124 @@ int testPotVortHAdv(int NVertLayers, Real RTol) {
    return Err;
 } // end testPotVortHAdv
 
+int testCoriolisAccelerationOnEdge(int NVertLayers, Real RTol) {
+
+   int Err = 0;
+   TestSetup Setup;
+
+   const auto Mesh   = HorzMesh::getDefault();
+   const auto VCoord = VertCoord::getDefault();
+
+   Array2DReal NormalVelEdge("NormalVelEdge", Mesh->NEdgesSize, NVertLayers);
+   Err += setVectorEdge(
+       KOKKOS_LAMBDA(Real(&VecField)[2], Real X, Real Y) {
+          VecField[0] = Setup.vectorX(X, Y);
+          VecField[1] = Setup.vectorY(X, Y);
+       },
+       NormalVelEdge, EdgeComponent::Normal, Geom, Mesh);
+
+   Array1DReal NormalBarotropicVelEdge("NormalBarotropicVelEdge",
+                                       Mesh->NEdgesSize);
+   Err += setScalar(
+       KOKKOS_LAMBDA(Real X, Real Y) { return Setup.scalarB(X, Y); },
+       NormalBarotropicVelEdge, Geom, Mesh, OnEdge);
+
+   Array1DReal FEdge("FEdge", Mesh->NEdgesSize);
+   Err += setScalar(
+       KOKKOS_LAMBDA(Real X, Real Y) { return Setup.planetaryVort(X, Y); },
+       FEdge, Geom, Mesh, OnEdge);
+
+   Array2DReal NumCoriolis2D("NumCoriolis2D", Mesh->NEdgesOwned, NVertLayers);
+   Array2DReal ExactCoriolis2D("ExactCoriolis2D", Mesh->NEdgesOwned,
+                               NVertLayers);
+   Array1DReal NumCoriolis1D("NumCoriolis1D", Mesh->NEdgesOwned);
+   Array1DReal ExactCoriolis1D("ExactCoriolis1D", Mesh->NEdgesOwned);
+
+   deepCopy(NumCoriolis2D, 0._Real);
+   deepCopy(ExactCoriolis2D, 0._Real);
+   deepCopy(NumCoriolis1D, 0._Real);
+   deepCopy(ExactCoriolis1D, 0._Real);
+
+   CoriolisAccelerationOnEdge CoriolisAccelOnE(Mesh, VCoord);
+
+   OMEGA_SCOPE(MinLayerEdgeBot, VCoord->MinLayerEdgeBot);
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
+   parallelForOuter(
+       {Mesh->NEdgesOwned}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 CoriolisAccelOnE(NumCoriolis2D, IEdge, KChunk, NormalVelEdge,
+                                  FEdge);
+              });
+       });
+
+   OMEGA_SCOPE(NEdgesOnEdge, Mesh->NEdgesOnEdge);
+   OMEGA_SCOPE(EdgesOnEdge, Mesh->EdgesOnEdge);
+   OMEGA_SCOPE(WeightsOnEdge, Mesh->WeightsOnEdge);
+   parallelForOuter(
+       {Mesh->NEdgesOwned}, KOKKOS_LAMBDA(int IEdge, const TeamMember &Team) {
+          const int KMin   = MinLayerEdgeBot(IEdge);
+          const int KMax   = MaxLayerEdgeTop(IEdge);
+          const int KRange = vertRangeChunked(KMin, KMax);
+          parallelForInner(
+              Team, KRange, INNER_LAMBDA(int KChunk) {
+                 const int KStart = chunkStart(KChunk, KMin);
+                 const int KLen   = chunkLength(KChunk, KStart, KMax);
+                 Real CoriolisTmp[VecLength] = {0};
+
+                 for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
+                    const int JEdge = EdgesOnEdge(IEdge, J);
+                    for (int KVec = 0; KVec < KLen; ++KVec) {
+                       const int K = KStart + KVec;
+                       CoriolisTmp[KVec] += WeightsOnEdge(IEdge, J) *
+                                            NormalVelEdge(JEdge, K) *
+                                            FEdge(JEdge);
+                    }
+                 }
+
+                 for (int KVec = 0; KVec < KLen; ++KVec) {
+                    const int K = KStart + KVec;
+                    ExactCoriolis2D(IEdge, K) += CoriolisTmp[KVec];
+                 }
+              });
+       });
+
+   parallelFor(
+       {Mesh->NEdgesOwned}, KOKKOS_LAMBDA(int IEdge) {
+          CoriolisAccelOnE(NumCoriolis1D, IEdge, NormalBarotropicVelEdge,
+                           FEdge);
+
+          Real CoriolisTmp = 0._Real;
+          for (int J = 0; J < NEdgesOnEdge(IEdge); ++J) {
+             const int JEdge = EdgesOnEdge(IEdge, J);
+             CoriolisTmp += WeightsOnEdge(IEdge, J) *
+                            NormalBarotropicVelEdge(JEdge) * FEdge(JEdge);
+          }
+          ExactCoriolis1D(IEdge) += CoriolisTmp;
+       });
+
+   ErrorMeasures Coriolis2DErrors;
+   Err += computeErrors(Coriolis2DErrors, NumCoriolis2D, ExactCoriolis2D, Mesh,
+                        OnEdge);
+   Err += checkErrors("TendencyTermsTest", "CoriolisAcceleration2D",
+                      Coriolis2DErrors, {0, 0}, RTol);
+
+   ErrorMeasures Coriolis1DErrors;
+   Err += computeErrors(Coriolis1DErrors, NumCoriolis1D, ExactCoriolis1D, Mesh,
+                        OnEdge);
+   Err += checkErrors("TendencyTermsTest", "CoriolisAcceleration1D",
+                      Coriolis1DErrors, {0, 0}, RTol);
+
+   if (Err == 0) {
+      LOG_INFO("TendencyTermsTest: CoriolisAccelerationOnEdge PASS");
+   }
+
+   return Err;
+} // end testCoriolisAccelerationOnEdge
+
 int testKEGrad(int NVertLayers, Real RTol) {
 
    int Err = 0;
@@ -1445,6 +1563,8 @@ int tendencyTermsTest(const std::string &MeshFile = DefaultMeshFile) {
    Err += testThickFluxDiv(NVertLayers, RTol);
 
    Err += testPotVortHAdv(NVertLayers, RTol);
+
+   Err += testCoriolisAccelerationOnEdge(NVertLayers, RTol);
 
    Err += testKEGrad(NVertLayers, RTol);
 

--- a/components/omega/test/ocn/VertAdvTest.cpp
+++ b/components/omega/test/ocn/VertAdvTest.cpp
@@ -51,23 +51,23 @@ Real tendTest(const int NLayers, VertAdv *VAdv) {
    Real Delta = Length / NLayers;
 
    VAdv->NVertLayers = NLayers;
-   VAdv->TotalVerticalPseudoVelocity =
-       Array2DReal("TotalVerticalPseudoVelocity", 1, NLayers + 1);
+   VAdv->TotalVerticalTransportPseudoVelocity =
+       Array2DReal("TotalVerticalTransportPseudoVelocity", 1, NLayers + 1);
    VAdv->VertFlux = Array3DReal("VertFlux", 1, 1, NLayers + 1);
    Array1DReal XLayer("XLayer", NLayers);
-   OMEGA_SCOPE(LocTotVertVel, VAdv->TotalVerticalPseudoVelocity);
+   OMEGA_SCOPE(LocTotVertTransVel, VAdv->TotalVerticalTransportPseudoVelocity);
    Array2DReal PseudoThick("PseudoThickness", 1, NLayers);
    Array3DReal TracerArray("TracerArray", 1, 1, NLayers);
    Array3DReal Tend("TracerArray", 1, 1, NLayers);
    TimeInterval ZeroTimeStep;
 
    // Set uniform velocity throughout domain
-   deepCopy(VAdv->TotalVerticalPseudoVelocity, 1._Real);
+   deepCopy(VAdv->TotalVerticalTransportPseudoVelocity, 1._Real);
    // Set velocities at top and bottom interfaces to 0.
    parallelFor(
        {1}, KOKKOS_LAMBDA(const int &) {
-          LocTotVertVel(0, 0)       = 0._Real;
-          LocTotVertVel(0, NLayers) = 0._Real;
+          LocTotVertTransVel(0, 0)       = 0._Real;
+          LocTotVertTransVel(0, NLayers) = 0._Real;
        });
    // Set X values, PseudoThickness, and Tracer values throughout domain
    parallelFor(
@@ -222,12 +222,12 @@ int main(int argc, char *argv[]) {
           });
 
       Real ProjDt = 1._Real;
-      // Compute vertical pseudo-velocity
-      DefVertAdv->computeVerticalPseudoVelocity(
+      // Compute vertical transport pseudo-velocity
+      DefVertAdv->computeVerticalTransportPseudoVelocity(
           NormalVelEdge, FluxPseudoThickEdge, PseudoThickCell, ProjDt);
 
-      HostArray2DReal VertVelH =
-          createHostMirrorCopy(DefVertAdv->VerticalPseudoVelocity);
+      HostArray2DReal VertTransVelH =
+          createHostMirrorCopy(DefVertAdv->VerticalTransportPseudoVelocity);
 
       Real Tol = 1e-10;
 
@@ -242,7 +242,7 @@ int main(int argc, char *argv[]) {
 
       for (int K = 1; K < NVertLayersP1; ++K) {
          Real Expected = (NVertLayers - K) * Perim0 * InvAreaCell0;
-         Real Diff     = std::abs(VertVelH(ICell0, K) - Expected);
+         Real Diff     = std::abs(VertTransVelH(ICell0, K) - Expected);
          if (Diff > Tol) {
             ++Err;
          }

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -254,8 +254,6 @@ int main(int argc, char *argv[]) {
 
       Array2DReal SpecVol("SpecVol", NCellsSize, NVertLayers);
       Array1DReal BottomGeomDepth("BottomGeomDepth", NCellsSize);
-      Array1DReal DepthIntegSpecificVolume("DepthIntegSpecificVolume",
-                                           NCellsSize);
       Array1DReal MaxLyrCellReal("MaxLyrCellReal", NCellsSize);
       deepCopy(MaxLyrCellReal, DefVertCoord->MaxLayerCell);
 
@@ -280,11 +278,6 @@ int main(int argc, char *argv[]) {
       auto SshCellH     = createHostMirrorCopy(DefVertCoord->SshCell);
       OMEGA_SCOPE(MinLayerCell, DefVertCoord->MinLayerCell);
       OMEGA_SCOPE(MaxLayerCell, DefVertCoord->MaxLayerCell);
-      parallelFor(
-          {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
-             DepthIntegSpecificVolume(ICell) =
-                 (MaxLayerCell(ICell) - MinLayerCell(ICell) + 1) / Rho0;
-          });
       DefVertCoord->computeGeomZHeight(PseudoThickness, SpecVol);
 
       /// Check results

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -173,8 +173,6 @@ int main(int argc, char *argv[]) {
       DefVertCoord->computePressure(PseudoThickness, SurfacePressure);
       auto PressInterfH = createHostMirrorCopy(DefVertCoord->PressureInterface);
       auto PressMidH    = createHostMirrorCopy(DefVertCoord->PressureMid);
-      auto TotalPseudoThicknessH =
-          createHostMirrorCopy(DefVertCoord->TotalPseudoThickness);
 
       /// Check results
       Err = 0;
@@ -182,10 +180,6 @@ int main(int argc, char *argv[]) {
          Real ExpectedTotal = (DefVertCoord->MaxLayerCellH(ICell) -
                                DefVertCoord->MinLayerCellH(ICell) + 1) /
                               (Gravity * Rho0);
-         if (!isApprox(TotalPseudoThicknessH(ICell), ExpectedTotal, RTol,
-                       ATol)) {
-            Err += 1;
-         }
          for (int K = DefVertCoord->MinLayerCellH(ICell);
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             // Interface pressure at layer K should be K+1

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -173,10 +173,19 @@ int main(int argc, char *argv[]) {
       DefVertCoord->computePressure(PseudoThickness, SurfacePressure);
       auto PressInterfH = createHostMirrorCopy(DefVertCoord->PressureInterface);
       auto PressMidH    = createHostMirrorCopy(DefVertCoord->PressureMid);
+      auto TotalPseudoThicknessH =
+          createHostMirrorCopy(DefVertCoord->TotalPseudoThickness);
 
       /// Check results
       Err = 0;
       for (int ICell = 0; ICell < NCellsAll; ICell++) {
+         Real ExpectedTotal = (DefVertCoord->MaxLayerCellH(ICell) -
+                               DefVertCoord->MinLayerCellH(ICell) + 1) /
+                              (Gravity * Rho0);
+         if (!isApprox(TotalPseudoThicknessH(ICell), ExpectedTotal, RTol,
+                       ATol)) {
+            Err += 1;
+         }
          for (int K = DefVertCoord->MinLayerCellH(ICell);
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             // Interface pressure at layer K should be K+1
@@ -245,6 +254,8 @@ int main(int argc, char *argv[]) {
 
       Array2DReal SpecVol("SpecVol", NCellsSize, NVertLayers);
       Array1DReal BottomGeomDepth("BottomGeomDepth", NCellsSize);
+      Array1DReal DepthIntegSpecificVolume("DepthIntegSpecificVolume",
+                                           NCellsSize);
       Array1DReal MaxLyrCellReal("MaxLyrCellReal", NCellsSize);
       deepCopy(MaxLyrCellReal, DefVertCoord->MaxLayerCell);
 
@@ -267,10 +278,27 @@ int main(int argc, char *argv[]) {
       auto GeomZInterfH = createHostMirrorCopy(DefVertCoord->GeomZInterface);
       auto GeomZMidH    = createHostMirrorCopy(DefVertCoord->GeomZMid);
       auto SshCellH     = createHostMirrorCopy(DefVertCoord->SshCell);
+      OMEGA_SCOPE(MinLayerCell, DefVertCoord->MinLayerCell);
+      OMEGA_SCOPE(MaxLayerCell, DefVertCoord->MaxLayerCell);
+      parallelFor(
+          {NCellsAll}, KOKKOS_LAMBDA(int ICell) {
+             DepthIntegSpecificVolume(ICell) =
+                 (MaxLayerCell(ICell) - MinLayerCell(ICell) + 1) / Rho0;
+          });
+      DefVertCoord->computeTotalGeometricThickness(DepthIntegSpecificVolume);
+      DefVertCoord->computeGeomZHeight(PseudoThickness, SpecVol);
+      auto TotalGeometricThicknessH =
+          createHostMirrorCopy(DefVertCoord->TotalGeometricThickness);
 
       /// Check results
       Err = 0;
       for (int ICell = 0; ICell < NCellsAll; ICell++) {
+         Real ExpectedTotal = DefVertCoord->MaxLayerCellH(ICell) -
+                              DefVertCoord->MinLayerCellH(ICell) + 1;
+         if (!isApprox(TotalGeometricThicknessH(ICell), ExpectedTotal, RTol,
+                       ATol)) {
+            Err += 1;
+         }
          for (int K = DefVertCoord->MinLayerCellH(ICell);
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// Z value at interface K should be -K

--- a/components/omega/test/ocn/VertCoordTest.cpp
+++ b/components/omega/test/ocn/VertCoordTest.cpp
@@ -285,20 +285,11 @@ int main(int argc, char *argv[]) {
              DepthIntegSpecificVolume(ICell) =
                  (MaxLayerCell(ICell) - MinLayerCell(ICell) + 1) / Rho0;
           });
-      DefVertCoord->computeTotalGeometricThickness(DepthIntegSpecificVolume);
       DefVertCoord->computeGeomZHeight(PseudoThickness, SpecVol);
-      auto TotalGeometricThicknessH =
-          createHostMirrorCopy(DefVertCoord->TotalGeometricThickness);
 
       /// Check results
       Err = 0;
       for (int ICell = 0; ICell < NCellsAll; ICell++) {
-         Real ExpectedTotal = DefVertCoord->MaxLayerCellH(ICell) -
-                              DefVertCoord->MinLayerCellH(ICell) + 1;
-         if (!isApprox(TotalGeometricThicknessH(ICell), ExpectedTotal, RTol,
-                       ATol)) {
-            Err += 1;
-         }
          for (int K = DefVertCoord->MinLayerCellH(ICell);
               K < DefVertCoord->MaxLayerCellH(ICell) + 1; K++) {
             /// Z value at interface K should be -K

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -225,10 +225,12 @@ int initTimeStepperTest(const std::string &mesh) {
    auto *DefPGrad = PressureGrad::getDefault();
    auto *DefVMix  = VertMix::getInstance();
 
-   int NTracers          = Tracers::getNumTracers();
-   const int NTimeLevels = 2;
-   auto *TestOceanState  = OceanState::create("TestState", DefMesh, DefHalo,
-                                              NVertLayers, NTimeLevels);
+   int NTracers            = Tracers::getNumTracers();
+   const int NTimeLevels   = 2;
+   const bool UseModeSplit = true;
+   auto *TestOceanState    = OceanState::create(
+       "TestState", DefMesh, DefHalo, NVertLayers, NTimeLevels, UseModeSplit);
+
    if (!TestOceanState) {
       Err++;
       LOG_ERROR("TimeStepperTest: error creating test state");

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -83,6 +83,7 @@ int initState() {
 
    auto *Mesh              = HorzMesh::getDefault();
    auto *State             = OceanState::get("TestState");
+   auto *VCoord            = VertCoord::getDefault();
    Array3DReal TracerArray = Tracers::getAll(0);
 
    Array2DReal PseudoThickCell = State->getPseudoThickness(0);
@@ -92,6 +93,10 @@ int initState() {
    deepCopy(PseudoThickCell, 1);
    deepCopy(NormalVelEdge, 1);
    deepCopy(TracerArray, 1);
+
+   // Split-explicit time steppers need to have valid values for these
+   deepCopy(VCoord->SurfacePressure, 0._Real);
+   deepCopy(VCoord->BottomGeomDepth, 500._Real);
 
    return Err;
 }

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -48,6 +48,10 @@ using namespace OMEGA;
 // Only one vertical layer is needed
 constexpr int NVertLayers = 1;
 
+// Baroclinic time step at the coarsest refinement level
+constexpr Real BaseTimeStepSeconds = 0.2;
+constexpr int BtrSubcyclesPerStep  = 10;
+
 // Custom tendency for normal velocity
 // du/dt = -coeff * u
 struct DecayVelocityTendency {
@@ -149,6 +153,18 @@ int initTimeStepperTest(const std::string &mesh) {
    // Open config file
    Config("Omega");
    Config::readAll("omega.yml");
+
+   // Override BtrTimeStep in the in-memory config so the split-explicit
+   // stepper runs BtrSubcyclesPerStep barotropic subcycles per baroclinic
+   // step, This is test-only.
+   Config *TestOmegaConfig = Config::getOmegaConfig();
+   Config TimeIntTestConfig("TimeIntegration");
+   TestOmegaConfig->get(TimeIntTestConfig);
+   Config ModeSplitShareTestConfig("ModeSplitShare");
+   TimeIntTestConfig.get(ModeSplitShareTestConfig);
+   ModeSplitShareTestConfig.set(
+       "BtrTimeStep",
+       std::to_string(BaseTimeStepSeconds / BtrSubcyclesPerStep));
 
    // Note that the default time stepper is not used in subsequent tests
    // but is initialized here because the number of time levels is needed
@@ -333,7 +349,6 @@ int testTimeStepper(const std::string &Name, TimeStepperType Type,
    const Real TimeEnd = 1;
    TimeInstant TimeEndTI(0, 0, 0, 0, 0, 1);
 
-   const Real BaseTimeStepSeconds = 0.2;
    TimeInterval TimeStepTI(BaseTimeStepSeconds, TimeUnits::Seconds);
 
    auto *TestTimeStepper = TimeStepper::create(
@@ -362,6 +377,9 @@ int testTimeStepper(const std::string &Name, TimeStepperType Type,
           TimeInterval(TimeStepSeconds, TimeUnits::Seconds));
 
       Err += initState();
+
+      TestTimeStepper->initializeStateFromInput(OceanState::get("TestState"),
+                                                false);
 
       timeLoop(TimeStart, TimeEnd);
 
@@ -437,6 +455,7 @@ int testOptionalStopTime(const std::string &Name, TimeStepperType Type) {
                        DefHalo);
    auto *State = OceanState::get("TestState");
    initState();
+   Stepper->initializeStateFromInput(State, false);
    TimeInstant CurTime = TimeStart;
    Stepper->doStep(State, CurTime);
 
@@ -489,10 +508,22 @@ int timeStepperTest(const std::string &MeshFile = "OmegaMesh.nc") {
    Err += testTimeStepper("RungeKutta2", TimeStepperType::RungeKutta2,
                           ExpectedOrder, ATol);
 
+   ExpectedOrder = 1;
+   ATol          = 0.15;
+   Err += testTimeStepper("SE-RK2", TimeStepperType::SplitExplicitRK2,
+                          ExpectedOrder, ATol);
+
+   ExpectedOrder = 2;
+   ATol          = 0.1;
+   Err += testTimeStepper("UnsplitRK2", TimeStepperType::UnsplitRK2,
+                          ExpectedOrder, ATol);
+
    // Verify stepper operates correctly without StopTime/EndAlarm
 
    Err += testOptionalStopTime("ForwardBackward",
                                TimeStepperType::ForwardBackward);
+   Err += testOptionalStopTime("SE-RK2", TimeStepperType::SplitExplicitRK2);
+   Err += testOptionalStopTime("UnsplitRK2", TimeStepperType::UnsplitRK2);
 
    if (Err == 0) {
       LOG_INFO("TimeStepperTest: Successful completion");


### PR DESCRIPTION
This PR introduces a split-explicit time stepper for computationally efficient time integration in Omega.

- Added a framework for split-explicit time stepping.
  - Separated and modularized the baroclinic and barotropic time-stepping components.
- Added two new time steppers: `SplitExplicitRK2` and `UnsplitRK2`.
  - `SplitExplicitRK2`: split time stepping using RK2 for the baroclinic time stepper
  - `UnsplitRK2`: unsplit RK2 time stepping.
- Added a barotropic time stepper: `Predictor-Corrector`
  - `Predictor-Corrector`: an explicitly subcycled predictor-corrector scheme.
- Added the related split time-stepping configuration options to config/Default.yml.

```
  TimeIntegration:
    CalendarType: No Leap
    TimeStepper: SplitExplicitRK2
    TimeStep: 0000_00:10:00
   ModeSplitShare:
      BtrTimeStepper: Predictor-Corrector
      BtrTimeStep: 0000_00:00:20
      NTimeStepIteration: 2
      NBclCoriolisIteration: 2
      ReinitSplitVelocity: false
```
- `NormalBarotropicVelocity`, `NormalBaroclinicVelocity`, `BarotropicPressureAnomaly` arrays were added to `State`.


Checklist
* [ ] Documentation:
  * [ ] [User's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/userGuide) has been updated
  * [ ] [Developer's Guide](https://github.com/E3SM-Project/Omega/tree/develop/components/omega/doc/devGuide) has been updated
  * [ ] Documentation has been [built locally](https://docs.e3sm.org/Omega/Omega/devGuide/BuildDocs.html) and changes look as expected
* Linting
  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.
* [ ] New tests:
  * [ ] CTest unit tests for new features have been added per the approved design.
  * [ ] Polaris tests for new features have been added per the approved design (and included in a test suite)


