### PR TITLE
Fix inactive layer guard in gradient Richardson number computation

### DIFF
--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -148,7 +148,7 @@ class GradRichardsonNum {
 
             // Skip this edge contribution if it would access
             // invalid edge velocity levels.
-            if (K1 > MaxLayerEdgeBot(JEdge) || K2 > MaxLayerEdgeBot(JEdge))
+            if (K > MaxLayerEdgeTop(JEdge))
                continue;
 
             Real DNormVel =

--- a/components/omega/test/ocn/VertMixTest.cpp
+++ b/components/omega/test/ocn/VertMixTest.cpp
@@ -14,6 +14,7 @@
 #include "Decomp.h"
 #include "Dimension.h"
 #include "Field.h"
+#include "FillValues.h"
 #include "HorzMesh.h"
 #include "IO.h"
 #include "IOStream.h"
@@ -142,21 +143,12 @@ void testGradRichNum() {
    /// Use deep copy to initialize results
    deepCopy(NormalVelEdge, NV);
    deepCopy(TangVelEdge, TV);
-   deepCopy(BruntVaisalaFreqSqCell, BVFP);
    deepCopy(TestVertMix->GradRichNum, 0.0);
-
-   parallelFor(
-       "populateArrays", {Mesh->NCellsAll, NVertLayers},
-       KOKKOS_LAMBDA(I4 ICell, I4 K) {
-          GeomZMid(ICell, K)  = -K;
-          NEdgesOnCell(ICell) = 5;
-          AreaCell(ICell)     = 3.6e10_Real;
-       });
 
    // Also test guard is working for skipping layer edge contribution
    // if it would access invalid edge velocity levels
    parallelFor(
-       "setMinMax", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+       "setMinMax", {Mesh->NCellsOwned}, KOKKOS_LAMBDA(I4 ICell) {
           MinLayerCell(ICell) = 0;
           if (ICell % 2 == 0) {
              MaxLayerCell(ICell) = 10;
@@ -165,37 +157,62 @@ void testGradRichNum() {
           }
        });
 
+   // Need to exchange halo after changing MaxLayerCell
+   MeshHalo->exchangeFullArrayHalo(MaxLayerCell, OnCell);
+
    // Refresh edge layer ranges after overriding MaxLayerCell.
    VCoord->minMaxLayerEdge(MeshHalo);
+
+   parallelForOuter(
+       "populateArrays", {Mesh->NCellsAll},
+       KOKKOS_LAMBDA(I4 ICell, const TeamMember &Team) {
+          AreaCell(ICell) = 3.6e10_Real;
+
+          // Set inactive layers to fill value to cause failure if used
+          parallelForInner(
+              Team, NVertLayers, INNER_LAMBDA(I4 K) {
+                 if (K > MaxLayerCell(ICell)) {
+                    GeomZMid(ICell, K) = FillValueReal;
+                 } else {
+                    GeomZMid(ICell, K) = -K;
+                 }
+              });
+
+          // Set inactive layers to fill value to cause failure if used
+          parallelForInner(
+              Team, NVertLayersP1, INNER_LAMBDA(I4 K) {
+                 if (K > MaxLayerCell(ICell) + 1) {
+                    BruntVaisalaFreqSqCell(ICell, K) = FillValueReal;
+                 } else {
+                    BruntVaisalaFreqSqCell(ICell, K) = BVFP;
+                 }
+              });
+       });
 
    // Rebind GradRichardsonNum so the functor captures refreshed edge ranges.
    TestVertMix->ComputeGradRichardsonNum = GradRichardsonNum(Mesh, VCoord);
 
    // Recapture after minMaxLayerEdge since it reallocates edge layer views.
    OMEGA_SCOPE(MaxLayerEdgeBot, VCoord->MaxLayerEdgeBot);
-
-   // filling CellsOnCell with simple mapping for this test
-   parallelFor(
-       "populateArrays", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
-          CellsOnCell(ICell, 0) = ICell;
-          CellsOnCell(ICell, 1) = ICell;
-          CellsOnCell(ICell, 2) = ICell;
-          CellsOnCell(ICell, 3) = ICell;
-          CellsOnCell(ICell, 4) = ICell;
-       });
+   OMEGA_SCOPE(MaxLayerEdgeTop, VCoord->MaxLayerEdgeTop);
 
    parallelFor(
        "populateArrays", {NEdgesAll, NVertLayers},
        KOKKOS_LAMBDA(I4 IEdge, I4 K) {
           if (K > MaxLayerEdgeBot(IEdge)) {
              NormalVelEdge(IEdge, K) =
-                 -9.99e30; // Fill value to cause failure if used
-             TangVelEdge(IEdge, K) =
-                 -9.99e30; // Fill value to cause failure if used
+                 FillValueReal; // Fill value to cause failure if used
           } else {
              NormalVelEdge(IEdge, K) = NormalVelEdge(IEdge, K) + 0.5 * K;
-             TangVelEdge(IEdge, K)   = TangVelEdge(IEdge, K) + 0.5 * K;
           }
+
+          if (K > MaxLayerEdgeTop(IEdge)) {
+             TangVelEdge(IEdge, K) =
+                 FillValueReal; // Fill value to cause failure if used
+          } else {
+             TangVelEdge(IEdge, K) = TangVelEdge(IEdge, K) + 0.5 * K;
+          }
+
           DcEdge(IEdge) = 2.0e5_Real;
           DvEdge(IEdge) = 1.45e5_Real;
        });
@@ -233,8 +250,8 @@ void testGradRichNum() {
                  bool HasValidEdge = false;
                  for (int J = 0; J < NEdgesOnCell(ICell); ++J) {
                     const I4 JEdge = EdgesOnCell(ICell, J);
-                    if (K1 <= MaxLayerEdgeBot(JEdge) &&
-                        K2 <= MaxLayerEdgeBot(JEdge)) {
+                    if (K1 <= MaxLayerEdgeTop(JEdge) &&
+                        K2 <= MaxLayerEdgeTop(JEdge)) {
                        HasValidEdge = true;
                        break;
                     }
@@ -264,6 +281,15 @@ void testGradRichNum() {
    } else {
       LOG_INFO("TestVertMix: GradRichNum PASS");
    }
+
+   // Reset MaxLayerCell to the original values
+   parallelFor(
+       "resetMinMax", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
+          MinLayerCell(ICell) = 0;
+          MaxLayerCell(ICell) = NVertLayers - 1;
+       });
+   // Refresh edge layer ranges after overriding MaxLayerCell.
+   VCoord->minMaxLayerEdge(MeshHalo);
 
    return;
 }
@@ -300,12 +326,6 @@ void testOneTwoOneFilter() {
           } else {
              GradRichNum(ICell, K) = -1.0;
           }
-       });
-
-   parallelFor(
-       "setMinMax", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
-          MinLayerCell(ICell) = 0;
-          MaxLayerCell(ICell) = NVertLayers - 1;
        });
 
    // Apply the 1-2-1 filter to each cell
@@ -803,20 +823,8 @@ void testTotalVertMix() {
    parallelFor(
        "populateArrays", {Mesh->NCellsAll, NVertLayers},
        KOKKOS_LAMBDA(I4 ICell, I4 K) {
-          GeomZMid(ICell, K)  = -K;
-          NEdgesOnCell(ICell) = 5;
-          AreaCell(ICell)     = 3.6e10_Real;
-       });
-
-   // current mesh has some CellsOnCell value > NCellsAll, so
-   // filling CellsOnCell with simple mapping for this test
-   parallelFor(
-       "populateArrays", {Mesh->NCellsAll}, KOKKOS_LAMBDA(I4 ICell) {
-          CellsOnCell(ICell, 0) = ICell;
-          CellsOnCell(ICell, 1) = ICell;
-          CellsOnCell(ICell, 2) = ICell;
-          CellsOnCell(ICell, 3) = ICell;
-          CellsOnCell(ICell, 4) = ICell;
+          GeomZMid(ICell, K) = -K;
+          AreaCell(ICell)    = 3.6e10_Real;
        });
 
    parallelFor(


### PR DESCRIPTION
Fixes https://github.com/E3SM-Project/Omega/issues/500

While fixing the Richardson number functor was trivial, adapting the vertical mixing test to this change turned out to be more complicated. I made the following changes to this test:
- Removed explicit setting of `CellsOnCell` and `NEdgesOnCell`. This test in now passing with the arrays read from the mesh file.
- Added a halo exchange after changing `MaxLayerCell` in `testGradRichNum`.
- Set `BruntVaisalaFreqSq` and `GeomZMid` to fill values in inactive layers in `testGradRichNum`.
- Moved the code that reset `MinLayerCell` and `MaxLayerCell` to 0 and `NVertLayers`, respectively, from `testOneTwoOneFilter` to the very end of `testGradRichNum` . I added a call to `VertCood::minMaxLayerEdge` right after to make the edge ranges consistent.


<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* Linting
  * [x] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [x] CMake build does not produce any new warnings from changes in this PR
* [x] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [x] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

* [x] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


