### PR TITLE
Make `applyVelVertMixImplicit` and applyTracerVertMixImplicit` public

### DIFF
--- a/components/omega/src/ocn/VertMix.h
+++ b/components/omega/src/ocn/VertMix.h
@@ -476,6 +476,17 @@ class VertMix {
    void VertMixImplicit(OceanState *State, AuxiliaryState *AuxState,
                         Array3DReal &TracerArray, int NTracers, int TimeLevel);
 
+   /// Apply implicit vertical mixing to velocities
+   void applyVelVertMixImplicit(OceanState *State,
+                                const AuxiliaryState *AuxState,
+                                int ThickTimeLevel, int VelTimeLevel);
+
+   /// Apply implicit vertical mixing to tracers
+   void applyTracerVertMixImplicit(OceanState *State,
+                                   const AuxiliaryState *AuxState,
+                                   Array3DReal &TracerArray, int NTracers,
+                                   int ThickTimeLevel, int VelTimeLevel);
+
  private:
    /// Private constructor
    VertMix(const std::string &Name, const HorzMesh *Mesh,
@@ -497,17 +508,6 @@ class VertMix {
 
    // Define fields and metadata
    void defineFields();
-
-   /// Apply implicit vertical mixing to velocities
-   void applyVelVertMixImplicit(OceanState *State,
-                                const AuxiliaryState *AuxState,
-                                int ThickTimeLevel, int VelTimeLevel);
-
-   /// Apply implicit vertical mixing to tracers
-   void applyTracerVertMixImplicit(OceanState *State,
-                                   const AuxiliaryState *AuxState,
-                                   Array3DReal &TracerArray, int NTracers,
-                                   int ThickTimeLevel, int VelTimeLevel);
 
 }; // End class VertMix
 


### PR DESCRIPTION
Making `applyVelVertMixImplicit` and applyTracerVertMixImplicit` private in #505 caused build errors on pm-gpu (gnugpu). This PR makes these functions public again.

Fixes #519.

<!--
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist

* Linting
  * [ ] [Pre-commit](https://docs.e3sm.org/Omega/Omega/devGuide/Linting.html) run locally
* Building
  * [ ] CMake build does not produce any new warnings from changes in this PR
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [x] CTests Pass
  - [x] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Which machines [CTest unit tests](https://docs.e3sm.org/Omega/Omega/devGuide/QuickStart.html#running-ctests)
        have been run on and indicate that are all passing.
  * The [Polaris omega_pr test suite](https://docs.e3sm.org/Omega/Omega/devGuide/Testing.html)
     has passed, using the Polaris `e3sm_submodules/Omega` baseline
  * Document machine(s), compiler(s), and the build path(s) used for `-p` for both the baseline (Polaris `e3sm_submodules/Omega`) and the PR build
  * Indicate "All tests passed" or document failing tests
  * Document testing used to verify the changes including any tests that are added/modified/impacted.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


