### PR TITLE
Fix syntax in `e3sm_omega_developer` definition

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -1156,6 +1156,7 @@ _TESTS = {
             "ERS_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",
             #"PEM_Vmct_Ln5.TL319_EC30to60E2r2.COMEGA-JRA1p5.omega-jra_1958",
             )
+    },
     "e3sm_test_bless" : {
         "time"  : "10:00",
         "tests" : (


### PR DESCRIPTION
There seems to have been a minor mistake in resolving the diffs from E3SM-Project/Omega#521, which resulted in the `e3sm_omega_developer` test suite definition missing it's closing bracket. 


<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Testing

  **aurora, oneapi-ifx, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **chrysalis, oneapi-ifx, openmpi**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **frontier, craygnu-mphipcc, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-cpu, gnu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

  **pm-gpu, gnugpu, mpich**
  - [ ] CTests Pass
  - [ ] Polaris omega_pr Pass

* [ ] Provide relevant details in a comment to the PR titled `Testing` with the following:
  * Document testing used to verify the changes including any tests that are added/modified/impacted.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->


